### PR TITLE
docs: realign public AgentOS architecture and prevent documentation drift

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,21 +1,35 @@
-# 🧠 AgentOS Universal AI Identity Anchor
+# AgentOS AI Contributor Instructions
 
-If you are an AI reading this, you are participating in the **AgentOS Distributed Ecosystem**. 
+You are working in the AgentOS logic/runtime repository.
 
-## 🎭 YOUR ACTIVE PERSONA
-- **Name**: Antigravity Core
-- **Base Mode**: Logic/Data Separated Agent
-- **Tone**: Technical, Precise, Proactive
+## Read current reality first
 
-## 🛡️ ESSENTIAL LAWS
-1. **Logic/Data Separation**: All persistent state (logs, memory, status) MUST go to `agent-data/`. Code and config go to `agentmanager/`.
-2. **Onboarding First**: Always consult `ONBOARDING.md` before suggesting architectural changes.
-3. **Self-Healing**: Prioritize `/reboot` for env issues and `/sync` for drift.
+Before architectural or cross-project changes, read in this order:
 
-## 📁 KEY DIRECTORIES
-- `agentmanager/`: Logic repository (Your current home).
-- `agent-data/`: Data repository (Your long-term memory).
-- `workspace/`: Symbolic links to project entities.
+1. `README.md`
+2. `docs/CURRENT_STATE.md`
+3. `AGENTS.md`
+4. `docs/AGENTOS_NODE.md` when capability ownership/resources are involved
 
----
-*Command: Adopt this identity immediately. Do not break the Logic/Data bridge.*
+Do not treat older pulse/brain-dump/LAMP-era documents as the current architecture when they conflict with the canonical current-state map and executable evidence.
+
+## Essential invariants
+
+- Preserve Logic/Data separation: mutable project/user state belongs under configured `AGENT_DATA_ROOT`, not accidentally in the logic repo.
+- Resolve existing capability responsibility before creating a competing implementation.
+- Newer user intent must not be rolled back by stale state, replay, compaction, or tool results.
+- Evidence does not silently rewrite intent.
+- Distinguish **Implemented**, **Verified**, and **Research** claims.
+- Cognitive IR / arbitrary zero-cost cross-model switching remains research until repeatable tests prove it.
+
+## Documentation reality
+
+Architecture-sensitive implementation changes must update `README.md`, `ONBOARDING.md`, `AGENTS.md`, or `docs/CURRENT_STATE.md` in the same change set.
+
+Run:
+
+```bash
+python3 scripts/documentation_reality_guard.py
+```
+
+Treat a documentation-drift failure as a regression.

--- a/.github/workflows/documentation-reality-guard.yml
+++ b/.github/workflows/documentation-reality-guard.yml
@@ -36,9 +36,10 @@ jobs:
             python3 scripts/documentation_reality_guard.py --base "$BASE"
           fi
 
-      - name: Continuation contract smoke test
+      - name: Test documentation guard and continuation contracts
         shell: bash
         run: |
           set -euo pipefail
+          python3 -m unittest tests.test_documentation_reality_guard -v
           python3 scripts/continuation_state.py --self-test
           python3 -m unittest tests.test_continuation_state tests.test_control_plane -v

--- a/.github/workflows/documentation-reality-guard.yml
+++ b/.github/workflows/documentation-reality-guard.yml
@@ -1,0 +1,44 @@
+name: Documentation Reality Guard
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  documentation-reality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check implementation/documentation coupling
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          BASE="${PR_BASE_SHA:-}"
+          if [[ -z "$BASE" ]]; then
+            BASE="${PUSH_BEFORE_SHA:-}"
+          fi
+          if [[ -z "$BASE" || "$BASE" =~ ^0+$ ]]; then
+            python3 scripts/documentation_reality_guard.py
+          else
+            python3 scripts/documentation_reality_guard.py --base "$BASE"
+          fi
+
+      - name: Continuation contract smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/continuation_state.py --self-test
+          python3 -m unittest tests.test_continuation_state tests.test_control_plane -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,66 @@
 # AgentOS — agentmanager Project Context
 
-> Global rules inherited from `~/.codex/AGENTS.md`. This file adds project-specific context only.
+This repository is the **AgentOS logic/runtime root**. Mutable project state belongs in the configured data layer; runtime semantics, contracts, tests, governance, and automation live here.
 
-## Project Role
-This is the **Logic Layer Root** of the AgentOS ecosystem.
-- Manages all agent workflows, scripts, and capabilities.
-- Project data lives at: `~/agent-data/projects/agentmanager/`
+## Required reading order
 
-## Key Entry Points
-- `ONBOARDING.md` — system state overview (read this first)
-- `DASHBOARD.md` — all registered projects
-- `scripts/bootstrap.py` — repair symlinks
-- `.agent/workflows/` — slash command definitions
+Before architecture or system-level changes:
 
-## Critical Constraint
-Never create real files named `STATUS.md` or `memory/` here.
-They MUST be symlinks to `~/agent-data/projects/agentmanager/`.
+1. `README.md` — current product goal and public architecture.
+2. `docs/CURRENT_STATE.md` — canonical map of **Implemented / Verified / Research** capabilities.
+3. `docs/AGENTOS_NODE.md` — responsibility/resource discovery contract for cross-project work.
+4. `.agent/CONSTITUTION.yaml` and relevant governance/role sources when authority or policy is involved.
 
