### PR TITLE
fix(agentos): recover stale nodes and inspect ONE runtime

### DIFF
--- a/.agentos/commands/realm-one-runtime-inspect.json
+++ b/.agentos/commands/realm-one-runtime-inspect.json
@@ -1,0 +1,5 @@
+{
+  "schema": "agentos.realm-command/v0.1",
+  "action": "realm.one.runtime.inspect",
+  "nonce": "bootstrap-20260827"
+}

--- a/.github/workflows/oracle-realm-one-inspect.yml
+++ b/.github/workflows/oracle-realm-one-inspect.yml
@@ -1,0 +1,56 @@
+name: Oracle Realm ONE Runtime Inspect
+
+on:
+  push:
+    paths:
+      - '.agentos/commands/realm-one-runtime-inspect.json'
+
+permissions:
+  contents: write
+
+jobs:
+  inspect:
+    if: github.actor == 'alstonhuang'
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inspect live ONE runtime
+        shell: bash
+        env:
+          AGENT_DATA_ROOT: /home/ubuntu/agent-data
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess
+          from pathlib import Path
+          from agent_core.node_registry import NodeRegistry
+
+          def run(argv):
+              p=subprocess.run(argv,text=True,capture_output=True,check=False,timeout=10)
+              return {'argv':argv,'returncode':p.returncode,'stdout':p.stdout[-12000:],'stderr':p.stderr[-4000:]}
+
+          result={
+              'schema':'agentos.one-runtime-inspection/v0.1',
+              'processes':run(['bash','-lc',"ps -eo pid,user,args | grep -E 'agentos|realm_server|agentos-one' | grep -v grep || true"]),
+              'listeners':run(['bash','-lc',"ss -ltnp 2>/dev/null | grep -E ':8780|:8766' || true"]),
+              'user_services':run(['bash','-lc',"systemctl --user --no-pager --plain list-units --type=service 2>/dev/null | grep -E 'agentos|realm' || true"]),
+              'health_8780':run(['bash','-lc',"curl -fsS --max-time 3 http://127.0.0.1:8780/v1/health || true"]),
+              'node_map':NodeRegistry().node_map(),
+          }
+          Path('/tmp/realm-one-runtime-inspection.json').write_text(json.dumps(result,indent=2,sort_keys=True)+'\n',encoding='utf-8')
+          print(json.dumps(result,indent=2,sort_keys=True))
+          PY
+      - name: Publish inspection evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          cp /tmp/realm-one-runtime-inspection.json .agentos/evidence/realm-one-runtime-inspection-current.json
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .agentos/evidence/realm-one-runtime-inspection-current.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'evidence(agentos): inspect live ONE runtime'
+          git push origin HEAD:main

--- a/agent_core/node_registry.py
+++ b/agent_core/node_registry.py
@@ -11,12 +11,17 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
 
 
-class NodeRegistry:
-    """Persistent ONE-side Realm Node Map.
+def _parse_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except ValueError:
+        return None
 
-    Logic lives in agentmanager; mutable Realm state lives outside the source
-    repository under AGENT_DATA_ROOT by default.
-    """
+
+class NodeRegistry:
+    """Persistent ONE-side Realm Node Map with heartbeat freshness semantics."""
 
     def __init__(self, path: str | Path | None = None):
         data_root = Path(os.environ.get('AGENT_DATA_ROOT', '/home/ubuntu/agent-data'))
@@ -78,7 +83,6 @@ class NodeRegistry:
     def record_heartbeat(self, heartbeat: dict[str, Any]) -> dict[str, Any]:
         if heartbeat.get('schema') != 'agentos.node-heartbeat/v0.1':
             raise ValueError('invalid heartbeat')
-
         manifest = heartbeat.get('manifest')
         if manifest is not None:
             if not isinstance(manifest, dict):
@@ -117,14 +121,34 @@ class NodeRegistry:
         self.save(data)
         return snapshot
 
+    def _effective_node(self, node: dict[str, Any]) -> dict[str, Any]:
+        result = dict(node)
+        reported = str(node.get('status') or 'unknown')
+        result['reported_status'] = reported
+        last = _parse_utc(node.get('last_heartbeat_at'))
+        stale_seconds = max(15, int(os.environ.get('AGENTOS_NODE_STALE_SECONDS', '30')))
+        age = None
+        if last is not None:
+            age = max(0, int((datetime.now(timezone.utc) - last).total_seconds()))
+        result['heartbeat_age_seconds'] = age
+        result['heartbeat_stale_after_seconds'] = stale_seconds
+        if reported == 'online' and (age is None or age > stale_seconds):
+            result['status'] = 'offline'
+            result['status_reason'] = 'heartbeat_stale'
+        else:
+            result['status'] = reported
+        return result
+
     def node_map(self) -> dict[str, Any]:
         data = self.load()
