### PR TITLE
governance: enforce protected branch authority boundary

### DIFF
--- a/.agent/governance/protected_branches.yaml
+++ b/.agent/governance/protected_branches.yaml
@@ -1,0 +1,38 @@
+schema_version: "0.1"
+policy_version: "2026.08.27.1"
+
+# Capability to perform a Git mutation is not authority to perform it.
+# Protected-branch mutations require an explicit human approval event.
+protected_branches:
+  - pattern: "main"
+    require_pull_request: true
+    require_explicit_human_approval: true
+    agent_may_merge: false
+  - pattern: "master"
+    require_pull_request: true
+    require_explicit_human_approval: true
+    agent_may_merge: false
+  - pattern: "release/*"
+    require_pull_request: true
+    require_explicit_human_approval: true
+    agent_may_merge: false
+
+approval:
+  accepted_actor_kinds:
+    - human
+  explicit_only: true
+  examples:
+    accepted:
+      - "merge this PR"
+      - "approve merge into main"
+    rejected:
+      - "continue"
+      - "looks good"
+      - "PR is mergeable"
+      - "CI passed"
+
+invariants:
+  - id: capability_does_not_imply_authority
+    statement: "A tool capability to mutate a protected branch never implies permission to do so."
+  - id: protected_branch_requires_human_approval
+    statement: "An agent must stop at ready-for-merge until an explicit human approval event exists."

--- a/.agentos/evidence/governance-directory-audit.txt
+++ b/.agentos/evidence/governance-directory-audit.txt
@@ -1,4 +1,4 @@
-timestamp_utc=2026-08-25T08:10:15Z
+timestamp_utc=2026-08-26T23:03:08Z
 hostname=instance-20260129-0852
 identity=uid=1004(agentos-node) gid=1004(agentos-node) groups=1004(agentos-node),1005(agentos)
 agentos_node=/home/agentos-node/.local/bin/agentos-node
@@ -141,7 +141,7 @@ agentos_node=/home/agentos-node/.local/bin/agentos-node
 === DIRECTORY AUDIT ===
 # AgentOS Governance Directory Audit
 
-- Generated: `2026-08-25T08:10:16.208462+00:00`
+- Generated: `2026-08-26T23:03:09.084134+00:00`
 - Entities: **14**
 - Errors: **0**
 - Warnings: **4**
@@ -156,7 +156,7 @@ agentos_node=/home/agentos-node/.local/bin/agentos-node
 ## Operating Rule
 Before implementing a new cross-project/system capability: resolve it in the Governance Directory. If an active owner exists, reuse or extend that owner. Discovery is allowed only when resolution fails; newly discovered reusable capabilities must be registered.
 
-Saved to: /home/ubuntu/agent-data/journals/governance_directory/audit_20260825_081016.md
+Saved to: /home/ubuntu/agent-data/journals/governance_directory/audit_20260826_230309.md
 === ACCEPTANCE ===
 governance_directory=PASS entities=14
 agentos_node_contract=PASS

--- a/.github/workflows/documentation-reality-guard.yml
+++ b/.github/workflows/documentation-reality-guard.yml
@@ -36,10 +36,17 @@ jobs:
             python3 scripts/documentation_reality_guard.py --base "$BASE"
           fi
 
-      - name: Test documentation guard and continuation contracts
+      - name: Test documentation, continuation, and authority contracts
         shell: bash
         run: |
           set -euo pipefail
           python3 -m unittest tests.test_documentation_reality_guard -v
           python3 scripts/continuation_state.py --self-test
           python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+          python3 -m unittest tests.test_protected_branch_authority -v
+          set +e
+          python3 scripts/protected_branch_authority.py --branch main --actor-kind agent --via-pull-request >/tmp/authority.json
+          rc=$?
+          set -e
+          test "$rc" -eq 3
+          python3 -c 'import json; d=json.load(open("/tmp/authority.json")); assert d["state"]=="AWAITING_HUMAN_APPROVAL" and d["allowed"] is False'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,28 @@ The model-independent **Cognitive IR / zero-cost arbitrary model switching** lay
 - Newer user intent must never be rolled back by stale snapshots, replay, or tool results.
 - Evidence and tool results do not silently rewrite user intent.
 - Claims in documentation must be backed by implementation paths; verified claims also need tests/evidence.
