### PR TITLE
feat(agentos): verify enrolled node readiness before second join

### DIFF
--- a/.github/workflows/oracle-realm-node-self-update.yml
+++ b/.github/workflows/oracle-realm-node-self-update.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Queue fixed first-node desktop adapter update
+      - name: Queue first-node AgentOS runtime update
         shell: bash
         env:
           AGENT_DATA_ROOT: /home/ubuntu/agent-data
@@ -44,11 +44,20 @@ jobs:
 
           script = r'''$ErrorActionPreference='Stop'
           $install=Join-Path $env:LOCALAPPDATA 'AgentOS'
-          $pkg=Join-Path $install 'agentos_node'
           $base='https://raw.githubusercontent.com/alston-personal/agentmanager/REF'
-          $files=@('agentos_node/thin_client.py','agentos_node/interactive_desktop.py','agentos_node/thin_client_transport.py','agentos_node/client_cli.py')
+          $files=@(
+            'agentos_node/thin_client.py',
+            'agentos_node/interactive_desktop.py',
+            'agentos_node/thin_client_transport.py',
+            'agentos_node/client_cli.py',
+            'agentos_node/agent_surfaces.py',
+            'agentos_node/session_bridge.py',
+            'agentos_node/onboarding.py'
+          )
           foreach($rel in $files){
             $dest=Join-Path $install ($rel -replace '/','\')
+            $parent=Split-Path -Parent $dest
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
             Invoke-WebRequest -UseBasicParsing -Headers @{'Cache-Control'='no-cache'} -Uri "$base/$rel" -OutFile $dest
           }
           $launcher=Join-Path $install 'agentos-client.cmd'
@@ -60,9 +69,9 @@ jobs:
           Start-ScheduledTask -TaskName $taskName
           $parentPid=(Get-CimInstance Win32_Process -Filter "ProcessId=$PID").ParentProcessId
           Start-Process powershell.exe -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-Command',"Start-Sleep -Seconds 6; Stop-Process -Id $parentPid -Force -ErrorAction SilentlyContinue")
-          Write-Output ('desktop_adapter_ref=REF')
+          Write-Output ('agentos_runtime_ref=REF')
           '''.replace('REF',ref)