-        nodes = sorted(data['nodes'].values(), key=lambda n: (n.get('role') != 'core', n.get('node_id', '')))
+        nodes = [self._effective_node(node) for node in data['nodes'].values()]
+        nodes.sort(key=lambda n: (n.get('role') != 'core', n.get('node_id', '')))
         realm_caps = sorted({cap for node in nodes for cap in node.get('capabilities', []) if node.get('status') != 'offline'})
-        tools = sorted({tool for node in nodes for tool in node.get('tool_presence', {})})
+        tools = sorted({tool for node in nodes for tool in node.get('tool_presence', {}) if node.get('status') != 'offline'})
         surface_providers = sorted({
             str(surface.get('provider'))
             for node in nodes
+            if node.get('status') != 'offline'
             for surface in (node.get('surface_inventory') or {}).get('surfaces', [])
             if isinstance(surface, dict) and surface.get('provider')
         })
@@ -132,6 +156,7 @@ class NodeRegistry:
             'schema': 'agentos.node-map/v0.1',
             'realm_id': data.get('realm_id'),
             'node_count': len(nodes),
+            'online_node_count': sum(1 for node in nodes if node.get('status') == 'online'),
             'nodes': nodes,
             'realm_capabilities': realm_caps,
             'realm_tool_presence': tools,