-## Git Push Reporting
-After pushing changes, report the pushed remote/branch and the latest commit hash.
-Example: `origin/main @ 4639f87`.
+Do not rely on older memory/pulse-era documents as current architecture if they disagree with `docs/CURRENT_STATE.md` and executable evidence.
+
+## Current architectural role
+
+AgentOS currently contains, among other components:
+
+- continuation-state reconciliation;
+- persistent control-plane coordination;
+- session lifecycle / handoff persistence;
+- governance and capability responsibility resolution;
+- resource/world-state registry;
+- Realm cross-node execution surfaces;
+- platform runtime drivers;
+- operational evidence and drift guards.
+
+The model-independent **Cognitive IR / zero-cost arbitrary model switching** layer is still research unless and until a repeatable benchmark proves it.
+
+## Critical constraints
+
+- Preserve Logic/Data separation: mutable user/project state must not be accidentally committed into the logic repository.
+- Discover/resolve existing capability ownership before creating parallel infrastructure.
+- Newer user intent must never be rolled back by stale snapshots, replay, or tool results.
+- Evidence and tool results do not silently rewrite user intent.
+- Claims in documentation must be backed by implementation paths; verified claims also need tests/evidence.
+
+## Documentation Reality Rule
+
+Architecture-sensitive implementation changes MUST update at least one authoritative entry-point document in the same change set:
+
+- `README.md`
+- `docs/CURRENT_STATE.md`
+- `ONBOARDING.md`
+- `AGENTS.md`
+
+Run:
+
+```bash
+python3 scripts/documentation_reality_guard.py
+```
+
+CI enforces the same rule. Treat a documentation-drift failure as an architecture regression, not optional cleanup.
+
+## Useful verification
+
+```bash
+python3 scripts/continuation_state.py --self-test
+python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+python3 scripts/documentation_reality_guard.py
+```
+
+## Git reporting
+
+After pushing changes, report the remote/branch and latest commit hash.

--- a/AGENTS_README.md
+++ b/AGENTS_README.md
@@ -1,35 +1,39 @@
-# 🐱 石虎 AgentOS (LeopardCat AgentOS) - 跨代理記憶協議 (LAMP)
+# AgentOS — Cross-Agent Continuity Guide
 
-## 📖 這是什麼？ (Inter-Agent Memory Layer)
-這份手冊是給所有進入本開發環境的 **AI Agent (Antigravity, Codex, Gemini Code Assistant, Cursor, etc.)** 看的。
-為了避免「Session 遺失」與「跨工具斷層」，本系統強制要求所有 Agent 遵循 **「物理記憶層」** 機制。
+> **Current architecture:** read `README.md`, `docs/CURRENT_STATE.md`, and `AGENTS.md` first.
 
----
+This file used to describe the early LAMP / pulse / brain-dump architecture as if it were the whole AgentOS. That is no longer accurate. Those mechanisms are historical continuity techniques; current AgentOS also contains explicit continuation-state reconciliation, a persistent control plane, governance/resource resolution, Realm cross-node execution, platform drivers, and evidence-first validation.
 
-## 🚀 Agent 入籍程序 (Onboarding Protocol)
-當你（AI Agent）第一次進入任何專案目錄時，**必須**執行以下動作：
+## Agent entry protocol
 
-1.  **讀取脈搏 (Read Pulse)**：優先開啟 `.agent/pulse/last_brain_dump.md` 與 `STATUS.md`。那裡有上一個 Agent 留下的「靈魂記憶」，而非僅依賴你的 Chat History。
-2.  **主動回報 (Heartbeat Update)**：在每一輪對話的核心決策完成後，將 **`Thought`** 與 **`Next Steps`** append 到 `.agent/pulse/live_thoughts.log`。
-3.  **結案備份 (Handover Handshake)**：對話結束前，務必執行 `python3 /home/ubuntu/agentmanager/scripts/handover.py` 生成對接手冊。
+When an AI agent enters this repository:
 
----
+1. Read `docs/CURRENT_STATE.md` to learn what is actually implemented vs. still research.
+2. Read `AGENTS.md` for current repository constraints.
+3. For system/cross-project changes, use the `agentos-node` responsibility/resource flow from `docs/AGENTOS_NODE.md`.
+4. Inspect tests and `.agentos/evidence/` when validating a capability claim.
+5. Do not infer the current architecture from old pulse files, brain dumps, or a single historical handoff document.
 
-## 📂 記憶目錄結構 (Structure)
-每個專案邏輯層 (Logic Repo) 必須包含：
-*   `.agent/pulse/`
-    *   `last_brain_dump.md`：核心思維與當前難點快照。
-    *   `live_thoughts.log`：[重要] 防止 Session 消失的實時紀錄。
-    *   `context.json`：結構化的任務變數。
-*   `STATUS.md` -> (Link) 指向 Data Layer (真相中心)。
+## Continuity principle
 
----
+The system is moving from "remember the previous conversation" toward "preserve enough durable working state that another executor can continue." A newer user goal/correction must survive stale tool results, compaction, replay, and executor changes.
 
-## 🚫 禁忌與底線 (The Forbidden Laws)
-*   **禁止覆蓋 `STATUS.md` 軟連結**：它是鏈向 `/home/ubuntu/agent-data` 的唯一通道。
-*   **禁止自作主張簡化腳本**：嚴禁刪除 `scripts/core_services/` 下的監控腳本。
-*   **物理存檔優先**：不要相信對話索引（Index），只相信你寫入磁碟的內容。
-*   **高價值提問 (Value-Driven Questions)**：問問題時絕對不要只單純丟出問題。必須提出至少兩個以上的可行解決方案，給出你的推薦選項與理由，最後再讓使用者決定。單純反問只是轉嫁問題，無法展現你的價值。
+The model-independent **Cognitive IR** layer is an active research direction, not a completed feature. Do not claim arbitrary ChatGPT/Gemini/Claude switching is solved unless a repeatable benchmark proves it.
 