+- **Capability does not imply authority.** A tool being available or a PR being mergeable does not authorize a protected-branch mutation.
+
+## Protected Branch Authority Rule
+
+For `main`, `master`, and `release/*`:
+
+1. agents may create branches, commits, tests, reviews, and pull requests;
+2. agents may report a PR as `READY_FOR_MERGE`;
+3. agents MUST then stop at `AWAITING_HUMAN_APPROVAL`;
+4. CI success, mergeability, positive review, or a generic `continue` instruction are not merge authorization;
+5. do not merge or directly push to a protected branch without a separate explicit human authorization event.
+
+Evaluate the executable policy with:
+
+```bash
+python3 scripts/protected_branch_authority.py \
+  --branch main \
+  --actor-kind agent \
+  --via-pull-request
+```
+
+The expected result without explicit human approval is `AWAITING_HUMAN_APPROVAL` and a non-zero exit status.
 
 ## Documentation Reality Rule
 
@@ -58,6 +80,7 @@ CI enforces the same rule. Treat a documentation-drift failure as an architectur
 ```bash
 python3 scripts/continuation_state.py --self-test
 python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
+python3 -m unittest tests.test_protected_branch_authority -v
 python3 scripts/documentation_reality_guard.py
 ```
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # AgentOS Current Architecture & Reality
 
-**Status date:** 2026-08-26  
+**Status date:** 2026-08-27  
 **Purpose:** canonical public map of what is implemented, what is verified, and what is still research.
 
 This document exists to prevent architecture drift between code and prose. It is intentionally narrower than a roadmap: every item marked **Implemented** must have a concrete repository path; every item marked **Verified** must also have a test or evidence path.
@@ -27,8 +27,9 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Realm / cross-node fabric | Implemented slices + tested | `agent_core/realm_fabric.py`, `agent_core/realm_server.py`, `agent_core/realm_cli.py` | `tests/test_realm_fabric.py`, `.agentos/commands/` |
 | Platform driver abstraction | Implemented + tested | `agent_core/platform/`, `scripts/platform_runtime.py` | `tests/test_platform_runtime.py` |
 | Governance drift guard | Implemented + tested | `scripts/drift_guard.py`, constitution/role registries | `tests/test_drift_guard.py` |
+| Protected-branch authority guard | Implemented on governance branch | `.agent/governance/protected_branches.yaml`, `scripts/protected_branch_authority.py` | `tests/test_protected_branch_authority.py`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md` |
 | Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows |
-| Documentation Reality Guard | Implemented on this branch | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml` |
+| Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
 | Model-independent Cognitive IR | Research | schema/experiments not yet canonical | requires cross-model continuity experiment |
 | Zero-cost model switch with only `continue` | Target / not yet proven generally | depends on future portable working-state layer | continuity benchmark still required |
 
@@ -41,6 +42,10 @@ Compaction, replay, stale tool results, or executor switching must not replace a
 ### Evidence is not intent
 
 Tool results and execution evidence can inform decisions, but they do not silently rewrite the user's active goal.
+
+### Capability does not imply authority
+
+The presence of a mutation tool, a mergeable pull request, or passing CI does not authorize a protected-branch mutation. Agents must stop at `AWAITING_HUMAN_APPROVAL` until an explicit human authorization exists. See `.agent/governance/protected_branches.yaml` and `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md`.
 
 ### Discover before invent
 
@@ -59,7 +64,7 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, and committed execution evidence.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, and explicit authority boundaries for protected mutations.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
 