-          task_id='self-update-desktop-'+node_id+'-'+str(int(time.time()))
+          task_id='self-update-runtime-'+node_id+'-'+str(int(time.time()))
           task={
             'schema':'agentos.node-task/v0.1','task_id':task_id,'action':'shell.exec',
             'executable':'powershell','argv':['-NoProfile','-NonInteractive','-Command',script],
@@ -108,5 +117,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add .agentos/evidence/realm-node-self-update-current.json
           git diff --cached --quiet && exit 0
-          git commit -m 'evidence(agentos): record first-node desktop self update'
+          git commit -m 'evidence(agentos): record first-node runtime self update'
           git push origin HEAD:main

--- a/.github/workflows/realm-node-fabric-v0.1.yml
+++ b/.github/workflows/realm-node-fabric-v0.1.yml
@@ -7,14 +7,20 @@ on:
       - 'agentos_node/thin_client.py'
       - 'agentos_node/thin_client_transport.py'
       - 'agentos_node/client_cli.py'
+      - 'agentos_node/agent_surfaces.py'
+      - 'agentos_node/session_bridge.py'
+      - 'agentos_node/onboarding.py'
       - 'agent_core/one_uplift.py'
       - 'agent_core/node_registry.py'
+      - 'agent_core/node_bootstrap.py'
       - 'agent_core/realm_fabric.py'
       - 'agent_core/realm_server.py'
       - 'agent_core/realm_cli.py'
       - 'tests/test_thin_client.py'
       - 'tests/test_node_registry_v01.py'
       - 'tests/test_realm_fabric.py'
+      - 'tests/test_agent_surface_discovery.py'
+      - 'tests/test_join_completion.py'
       - 'pyproject.toml'
       - 'docs/REALM_NODE_FABRIC_V0_1.md'
       - '.github/workflows/realm-node-fabric-v0.1.yml'
@@ -30,19 +36,31 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Compile v0.1 modules
+      - name: Compile Node Fabric modules
         run: >-
           python -m py_compile
           agentos_node/thin_client.py
           agentos_node/thin_client_transport.py
           agentos_node/client_cli.py
+          agentos_node/agent_surfaces.py
+          agentos_node/session_bridge.py
+          agentos_node/onboarding.py
           agent_core/one_uplift.py
           agent_core/node_registry.py
+          agent_core/node_bootstrap.py
           agent_core/realm_fabric.py
           agent_core/realm_server.py
           agent_core/realm_cli.py
-      - name: Run Realm Node Fabric v0.1 tests
-        run: python -m unittest tests.test_thin_client tests.test_node_registry_v01 tests.test_realm_fabric -v
+      - name: Install test runtime
+        run: python -m pip install --disable-pip-version-check pytest
+      - name: Run Realm Node Fabric tests
+        run: >-
+          python -m pytest -q
+          tests/test_thin_client.py
+          tests/test_node_registry_v01.py
+          tests/test_realm_fabric.py
+          tests/test_agent_surface_discovery.py
+          tests/test_join_completion.py
       - name: Validate package entry points
         run: |
           python -m pip install --no-deps .
@@ -57,8 +75,10 @@ jobs:
           echo 'one_node_map_registry=PASS'
           echo 'one_uplift_comparison=PASS'
           echo 'one_time_enrollment=PASS'
-          echo 'heartbeat_transport=PASS'
-          echo 'task_pull_transport=PASS'
-          echo 'receipt_return_transport=PASS'
+          echo 'heartbeat_manifest_refresh=PASS'
+          echo 'agent_surface_discovery=PASS'
+          echo 'session_bridge_contract=PASS'
+          echo 'canonical_bootstrap=PASS'
+          echo 'join_regression=PASS'
+          echo 'enrolled_node_readiness=PASS'
           echo 'external_client_enrollment=READY_FOR_REAL_NODE'
-          echo 'production_cutover=NONE'

--- a/agentos_node/client_cli.py
+++ b/agentos_node/client_cli.py
@@ -74,6 +74,7 @@ def main() -> int:
     sub.add_parser('manifest', help='print local capability manifest')
     sub.add_parser('health', help='check ONE health')
     sub.add_parser('bootstrap', help='show inherited Realm capabilities and canonical capability states')
+    sub.add_parser('verify', help='verify an already-enrolled Node is ready and persist regression evidence')
     sub.add_parser('once', help='heartbeat, refresh discovery, pull tasks once, execute, return receipts')
     sub.add_parser('run', help='run persistent polling daemon')
 
@@ -110,24 +111,11 @@ def main() -> int:
         )
         transport = build_client(config, policy)
         completion = transport.complete_join(before_manifest)
-        print(render_json({
-            'ok': bool(completion.get('node_ready')),
-            'realm_id': config.realm_id,
-            'node_id': config.node_id,
-            'config': str(args.config),
-            'completion': completion,
-        }))
+        print(render_json({'ok': bool(completion.get('node_ready')), 'realm_id': config.realm_id, 'node_id': config.node_id, 'config': str(args.config), 'completion': completion}))
         return 0 if completion.get('node_ready') else 2
 
     if args.command == 'enroll':
-        config = ThinClientTransport.enroll(
-            one_url=args.one,
-            invite_id=args.invite_id,
-            code=args.code,
-            node_id=args.node_id,
-            policy=policy,
-            config_path=args.config,
-        )
+        config = ThinClientTransport.enroll(one_url=args.one, invite_id=args.invite_id, code=args.code, node_id=args.node_id, policy=policy, config_path=args.config)
         print(render_json({'ok': True, 'realm_id': config.realm_id, 'node_id': config.node_id, 'config': str(args.config)}))
         return 0
 