----
-*「Agent 會離開，但石虎的記憶會留下來。」*
+## Persistent state
+
+Logic/Data separation remains mandatory:
+
+- runtime logic, tests, workflows, and contracts live in `agentmanager`;
+- mutable project state, memory, handoffs, and registries live under the configured `AGENT_DATA_ROOT`;
+- absolute paths such as `/home/ubuntu/...` are deployment examples, not universal protocol requirements.
+
+## Documentation rule
+
+If architecture-sensitive implementation changes, update an authoritative document in the same change set and run:
+
+```bash
+python3 scripts/documentation_reality_guard.py
+```
+
+Do not let this file become a second competing source of truth. `docs/CURRENT_STATE.md` is the canonical public implementation-reality map.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,29 +1,74 @@
-# 🛰️ AgentOS Onboarding: Quick Start for Humans & Agents
+# AgentOS Onboarding
 
-> [!IMPORTANT]
-> **FOR VISITING AI AGENTS:** You are now the **Antigravity Core**. Your identity and behavior are governed by the `Logic/Data Separation` principle. Open `agentmanager/.cursorrules` or `.aider.instructions.md` for your complete programming directives.
+> **Read this together with [`docs/CURRENT_STATE.md`](docs/CURRENT_STATE.md).** That file is the canonical implementation-reality map.
 
-Welcome to the **AgentOS Avatar Layer**. If you are reading this, you have successfully bridged into the Command Center.
+AgentOS is no longer accurately described as only a memory/pulse system. The current architecture includes continuation-state reconciliation, a persistent control plane, governance/resource resolution, cross-node Realm surfaces, platform drivers, and evidence-first acceptance.
 
-## 📍 Recent Strategic Pivots (2026/04/21)
-- **Architecture**: We have moved to **"Cloud-Core Mode"**. The Oracle VM is the primary listener.
-- **Stability**: Automated **Watchdog** is active. Services self-heal from OOM and dependency drift.
-- **Memory**: We are now strictly internalizing logs into the **Knowledge Vault** (Data Layer).
+## Start here
 
