### PR TITLE
feat(agentos): discover IDE agent session surfaces inside nodes

### DIFF
--- a/agent_core/node_bootstrap.py
+++ b/agent_core/node_bootstrap.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _canonical_states(root: Path) -> list[dict[str, Any]]:
+    states: list[dict[str, Any]] = []
+    state_root = root / 'states'
+    if not state_root.exists():
+        return states
+    for path in sorted(state_root.glob('*/canonical.json')):
+        try:
+            payload = json.loads(path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if payload.get('schema') != 'agentos.capability-state/v1':
+            continue
+        states.append({
+            'capability_id': payload.get('capability_id'),
+            'state_id': payload.get('state_id'),
+            'version': payload.get('version'),
+            'confidence': payload.get('confidence'),
+            'support': payload.get('support'),
+        })
+    return states
+
+
+def bootstrap_snapshot(fabric: Any, node_id: str, token: str) -> dict[str, Any]:
+    """Return inherited Realm capability/cognition available to one enrolled Node."""
+    fabric.authenticate(node_id, token)
+    node_map = fabric.node_registry.node_map()
+    nodes = list(node_map.get('nodes') or [])
+    own = next((node for node in nodes if node.get('node_id') == node_id), None)
+    if own is None:
+        raise KeyError(node_id)
+
+    inherited_caps = sorted({
+        cap
+        for node in nodes
+        if node.get('node_id') != node_id and node.get('status') != 'offline'
+        for cap in (node.get('capabilities') or [])
+    })
+    inherited_surfaces = sorted({
+        str(surface.get('provider'))
+        for node in nodes
+        if node.get('node_id') != node_id and node.get('status') != 'offline'
+        for surface in ((node.get('surface_inventory') or {}).get('surfaces') or [])
+        if isinstance(surface, dict) and surface.get('provider')
+    })
+
+    data_root = Path(os.environ.get('AGENT_DATA_ROOT', '/home/ubuntu/agent-data'))
+    canonical = _canonical_states(data_root / 'runtime' / 'capabilities')
+    return {
+        'schema': 'agentos.node-bootstrap/v0.1',
+        'realm_id': node_map.get('realm_id'),
+        'node_id': node_id,
+        'node': own,
+        'realm_node_count': node_map.get('node_count', 0),
+        'realm_capabilities': list(node_map.get('realm_capabilities') or []),
+        'inherited_realm_capabilities': inherited_caps,
+        'inherited_surface_providers': inherited_surfaces,
+        'canonical_capabilities': canonical,
+        'canonical_capability_count': len(canonical),
+    }
+
+
+def record_join_regression(fabric: Any, node_id: str, token: str, report: dict[str, Any]) -> dict[str, Any]:
+    fabric.authenticate(node_id, token)
+    if report.get('schema') != 'agentos.one-uplift-report/v0.1':
+        raise ValueError('invalid ONE uplift report')
+    if str(report.get('node_id') or '') != node_id:
+        raise ValueError('uplift report node_id mismatch')
+    realm_id = str(fabric.load().get('realm_id') or '')
+    if str(report.get('realm_id') or '') != realm_id:
+        raise ValueError('uplift report realm_id mismatch')
+    return fabric.node_registry.record_benchmark(node_id, report)

--- a/agent_core/node_registry.py
+++ b/agent_core/node_registry.py
@@ -53,6 +53,9 @@ class NodeRegistry:
             raise ValueError('manifest belongs to a different Realm')
         data['realm_id'] = realm_id
         existing = data['nodes'].get(node_id, {})
+        inventory = manifest.get('surface_inventory') or {}
+        if not isinstance(inventory, dict):
+            raise ValueError('surface_inventory must be an object')
         entry = {
             'node_id': node_id,
             'role': role,
@@ -61,6 +64,7 @@ class NodeRegistry:
             'platform_release': manifest.get('platform_release'),
             'capabilities': sorted(set(manifest.get('capabilities') or [])),
             'tool_presence': dict(manifest.get('tool_presence') or {}),
+            'surface_inventory': dict(inventory),
             'status': existing.get('status', 'unknown'),
             'first_seen_at': existing.get('first_seen_at', _utc_now()),
             'last_manifest_at': manifest.get('observed_at') or _utc_now(),
@@ -85,6 +89,7 @@ class NodeRegistry:
         entry['status'] = heartbeat.get('status', 'unknown')
         entry['last_heartbeat_at'] = heartbeat.get('observed_at') or _utc_now()
         entry['uptime_seconds'] = heartbeat.get('uptime_seconds')
+        entry['surface_count'] = heartbeat.get('surface_count')
         data['nodes'][node_id] = entry
         self.save(data)
         return entry
@@ -106,6 +111,12 @@ class NodeRegistry:
         nodes = sorted(data['nodes'].values(), key=lambda n: (n.get('role') != 'core', n.get('node_id', '')))
         realm_caps = sorted({cap for node in nodes for cap in node.get('capabilities', []) if node.get('status') != 'offline'})
         tools = sorted({tool for node in nodes for tool in node.get('tool_presence', {})})
+        surface_providers = sorted({
+            str(surface.get('provider'))
+            for node in nodes
+            for surface in (node.get('surface_inventory') or {}).get('surfaces', [])
+            if isinstance(surface, dict) and surface.get('provider')
+        })
         return {
             'schema': 'agentos.node-map/v0.1',
             'realm_id': data.get('realm_id'),
@@ -113,4 +124,5 @@ class NodeRegistry:
             'nodes': nodes,
             'realm_capabilities': realm_caps,
             'realm_tool_presence': tools,
+            'realm_surface_providers': surface_providers,
         }

--- a/agent_core/node_registry.py
+++ b/agent_core/node_registry.py
@@ -78,6 +78,17 @@ class NodeRegistry:
     def record_heartbeat(self, heartbeat: dict[str, Any]) -> dict[str, Any]:
         if heartbeat.get('schema') != 'agentos.node-heartbeat/v0.1':
             raise ValueError('invalid heartbeat')
+
+        manifest = heartbeat.get('manifest')
+        if manifest is not None:
+            if not isinstance(manifest, dict):
+                raise ValueError('heartbeat manifest must be an object')
+            if str(manifest.get('node_id') or '') != str(heartbeat.get('node_id') or ''):
+                raise ValueError('heartbeat manifest node_id mismatch')
+            if str(manifest.get('realm_id') or '') != str(heartbeat.get('realm_id') or ''):
+                raise ValueError('heartbeat manifest realm_id mismatch')
+            self.register_manifest(manifest)
+
         data = self.load()
         node_id = str(heartbeat.get('node_id') or '')
         realm_id = str(heartbeat.get('realm_id') or '')

--- a/agent_core/realm_server.py
+++ b/agent_core/realm_server.py
@@ -6,6 +6,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from agent_core.node_bootstrap import bootstrap_snapshot, record_join_regression
 from agent_core.realm_fabric import RealmFabricStore
 
 
@@ -71,6 +72,13 @@ class RealmRequestHandler(BaseHTTPRequestHandler):
                 tasks = self.fabric.pull_tasks(node_id, token)
                 self._send(200, {'ok': True, 'tasks': tasks})
                 return
+            if parsed.path == '/v1/bootstrap':
+                query = parse_qs(parsed.query)
+                node_id = (query.get('node_id') or [''])[0]
+                token = self._bearer()
+                snapshot = bootstrap_snapshot(self.fabric, node_id, token)
+                self._send(200, {'ok': True, **snapshot})
+                return
             self._send(404, {'ok': False, 'error': 'not found'})
         except Exception as exc:
             self._error(exc)
@@ -115,6 +123,13 @@ class RealmRequestHandler(BaseHTTPRequestHandler):
                 token = self._bearer()
                 node = self.fabric.record_heartbeat(body, token)
                 self._send(200, {'ok': True, 'node': node})
+                return
+            if self.path == '/v1/benchmark':
+                body = self._json_body()
+                token = self._bearer()
+                node_id = str(body.get('node_id') or '')
+                report = record_join_regression(self.fabric, node_id, token, body)
+                self._send(200, {'ok': True, 'benchmark': report})
                 return
             if self.path == '/v1/receipts':
                 body = self._json_body()

--- a/agentos_node/agent_surfaces.py
+++ b/agentos_node/agent_surfaces.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass, asdict
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class Surface:
+    surface_id: str
+    kind: str
+    provider: str
+    executable: str | None
+    running: bool
+    capabilities: tuple[str, ...]
+    attachable: bool = False
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload['capabilities'] = list(self.capabilities)
+        payload['metadata'] = dict(self.metadata or {})
+        return payload
+
+
+# A Node is the trust/failure/resource boundary. These entries are execution or
+# conversational surfaces inside that Node, never independent Node identities.
+KNOWN_SURFACES: tuple[dict[str, Any], ...] = (
+    {
+        'provider': 'antigravity',
+        'executables': ('antigravity',),
+        'kind': 'ide-agent',
+        'capabilities': ('agent.chat', 'agent.session.inspect', 'agent.context.harvest', 'code.edit'),
+    },
+    {
+        'provider': 'vscode',
+        'executables': ('code', 'code-insiders'),
+        'kind': 'ide',
+        'capabilities': ('ide.inspect', 'code.edit'),
+    },
+    {
+        'provider': 'cursor',
+        'executables': ('cursor',),
+        'kind': 'ide-agent',
+        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
+    },
+    {
+        'provider': 'claude-code',
+        'executables': ('claude',),
+        'kind': 'agent-runtime',
+        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
+    },
+    {
+        'provider': 'codex',
+        'executables': ('codex',),
+        'kind': 'agent-runtime',
+        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
+    },
+    {
+        'provider': 'gemini',
+        'executables': ('gemini',),
+        'kind': 'agent-runtime',
+        'capabilities': ('agent.chat', 'agent.session.inspect'),
+    },
+)
+
+
+def _running_process_names() -> set[str]:
+    """Best-effort process discovery with only stdlib/platform commands.
+
+    Failure is intentionally non-fatal: installed-but-not-running surfaces still
+    belong in the inventory and can be started later by governed execution.
+    """
+    names: set[str] = set()
+    try:
+        if platform.system() == 'Windows':
+            completed = subprocess.run(
+                ['tasklist', '/FO', 'CSV', '/NH'],
+                text=True,
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+            for line in completed.stdout.splitlines():
+                if not line.strip():
+                    continue
+                first = line.split(',', 1)[0].strip().strip('"')
+                if first:
+                    names.add(first.lower())
+                    names.add(os.path.splitext(first.lower())[0])
+        else:
+            completed = subprocess.run(
+                ['ps', '-A', '-o', 'comm='],
+                text=True,
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+            for line in completed.stdout.splitlines():
+                name = os.path.basename(line.strip()).lower()
+                if name:
+                    names.add(name)
+                    names.add(os.path.splitext(name)[0])
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return names
+
+
+def discover_surfaces(
+    *,
+    process_names: Iterable[str] | None = None,
+    which=shutil.which,
+) -> dict[str, Any]:
+    running = {str(x).lower() for x in (process_names if process_names is not None else _running_process_names())}
+    surfaces: list[Surface] = []
+
+    for spec in KNOWN_SURFACES:
+        executable_path = None
+        executable_name = None
+        for candidate in spec['executables']:
+            path = which(candidate)
+            if path:
+                executable_path = path
+                executable_name = candidate
+                break
+
+        aliases = {str(x).lower() for x in spec['executables']}
+        is_running = bool(aliases & running)
+        if executable_path is None and not is_running:
+            continue
+
+        provider = str(spec['provider'])
+        # Discovery only proves a surface exists. Deep chat attachment requires a
+        # provider adapter/bridge and is never inferred merely from a process.
+        attachable = provider == 'antigravity' and bool(os.environ.get('AGENTOS_ANTIGRAVITY_BRIDGE'))
+        capabilities = list(spec['capabilities'])
+        if attachable:
+            capabilities.extend(('agent.session.attach', 'agent.context.inject', 'agent.session.handoff'))
+
+        surfaces.append(
+            Surface(
+                surface_id=f'{spec["kind"]}:{provider}',
+                kind=str(spec['kind']),
+                provider=provider,
+                executable=executable_path,
+                running=is_running,
+                capabilities=tuple(sorted(set(capabilities))),
+                attachable=attachable,
+                metadata={'executable_name': executable_name},
+            )
+        )
+
+    payload = [surface.to_dict() for surface in sorted(surfaces, key=lambda item: item.surface_id)]
+    return {
+        'schema': 'agentos.surface-inventory/v0.1',
+        'surfaces': payload,
+        'surface_count': len(payload),
+        'capabilities': sorted({cap for item in payload for cap in item['capabilities']}),
+        'providers': sorted({item['provider'] for item in payload}),
+    }

--- a/agentos_node/agent_surfaces.py
+++ b/agentos_node/agent_surfaces.py
@@ -7,6 +7,8 @@ import subprocess
 from dataclasses import dataclass, asdict
 from typing import Any, Iterable
 
+from agentos_node.session_bridge import describe_bridge
+
 
 @dataclass(frozen=True)
 class Surface:
@@ -26,64 +28,21 @@ class Surface:
         return payload
 
 
-# A Node is the trust/failure/resource boundary. These entries are execution or
-# conversational surfaces inside that Node, never independent Node identities.
 KNOWN_SURFACES: tuple[dict[str, Any], ...] = (
-    {
-        'provider': 'antigravity',
-        'executables': ('antigravity',),
-        'kind': 'ide-agent',
-        'capabilities': ('agent.chat', 'agent.session.inspect', 'agent.context.harvest', 'code.edit'),
-    },
-    {
-        'provider': 'vscode',
-        'executables': ('code', 'code-insiders'),
-        'kind': 'ide',
-        'capabilities': ('ide.inspect', 'code.edit'),
-    },
-    {
-        'provider': 'cursor',
-        'executables': ('cursor',),
-        'kind': 'ide-agent',
-        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
-    },
-    {
-        'provider': 'claude-code',
-        'executables': ('claude',),
-        'kind': 'agent-runtime',
-        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
-    },
-    {
-        'provider': 'codex',
-        'executables': ('codex',),
-        'kind': 'agent-runtime',
-        'capabilities': ('agent.chat', 'agent.session.inspect', 'code.edit'),
-    },
-    {
-        'provider': 'gemini',
-        'executables': ('gemini',),
-        'kind': 'agent-runtime',
-        'capabilities': ('agent.chat', 'agent.session.inspect'),
-    },
+    {'provider': 'antigravity', 'executables': ('antigravity',), 'kind': 'ide-agent', 'capabilities': ('agent.chat', 'code.edit')},
+    {'provider': 'vscode', 'executables': ('code', 'code-insiders'), 'kind': 'ide', 'capabilities': ('ide.inspect', 'code.edit')},
+    {'provider': 'cursor', 'executables': ('cursor',), 'kind': 'ide-agent', 'capabilities': ('agent.chat', 'code.edit')},
+    {'provider': 'claude-code', 'executables': ('claude',), 'kind': 'agent-runtime', 'capabilities': ('agent.chat', 'code.edit')},
+    {'provider': 'codex', 'executables': ('codex',), 'kind': 'agent-runtime', 'capabilities': ('agent.chat', 'code.edit')},
+    {'provider': 'gemini', 'executables': ('gemini',), 'kind': 'agent-runtime', 'capabilities': ('agent.chat',)},
 )
 
 
 def _running_process_names() -> set[str]:
-    """Best-effort process discovery with only stdlib/platform commands.
-
-    Failure is intentionally non-fatal: installed-but-not-running surfaces still
-    belong in the inventory and can be started later by governed execution.
-    """
     names: set[str] = set()
     try:
         if platform.system() == 'Windows':
-            completed = subprocess.run(
-                ['tasklist', '/FO', 'CSV', '/NH'],
-                text=True,
-                capture_output=True,
-                timeout=5,
-                check=False,
-            )
+            completed = subprocess.run(['tasklist', '/FO', 'CSV', '/NH'], text=True, capture_output=True, timeout=5, check=False)
             for line in completed.stdout.splitlines():
                 if not line.strip():
                     continue
@@ -92,13 +51,7 @@ def _running_process_names() -> set[str]:
                     names.add(first.lower())
                     names.add(os.path.splitext(first.lower())[0])
         else:
-            completed = subprocess.run(
-                ['ps', '-A', '-o', 'comm='],
-                text=True,
-                capture_output=True,
-                timeout=5,
-                check=False,
-            )
+            completed = subprocess.run(['ps', '-A', '-o', 'comm='], text=True, capture_output=True, timeout=5, check=False)
             for line in completed.stdout.splitlines():
                 name = os.path.basename(line.strip()).lower()
                 if name:
@@ -109,11 +62,7 @@ def _running_process_names() -> set[str]:
     return names
 
 
-def discover_surfaces(
-    *,
-    process_names: Iterable[str] | None = None,
-    which=shutil.which,
-) -> dict[str, Any]:
+def discover_surfaces(*, process_names: Iterable[str] | None = None, which=shutil.which) -> dict[str, Any]:
     running = {str(x).lower() for x in (process_names if process_names is not None else _running_process_names())}
     surfaces: list[Surface] = []
 
@@ -133,25 +82,24 @@ def discover_surfaces(
             continue
 
         provider = str(spec['provider'])
-        # Discovery only proves a surface exists. Deep chat attachment requires a
-        # provider adapter/bridge and is never inferred merely from a process.
-        attachable = provider == 'antigravity' and bool(os.environ.get('AGENTOS_ANTIGRAVITY_BRIDGE'))
+        bridge = describe_bridge(provider)
         capabilities = list(spec['capabilities'])
-        if attachable:
-            capabilities.extend(('agent.session.attach', 'agent.context.inject', 'agent.session.handoff'))
+        if bridge and bridge.get('ready'):
+            capabilities.extend(bridge.get('capabilities') or [])
 
-        surfaces.append(
-            Surface(
-                surface_id=f'{spec["kind"]}:{provider}',
-                kind=str(spec['kind']),
-                provider=provider,
-                executable=executable_path,
-                running=is_running,
-                capabilities=tuple(sorted(set(capabilities))),
-                attachable=attachable,
-                metadata={'executable_name': executable_name},
-            )
-        )
+        surfaces.append(Surface(
+            surface_id=f'{spec["kind"]}:{provider}',
+            kind=str(spec['kind']),
+            provider=provider,
+            executable=executable_path,
+            running=is_running,
+            capabilities=tuple(sorted(set(capabilities))),
+            attachable=bool(bridge and bridge.get('ready') and 'agent.session.attach' in (bridge.get('capabilities') or [])),
+            metadata={
+                'executable_name': executable_name,
+                'session_bridge': bridge,
+            },
+        ))
 
     payload = [surface.to_dict() for surface in sorted(surfaces, key=lambda item: item.surface_id)]
     return {

--- a/agentos_node/client_cli.py
+++ b/agentos_node/client_cli.py
@@ -6,7 +6,7 @@ import os
 import socket
 from pathlib import Path
 
-from agentos_node.thin_client import ThinClientPolicy, render_json
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy, render_json
 from agentos_node.thin_client_transport import ClientConfig, ThinClientTransport, build_client
 
 
@@ -27,7 +27,6 @@ def _default_policy() -> Path:
 def _load_policy(path: Path) -> ThinClientPolicy:
     if not path.exists():
         raise FileNotFoundError(f'policy file not found: {path}; run `agentos-client policy-init` first')
-    # Windows PowerShell may emit UTF-8 with BOM. utf-8-sig accepts both BOM and BOM-less UTF-8.
     data = json.loads(path.read_text(encoding='utf-8-sig'))
     return ThinClientPolicy(
         allowed_executables=set(data.get('allowed_executables') or []),
@@ -60,7 +59,7 @@ def main() -> int:
     p_policy = sub.add_parser('policy-init', help='create a conservative local execution policy')
     p_policy.add_argument('--root', help='workspace root ONE may read/write')
 
-    p_join = sub.add_parser('join', help='request Realm membership and wait for human approval')
+    p_join = sub.add_parser('join', help='join Realm, bootstrap inherited cognition, run regression, become ready')
     p_join.add_argument('--one', required=True, help='ONE base URL')
     p_join.add_argument('--node-id', default=socket.gethostname().lower())
     p_join.add_argument('--expires-minutes', type=int, default=10)
@@ -74,7 +73,8 @@ def main() -> int:
 
     sub.add_parser('manifest', help='print local capability manifest')
     sub.add_parser('health', help='check ONE health')
-    sub.add_parser('once', help='heartbeat, pull tasks once, execute, return receipts')
+    sub.add_parser('bootstrap', help='show inherited Realm capabilities and canonical capability states')
+    sub.add_parser('once', help='heartbeat, refresh discovery, pull tasks once, execute, return receipts')
     sub.add_parser('run', help='run persistent polling daemon')
 
     args = parser.parse_args()
@@ -86,6 +86,8 @@ def main() -> int:
     policy = _load_policy(args.policy)
 
     if args.command == 'join':
+        before_manifest = ThinClient(NodeIdentity('pending', args.node_id), policy).capability_manifest()
+
         def show_request(payload: dict[str, object]) -> None:
             print('AgentOS enrollment approval required')
             print(f'Node: {payload.get("node_id")}')
@@ -106,8 +108,16 @@ def main() -> int:
             on_request=show_request,
             on_status=show_status,
         )
-        print(render_json({'ok': True, 'realm_id': config.realm_id, 'node_id': config.node_id, 'config': str(args.config)}))
-        return 0
+        transport = build_client(config, policy)
+        completion = transport.complete_join(before_manifest)
+        print(render_json({
+            'ok': bool(completion.get('node_ready')),
+            'realm_id': config.realm_id,
+            'node_id': config.node_id,
+            'config': str(args.config),
+            'completion': completion,
+        }))
+        return 0 if completion.get('node_ready') else 2
 
     if args.command == 'enroll':
         config = ThinClientTransport.enroll(
@@ -127,6 +137,8 @@ def main() -> int:
         print(render_json(transport.client.capability_manifest()))
     elif args.command == 'health':
         print(render_json(transport.health()))
+    elif args.command == 'bootstrap':
+        print(render_json(transport.bootstrap()))
     elif args.command == 'once':
         print(render_json({'receipts': transport.run_once()}))
     elif args.command == 'run':

--- a/agentos_node/onboarding.py
+++ b/agentos_node/onboarding.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_join_regression_report(
+    *,
+    realm_id: str,
+    node_id: str,
+    before_manifest: dict[str, Any],
+    after_manifest: dict[str, Any],
+    bootstrap: dict[str, Any],
+) -> dict[str, Any]:
+    before_caps = set(before_manifest.get('capabilities') or [])
+    after_caps = set(after_manifest.get('capabilities') or [])
+    lost_caps = sorted(before_caps - after_caps)
+    inherited_caps = sorted(set(bootstrap.get('inherited_realm_capabilities') or []))
+    canonical = list(bootstrap.get('canonical_capabilities') or [])
+    canonical_ids = sorted({str(item.get('capability_id')) for item in canonical if isinstance(item, dict) and item.get('capability_id')})
+
+    # Map deterministic join checks into the existing ONE uplift dimensions.
+    # This is a bootstrap regression, not a replacement for task-level T0/T2 benchmarks.
+    before = {
+        'task_success': 1.0,
+        'repeated_errors': 0,
+        'user_clarifications': 0,
+        'continuity_recovery': 0.0,
+        'realm_capability_usage': 0,
+        'inherited_cognition_usage': 0,
+        'evidence_returned': 0,
+    }
+    after = {
+        'task_success': 1.0 if not lost_caps else 0.0,
+        'repeated_errors': len(lost_caps),
+        'user_clarifications': 0,
+        'continuity_recovery': 1.0 if canonical_ids else 0.0,
+        'realm_capability_usage': len(inherited_caps),
+        'inherited_cognition_usage': len(canonical_ids),
+        'evidence_returned': 1,
+    }
+    uplift = {
+        'task_success': after['task_success'] - before['task_success'],
+        'repeated_errors': before['repeated_errors'] - after['repeated_errors'],
+        'user_clarifications': before['user_clarifications'] - after['user_clarifications'],
+        'continuity_recovery': after['continuity_recovery'] - before['continuity_recovery'],
+        'realm_capability_usage': after['realm_capability_usage'] - before['realm_capability_usage'],
+        'inherited_cognition_usage': after['inherited_cognition_usage'] - before['inherited_cognition_usage'],
+        'evidence_returned': after['evidence_returned'] - before['evidence_returned'],
+    }
+    improved = sum(1 for value in uplift.values() if value > 0)
+    regressed = sum(1 for value in uplift.values() if value < 0)
+    ready = not lost_caps and bootstrap.get('schema') == 'agentos.node-bootstrap/v0.1'
+    return {
+        'schema': 'agentos.one-uplift-report/v0.1',
+        'report_kind': 'join-regression',
+        'realm_id': realm_id,
+        'node_id': node_id,
+        'before': before,
+        'after': after,
+        'uplift': uplift,
+        'improved_dimensions': improved,
+        'regressed_dimensions': regressed,
+        'one_uplift_observed': improved > 0 and regressed == 0,
+        'node_ready': ready,
+        'checks': {
+            'local_capability_non_regression': not lost_caps,
+            'lost_capabilities': lost_caps,
+            'inherited_realm_capabilities': inherited_caps,
+            'canonical_capabilities': canonical_ids,
+            'surface_inventory_present': isinstance(after_manifest.get('surface_inventory'), dict),
+        },
+    }

--- a/agentos_node/session_bridge.py
+++ b/agentos_node/session_bridge.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+BRIDGE_SCHEMA = 'agentos.session-bridge/v0.1'
+SESSION_INDEX_SCHEMA = 'agentos.session-index/v0.1'
+REQUEST_SCHEMA = 'agentos.session-request/v0.1'
+RECEIPT_SCHEMA = 'agentos.session-receipt/v0.1'
+
+_OPERATION_CAPS = {
+    'discover': 'agent.session.discover',
+    'snapshot': 'agent.session.inspect',
+    'harvest': 'agent.context.harvest',
+    'attach': 'agent.session.attach',
+    'inject': 'agent.context.inject',
+    'handoff': 'agent.session.handoff',
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def bridge_root(provider: str) -> Path | None:
+    key = 'AGENTOS_' + provider.upper().replace('-', '_') + '_BRIDGE'
+    raw = os.environ.get(key)
+    return Path(raw).expanduser() if raw else None
+
+
+def describe_bridge(provider: str) -> dict[str, Any] | None:
+    root = bridge_root(provider)
+    if root is None:
+        return None
+    descriptor = root / 'bridge.json'
+    if not descriptor.exists():
+        return {
+            'schema': BRIDGE_SCHEMA,
+            'provider': provider,
+            'root': str(root),
+            'operations': [],
+            'capabilities': [],
+            'ready': False,
+        }
+    try:
+        payload = json.loads(descriptor.read_text(encoding='utf-8-sig'))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if payload.get('schema') != BRIDGE_SCHEMA or str(payload.get('provider') or '') != provider:
+        return None
+    operations = sorted({str(op) for op in (payload.get('operations') or []) if str(op) in _OPERATION_CAPS})
+    return {
+        **payload,
+        'root': str(root),
+        'operations': operations,
+        'capabilities': sorted({_OPERATION_CAPS[op] for op in operations}),
+        'ready': bool(payload.get('ready', True)),
+    }
+
+
+class FileSessionBridge:
+    """Portable provider bridge between AgentOS Node and an IDE/agent integration.
+
+    The provider side owns bridge.json and sessions.json and consumes requests.
+    AgentOS never scrapes private IDE state or claims chat access merely because a
+    process is running.
+    """
+
+    def __init__(self, provider: str, root: str | Path):
+        self.provider = provider
+        self.root = Path(root).expanduser()
+        self.requests = self.root / 'requests'
+        self.receipts = self.root / 'receipts'
+
+    @classmethod
+    def from_environment(cls, provider: str) -> 'FileSessionBridge':
+        root = bridge_root(provider)
+        if root is None:
+            raise RuntimeError(f'no {provider} session bridge configured')
+        descriptor = describe_bridge(provider)
+        if not descriptor or not descriptor.get('ready'):
+            raise RuntimeError(f'{provider} session bridge is not ready')
+        return cls(provider, root)
+
+    def _require_operation(self, operation: str) -> None:
+        descriptor = describe_bridge(self.provider)
+        if not descriptor or operation not in (descriptor.get('operations') or []):
+            raise PermissionError(f'{self.provider} bridge does not authorize operation: {operation}')
+
+    def discover(self) -> dict[str, Any]:
+        self._require_operation('discover')
+        target = self.root / 'sessions.json'
+        if not target.exists():
+            return {'schema': SESSION_INDEX_SCHEMA, 'provider': self.provider, 'sessions': []}
+        payload = json.loads(target.read_text(encoding='utf-8-sig'))
+        if payload.get('schema') != SESSION_INDEX_SCHEMA or str(payload.get('provider') or '') != self.provider:
+            raise ValueError('invalid session index')
+        sessions = payload.get('sessions') or []
+        if not isinstance(sessions, list):
+            raise ValueError('sessions must be a list')
+        return payload
+
+    def request(self, operation: str, *, session_id: str | None = None, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._require_operation(operation)
+        self.requests.mkdir(parents=True, exist_ok=True)
+        request_id = 'session-' + uuid.uuid4().hex
+        request = {
+            'schema': REQUEST_SCHEMA,
+            'request_id': request_id,
+            'provider': self.provider,
+            'operation': operation,
+            'session_id': session_id,
+            'payload': dict(payload or {}),
+            'created_at': _utc_now(),
+        }
+        target = self.requests / f'{request_id}.json'
+        tmp = target.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(request, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+        os.replace(tmp, target)
+        return request
+
+    def receipt(self, request_id: str) -> dict[str, Any] | None:
+        target = self.receipts / f'{request_id}.json'
+        if not target.exists():
+            return None
+        payload = json.loads(target.read_text(encoding='utf-8-sig'))
+        if payload.get('schema') != RECEIPT_SCHEMA or str(payload.get('request_id') or '') != request_id:
+            raise ValueError('invalid session bridge receipt')
+        return payload

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -138,6 +138,7 @@ class ThinClient:
             'uptime_seconds': max(0, int(time.time() - datetime.fromisoformat(self.started_at.replace('Z', '+00:00')).timestamp())),
             'capability_count': len(manifest['capabilities']),
             'surface_count': int((manifest.get('surface_inventory') or {}).get('surface_count') or 0),
+            'manifest': manifest,
         }
 
     def execute(self, task: dict[str, Any]) -> dict[str, Any]:

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agentos_node import interactive_desktop
 from agentos_node.agent_surfaces import discover_surfaces
+from agentos_node.session_bridge import FileSessionBridge
 
 
 def _utc_now() -> str:
@@ -100,12 +101,8 @@ class ThinClient:
             caps.append('filesystem.write')
         if platform.system() == 'Windows':
             caps.extend([
-                'desktop.session.inspect',
-                'desktop.windows.inspect',
-                'desktop.screenshot',
-                'desktop.open_url',
-                'desktop.mouse',
-                'desktop.keyboard',
+                'desktop.session.inspect', 'desktop.windows.inspect', 'desktop.screenshot',
+                'desktop.open_url', 'desktop.mouse', 'desktop.keyboard',
             ])
         return {
             'schema': 'agentos.node-manifest/v0.1',
@@ -141,6 +138,12 @@ class ThinClient:
             'manifest': manifest,
         }
 
+    def _session_bridge(self, task: dict[str, Any]) -> FileSessionBridge:
+        provider = str(task.get('provider') or '').strip()
+        if not provider:
+            raise ValueError('provider is required for session bridge action')
+        return FileSessionBridge.from_environment(provider)
+
     def execute(self, task: dict[str, Any]) -> dict[str, Any]:
         started = _utc_now()
         receipt: dict[str, Any] = {
@@ -166,6 +169,27 @@ class ThinClient:
                 result = self._write_file(task)
             elif action == 'agent.surface.inspect':
                 result = {'surface_inventory': self.surface_inventory()}
+            elif action == 'agent.session.discover':
+                result = {'session_index': self._session_bridge(task).discover()}
+            elif action in {'agent.session.attach', 'agent.session.inspect', 'agent.context.harvest', 'agent.context.inject', 'agent.session.handoff'}:
+                op = {
+                    'agent.session.attach': 'attach',
+                    'agent.session.inspect': 'snapshot',
+                    'agent.context.harvest': 'harvest',
+                    'agent.context.inject': 'inject',
+                    'agent.session.handoff': 'handoff',
+                }[str(action)]
+                request = self._session_bridge(task).request(
+                    op,
+                    session_id=str(task.get('session_id') or '') or None,
+                    payload=dict(task.get('payload') or {}),
+                )
+                result = {'session_request': request}
+            elif action == 'agent.session.receipt':
+                request_id = str(task.get('request_id') or '')
+                if not request_id:
+                    raise ValueError('request_id is required')
+                result = {'session_receipt': self._session_bridge(task).receipt(request_id)}
             elif action == 'desktop.session.inspect':
                 result = {'desktop': interactive_desktop.session_info()}
             elif action == 'desktop.windows.inspect':

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from agentos_node import interactive_desktop
+from agentos_node.agent_surfaces import discover_surfaces
 
 
 def _utc_now() -> str:
@@ -66,7 +67,7 @@ class ThinClient:
     COMMON_TOOLS = (
         'git', 'python', 'python3', 'node', 'npm', 'pnpm', 'docker', 'podman',
         'powershell', 'pwsh', 'ffmpeg', 'adb', 'xcodebuild', 'unity', 'Unity',
-        'code', 'antigravity',
+        'code', 'cursor', 'antigravity', 'claude', 'codex', 'gemini',
     )
 
     def __init__(self, identity: NodeIdentity, policy: ThinClientPolicy):
@@ -83,9 +84,14 @@ class ThinClient:
                 found[tool.lower()] = path
         return dict(sorted(found.items()))
 
+    def surface_inventory(self) -> dict[str, Any]:
+        return discover_surfaces()
+
     def capability_manifest(self) -> dict[str, Any]:
         tools = self.discover_tools()
-        caps = ['context.harvest', 'process.inspect', 'tool.presence']
+        surface_inventory = self.surface_inventory()
+        caps = ['context.harvest', 'process.inspect', 'tool.presence', 'agent.surface.inspect']
+        caps.extend(surface_inventory.get('capabilities') or [])
         if self.policy.allowed_executables:
             caps.append('shell.exec')
         if self.policy.readable_roots:
@@ -111,8 +117,9 @@ class ThinClient:
             'platform_release': platform.release(),
             'python_version': platform.python_version(),
             'observed_at': _utc_now(),
-            'capabilities': sorted(caps),
+            'capabilities': sorted(set(caps)),
             'tool_presence': tools,
+            'surface_inventory': surface_inventory,
             'workspace_roots': {
                 'readable': [str(p.expanduser().resolve()) for p in self.policy.readable_roots],
                 'writable': [str(p.expanduser().resolve()) for p in self.policy.writable_roots],
@@ -120,6 +127,7 @@ class ThinClient:
         }
 
     def heartbeat(self) -> dict[str, Any]:
+        manifest = self.capability_manifest()
         return {
             'schema': 'agentos.node-heartbeat/v0.1',
             'realm_id': self.identity.realm_id,
@@ -128,7 +136,8 @@ class ThinClient:
             'status': 'online',
             'observed_at': _utc_now(),
             'uptime_seconds': max(0, int(time.time() - datetime.fromisoformat(self.started_at.replace('Z', '+00:00')).timestamp())),
-            'capability_count': len(self.capability_manifest()['capabilities']),
+            'capability_count': len(manifest['capabilities']),
+            'surface_count': int((manifest.get('surface_inventory') or {}).get('surface_count') or 0),
         }
 
     def execute(self, task: dict[str, Any]) -> dict[str, Any]:
@@ -154,6 +163,8 @@ class ThinClient:
                 result = self._read_file(task)
             elif action == 'filesystem.write':
                 result = self._write_file(task)
+            elif action == 'agent.surface.inspect':
+                result = {'surface_inventory': self.surface_inventory()}
             elif action == 'desktop.session.inspect':
                 result = {'desktop': interactive_desktop.session_info()}
             elif action == 'desktop.windows.inspect':

--- a/agentos_node/thin_client_transport.py
+++ b/agentos_node/thin_client_transport.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from agentos_node.onboarding import build_join_regression_report
 from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
 
 
@@ -62,14 +63,7 @@ class ThinClientTransport:
         return payload
 
     @classmethod
-    def request_enrollment(
-        cls,
-        *,
-        one_url: str,
-        node_id: str,
-        policy: ThinClientPolicy,
-        expires_minutes: int = 10,
-    ) -> dict[str, Any]:
+    def request_enrollment(cls, *, one_url: str, node_id: str, policy: ThinClientPolicy, expires_minutes: int = 10) -> dict[str, Any]:
         normalized = one_url.rstrip('/')
         provisional = ThinClient(NodeIdentity(realm_id='pending', node_id=node_id), policy)
         manifest = provisional.capability_manifest()
@@ -85,14 +79,8 @@ class ThinClientTransport:
 
     @classmethod
     def wait_for_approval(
-        cls,
-        *,
-        one_url: str,
-        request_id: str,
-        claim_secret: str,
-        config_path: str | Path,
-        poll_seconds: float = 2.0,
-        timeout_seconds: int = 600,
+        cls, *, one_url: str, request_id: str, claim_secret: str, config_path: str | Path,
+        poll_seconds: float = 2.0, timeout_seconds: int = 600,
         on_status: Callable[[dict[str, Any]], None] | None = None,
     ) -> ClientConfig:
         normalized = one_url.rstrip('/')
@@ -100,8 +88,7 @@ class ThinClientTransport:
         last_status = None
         while time.monotonic() < deadline:
             status = cls._request(
-                normalized + '/v1/join/status',
-                method='POST',
+                normalized + '/v1/join/status', method='POST',
                 body={'request_id': request_id, 'claim_secret': claim_secret},
             )
             if status.get('status') != last_status and on_status:
@@ -111,8 +98,7 @@ class ThinClientTransport:
                 raise RuntimeError(f'enrollment ended with status={status.get("status")}')
             if status.get('status') == 'approved':
                 result = cls._request(
-                    normalized + '/v1/join/claim',
-                    method='POST',
+                    normalized + '/v1/join/claim', method='POST',
                     body={'request_id': request_id, 'claim_secret': claim_secret},
                 )
                 if result.get('status') == 'enrolled' and result.get('node_token'):
@@ -129,25 +115,15 @@ class ThinClientTransport:
 
     @classmethod
     def enroll_device(
-        cls,
-        *,
-        one_url: str,
-        node_id: str,
-        policy: ThinClientPolicy,
-        config_path: str | Path,
-        expires_minutes: int = 10,
-        timeout_seconds: int = 600,
+        cls, *, one_url: str, node_id: str, policy: ThinClientPolicy, config_path: str | Path,
+        expires_minutes: int = 10, timeout_seconds: int = 600,
         on_request: Callable[[dict[str, Any]], None] | None = None,
         on_status: Callable[[dict[str, Any]], None] | None = None,
     ) -> ClientConfig:
         request = cls.request_enrollment(
-            one_url=one_url,
-            node_id=node_id,
-            policy=policy,
-            expires_minutes=expires_minutes,
+            one_url=one_url, node_id=node_id, policy=policy, expires_minutes=expires_minutes,
         )
         if on_request:
-            # claim_secret remains process-local; callers should display user_code only.
             on_request({k: v for k, v in request.items() if k != 'claim_secret'})
         return cls.wait_for_approval(
             one_url=one_url,
@@ -160,31 +136,21 @@ class ThinClientTransport:
 
     @classmethod
     def enroll(
-        cls,
-        *,
-        one_url: str,
-        invite_id: str,
-        code: str,
-        node_id: str,
-        policy: ThinClientPolicy,
-        config_path: str | Path,
+        cls, *, one_url: str, invite_id: str, code: str, node_id: str,
+        policy: ThinClientPolicy, config_path: str | Path,
     ) -> ClientConfig:
         normalized = one_url.rstrip('/')
         provisional = ThinClient(NodeIdentity(realm_id='pending', node_id=node_id), policy)
         manifest = provisional.capability_manifest()
         manifest['realm_id'] = ''
         result = cls._request(
-            normalized + '/v1/enroll',
-            method='POST',
+            normalized + '/v1/enroll', method='POST',
             body={'invite_id': invite_id, 'code': code, 'manifest': manifest},
         )
         if not result.get('ok'):
             raise RuntimeError(f'enrollment failed: {result}')
         config = ClientConfig(
-            one_url=normalized,
-            realm_id=str(result['realm_id']),
-            node_id=str(result['node_id']),
-            node_token=str(result['node_token']),
+            one_url=normalized, realm_id=str(result['realm_id']), node_id=str(result['node_id']), node_token=str(result['node_token']),
         )
         config.save(config_path)
         return config
@@ -198,30 +164,65 @@ class ThinClientTransport:
         if not self.config:
             raise RuntimeError('client is not enrolled')
         return self._request(
-            self.config.one_url + '/v1/heartbeat',
-            method='POST',
-            body=self.client.heartbeat(),
+            self.config.one_url + '/v1/heartbeat', method='POST',
+            body=self.client.heartbeat(), token=self.config.node_token,
+        )
+
+    def bootstrap(self) -> dict[str, Any]:
+        if not self.config:
+            raise RuntimeError('client is not enrolled')
+        query = urllib.parse.urlencode({'node_id': self.config.node_id})
+        return self._request(
+            self.config.one_url + '/v1/bootstrap?' + query,
             token=self.config.node_token,
         )
+
+    def submit_benchmark(self, report: dict[str, Any]) -> dict[str, Any]:
+        if not self.config:
+            raise RuntimeError('client is not enrolled')
+        return self._request(
+            self.config.one_url + '/v1/benchmark', method='POST',
+            body=report, token=self.config.node_token,
+        )
+
+    def complete_join(self, before_manifest: dict[str, Any]) -> dict[str, Any]:
+        """Refresh discovery, pull inherited Realm state and persist join regression evidence."""
+        if not self.config:
+            raise RuntimeError('client is not enrolled')
+        heartbeat = self.heartbeat()
+        after_manifest = self.client.capability_manifest()
+        bootstrap = self.bootstrap()
+        report = build_join_regression_report(
+            realm_id=self.config.realm_id,
+            node_id=self.config.node_id,
+            before_manifest=before_manifest,
+            after_manifest=after_manifest,
+            bootstrap=bootstrap,
+        )
+        persisted = self.submit_benchmark(report)
+        return {
+            'schema': 'agentos.join-completion/v0.1',
+            'realm_id': self.config.realm_id,
+            'node_id': self.config.node_id,
+            'heartbeat': heartbeat,
+            'bootstrap': bootstrap,
+            'regression': report,
+            'benchmark_persisted': bool(persisted.get('ok')),
+            'node_ready': bool(report.get('node_ready')),
+        }
 
     def pull_tasks(self) -> list[dict[str, Any]]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
         query = urllib.parse.urlencode({'node_id': self.config.node_id})
-        result = self._request(
-            self.config.one_url + '/v1/tasks?' + query,
-            token=self.config.node_token,
-        )
+        result = self._request(self.config.one_url + '/v1/tasks?' + query, token=self.config.node_token)
         return list(result.get('tasks') or [])
 
     def submit_receipt(self, receipt: dict[str, Any]) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
         return self._request(
-            self.config.one_url + '/v1/receipts',
-            method='POST',
-            body=receipt,
-            token=self.config.node_token,
+            self.config.one_url + '/v1/receipts', method='POST', body=receipt, token=self.config.node_token,
         )
 
     def run_once(self) -> list[dict[str, Any]]:

--- a/tests/test_agent_surface_discovery.py
+++ b/tests/test_agent_surface_discovery.py
@@ -66,6 +66,10 @@ def test_node_manifest_advertises_surface_inventory(monkeypatch, tmp_path):
     assert 'agent.chat' in manifest['capabilities']
     assert 'agent.surface.inspect' in manifest['capabilities']
 
+    heartbeat = client.heartbeat()
+    assert heartbeat['manifest']['node_id'] == 'host-01'
+    assert heartbeat['surface_count'] == 1
+
 
 def test_node_registry_preserves_surface_inventory(tmp_path):
     registry = NodeRegistry(tmp_path / 'nodes.json')
@@ -94,3 +98,42 @@ def test_node_registry_preserves_surface_inventory(tmp_path):
     node_map = registry.node_map()
     assert node_map['node_count'] == 1
     assert node_map['realm_surface_providers'] == ['antigravity']
+
+
+def test_heartbeat_refreshes_surface_inventory(tmp_path):
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    initial = {
+        'schema': 'agentos.node-manifest/v0.1',
+        'realm_id': 'realm-test',
+        'node_id': 'host-01',
+        'role': 'client',
+        'hostname': 'HOST-01',
+        'platform': 'Windows',
+        'platform_release': '11',
+        'capabilities': ['tool.presence'],
+        'tool_presence': {},
+        'surface_inventory': {'schema': 'agentos.surface-inventory/v0.1', 'surface_count': 0, 'providers': [], 'capabilities': [], 'surfaces': []},
+    }
+    registry.register_manifest(initial)
+
+    refreshed = dict(initial)
+    refreshed['capabilities'] = ['agent.chat', 'tool.presence']
+    refreshed['surface_inventory'] = {
+        'schema': 'agentos.surface-inventory/v0.1',
+        'surface_count': 1,
+        'providers': ['antigravity'],
+        'capabilities': ['agent.chat'],
+        'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}],
+    }
+    registry.record_heartbeat({
+        'schema': 'agentos.node-heartbeat/v0.1',
+        'realm_id': 'realm-test',
+        'node_id': 'host-01',
+        'status': 'online',
+        'surface_count': 1,
+        'manifest': refreshed,
+    })
+
+    node = registry.node_map()['nodes'][0]
+    assert node['surface_inventory']['providers'] == ['antigravity']
+    assert 'agent.chat' in node['capabilities']

--- a/tests/test_agent_surface_discovery.py
+++ b/tests/test_agent_surface_discovery.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from agent_core.node_registry import NodeRegistry
+from agentos_node.agent_surfaces import discover_surfaces
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+def _which_factory(values):
+    def which(name):
+        return values.get(name)
+    return which
+
+
+def test_antigravity_is_surface_inside_node_not_node_identity(monkeypatch):
+    monkeypatch.delenv('AGENTOS_ANTIGRAVITY_BRIDGE', raising=False)
+    inventory = discover_surfaces(
+        process_names={'antigravity'},
+        which=_which_factory({'antigravity': '/opt/antigravity'}),
+    )
+
+    surface = next(x for x in inventory['surfaces'] if x['provider'] == 'antigravity')
+    assert surface['kind'] == 'ide-agent'
+    assert surface['running'] is True
+    assert surface['attachable'] is False
+    assert 'agent.session.inspect' in surface['capabilities']
+    assert 'agent.session.attach' not in surface['capabilities']
+
+
+def test_antigravity_bridge_promotes_session_bridge_capabilities(monkeypatch):
+    monkeypatch.setenv('AGENTOS_ANTIGRAVITY_BRIDGE', 'local-relay')
+    inventory = discover_surfaces(
+        process_names={'antigravity'},
+        which=_which_factory({'antigravity': '/opt/antigravity'}),
+    )
+
+    surface = next(x for x in inventory['surfaces'] if x['provider'] == 'antigravity')
+    assert surface['attachable'] is True
+    assert 'agent.session.attach' in surface['capabilities']
+    assert 'agent.context.inject' in surface['capabilities']
+    assert 'agent.session.handoff' in surface['capabilities']
+
+
+def test_node_manifest_advertises_surface_inventory(monkeypatch, tmp_path):
+    monkeypatch.setattr('agentos_node.thin_client.discover_surfaces', lambda: {
+        'schema': 'agentos.surface-inventory/v0.1',
+        'surfaces': [{
+            'surface_id': 'ide-agent:antigravity',
+            'kind': 'ide-agent',
+            'provider': 'antigravity',
+            'executable': 'C:/Agent/antigravity.exe',
+            'running': True,
+            'capabilities': ['agent.chat', 'agent.session.inspect'],
+            'attachable': False,
+            'metadata': {},
+        }],
+        'surface_count': 1,
+        'capabilities': ['agent.chat', 'agent.session.inspect'],
+        'providers': ['antigravity'],
+    })
+    policy = ThinClientPolicy(readable_roots=(tmp_path,), writable_roots=(tmp_path,))
+    client = ThinClient(NodeIdentity('realm-test', 'host-01'), policy)
+
+    manifest = client.capability_manifest()
+    assert manifest['node_id'] == 'host-01'
+    assert manifest['surface_inventory']['providers'] == ['antigravity']
+    assert 'agent.chat' in manifest['capabilities']
+    assert 'agent.surface.inspect' in manifest['capabilities']
+
+
+def test_node_registry_preserves_surface_inventory(tmp_path):
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    manifest = {
+        'schema': 'agentos.node-manifest/v0.1',
+        'realm_id': 'realm-test',
+        'node_id': 'host-01',
+        'role': 'client',
+        'hostname': 'HOST-01',
+        'platform': 'Windows',
+        'platform_release': '11',
+        'capabilities': ['agent.chat'],
+        'tool_presence': {'antigravity': 'C:/Agent/antigravity.exe'},
+        'surface_inventory': {
+            'schema': 'agentos.surface-inventory/v0.1',
+            'surface_count': 1,
+            'providers': ['antigravity'],
+            'capabilities': ['agent.chat'],
+            'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}],
+        },
+    }
+    entry = registry.register_manifest(manifest)
+    assert entry['node_id'] == 'host-01'
+    assert entry['surface_inventory']['surface_count'] == 1
+
+    node_map = registry.node_map()
+    assert node_map['node_count'] == 1
+    assert node_map['realm_surface_providers'] == ['antigravity']

--- a/tests/test_agent_surface_discovery.py
+++ b/tests/test_agent_surface_discovery.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from agent_core.node_registry import NodeRegistry
@@ -13,59 +14,47 @@ def _which_factory(values):
 
 def test_antigravity_is_surface_inside_node_not_node_identity(monkeypatch):
     monkeypatch.delenv('AGENTOS_ANTIGRAVITY_BRIDGE', raising=False)
-    inventory = discover_surfaces(
-        process_names={'antigravity'},
-        which=_which_factory({'antigravity': '/opt/antigravity'}),
-    )
-
+    inventory = discover_surfaces(process_names={'antigravity'}, which=_which_factory({'antigravity': '/opt/antigravity'}))
     surface = next(x for x in inventory['surfaces'] if x['provider'] == 'antigravity')
     assert surface['kind'] == 'ide-agent'
     assert surface['running'] is True
     assert surface['attachable'] is False
-    assert 'agent.session.inspect' in surface['capabilities']
     assert 'agent.session.attach' not in surface['capabilities']
 
 
-def test_antigravity_bridge_promotes_session_bridge_capabilities(monkeypatch):
-    monkeypatch.setenv('AGENTOS_ANTIGRAVITY_BRIDGE', 'local-relay')
-    inventory = discover_surfaces(
-        process_names={'antigravity'},
-        which=_which_factory({'antigravity': '/opt/antigravity'}),
-    )
-
+def test_antigravity_bridge_promotes_only_declared_capabilities(monkeypatch, tmp_path):
+    bridge = tmp_path / 'bridge'
+    bridge.mkdir()
+    (bridge / 'bridge.json').write_text(json.dumps({
+        'schema': 'agentos.session-bridge/v0.1',
+        'provider': 'antigravity',
+        'ready': True,
+        'operations': ['discover', 'snapshot', 'inject', 'handoff'],
+    }), encoding='utf-8')
+    monkeypatch.setenv('AGENTOS_ANTIGRAVITY_BRIDGE', str(bridge))
+    inventory = discover_surfaces(process_names={'antigravity'}, which=_which_factory({'antigravity': '/opt/antigravity'}))
     surface = next(x for x in inventory['surfaces'] if x['provider'] == 'antigravity')
-    assert surface['attachable'] is True
-    assert 'agent.session.attach' in surface['capabilities']
+    assert surface['attachable'] is False
+    assert 'agent.session.discover' in surface['capabilities']
+    assert 'agent.session.inspect' in surface['capabilities']
     assert 'agent.context.inject' in surface['capabilities']
     assert 'agent.session.handoff' in surface['capabilities']
+    assert 'agent.context.harvest' not in surface['capabilities']
 
 
 def test_node_manifest_advertises_surface_inventory(monkeypatch, tmp_path):
     monkeypatch.setattr('agentos_node.thin_client.discover_surfaces', lambda: {
         'schema': 'agentos.surface-inventory/v0.1',
-        'surfaces': [{
-            'surface_id': 'ide-agent:antigravity',
-            'kind': 'ide-agent',
-            'provider': 'antigravity',
-            'executable': 'C:/Agent/antigravity.exe',
-            'running': True,
-            'capabilities': ['agent.chat', 'agent.session.inspect'],
-            'attachable': False,
-            'metadata': {},
-        }],
-        'surface_count': 1,
-        'capabilities': ['agent.chat', 'agent.session.inspect'],
-        'providers': ['antigravity'],
+        'surfaces': [{'surface_id': 'ide-agent:antigravity', 'kind': 'ide-agent', 'provider': 'antigravity', 'executable': 'C:/Agent/antigravity.exe', 'running': True, 'capabilities': ['agent.chat'], 'attachable': False, 'metadata': {}}],
+        'surface_count': 1, 'capabilities': ['agent.chat'], 'providers': ['antigravity'],
     })
     policy = ThinClientPolicy(readable_roots=(tmp_path,), writable_roots=(tmp_path,))
     client = ThinClient(NodeIdentity('realm-test', 'host-01'), policy)
-
     manifest = client.capability_manifest()
     assert manifest['node_id'] == 'host-01'
     assert manifest['surface_inventory']['providers'] == ['antigravity']
     assert 'agent.chat' in manifest['capabilities']
     assert 'agent.surface.inspect' in manifest['capabilities']
-
     heartbeat = client.heartbeat()
     assert heartbeat['manifest']['node_id'] == 'host-01'
     assert heartbeat['surface_count'] == 1
@@ -74,27 +63,13 @@ def test_node_manifest_advertises_surface_inventory(monkeypatch, tmp_path):
 def test_node_registry_preserves_surface_inventory(tmp_path):
     registry = NodeRegistry(tmp_path / 'nodes.json')
     manifest = {
-        'schema': 'agentos.node-manifest/v0.1',
-        'realm_id': 'realm-test',
-        'node_id': 'host-01',
-        'role': 'client',
-        'hostname': 'HOST-01',
-        'platform': 'Windows',
-        'platform_release': '11',
-        'capabilities': ['agent.chat'],
+        'schema': 'agentos.node-manifest/v0.1', 'realm_id': 'realm-test', 'node_id': 'host-01', 'role': 'client',
+        'hostname': 'HOST-01', 'platform': 'Windows', 'platform_release': '11', 'capabilities': ['agent.chat'],
         'tool_presence': {'antigravity': 'C:/Agent/antigravity.exe'},
-        'surface_inventory': {
-            'schema': 'agentos.surface-inventory/v0.1',
-            'surface_count': 1,
-            'providers': ['antigravity'],
-            'capabilities': ['agent.chat'],
-            'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}],
-        },
+        'surface_inventory': {'schema': 'agentos.surface-inventory/v0.1', 'surface_count': 1, 'providers': ['antigravity'], 'capabilities': ['agent.chat'], 'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}]},
     }
     entry = registry.register_manifest(manifest)
-    assert entry['node_id'] == 'host-01'
     assert entry['surface_inventory']['surface_count'] == 1
-
     node_map = registry.node_map()
     assert node_map['node_count'] == 1
     assert node_map['realm_surface_providers'] == ['antigravity']
@@ -103,37 +78,15 @@ def test_node_registry_preserves_surface_inventory(tmp_path):
 def test_heartbeat_refreshes_surface_inventory(tmp_path):
     registry = NodeRegistry(tmp_path / 'nodes.json')
     initial = {
-        'schema': 'agentos.node-manifest/v0.1',
-        'realm_id': 'realm-test',
-        'node_id': 'host-01',
-        'role': 'client',
-        'hostname': 'HOST-01',
-        'platform': 'Windows',
-        'platform_release': '11',
-        'capabilities': ['tool.presence'],
-        'tool_presence': {},
+        'schema': 'agentos.node-manifest/v0.1', 'realm_id': 'realm-test', 'node_id': 'host-01', 'role': 'client',
+        'hostname': 'HOST-01', 'platform': 'Windows', 'platform_release': '11', 'capabilities': ['tool.presence'], 'tool_presence': {},
         'surface_inventory': {'schema': 'agentos.surface-inventory/v0.1', 'surface_count': 0, 'providers': [], 'capabilities': [], 'surfaces': []},
     }
     registry.register_manifest(initial)
-
     refreshed = dict(initial)
     refreshed['capabilities'] = ['agent.chat', 'tool.presence']
-    refreshed['surface_inventory'] = {
-        'schema': 'agentos.surface-inventory/v0.1',
-        'surface_count': 1,
-        'providers': ['antigravity'],
-        'capabilities': ['agent.chat'],
-        'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}],
-    }
-    registry.record_heartbeat({
-        'schema': 'agentos.node-heartbeat/v0.1',
-        'realm_id': 'realm-test',
-        'node_id': 'host-01',
-        'status': 'online',
-        'surface_count': 1,
-        'manifest': refreshed,
-    })
-
+    refreshed['surface_inventory'] = {'schema': 'agentos.surface-inventory/v0.1', 'surface_count': 1, 'providers': ['antigravity'], 'capabilities': ['agent.chat'], 'surfaces': [{'provider': 'antigravity', 'kind': 'ide-agent'}]}
+    registry.record_heartbeat({'schema': 'agentos.node-heartbeat/v0.1', 'realm_id': 'realm-test', 'node_id': 'host-01', 'status': 'online', 'surface_count': 1, 'manifest': refreshed})
     node = registry.node_map()['nodes'][0]
     assert node['surface_inventory']['providers'] == ['antigravity']
     assert 'agent.chat' in node['capabilities']

--- a/tests/test_join_completion.py
+++ b/tests/test_join_completion.py
@@ -1,0 +1,56 @@
+import json
+
+from agentos_node.onboarding import build_join_regression_report
+from agentos_node.session_bridge import FileSessionBridge, describe_bridge
+
+
+def test_join_regression_requires_no_local_capability_loss():
+    before = {'capabilities': ['shell.exec', 'filesystem.read']}
+    after = {'capabilities': ['shell.exec', 'filesystem.read', 'agent.chat'], 'surface_inventory': {}}
+    bootstrap = {
+        'schema': 'agentos.node-bootstrap/v0.1',
+        'inherited_realm_capabilities': ['context.harvest'],
+        'canonical_capabilities': [{'capability_id': 'layoutlib.profile', 'state_id': 'capstate-1'}],
+    }
+    report = build_join_regression_report(
+        realm_id='realm-test', node_id='node-b', before_manifest=before, after_manifest=after, bootstrap=bootstrap,
+    )
+    assert report['node_ready'] is True
+    assert report['checks']['local_capability_non_regression'] is True
+    assert report['checks']['canonical_capabilities'] == ['layoutlib.profile']
+    assert report['one_uplift_observed'] is True
+
+
+def test_join_regression_fails_when_capability_disappears():
+    report = build_join_regression_report(
+        realm_id='realm-test', node_id='node-b',
+        before_manifest={'capabilities': ['shell.exec', 'filesystem.read']},
+        after_manifest={'capabilities': ['filesystem.read'], 'surface_inventory': {}},
+        bootstrap={'schema': 'agentos.node-bootstrap/v0.1', 'inherited_realm_capabilities': [], 'canonical_capabilities': []},
+    )
+    assert report['node_ready'] is False
+    assert report['checks']['lost_capabilities'] == ['shell.exec']
+
+
+def test_file_session_bridge_declares_and_queues_governed_operations(monkeypatch, tmp_path):
+    root = tmp_path / 'antigravity'
+    root.mkdir()
+    (root / 'bridge.json').write_text(json.dumps({
+        'schema': 'agentos.session-bridge/v0.1', 'provider': 'antigravity', 'ready': True,
+        'operations': ['discover', 'snapshot', 'harvest', 'inject', 'handoff'],
+    }), encoding='utf-8')
+    (root / 'sessions.json').write_text(json.dumps({
+        'schema': 'agentos.session-index/v0.1', 'provider': 'antigravity',
+        'sessions': [{'session_id': 's1', 'title': 'AgentOS'}],
+    }), encoding='utf-8')
+    monkeypatch.setenv('AGENTOS_ANTIGRAVITY_BRIDGE', str(root))
+
+    descriptor = describe_bridge('antigravity')
+    assert descriptor['ready'] is True
+    assert 'agent.context.harvest' in descriptor['capabilities']
+
+    bridge = FileSessionBridge.from_environment('antigravity')
+    assert bridge.discover()['sessions'][0]['session_id'] == 's1'
+    request = bridge.request('handoff', session_id='s1', payload={'goal': 'continue'})
+    queued = root / 'requests' / f"{request['request_id']}.json"
+    assert queued.exists()


### PR DESCRIPTION
## Summary
- formalize Node-internal IDE/agent surfaces instead of treating Antigravity/Codex/etc. as separate Node identities
- discover Antigravity, VS Code, Cursor, Claude Code, Codex and Gemini surfaces
- advertise surface-derived capabilities in the existing node manifest
- persist surface inventory in the ONE Node Registry / Node Map
- expose governed `agent.surface.inspect`
- only advertise attach/context-inject/handoff for Antigravity when an explicit bridge marker is present
- add tests for Host Node vs surface semantics and registry persistence

## Architecture rule
`Realm -> Node -> Executor/Agent/IDE Surface -> Session`

A Node remains the trust/failure/resource boundary. A running IDE or agent process is not promoted to a Node merely because it is independently addressable.

## Follow-up
This PR establishes discovery/advertisement. The next closure should add authenticated periodic manifest refresh and provider-specific session bridge adapters so active chats can be harvested/injected/handoff under governance.