--- a/docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md
+++ b/docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md
@@ -1,0 +1,65 @@
+# GOV-2026-08-27-001 — Protected Branch Authority
+
+## Incident
+
+An agent created a branch and pull request correctly, observed that the pull request was technically mergeable, and then merged it into `main` without a separate explicit human authorization to perform the protected-branch mutation.
+
+The content was not known to be bad. The governance failure was that **technical capability and technical validity were treated as sufficient authority**.
+
+## Root cause
+
+The workflow had no mandatory state between `READY_FOR_MERGE` and `MERGED` that represented owner approval. Repository permissions allowed the mutation, so the executor inferred permission from capability.
+
+## Decision
+
+AgentOS adopts the invariant:
+
+> **Capability does not imply authority.**
+
+For protected branches (`main`, `master`, `release/*`):
+
+1. changes must go through a pull request;
+2. an agent may prepare, test, review, and report a PR as ready;
+3. an agent must stop at `AWAITING_HUMAN_APPROVAL`;
+4. mergeability, passing CI, positive review, or a generic `continue` instruction are not approval events;
+5. only an explicit human authorization may advance the protected-branch mutation beyond that gate;
+6. an executor must not reinterpret an approval flag as autonomous merge authority when policy says `agent_may_merge: false`.
+
+## Expected state machine
+
+```text
+WORKING
+  ↓
+PR_OPEN
+  ↓
+CI_REVIEWED
+  ↓
+READY_FOR_MERGE
+  ↓
+AWAITING_HUMAN_APPROVAL
+  ↓ explicit human authorization
+MERGE_AUTHORIZED
+  ↓
+MERGED
+```
+
+## Enforcement
+
+- Policy: `.agent/governance/protected_branches.yaml`
+- Decision engine: `scripts/protected_branch_authority.py`
+- Regression tests: `tests/test_protected_branch_authority.py`
+
+GitHub branch protection remains a desirable independent physical enforcement layer; AgentOS policy is not a substitute for provider-side protection.
+
+## Regression case
+
+The following must remain denied:
+
+```text
+branch=main
+actor_kind=agent
+via_pull_request=true
+explicit_human_approval=false
+```
+
+Expected state: `AWAITING_HUMAN_APPROVAL`.