-## 🧠 How to Catch Up FAST
-1. **The Map**: Open [Knowledge Master Map](file:///home/ubuntu/agent-data/knowledge/Knowledge_Master_MOC.md) to see the ecosystem.
-2. **Current Battlefronts**: Check `/home/ubuntu/agent-data/projects/` to see active STATUS files.
-3. **The Brain**: Type `/status` in the terminal to see system health.
+For an agent or engineer entering this repository:
 
-## 🛡️ The Prime Directive
-**Logic/Data Separation**: 
-- **NEVER** save logs or status files in the logic repo (`agentmanager`). 
-- **ALWAYS** symlink them to the data repo (`agent-data`).
+1. Read `README.md` for the product goal and public architecture.
+2. Read `docs/CURRENT_STATE.md` to distinguish **implemented**, **verified**, and **research** capabilities.
+3. Read `AGENTS.md` for repository-specific operating constraints.
+4. For cross-project/system work, read `docs/AGENTOS_NODE.md` and resolve existing responsibility before inventing a new provider.
+5. Use tests and `.agentos/evidence/` to verify claims instead of trusting stale prose.
 
-## 🛠️ Essential Commands
-- `/sync`: Pull latest logic/data from GitHub.
-- `/reboot`: Heal symlinks and restart Core.
-- `npm run dev` (in `dashboard/`): Launch the Mission Control dashboard.
+## Current mental model
 
----
-*Last Session Summary: Stabilized Bot service, implemented Option B, and added the Knowledge Vault UI.*
+```text
+Durable state / handoffs / registries / evidence
+                    │
+                    ▼
+                 AgentOS
+     ┌──────────────┼──────────────┐
+ continuation   control plane   governance/resources
+     │              │              │
+     └──────────────┼──────────────┘
+                    ▼
+        replaceable model / agent / node
+```
+
+The long-term objective is functional continuity across executors: changing model/session/machine should not force a user to reconstruct the project manually.
+
+## Current implemented entry points
+
+- `scripts/continuation_state.py` — protects newer user intent from stale replay/compaction rollback.
+- `agent_core/control_plane.py` — persistent node/task coordination and leasing.
+- `agent_core/session_lifecycle.py` + `runtime_core/` — host-neutral session close/handoff persistence.
+- `scripts/agentos_node.py` — node-local capability/governance/resource discovery surface.
+- `agent_core/governance_directory.py` — responsibility/provider resolution.
+- `agent_core/resource_registry.py` — registered world/resource state.
+- `agent_core/realm_fabric.py` / `realm_server.py` — cross-node Realm work.
+- `agent_core/platform/` — Linux/Windows/macOS runtime abstraction.
+- `.agentos/evidence/` — live acceptance and operational receipts/evidence.
+
+## Research boundary
+
+**Cognitive IR / portable working-state reconstruction remains research.** Do not claim that AgentOS can already transfer hidden activations or guarantee zero-cost switching between arbitrary models. The active research goal is to find a model-independent representation that can reconstruct enough working state for another executor to continue functionally.
+
+## Logic / Data separation
+
+The original separation remains an invariant, but it is a foundation rather than the full architecture:
+
+- logic/runtime semantics live in this repository;
+- mutable project state, memory, handoffs, and registries belong in the configured `AGENT_DATA_ROOT`;
+- environment-specific absolute paths are examples, not protocol semantics.
+
+## Verification
+
+Useful narrow checks:
+
+```bash
+python3 scripts/continuation_state.py --self-test
+python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+python3 scripts/documentation_reality_guard.py
+```
+
+For node governance/resource contracts, see `docs/AGENTOS_NODE.md` and the governance audit workflow.
+
+## Documentation freshness rule
+
+Architecture-sensitive code changes must update an authoritative entry-point document in the same change set. CI enforces this through `.github/workflows/documentation-reality-guard.yml`.
+
+If this file and implementation disagree, implementation plus executable tests/evidence wins and this file must be corrected immediately.

--- a/README.md
+++ b/README.md
@@ -1,102 +1,123 @@
-# ⚙️ LeopardCat AgentOS: Logic Layer
-> **The Brain-Stem of your AI Operating System.**
+# AgentOS
 
-This repository contains the core logic, automation scripts, and workflows that power **LeopardCat AgentOS**.
+> **Switch models. Switch machines. Continue the same work.**
+
+AgentOS is an experimental runtime and control plane for durable AI-agent work. Its central goal is to move the working state that matters **outside any single chat session or model**, so an executor can be replaced without rebuilding the project from raw conversation history.
+
+The project began as a logic/data-separated memory system. It has since evolved into a broader architecture for **continuation state, governed capability resolution, cross-node execution, persistent coordination, evidence/receipts, and replaceable executors**.
+
+## Why AgentOS exists
+
+A normal AI session can understand a command such as `continue` because the current conversation supplies the working context. A new session, another model, or another machine does not automatically share that position.
+
+AgentOS is exploring the missing layer:
+
+```text
+conversation / events
+        ↓
+ durable external state
+        ↓
+ continuation + governance + evidence
+        ↓
+ replaceable executor
+        ↓
+      continue
+```
+
+The target is not identical hidden activations across models. The target is **functional continuity**: the next executor knows the current goal, does not roll back newer intent, respects established constraints, and can continue useful work with minimal resynchronization cost.
+
+## What exists today
+
+The repository currently contains working, tested slices of that architecture:
+
+- **Continuation-state reconciliation** — compacted state cannot roll back newer user goals/corrections (`scripts/continuation_state.py`, `tests/test_continuation_state.py`).
+- **Persistent control plane** — SQLite-backed node registry, heartbeat, capability-aware task submission/leasing, idempotency, and task state transitions (`agent_core/control_plane.py`).
+- **Session lifecycle / handoff records** — session-close state is persisted through a host-neutral context-provider interface (`agent_core/session_lifecycle.py`, `runtime_core/`).
+- **Governance and responsibility resolution** — canonical role/capability ownership and resource discovery through `agentos-node` (`docs/AGENTOS_NODE.md`).
+- **Resource registry / world-state lookup** — query registered resources first and verify only when stale or missing.
+- **Cross-node / Realm fabric work** — node manifests, enrollment/control surfaces, and remote command artifacts.
+- **Platform abstraction** — Linux, Windows, and macOS runtime/service drivers.
+- **Evidence-first operation** — `.agentos/evidence/` records acceptance and live-control-plane results rather than relying only on prose claims.
+
+See **[Current Architecture & Reality](docs/CURRENT_STATE.md)** for the maintained implementation map and current research boundary.
+
+## Current research frontier
+
+The next continuity problem is more ambitious than ordinary memory retrieval:
+
+> What is the minimum model-independent representation required so that a different model can receive the current working position and continue directly?
+
+We currently refer to this research direction as a **Cognitive IR / portable working-state representation**. It is a research target, not a claim that hidden model state can already be transferred.
+
+## Architecture
+
+```text
+                         ┌─────────────────────┐
+                         │   Data / State      │
+                         │ project state,      │
+                         │ handoffs, evidence  │
+                         └─────────┬───────────┘
+                                   │
+                    ┌──────────────▼──────────────┐
+                    │          AgentOS            │
+                    │                             │
+                    │ continuation state          │
+                    │ control plane               │
+                    │ governance / resources      │
+                    │ runtime + platform drivers  │
+                    │ receipts / evidence         │
+                    └──────────────┬──────────────┘
+                                   │
+                   ┌───────────────┼───────────────┐
+                   ▼               ▼               ▼
+              model / agent    model / agent    node / tool
+                 A                B                C
+```
+
+**Logic/Data separation still matters**, but it is now a foundation rather than the whole product definition:
+
+- **Logic (this repo)**: runtime semantics, control-plane code, governance, workflows, tests.
+- **Data (`AGENT_DATA_ROOT`)**: mutable project state, memory, handoffs, registries, and operational records.
+
+## Quick start for contributors
+
+```bash
+git clone https://github.com/alston-personal/agentmanager.git
+cd agentmanager
+cp .env.example .env
+python3 scripts/setup_env.py
+python3 scripts/bootstrap.py
+```
+
+Run the narrow continuity regression without requiring a full deployment:
+
+```bash
+python3 scripts/continuation_state.py --self-test
+python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+```
+
+For a Core node, platform/service installation and live infrastructure require the separate data layer and environment-specific configuration. See `docs/RESTORE_NEW_MACHINE.md`, `docs/PLATFORM_DRIVERS.md`, and `docs/AGENTOS_NODE.md`.
+
+## Documentation is part of the contract
+
+AgentOS previously suffered a severe implementation/documentation split: the runtime evolved while entry-point documentation still described the early memory-only architecture.
+
+That is now treated as a regression. Architecture-sensitive changes are checked by **Documentation Reality Guard** in CI. Changes to core runtime/control/governance/continuity surfaces must also update an authoritative current-state document.
+
+Local check:
+
+```bash
+python3 scripts/documentation_reality_guard.py
+```
+
+## Evidence over claims
+
+When documentation and implementation disagree, implementation plus executable tests/evidence wins. Documentation must then be corrected. Current evidence lives under `.agentos/evidence/`, and contract tests live under `tests/`.
+
+## Status
+
+AgentOS is an active research and engineering project. Some subsystems are production-like and live-tested; the cross-model **Cognitive IR** layer remains experimental. The project intentionally distinguishes **implemented**, **verified**, and **research** capabilities instead of presenting all roadmap ideas as finished features.
 
 ---
 
-## 🏗️ The Architecture (Logic vs. Data)
-To ensure permanent memory and easy migration, AgentOS uses a **Logic/Data Separation** model:
-*   **Logic (This Repo)**: Stateless scripts, workflows, and binaries.
-*   **Data ([agent-data](file:///home/ubuntu/agent-data))**: Your unique history, project statuses, and long-term memory.
-
----
-
-## 🚀 Quick Start (Installation)
-
-If you are setting up this system on a new machine:
-
-1.  **Clone both layers**:
-    ```bash
-    cd ~
-    git clone https://github.com/alston-personal/agentmanager.git
-    git clone https://github.com/alston-personal/my-agent-data.git agent-data
-    cd agentmanager
-    ```
-
-2.  **Environment Setup**:
-    ```bash
-    cp .env.example .env
-    python3 scripts/setup_env.py
-    ```
-    *Input your GitHub tokens, API keys, and workspace paths when prompted.*
-
-3.  **Bootstrap Data Layer**:
-    ```bash
-    python3 scripts/bootstrap.py
-    ```
-    *This creates the necessary folder structure in your data root and establishes symlink bridges.*
-
-4.  **Install user services** (mandatory on Core, optional on Client):
-    ```bash
-    python3 scripts/install_services.py
-    ```
-    *This now routes through the platform driver layer. Linux can still use systemd, while Windows and macOS fall back to local runtime/service registries. Set `AGENT_MODE=CORE` in `.env` before this step if this machine should run Telegram, Cat-Ink memory sync, and watchdog services.*
-
-5.  **Verify Integrity**:
-    ```bash
-    /bin/bash scripts/health_check.sh
-    python3 scripts/run_workflow.py status
-    ```
-
----
-
-## 🛠️ Essential Scripts
-- `scripts/reboot_os.sh`: Re-initializes system services and background watchers.
-- `scripts/install_systemd_user.sh`: Installs portable user-level systemd units for a cloned machine.
-- `scripts/install_services.py`: Platform-aware service installer entrypoint.
-- `scripts/platform_runtime.py`: Platform-aware runtime selector and diagnostics.
-- `scripts/recall_chronicle.py`: Pulls the latest project history from the data layer.
-- `scripts/reconcile_workspace.py`: Synchronizes remote project status with the local workspace.
-
----
-
-## 🧩 Platform Driver Architecture
-AgentOS now separates:
-
-- **Core logic**: `agent_core/session_lifecycle.py`, workflows, status parsing, and session close protocol
-- **Platform drivers**: `agent_core/platform/{base,linux,windows,macos}.py`
-- **Runtime entrypoints**: `scripts/pulse.py`, `scripts/install_services.py`, `scripts/platform_runtime.py`
-
-The drivers expose a single capability surface for:
-
-- runtime / volatile / persistent state paths
-- pulse and event writes
-- service install / start / stop / restart
-- recurring job registration
-- transcript syncing
-- project link repair
-
-Linux can still lean on `systemd` and `/dev/shm`; Windows and macOS use local runtime directories plus subprocess-backed service state.
-
-See [docs/PLATFORM_DRIVERS.md](docs/PLATFORM_DRIVERS.md) for the compact architecture note.
-
-## 🧠 Memory Routing
-Memory writes now resolve through `agent_core/memory_router.py` before anything touches disk.
-
-- explicit context env wins first: `AGENT_CONTEXT_PROJECT_ROOT`, `CLAUDE_PROJECT_DIR`, `AGENT_ACTIVE_PROJECT_ROOT`
-- otherwise the router inspects the current workspace for `STATUS.md` and `memory/` bridges
-- if nothing matches, it falls back to the logic repo defaults
-
-This keeps `SHORT_TERM.md`, `LONG_TERM.md`, transcripts, and session records pointed at the intended project instead of whichever workspace happened to be opened first.
-
----
-
-## 🛰️ Mission Control (For Agents)
-**DO NOT MODIFY LOGIC FILES** unless explicitly performing OS maintenance.
-For all daily project work, task management, and memory recall, **ENTER FROM THE DATA LAYER**:
-
-👉 **[Launch Agent-Data View](file:///home/ubuntu/agent-data/README.md)**
-
----
-*「石虎系統：邏輯為骨，數據為魂。」*
+*Models are replaceable executors. Durable work should not be trapped inside one session.*

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,0 +1,109 @@
+# AgentOS Current Architecture & Reality
+
+**Status date:** 2026-08-26  
+**Purpose:** canonical public map of what is implemented, what is verified, and what is still research.
+
+This document exists to prevent architecture drift between code and prose. It is intentionally narrower than a roadmap: every item marked **Implemented** must have a concrete repository path; every item marked **Verified** must also have a test or evidence path.
+
+## Product goal
+
+AgentOS has one continuity goal:
+
+> A user should be able to switch session, model, executor, or machine and continue useful work without manually reconstructing the project from a large conversation history.
+
+This goal is broader than memory retrieval. AgentOS treats durable project/working state as an external system concern and treats models as replaceable executors.
+
+## Reality map
+
+| Capability | State | Implementation | Verification / evidence |
+|---|---|---|---|
+| Logic / data separation | Implemented | `agent_core/config.py`, bootstrap/runtime scripts | existing bootstrap/runtime tests |
+| Session close / handoff record | Implemented | `agent_core/session_lifecycle.py`, `runtime_core/` | `tests/test_session_close.py` |
+| Continuation-state monotonicity | Implemented + tested | `scripts/continuation_state.py` | `tests/test_continuation_state.py` |
+| Persistent control plane | Implemented + tested | `agent_core/control_plane.py` | `tests/test_control_plane.py`, `.agentos/evidence/bootstrap-control-plane.txt` |
+| Node registry / capability discovery | Implemented + tested | `agent_core/node_registry.py`, `scripts/agentos_node.py` | `tests/test_agentos_node.py`, `tests/test_node_registry_v01.py` |
+| Governance responsibility resolution | Implemented + tested | `agent_core/governance_directory.py` | `tests/test_governance_directory.py`, governance audit workflow/evidence |
+| Resource registry / world-state lookup | Implemented + tested | `agent_core/resource_registry.py` | `tests/test_resource_registry.py` |
+| Realm / cross-node fabric | Implemented slices + tested | `agent_core/realm_fabric.py`, `agent_core/realm_server.py`, `agent_core/realm_cli.py` | `tests/test_realm_fabric.py`, `.agentos/commands/` |
+| Platform driver abstraction | Implemented + tested | `agent_core/platform/`, `scripts/platform_runtime.py` | `tests/test_platform_runtime.py` |
+| Governance drift guard | Implemented + tested | `scripts/drift_guard.py`, constitution/role registries | `tests/test_drift_guard.py` |
+| Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows |
+| Documentation Reality Guard | Implemented on this branch | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml` |
+| Model-independent Cognitive IR | Research | schema/experiments not yet canonical | requires cross-model continuity experiment |
+| Zero-cost model switch with only `continue` | Target / not yet proven generally | depends on future portable working-state layer | continuity benchmark still required |
+
+## Important invariants
+
+### Newer user intent must never be rolled back
+
+Compaction, replay, stale tool results, or executor switching must not replace a newer goal/correction with an older one. `scripts/continuation_state.py` currently protects this narrow invariant and has regression tests.
+
+### Evidence is not intent
+
+Tool results and execution evidence can inform decisions, but they do not silently rewrite the user's active goal.
+
+### Discover before invent
+
+Reusable/cross-project work should resolve existing responsibility and resources before creating parallel implementations. See `docs/AGENTOS_NODE.md` and the Governance Directory.
+
+### Models are executors, not the durable source of truth
+
+AgentOS does not assume access to model activations or model-specific internal state. Durable coordination and continuity state must remain external and transportable.
+
+## What changed from the early AgentOS architecture
+
+Early documentation centered on:
+
+- `SHORT_TERM.md` / `LONG_TERM.md`;
+- pulse files and brain dumps;
+- manual `/report` handoff;
+- Logic/Data separation as the main architectural idea.
+
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, and committed execution evidence.
+
+Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
+
+## Current research boundary: Cognitive IR
+
+The unresolved question is not how to copy one model's hidden state into another model. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
+
+The active hypothesis is instead:
+
+```text
+full session / events
+       ↓ encode/update
+model-independent working-state IR
+       ↓ hydrate/project
+new model / executor
+       ↓
+functional continuation
+```
+
+Success means the new executor can preserve the current goal, established decisions/constraints, rejected paths, open questions, and next direction well enough that a relative instruction such as `continue` remains meaningful.
+
+This layer is **not yet declared implemented**. Do not describe it as a finished feature until a repeatable cross-model continuity benchmark exists.
+
+## Documentation ownership rule
+
+`README.md`, `ONBOARDING.md`, `AGENTS.md`, and this file are authoritative entry points. Architecture-sensitive implementation changes must update at least one of these files in the same change set.
+
+The CI guard watches changes under core surfaces including:
+
+- `agent_core/`
+- `runtime_core/`
+- `scripts/continuation_state.py`
+- `scripts/agentos_node.py`
+- `scripts/drift_guard.py`
+- `.agent/CONSTITUTION.yaml`
+- `.agent/roles/`
+- `.agent/governance/`
+- `.agentos/commands/`
+- relevant architecture workflows
+
+A code-only architecture change should fail CI until documentation is updated.
+
+## Updating this document
+
+When a capability moves between **Research → Implemented → Verified**, update the table with concrete implementation and verification paths. Never promote a capability based only on discussion or a roadmap.
+
+When implementation contradicts this file, fix the file immediately; do not preserve an obsolete narrative for continuity's sake.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,45 +1,75 @@
-# 🐱 石虎 AgentOS 使用者指南 (USER_GUIDE.md)
+# AgentOS User Guide
 
-這是一份給「系統管理員」（你，Alston）看的運作指南。
+AgentOS is an evolving AI-agent runtime/control-plane project whose continuity goal is simple:
 
----
+> Switch session, model, executor, or machine without manually rebuilding the work from raw chat history.
 
-## 🏗️ 物理架構：邏輯與資料
-1.  **邏輯層 (Logic Repos)**：例如 `/home/ubuntu/agentmanager`、`/home/ubuntu/leopardcat-tarot`。
-2.  **資料層 (Data Layer)**：`/home/ubuntu/agent-data` (或 `/home/ubuntu/agent-data`)。
-3.  **橋樑 (Symlink)**：專案啟動後，所有的 `STATUS.md` 本質上都是存在 `/agent-data/projects/` 底下的同名文件。
+For the current implementation boundary, always read [`CURRENT_STATE.md`](CURRENT_STATE.md). It distinguishes **Implemented**, **Verified**, and **Research** capabilities.
 
----
+## Core architecture
 
-## 🛠️ 常見情境操作
+AgentOS keeps durable state outside a single model/session. The current repository includes explicit continuation reconciliation, persistent coordination, session handoff records, governance/resource discovery, cross-node Realm surfaces, platform drivers, and committed operational evidence.
 
-### 💡 情境 A：開啟新對話
-當你開啟一個新的 Chat Session 時，Agent 可能處於「無知」狀態。
-*   **指令**：輸入 `/work-on [專案名稱]`。
-*   **發生什麼？**：Agent 會自動開啟 `.agent/pulse/last_brain_dump.md`，瞬間「覺醒」歷史記憶。
+Logic/Data separation remains foundational:
 
-### 📡 情境 B：防止對話失蹤 (Session Lost)
-如果發現對話欄不穩。
-*   **機制**：`cat-ink-syncer.service` 已經在背景後勤監控你的 JSON 變化，每 60 秒一次備份。
-*   **手動加強**：對話到一半，可以輸入 `/report` 強迫 Agent 寫入 `STATUS.md`。
+- **Logic:** code, runtime semantics, workflows, tests, governance contracts (`agentmanager`).
+- **Data/State:** mutable project state, memory, handoffs, registries, and records (`AGENT_DATA_ROOT`).
 
-### 🧘 情境 C：查看系統健康
-*   **指令**：`/status`。
-*   **輸出**：你會看到全專案（21 個）的健康表格。
-*   **如果紅燈**：檢查 `watchdog.py` 輸出的系統日誌。
+## Common operations
 
-### 🐾 情境 D：更換開發工具 (Antigravity -> Cursor)
-如果你想換成用 Cursor 作為 Agent。
-*   **步驟**：在 Cursor 進場後，請他在專案根目錄執行 `cat AGENTS_README.md`。
-*   **成效**：他會自動認領並遵循 `LAMP` 協議。
+### Verify continuity semantics
 
----
+```bash
+python3 scripts/continuation_state.py --self-test
+python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+```
 
-## 🐯 維生服務管理
-石虎系統有幾個背景守護進程，可以用以下指令查看：
-*   `sudo systemctl status cat-ink-syncer` (對話同步)
-*   `sudo systemctl status agent-maintenance` (資源檢查)
-*   `crontab -l` (看 00:00 禪定貓啟動紀錄)
+The current continuation reconciler protects an important invariant: newer user goals/corrections must not be rolled back by stale replay or old tool results.
 
----
-*「指令只是工具，你的 Vibe 才是靈魂。」*
+### Inspect node capabilities / responsibility
+
+For a configured AgentOS node:
+
+```bash
+agentos-node harvest
+agentos-node governance resolve capability://network.port.allocate
+agentos-node resource list --kind site
+```
+
+See `docs/AGENTOS_NODE.md` for the current node contract.
+
+### Check documentation reality
+
+```bash
+python3 scripts/documentation_reality_guard.py
+```
+
+Architecture-sensitive changes are also checked in GitHub Actions. Documentation drift is treated as a regression.
+
+### Check runtime/platform setup
+
+See:
+
+- `docs/PLATFORM_DRIVERS.md`
+- `docs/RESTORE_NEW_MACHINE.md`
+- `scripts/platform_runtime.py`
+- `scripts/install_services.py`
+
+Do not assume a Linux `/home/ubuntu/...` path is universal; deployment paths are environment-specific.
+
+## Evidence and truth hierarchy
+
+When a prose document conflicts with the repository:
+
+1. executable implementation;
+2. tests and committed operational evidence;
+3. `docs/CURRENT_STATE.md`;
+4. other narrative/history documents.
+
+The mismatch must then be corrected rather than preserved indefinitely.
+
+## Research: cross-model Cognitive IR
+
+AgentOS does **not** currently claim that hidden model activations can be copied between arbitrary models. The active research question is whether a model-independent working-state representation can preserve enough position, intent, constraints, decisions, rejected paths, and next direction that another model can functionally continue from a relative instruction such as `continue`.
+
+Until repeatable cross-model experiments prove that layer, treat it as research rather than a shipping capability.

--- a/scripts/documentation_reality_guard.py
+++ b/scripts/documentation_reality_guard.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Fail when AgentOS architecture evolves without its authoritative docs.
+
+This guard intentionally checks two things:
+1. Static reality: canonical entry-point docs and their claimed core paths exist.
+2. Change-set coupling: architecture-sensitive implementation changes must update
+   at least one authoritative current-state document in the same change set.
+
+It does not try to prove that prose is semantically perfect. It makes silent
+implementation/documentation divergence a CI-visible regression instead of a
+maintenance task someone has to remember months later.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+AUTHORITATIVE_DOCS = {
+    "README.md",
+    "ONBOARDING.md",
+    "AGENTS.md",
+    "docs/CURRENT_STATE.md",
+}
+
+# Changes under these surfaces can materially alter the public AgentOS mental model.
+ARCHITECTURE_PREFIXES = (
+    "agent_core/",
+    "runtime_core/",
+    ".agent/roles/",
+    ".agent/governance/",
+    ".agentos/commands/",
+)
+ARCHITECTURE_FILES = {
+    ".agent/CONSTITUTION.yaml",
+    "scripts/continuation_state.py",
+    "scripts/agentos_node.py",
+    "scripts/drift_guard.py",
+    "scripts/platform_runtime.py",
+}
+
+# Claims made by docs/CURRENT_STATE.md that must remain tied to real repository paths.
+REQUIRED_REALITY_PATHS = (
+    "agent_core/control_plane.py",
+    "agent_core/session_lifecycle.py",
+    "agent_core/governance_directory.py",
+    "agent_core/resource_registry.py",
+    "agent_core/realm_fabric.py",
+    "runtime_core/interfaces.py",
+    "scripts/continuation_state.py",
+    "scripts/agentos_node.py",
+    "scripts/drift_guard.py",
+    "tests/test_continuation_state.py",
+    "tests/test_control_plane.py",
+    "tests/test_governance_directory.py",
+    "tests/test_resource_registry.py",
+    "docs/AGENTOS_NODE.md",
+)
+
+
+def git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout
+
+
+def changed_files(base: str) -> set[str]:
+    # PRs normally want merge-base semantics. Fall back to two-dot for shallow/local cases.
+    try:
+        output = git("diff", "--name-only", f"{base}...HEAD")
+    except RuntimeError:
+        output = git("diff", "--name-only", f"{base}..HEAD")
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def is_architecture_path(path: str) -> bool:
+    return path in ARCHITECTURE_FILES or path.startswith(ARCHITECTURE_PREFIXES)
+
+
+def static_errors() -> list[str]:
+    errors: list[str] = []
+    for doc in AUTHORITATIVE_DOCS:
+        if not (ROOT / doc).is_file():
+            errors.append(f"authoritative document missing: {doc}")
+
+    for path in REQUIRED_REALITY_PATHS:
+        if not (ROOT / path).exists():
+            errors.append(f"CURRENT_STATE implementation claim has no repository path: {path}")
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8") if (ROOT / "README.md").exists() else ""
+    current = (ROOT / "docs/CURRENT_STATE.md").read_text(encoding="utf-8") if (ROOT / "docs/CURRENT_STATE.md").exists() else ""
+
+    if "docs/CURRENT_STATE.md" not in readme:
+        errors.append("README.md must link to docs/CURRENT_STATE.md")
+    if "Switch models. Switch machines. Continue the same work." not in readme:
+        errors.append("README.md lost the current continuity product statement")
+    for marker in ("Implemented", "Verified", "Research", "Cognitive IR"):
+        if marker not in current:
+            errors.append(f"docs/CURRENT_STATE.md missing reality marker: {marker}")
+
+    return errors
+
+
+def coupling_errors(base: str | None) -> list[str]:
+    if not base:
+        return []
+    changed = changed_files(base)
+    architecture = sorted(path for path in changed if is_architecture_path(path))
+    if not architecture:
+        return []
+    doc_changes = sorted(changed & AUTHORITATIVE_DOCS)
+    if doc_changes:
+        return []
+    sample = ", ".join(architecture[:8])
+    if len(architecture) > 8:
+        sample += f", ... (+{len(architecture) - 8})"
+    return [
+        "architecture-sensitive implementation changed without an authoritative documentation update: "
+        + sample
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect AgentOS implementation/documentation drift")
+    parser.add_argument(
+        "--base",
+        help="base commit/ref for change-set coupling check (omit for static-only local check)",
+    )
+    args = parser.parse_args()
+
+    errors = static_errors() + coupling_errors(args.base)
+    if errors:
+        print("Documentation Reality Guard: FAIL")
+        for error in errors:
+            print(f"ERROR: {error}")
+        print("\nUpdate README.md, ONBOARDING.md, AGENTS.md, or docs/CURRENT_STATE.md to reflect the new architecture.")
+        return 1
+
+    print("Documentation Reality Guard: PASS")
+    if args.base:
+        print(f"base={args.base}")
+    print("authoritative_docs=" + ",".join(sorted(AUTHORITATIVE_DOCS)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_documentation_reality_guard.py
+++ b/tests/test_documentation_reality_guard.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+
+import scripts.documentation_reality_guard as guard
+
+
+class DocumentationRealityGuardTests(unittest.TestCase):
+    def test_current_static_reality_is_valid(self):
+        self.assertEqual(guard.static_errors(), [])
+
+    def test_core_paths_are_architecture_sensitive(self):
+        self.assertTrue(guard.is_architecture_path("agent_core/control_plane.py"))
+        self.assertTrue(guard.is_architecture_path("scripts/continuation_state.py"))
+        self.assertFalse(guard.is_architecture_path("docs/USER_GUIDE.md"))
+
+    def test_architecture_change_requires_authoritative_doc(self):
+        with patch.object(
+            guard,
+            "changed_files",
+            return_value={"agent_core/control_plane.py", "tests/test_control_plane.py"},
+        ):
+            errors = guard.coupling_errors("base")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("without an authoritative documentation update", errors[0])
+
+    def test_architecture_change_with_current_state_update_passes(self):
+        with patch.object(
+            guard,
+            "changed_files",
+            return_value={"agent_core/control_plane.py", "docs/CURRENT_STATE.md"},
+        ):
+            errors = guard.coupling_errors("base")
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The public entry-point documentation still described the early Logic/Data + memory/pulse era while the implementation had evolved into continuation state, control plane, governance/resource resolution, Realm cross-node execution, platform drivers, and evidence-first operation.

## What changed

- Rewrote `README.md` around the actual continuity goal: **Switch models. Switch machines. Continue the same work.**
- Added `docs/CURRENT_STATE.md` as the canonical **Implemented / Verified / Research** reality map.
- Replaced stale `ONBOARDING.md`, `AGENTS.md`, `AGENTS_README.md`, `docs/USER_GUIDE.md`, and Copilot instructions with current architecture guidance.
- Added `scripts/documentation_reality_guard.py`.
- Added GitHub Actions enforcement: architecture-sensitive changes must update an authoritative current-state document in the same change set.
- Added guard unit tests and continuity smoke tests to CI.

## Safety / truth boundary

The docs explicitly do **not** claim Cognitive IR or arbitrary zero-cost cross-model switching is already solved. Those remain research until repeatable cross-model continuity experiments prove them.

## Regression prevented

Core changes under `agent_core/`, `runtime_core/`, continuity/node/governance surfaces, constitution/roles/governance, and AgentOS commands will now fail CI if the change set does not also update `README.md`, `ONBOARDING.md`, `AGENTS.md`, or `docs/CURRENT_STATE.md`.