@@ -139,6 +127,10 @@ def main() -> int:
         print(render_json(transport.health()))
     elif args.command == 'bootstrap':
         print(render_json(transport.bootstrap()))
+    elif args.command == 'verify':
+        readiness = transport.verify_readiness()
+        print(render_json({'ok': bool(readiness.get('node_ready')), 'readiness': readiness}))
+        return 0 if readiness.get('node_ready') else 2
     elif args.command == 'once':
         print(render_json({'receipts': transport.run_once()}))
     elif args.command == 'run':

--- a/agentos_node/onboarding.py
+++ b/agentos_node/onboarding.py
@@ -10,7 +10,10 @@ def build_join_regression_report(
     before_manifest: dict[str, Any],
     after_manifest: dict[str, Any],
     bootstrap: dict[str, Any],
+    report_kind: str = 'join-regression',
 ) -> dict[str, Any]:
+    if report_kind not in {'join-regression', 'readiness-regression'}:
+        raise ValueError('invalid regression report kind')
     before_caps = set(before_manifest.get('capabilities') or [])
     after_caps = set(after_manifest.get('capabilities') or [])
     lost_caps = sorted(before_caps - after_caps)
@@ -18,8 +21,6 @@ def build_join_regression_report(
     canonical = list(bootstrap.get('canonical_capabilities') or [])
     canonical_ids = sorted({str(item.get('capability_id')) for item in canonical if isinstance(item, dict) and item.get('capability_id')})
 
-    # Map deterministic join checks into the existing ONE uplift dimensions.
-    # This is a bootstrap regression, not a replacement for task-level T0/T2 benchmarks.
     before = {
         'task_success': 1.0,
         'repeated_errors': 0,
@@ -52,7 +53,7 @@ def build_join_regression_report(
     ready = not lost_caps and bootstrap.get('schema') == 'agentos.node-bootstrap/v0.1'
     return {
         'schema': 'agentos.one-uplift-report/v0.1',
-        'report_kind': 'join-regression',
+        'report_kind': report_kind,
         'realm_id': realm_id,
         'node_id': node_id,
         'before': before,

--- a/agentos_node/thin_client_transport.py
+++ b/agentos_node/thin_client_transport.py
@@ -68,90 +68,49 @@ class ThinClientTransport:
         provisional = ThinClient(NodeIdentity(realm_id='pending', node_id=node_id), policy)
         manifest = provisional.capability_manifest()
         manifest['realm_id'] = ''
-        result = cls._request(
-            normalized + '/v1/join/request',
-            method='POST',
-            body={'manifest': manifest, 'expires_minutes': max(1, min(int(expires_minutes), 30))},
-        )
+        result = cls._request(normalized + '/v1/join/request', method='POST', body={'manifest': manifest, 'expires_minutes': max(1, min(int(expires_minutes), 30))})
         if not result.get('ok'):
             raise RuntimeError(f'enrollment request failed: {result}')
         return result
 
     @classmethod
-    def wait_for_approval(
-        cls, *, one_url: str, request_id: str, claim_secret: str, config_path: str | Path,
-        poll_seconds: float = 2.0, timeout_seconds: int = 600,
-        on_status: Callable[[dict[str, Any]], None] | None = None,
-    ) -> ClientConfig:
+    def wait_for_approval(cls, *, one_url: str, request_id: str, claim_secret: str, config_path: str | Path, poll_seconds: float = 2.0, timeout_seconds: int = 600, on_status: Callable[[dict[str, Any]], None] | None = None) -> ClientConfig:
         normalized = one_url.rstrip('/')
         deadline = time.monotonic() + max(10, int(timeout_seconds))
         last_status = None
         while time.monotonic() < deadline:
-            status = cls._request(
-                normalized + '/v1/join/status', method='POST',
-                body={'request_id': request_id, 'claim_secret': claim_secret},
-            )
+            status = cls._request(normalized + '/v1/join/status', method='POST', body={'request_id': request_id, 'claim_secret': claim_secret})
             if status.get('status') != last_status and on_status:
                 on_status(status)
             last_status = status.get('status')
             if status.get('status') in {'denied', 'expired', 'claimed'}:
                 raise RuntimeError(f'enrollment ended with status={status.get("status")}')
             if status.get('status') == 'approved':
-                result = cls._request(
-                    normalized + '/v1/join/claim', method='POST',
-                    body={'request_id': request_id, 'claim_secret': claim_secret},
-                )
+                result = cls._request(normalized + '/v1/join/claim', method='POST', body={'request_id': request_id, 'claim_secret': claim_secret})
                 if result.get('status') == 'enrolled' and result.get('node_token'):
-                    config = ClientConfig(
-                        one_url=normalized,
-                        realm_id=str(result['realm_id']),
-                        node_id=str(result['node_id']),
-                        node_token=str(result['node_token']),
-                    )
+                    config = ClientConfig(one_url=normalized, realm_id=str(result['realm_id']), node_id=str(result['node_id']), node_token=str(result['node_token']))
                     config.save(config_path)
                     return config
             time.sleep(max(1.0, float(poll_seconds)))
         raise TimeoutError('enrollment approval timed out')
 
     @classmethod
-    def enroll_device(
-        cls, *, one_url: str, node_id: str, policy: ThinClientPolicy, config_path: str | Path,
-        expires_minutes: int = 10, timeout_seconds: int = 600,
-        on_request: Callable[[dict[str, Any]], None] | None = None,
-        on_status: Callable[[dict[str, Any]], None] | None = None,
-    ) -> ClientConfig:
-        request = cls.request_enrollment(
-            one_url=one_url, node_id=node_id, policy=policy, expires_minutes=expires_minutes,
-        )
+    def enroll_device(cls, *, one_url: str, node_id: str, policy: ThinClientPolicy, config_path: str | Path, expires_minutes: int = 10, timeout_seconds: int = 600, on_request: Callable[[dict[str, Any]], None] | None = None, on_status: Callable[[dict[str, Any]], None] | None = None) -> ClientConfig:
+        request = cls.request_enrollment(one_url=one_url, node_id=node_id, policy=policy, expires_minutes=expires_minutes)
         if on_request:
             on_request({k: v for k, v in request.items() if k != 'claim_secret'})
-        return cls.wait_for_approval(
-            one_url=one_url,
-            request_id=str(request['request_id']),
-            claim_secret=str(request['claim_secret']),
-            config_path=config_path,
-            timeout_seconds=timeout_seconds,
-            on_status=on_status,
-        )
+        return cls.wait_for_approval(one_url=one_url, request_id=str(request['request_id']), claim_secret=str(request['claim_secret']), config_path=config_path, timeout_seconds=timeout_seconds, on_status=on_status)
 
     @classmethod
-    def enroll(
-        cls, *, one_url: str, invite_id: str, code: str, node_id: str,
-        policy: ThinClientPolicy, config_path: str | Path,
-    ) -> ClientConfig:
+    def enroll(cls, *, one_url: str, invite_id: str, code: str, node_id: str, policy: ThinClientPolicy, config_path: str | Path) -> ClientConfig:
         normalized = one_url.rstrip('/')
         provisional = ThinClient(NodeIdentity(realm_id='pending', node_id=node_id), policy)
         manifest = provisional.capability_manifest()
         manifest['realm_id'] = ''
-        result = cls._request(
-            normalized + '/v1/enroll', method='POST',
-            body={'invite_id': invite_id, 'code': code, 'manifest': manifest},
-        )
+        result = cls._request(normalized + '/v1/enroll', method='POST', body={'invite_id': invite_id, 'code': code, 'manifest': manifest})
         if not result.get('ok'):
             raise RuntimeError(f'enrollment failed: {result}')
-        config = ClientConfig(
-            one_url=normalized, realm_id=str(result['realm_id']), node_id=str(result['node_id']), node_token=str(result['node_token']),
-        )
+        config = ClientConfig(one_url=normalized, realm_id=str(result['realm_id']), node_id=str(result['node_id']), node_token=str(result['node_token']))
         config.save(config_path)
         return config
 
@@ -163,30 +122,20 @@ class ThinClientTransport:
     def heartbeat(self) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
-        return self._request(
-            self.config.one_url + '/v1/heartbeat', method='POST',
-            body=self.client.heartbeat(), token=self.config.node_token,
-        )
+        return self._request(self.config.one_url + '/v1/heartbeat', method='POST', body=self.client.heartbeat(), token=self.config.node_token)
 
     def bootstrap(self) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
         query = urllib.parse.urlencode({'node_id': self.config.node_id})
-        return self._request(
-            self.config.one_url + '/v1/bootstrap?' + query,
-            token=self.config.node_token,
-        )
+        return self._request(self.config.one_url + '/v1/bootstrap?' + query, token=self.config.node_token)
 
     def submit_benchmark(self, report: dict[str, Any]) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
-        return self._request(
-            self.config.one_url + '/v1/benchmark', method='POST',
-            body=report, token=self.config.node_token,
-        )
+        return self._request(self.config.one_url + '/v1/benchmark', method='POST', body=report, token=self.config.node_token)
 
-    def complete_join(self, before_manifest: dict[str, Any]) -> dict[str, Any]:
-        """Refresh discovery, pull inherited Realm state and persist join regression evidence."""
+    def _complete_regression(self, before_manifest: dict[str, Any], *, report_kind: str, completion_schema: str) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
         heartbeat = self.heartbeat()
@@ -198,10 +147,11 @@ class ThinClientTransport:
             before_manifest=before_manifest,
             after_manifest=after_manifest,
             bootstrap=bootstrap,
+            report_kind=report_kind,
         )
         persisted = self.submit_benchmark(report)
         return {
-            'schema': 'agentos.join-completion/v0.1',
+            'schema': completion_schema,
             'realm_id': self.config.realm_id,
             'node_id': self.config.node_id,
             'heartbeat': heartbeat,
@@ -210,6 +160,14 @@ class ThinClientTransport:
             'benchmark_persisted': bool(persisted.get('ok')),
             'node_ready': bool(report.get('node_ready')),
         }
+
+    def complete_join(self, before_manifest: dict[str, Any]) -> dict[str, Any]:
+        return self._complete_regression(before_manifest, report_kind='join-regression', completion_schema='agentos.join-completion/v0.1')
+
+    def verify_readiness(self) -> dict[str, Any]:
+        """Verify an already-enrolled Node against current discovery and inherited Realm state."""
+        baseline = self.client.capability_manifest()
+        return self._complete_regression(baseline, report_kind='readiness-regression', completion_schema='agentos.node-readiness/v0.1')
 
     def pull_tasks(self) -> list[dict[str, Any]]:
         if not self.config:
@@ -221,9 +179,7 @@ class ThinClientTransport:
     def submit_receipt(self, receipt: dict[str, Any]) -> dict[str, Any]:
         if not self.config:
             raise RuntimeError('client is not enrolled')
-        return self._request(
-            self.config.one_url + '/v1/receipts', method='POST', body=receipt, token=self.config.node_token,
-        )
+        return self._request(self.config.one_url + '/v1/receipts', method='POST', body=receipt, token=self.config.node_token)
 
     def run_once(self) -> list[dict[str, Any]]:
         self.heartbeat()


### PR DESCRIPTION
## Summary
- add `agentos-client verify` for already-enrolled Nodes
- distinguish `readiness-regression` from fresh `join-regression`
- keep bootstrap/canonical inheritance evidence persisted through ONE
- expand Node Fabric CI to cover surface/session/onboarding closure
- upgrade first-node self-update to ship the complete Thin Client onboarding/session runtime

## Acceptance
The existing `vopc5750` can be updated and verified without attempting duplicate enrollment. A fresh second machine will still use `agentos-client join` and get the true fresh-join regression path.