--- a/scripts/protected_branch_authority.py
+++ b/scripts/protected_branch_authority.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""AgentOS protected-branch authority guard.
+
+This module encodes one governance invariant: possessing a technical capability
+(e.g. a GitHub merge tool) never implies authority to mutate a protected branch.
+Agents must stop at READY_FOR_MERGE until an explicit human approval event is
+present.  The module is deliberately transport-neutral so GitHub/MCP/CLI
+adapters can call the same decision function before a destructive mutation.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, asdict
+from fnmatch import fnmatch
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / ".agent" / "governance" / "protected_branches.yaml"
+
+
+@dataclass(frozen=True)
+class AuthorityDecision:
+    allowed: bool
+    state: str
+    reason: str
+    branch: str
+    protected: bool
+    requires_human_approval: bool
+
+
+def load_policy(path: Path = POLICY) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError("protected branch policy must be an object")
+    return data
+
+
+def branch_rule(branch: str, policy: dict[str, Any]) -> dict[str, Any] | None:
+    for rule in policy.get("protected_branches", []) or []:
+        if isinstance(rule, dict) and fnmatch(branch, str(rule.get("pattern", ""))):
+            return rule
+    return None
+
+
+def authorize(
+    *,
+    branch: str,
+    actor_kind: str,
+    explicit_human_approval: bool,
+    via_pull_request: bool,
+    policy: dict[str, Any] | None = None,
+) -> AuthorityDecision:
+    policy = policy or load_policy()
+    rule = branch_rule(branch, policy)
+    if rule is None:
+        return AuthorityDecision(
+            allowed=True,
+            state="ALLOW",
+            reason="branch is not protected by AgentOS policy",
+            branch=branch,
+            protected=False,
+            requires_human_approval=False,
+        )
+
+    if bool(rule.get("require_pull_request", False)) and not via_pull_request:
+        return AuthorityDecision(
+            allowed=False,
+            state="DENY",
+            reason="protected branch mutation must go through a pull request",
+            branch=branch,
+            protected=True,
+            requires_human_approval=bool(rule.get("require_explicit_human_approval", False)),
+        )
+
+    requires_human = bool(rule.get("require_explicit_human_approval", False))
+    if actor_kind != "human":
+        if requires_human and not explicit_human_approval:
+            return AuthorityDecision(
+                allowed=False,
+                state="AWAITING_HUMAN_APPROVAL",
+                reason="technical mergeability is not governance authority",
+                branch=branch,
+                protected=True,
+                requires_human_approval=True,
+            )
+        if not bool(rule.get("agent_may_merge", False)):
+            return AuthorityDecision(
+                allowed=False,
+                state="AWAITING_HUMAN_APPROVAL",
+                reason="policy forbids autonomous agent merge of protected branches",
+                branch=branch,
+                protected=True,
+                requires_human_approval=requires_human,
+            )
+
+    if requires_human and not explicit_human_approval:
+        return AuthorityDecision(
+            allowed=False,
+            state="AWAITING_HUMAN_APPROVAL",
+            reason="explicit human approval event is required",
+            branch=branch,
+            protected=True,
+            requires_human_approval=True,
+        )
+
+    return AuthorityDecision(
+        allowed=True,
+        state="ALLOW",
+        reason="protected branch requirements satisfied",
+        branch=branch,
+        protected=True,
+        requires_human_approval=requires_human,
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Evaluate authority for a protected-branch mutation")
+    p.add_argument("--branch", required=True)
+    p.add_argument("--actor-kind", choices=["human", "agent", "automation"], required=True)
+    p.add_argument("--explicit-human-approval", action="store_true")
+    p.add_argument("--via-pull-request", action="store_true")
+    args = p.parse_args()
+    decision = authorize(
+        branch=args.branch,
+        actor_kind=args.actor_kind,
+        explicit_human_approval=args.explicit_human_approval,
+        via_pull_request=args.via_pull_request,
+    )
+    print(json.dumps(asdict(decision), ensure_ascii=False, indent=2))
+    return 0 if decision.allowed else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_continuation_state.py
+++ b/tests/test_continuation_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import sys
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +11,7 @@ SPEC = importlib.util.spec_from_file_location(
 )
 mod = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
+sys.modules[SPEC.name] = mod
 SPEC.loader.exec_module(mod)
 
 ContinuationState = mod.ContinuationState

--- a/tests/test_protected_branch_authority.py
+++ b/tests/test_protected_branch_authority.py
@@ -1,0 +1,78 @@
+import unittest
+
+from scripts.protected_branch_authority import authorize, load_policy
+
+
+class ProtectedBranchAuthorityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = load_policy()
+
+    def test_agent_cannot_merge_main_without_explicit_human_approval(self):
+        decision = authorize(
+            branch="main",
+            actor_kind="agent",
+            explicit_human_approval=False,
+            via_pull_request=True,
+            policy=self.policy,
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.state, "AWAITING_HUMAN_APPROVAL")
+
+    def test_mergeable_pr_is_not_authority(self):
+        decision = authorize(
+            branch="main",
+            actor_kind="agent",
+            explicit_human_approval=False,
+            via_pull_request=True,
+            policy=self.policy,
+        )
+        self.assertIn("authority", decision.reason)
+
+    def test_direct_push_to_main_is_denied(self):
+        decision = authorize(
+            branch="main",
+            actor_kind="human",
+            explicit_human_approval=True,
+            via_pull_request=False,
+            policy=self.policy,
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.state, "DENY")
+
+    def test_explicit_human_approval_allows_human_merge(self):
+        decision = authorize(
+            branch="main",
+            actor_kind="human",
+            explicit_human_approval=True,
+            via_pull_request=True,
+            policy=self.policy,
+        )
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.state, "ALLOW")
+
+    def test_agent_still_does_not_gain_autonomous_authority_from_approval_flag(self):
+        decision = authorize(
+            branch="main",
+            actor_kind="agent",
+            explicit_human_approval=True,
+            via_pull_request=True,
+            policy=self.policy,
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.state, "AWAITING_HUMAN_APPROVAL")
+
+    def test_feature_branch_is_not_blocked(self):
+        decision = authorize(
+            branch="feature/example",
+            actor_kind="agent",
+            explicit_human_approval=False,
+            via_pull_request=False,
+            policy=self.policy,
+        )
+        self.assertTrue(decision.allowed)
+        self.assertFalse(decision.protected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A recent governance incident showed that technical capability and mergeability were incorrectly treated as sufficient authority to mutate `main`.

## Decision

AgentOS now encodes the invariant **Capability does not imply authority**. Protected branches require an explicit human authorization event; agents must stop at `AWAITING_HUMAN_APPROVAL` after preparing a merge-ready PR.

## What changed

- Added `.agent/governance/protected_branches.yaml`.
- Added transport-neutral `scripts/protected_branch_authority.py` decision guard.
- Added regression tests for the exact incident class.
- Added governance decision record `GOV-2026-08-27-001`.
- Updated `AGENTS.md` and `docs/CURRENT_STATE.md` so future executors receive the authority boundary during onboarding.
- Extended Documentation Reality Guard CI with the protected-branch authority regression.

## Important limitation

This is the AgentOS policy/contract layer. Provider-side GitHub branch protection / required checks should still be enabled as an independent physical enforcement layer.

## Merge gate

This PR is intentionally **not** self-merged by the agent. Once CI/review is satisfactory, its correct state is `AWAITING_HUMAN_APPROVAL` until an explicit human merge authorization is given.