--- a/scripts/recover-agentos-node.ps1
+++ b/scripts/recover-agentos-node.ps1
@@ -1,0 +1,65 @@
+param(
+  [string]$Ref = 'main',
+  [switch]$SkipVerify
+)
+
+$ErrorActionPreference = 'Stop'
+$install = Join-Path $env:LOCALAPPDATA 'AgentOS'
+$pkg = Join-Path $install 'agentos_node'
+$base = "https://raw.githubusercontent.com/alston-personal/agentmanager/$Ref"
+$files = @(
+  'agentos_node/thin_client.py',
+  'agentos_node/interactive_desktop.py',
+  'agentos_node/thin_client_transport.py',
+  'agentos_node/client_cli.py',
+  'agentos_node/agent_surfaces.py',
+  'agentos_node/session_bridge.py',
+  'agentos_node/onboarding.py'
+)
+
+New-Item -ItemType Directory -Force -Path $pkg | Out-Null
+foreach ($rel in $files) {
+  $dest = Join-Path $install ($rel -replace '/', '\')
+  $parent = Split-Path -Parent $dest
+  New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  Invoke-WebRequest -UseBasicParsing -Headers @{'Cache-Control'='no-cache'} -Uri "$base/$rel" -OutFile $dest
+}
+
+$launcher = Join-Path $install 'agentos-client.cmd'
+if (-not (Test-Path $launcher)) {
+  $python = (Get-Command python -ErrorAction Stop).Source
+  $launcherText = "@echo off`r`nset PYTHONPATH=$install`r`n`"$python`" -m agentos_node.client_cli %*`r`n"
+  Set-Content -Path $launcher -Value $launcherText -Encoding ASCII
+}
+
+$config = Join-Path $env:USERPROFILE '.agentos\client.json'
+$policy = Join-Path $env:USERPROFILE '.agentos\policy.json'
+if (-not (Test-Path $config)) { throw "Existing Node config not found: $config" }
+if (-not (Test-Path $policy)) { throw "Existing Node policy not found: $policy" }
+
+$taskName = 'AgentOS Thin Client'
+$action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument "/d /c `"$launcher`" run" -WorkingDirectory $install
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -RestartCount 5 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit ([TimeSpan]::Zero)
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description 'AgentOS Thin Client user-session daemon' -Force | Out-Null
+Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 1
+Start-ScheduledTask -TaskName $taskName
+Start-Sleep -Seconds 3
+
+$health = & $launcher health 2>&1
+Write-Host $health
+if ($LASTEXITCODE -ne 0) { throw 'AgentOS ONE health check failed after recovery' }
+
+$manifest = & $launcher manifest 2>&1
+Write-Host $manifest
+if ($LASTEXITCODE -ne 0) { throw 'AgentOS manifest discovery failed after recovery' }
+
+if (-not $SkipVerify) {
+  $verify = & $launcher verify 2>&1
+  Write-Host $verify
+  if ($LASTEXITCODE -ne 0) { throw 'AgentOS readiness verification failed after recovery' }
+}
+
+Write-Host 'agentos_node_recovery=PASS'
+Write-Host "agentos_runtime_ref=$Ref"

--- a/tests/test_node_registry_v01.py
+++ b/tests/test_node_registry_v01.py
@@ -7,29 +7,29 @@ from agent_core.one_uplift import BenchmarkMetrics, compare_before_after
 
 
 class TestNodeRegistryV01(unittest.TestCase):
+    def _manifest(self, node_id='core-test-01'):
+        return {
+            'schema': 'agentos.node-manifest/v0.1',
+            'realm_id': 'realm-test',
+            'node_id': node_id,
+            'role': 'core',
+            'hostname': 'core-host',
+            'platform': 'Linux',
+            'platform_release': 'test',
+            'capabilities': ['shell.exec', 'filesystem.read'],
+            'tool_presence': {'git': '/usr/bin/git'},
+        }
+
     def test_node_map_and_benchmark_history(self):
         with tempfile.TemporaryDirectory() as tmp:
             registry = NodeRegistry(Path(tmp) / 'nodes.json')
-            manifest = {
-                'schema': 'agentos.node-manifest/v0.1',
-                'realm_id': 'realm-test',
-                'node_id': 'core-test-01',
-                'role': 'core',
-                'hostname': 'core-host',
-                'platform': 'Linux',
-                'platform_release': 'test',
-                'capabilities': ['shell.exec', 'filesystem.read'],
-                'tool_presence': {'git': '/usr/bin/git'},
-                'observed_at': '2026-08-26T00:00:00Z',
-            }
-            registry.register_manifest(manifest)
+            registry.register_manifest(self._manifest())
             registry.record_heartbeat({
                 'schema': 'agentos.node-heartbeat/v0.1',
                 'realm_id': 'realm-test',
                 'node_id': 'core-test-01',
                 'role': 'core',
                 'status': 'online',
-                'observed_at': '2026-08-26T00:00:01Z',
                 'uptime_seconds': 10,
             })
             before = BenchmarkMetrics(0.5, 2, 3, 0.2, 0, 0, 0)
@@ -40,9 +40,32 @@ class TestNodeRegistryV01(unittest.TestCase):
             node_map = registry.node_map()
             self.assertEqual(node_map['realm_id'], 'realm-test')
             self.assertEqual(node_map['node_count'], 1)
+            self.assertEqual(node_map['online_node_count'], 1)
             self.assertIn('shell.exec', node_map['realm_capabilities'])
             self.assertIn('git', node_map['realm_tool_presence'])
             self.assertTrue(node_map['nodes'][0]['benchmark']['one_uplift_observed'])
+            self.assertEqual(node_map['nodes'][0]['reported_status'], 'online')
+
+    def test_stale_online_node_is_effectively_offline(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = NodeRegistry(Path(tmp) / 'nodes.json')
+            registry.register_manifest(self._manifest('stale-node'))
+            registry.record_heartbeat({
+                'schema': 'agentos.node-heartbeat/v0.1',
+                'realm_id': 'realm-test',
+                'node_id': 'stale-node',
+                'role': 'core',
+                'status': 'online',
+                'observed_at': '2020-01-01T00:00:00Z',
+                'uptime_seconds': 10,
+            })
+            node_map = registry.node_map()
+            node = node_map['nodes'][0]
+            self.assertEqual(node['reported_status'], 'online')
+            self.assertEqual(node['status'], 'offline')
+            self.assertEqual(node['status_reason'], 'heartbeat_stale')
+            self.assertEqual(node_map['online_node_count'], 0)
+            self.assertNotIn('shell.exec', node_map['realm_capabilities'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- derive effective offline status from stale heartbeats instead of trusting old `online`
- exclude stale Nodes from Realm capabilities/tool/surface aggregation
- add idempotent Windows Node recovery bootstrap
- add governed Oracle ONE runtime inspection evidence
- cover stale heartbeat semantics in Node Registry tests

This addresses the first real readiness failure: `vopc5750` has not heartbeated since 2026-08-26 and therefore could not consume the queued runtime update.