### PR TITLE
Add Closure Reality ledger and audit guard

### DIFF
--- a/.agent/closure/ledger.yaml
+++ b/.agent/closure/ledger.yaml
@@ -1,0 +1,202 @@
+schema_version: "0.1"
+updated_at: "2026-08-27"
+
+stages:
+  - DISCOVERED
+  - SPECIFIED
+  - PROTOTYPED
+  - IMPLEMENTED
+  - INTEGRATED
+  - VERIFIED
+  - OPERATING
+  - GUARDED
+  - CLOSED
+
+rules:
+  closed_requires:
+    - owner
+    - implementation
+    - integration_evidence
+    - verification_evidence
+    - operating_evidence
+    - regression_guard
+  no_silent_park: true
+  evidence_over_claims: true
+
+items:
+  - id: documentation-reality-guard
+    owner: governance.keeper
+    stage: GUARDED
+    implementation:
+      - scripts/documentation_reality_guard.py
+      - .github/workflows/documentation-reality-guard.yml
+    integration_evidence:
+      - .github/workflows/documentation-reality-guard.yml
+    verification_evidence:
+      - tests/test_documentation_reality_guard.py
+    operating_evidence:
+      - github-actions
+    regression_guard:
+      - tests/test_documentation_reality_guard.py
+    gaps: []
+
+  - id: protected-branch-authority
+    owner: governance.keeper
+    stage: GUARDED
+    implementation:
+      - scripts/protected_branch_authority.py
+      - .agent/governance/protected_branches.yaml
+    integration_evidence:
+      - docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md
+    verification_evidence:
+      - tests/test_protected_branch_authority.py
+    operating_evidence:
+      - "PR #10 human-approval-before-merge flow"
+    regression_guard:
+      - tests/test_protected_branch_authority.py
+    gaps:
+      - "GitHub-native branch protection / required checks should remain independently enforced where available"
+
+  - id: role-registry-and-inheritance
+    owner: governance.spec_steward
+    stage: VERIFIED
+    implementation:
+      - .agent/roles/registry.yaml
+      - .agent/roles/base_role.md
+      - .agent/roles/parents/
+    integration_evidence:
+      - agent_core/governance_directory.py
+    verification_evidence:
+      - tests/test_governance_directory.py
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "role status currently describes contract validity, not runtime employee activity"
+      - "no end-to-end employee lifecycle evidence"
+
+  - id: agent-employee-runtime
+    owner: governance.spec_steward
+    stage: DISCOVERED
+    implementation: []
+    integration_evidence: []
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "durable AgentInstance identity"
+      - "per-agent memory namespace"
+      - "assignment and activation runtime"
+      - "agent-to-agent inbox/outbox messaging"
+      - "handoff and lifecycle closure"
+      - "executor binding independent of employee identity"
+
+  - id: per-agent-durable-memory
+    owner: governance.spec_steward
+    stage: SPECIFIED
+    implementation:
+      - .agent/roles/parents/
+    integration_evidence:
+      - agent_core/memory_router.py
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "current memory router is project-scoped rather than employee-scoped"
+      - "role Memory Scope declarations are not equivalent to durable per-agent memory"
+
+  - id: responsibility-resolution
+    owner: governance.keeper
+    stage: VERIFIED
+    implementation:
+      - agent_core/governance_directory.py
+      - .agent/roles/registry.yaml
+    integration_evidence:
+      - docs/AGENTOS_NODE.md
+    verification_evidence:
+      - tests/test_governance_directory.py
+    operating_evidence: []
+    regression_guard:
+      - tests/test_governance_directory.py
+    gaps:
+      - "resolution does not itself activate an employee or guarantee task ownership at runtime"
+
+  - id: cognitive-ir
+    owner: governance.spec_steward
+    stage: PROTOTYPED
+    implementation:
+      - docs/CURRENT_STATE.md
+    integration_evidence: []
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "model-independent schema is not canonical"
+      - "repeatable cross-model continuation benchmark is missing"
+
+  - id: cognitive-thread-return-stack
+    owner: governance.spec_steward
+    stage: PROTOTYPED
+    implementation: []
+    integration_evidence: []
+    verification_evidence:
+      - "conversation-level prototype: nested A -> B -> C -> return preserves parent HEAD"
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "not integrated into continuation_state runtime"
+      - "cross-model thread-return experiment missing"
+
+  - id: capability-learning-loop
+    owner: governance.spec_steward
+    stage: SPECIFIED
+    implementation:
+      - docs/agentos_ecosystem/CAPABILITY_EVOLUTION.md
+    integration_evidence: []
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "first full LayoutLib execution-to-canonical-learning loop still needs durable end-to-end evidence"
+
+  - id: chronicler
+    owner: governance.spec_steward
+    stage: SPECIFIED
+    implementation:
+      - .agent/roles/registry.yaml
+    integration_evidence: []
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "role status remains proposed"
+      - "no activation/runtime source"
+      - "chronicle projection is still manually triggered"
+
+  - id: matters-publisher-skill
+    owner: sector.paw
+    stage: IMPLEMENTED
+    implementation:
+      - .agent/skills/matters_publisher/SKILL.md
+      - .agent/skills/matters_publisher/scripts/
+    integration_evidence: []
+    verification_evidence: []
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "skill exists but no current role/employee activation path proves it is routinely used"
+
+  - id: closure-audit
+    owner: governance.spec_steward
+    stage: IMPLEMENTED
+    implementation:
+      - .agent/closure/ledger.yaml
+      - scripts/closure_audit.py
+    integration_evidence:
+      - docs/CLOSURE_REALITY.md
+    verification_evidence:
+      - tests/test_closure_audit.py
+    operating_evidence: []
+    regression_guard:
+      - tests/test_closure_audit.py
+    gaps:
+      - "promote to GUARDED only after CI evidence exists"

--- a/.github/workflows/closure-audit.yml
+++ b/.github/workflows/closure-audit.yml
@@ -1,0 +1,33 @@
+name: Closure Audit
+
+on:
+  pull_request:
+    paths:
+      - '.agent/closure/**'
+      - 'scripts/closure_audit.py'
+      - 'tests/test_closure_audit.py'
+      - 'docs/CLOSURE_REALITY.md'
+      - '.github/workflows/closure-audit.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.agent/closure/**'
+      - 'scripts/closure_audit.py'
+      - 'tests/test_closure_audit.py'
+      - 'docs/CLOSURE_REALITY.md'
+      - '.github/workflows/closure-audit.yml'
+
+jobs:
+  closure-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml
+      - name: Validate closure ledger
+        run: python3 scripts/closure_audit.py --summary
+      - name: Run closure audit regression tests
+        run: python3 -m unittest tests.test_closure_audit -v

--- a/docs/CLOSURE_REALITY.md
+++ b/docs/CLOSURE_REALITY.md
@@ -1,0 +1,124 @@
+# AgentOS Closure Reality
+
+**Status:** active governance checkpoint  
+**Date:** 2026-08-27
+
+AgentOS has repeatedly produced strong ideas, specifications, prototypes, and partial implementations faster than those ideas become durable operating capabilities. This document defines the anti-drift discipline for that failure mode.
+
+## Problem: Closure Gap
+
+A capability is not complete because it was discussed, specified, prototyped, or even implemented once. The recurring failure pattern is:
+
+```text
+idea -> discussion -> spec -> prototype -> partial implementation
+                                      \
+                                       -> attention moves elsewhere
+```
+
+The missing tail is:
+
+```text
+integration -> verification -> real operation -> regression guard -> closure
+```
+
+The canonical machine-readable inventory is `.agent/closure/ledger.yaml`.
+
+## Lifecycle
+
+Every material capability, role/runtime promise, research result, or governance mechanism should converge to one explicit stage:
+
+```text
+DISCOVERED
+  -> SPECIFIED
+  -> PROTOTYPED
+  -> IMPLEMENTED
+  -> INTEGRATED
+  -> VERIFIED
+  -> OPERATING
+  -> GUARDED
+  -> CLOSED
+```
+
+`CLOSED` does **not** mean immutable. It means the current claim has an owner, implementation, integration evidence, verification evidence, real operating evidence, and regression protection, with no known closure gap remaining.
+
+A later architecture change may legitimately move an item backward or supersede it, but the transition must be explicit.
+
+## Evidence gates
+
+The audit enforces minimum gates:
+
+- `IMPLEMENTED` requires implementation evidence.
+- `INTEGRATED` additionally requires integration evidence.
+- `VERIFIED` additionally requires verification evidence.
+- `OPERATING` additionally requires operating evidence.
+- `GUARDED` additionally requires a regression guard.
+- `CLOSED` must retain no known gaps.
+
+Run:
+
+```bash
+python3 scripts/closure_audit.py --summary
+python3 -m unittest tests.test_closure_audit -v
+```
+
+## No Silent Park
+
+If a discussion produces a meaningful architecture hypothesis or work item that will not be completed immediately, it must not disappear into conversation history. Record at least:
+
+- stable id;
+- owner;
+- current stage;
+- evidence already obtained;
+- known gaps;
+- the condition or experiment required to advance it.
+
+A parked item is valid. An unrecorded abandoned item is drift.
+
+## Reality dimensions
+
+Architecture review must ask two independent questions:
+
+1. **Architecture Reality:** does the thing actually exist?
+2. **Closure Reality:** did it reach the operational stage being claimed?
+
+This prevents misleading declarations such as a role marked `active` when only its contract exists but no employee activation/runtime evidence exists.
+
+## Initial audit findings
+
+The first ledger deliberately includes both strong and weak examples.
+
+### Near closure / guarded
+
+- Documentation Reality Guard.
+- Protected-branch authority boundary.
+
+These have implementation, verification, operating evidence, and regression protection.
+
+### Material closure gaps
+
+- Agent Organization / Employee Runtime: role definitions and responsibility resolution exist, but durable employees, assignment/activation, per-agent memory, messaging, handoff, and lifecycle closure are not proven end-to-end.
+- Per-agent durable memory: role documents define memory scope, while the current memory router remains project-scoped.
+- Cognitive IR: research/prototype direction exists, but there is no canonical portable schema with repeatable cross-model continuation evidence.
+- Cognitive Thread / HEAD / Return Stack: the idea has a conversation-level prototype but is not integrated into continuation runtime.
+- Capability learning loop: the architecture is specified, while the first complete LayoutLib execution-to-canonical-learning closed loop still needs durable evidence.
+- Chronicler: the role is defined/proposed but is not an operating employee.
+- Publisher capability: a Matters publishing skill exists, but current organization runtime does not prove routine role-driven activation.
+
+## Closure priority rule
+
+Prioritize gaps by leverage, not novelty. A gap should move upward when closing it unlocks multiple existing capabilities.
+
+Current hypothesis: restoring the **Agent Employee / Organization Runtime** is a high-leverage closure target because it can reactivate existing roles, skills, memory scopes, responsibility resolution, Chronicle maintenance, review, publication, and future work-thread ownership without inventing parallel systems.
+
+This remains a hypothesis until the closure audit and a real end-to-end employee workflow prove it.
+
+## Governance rule
+
+Do not use `active`, `implemented`, or `complete` as interchangeable words.
+
+- `active role contract` means the definition is valid.
+- `implemented capability` means code/artifact exists.
+- `operating capability` requires real runtime evidence.
+- `closed capability` requires all closure gates.
+
+Claims must use the narrowest justified stage.

--- a/scripts/closure_audit.py
+++ b/scripts/closure_audit.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except Exception as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required for closure audit") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LEDGER = ROOT / ".agent" / "closure" / "ledger.yaml"
+
+ORDER = {
+    "DISCOVERED": 0,
+    "SPECIFIED": 1,
+    "PROTOTYPED": 2,
+    "IMPLEMENTED": 3,
+    "INTEGRATED": 4,
+    "VERIFIED": 5,
+    "OPERATING": 6,
+    "GUARDED": 7,
+    "CLOSED": 8,
+}
+
+REQUIRED_FIELDS = (
+    "id",
+    "owner",
+    "stage",
+    "implementation",
+    "integration_evidence",
+    "verification_evidence",
+    "operating_evidence",
+    "regression_guard",
+    "gaps",
+)
+
+
+def load_ledger(path: Path = DEFAULT_LEDGER) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError("closure ledger root must be a mapping")
+    return data
+
+
+def _nonempty(value: Any) -> bool:
+    return isinstance(value, list) and len(value) > 0
+
+
+def audit(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    seen: set[str] = set()
+
+    for item in data.get("items", []) or []:
+        if not isinstance(item, dict):
+            errors.append("closure item must be a mapping")
+            continue
+
+        missing = [field for field in REQUIRED_FIELDS if field not in item]
+        if missing:
+            errors.append(f"{item.get('id', '<unknown>')}: missing fields {', '.join(missing)}")
+            continue
+
+        item_id = str(item["id"])
+        if item_id in seen:
+            errors.append(f"{item_id}: duplicate id")
+        seen.add(item_id)
+
+        stage = str(item["stage"])
+        if stage not in ORDER:
+            errors.append(f"{item_id}: unknown stage {stage}")
+            continue
+
+        if not str(item.get("owner") or "").strip():
+            errors.append(f"{item_id}: owner is required")
+
+        rank = ORDER[stage]
+        if rank >= ORDER["IMPLEMENTED"] and not _nonempty(item["implementation"]):
+            errors.append(f"{item_id}: {stage} requires implementation evidence")
+        if rank >= ORDER["INTEGRATED"] and not _nonempty(item["integration_evidence"]):
+            errors.append(f"{item_id}: {stage} requires integration evidence")
+        if rank >= ORDER["VERIFIED"] and not _nonempty(item["verification_evidence"]):
+            errors.append(f"{item_id}: {stage} requires verification evidence")
+        if rank >= ORDER["OPERATING"] and not _nonempty(item["operating_evidence"]):
+            errors.append(f"{item_id}: {stage} requires operating evidence")
+        if rank >= ORDER["GUARDED"] and not _nonempty(item["regression_guard"]):
+            errors.append(f"{item_id}: {stage} requires regression guard")
+
+        if stage == "CLOSED" and item["gaps"]:
+            errors.append(f"{item_id}: CLOSED item cannot retain gaps")
+
+    return errors
+
+
+def render_summary(data: dict[str, Any]) -> str:
+    rows = []
+    for item in data.get("items", []) or []:
+        if not isinstance(item, dict):
+            continue
+        rows.append(
+            (
+                str(item.get("id", "?")),
+                str(item.get("stage", "?")),
+                len(item.get("gaps") or []),
+            )
+        )
+    rows.sort(key=lambda r: (ORDER.get(r[1], -1), r[0]))
+    lines = ["Closure Reality", "==============="]
+    lines.extend(f"{stage:12} gaps={gaps:<2} {item_id}" for item_id, stage, gaps in rows)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate AgentOS closure ledger")
+    parser.add_argument("--ledger", type=Path, default=DEFAULT_LEDGER)
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    data = load_ledger(args.ledger)
+    errors = audit(data)
+    if args.summary:
+        print(render_summary(data))
+    if errors:
+        print("Closure audit FAILED")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Closure audit PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_closure_audit.py
+++ b/tests/test_closure_audit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "closure_audit.py"
+SPEC = importlib.util.spec_from_file_location("closure_audit", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ClosureAuditTests(unittest.TestCase):
+    def _item(self, **updates):
+        item = {
+            "id": "x",
+            "owner": "governance.spec_steward",
+            "stage": "DISCOVERED",
+            "implementation": [],
+            "integration_evidence": [],
+            "verification_evidence": [],
+            "operating_evidence": [],
+            "regression_guard": [],
+            "gaps": ["not done"],
+        }
+        item.update(updates)
+        return item
+
+    def test_discovered_item_may_have_no_evidence(self):
+        self.assertEqual([], MODULE.audit({"items": [self._item()]}))
+
+    def test_implemented_requires_implementation(self):
+        errors = MODULE.audit({"items": [self._item(stage="IMPLEMENTED")]})
+        self.assertTrue(any("requires implementation evidence" in e for e in errors))
+
+    def test_verified_requires_integration_and_verification(self):
+        errors = MODULE.audit(
+            {
+                "items": [
+                    self._item(
+                        stage="VERIFIED",
+                        implementation=["a.py"],
+                    )
+                ]
+            }
+        )
+        self.assertTrue(any("requires integration evidence" in e for e in errors))
+        self.assertTrue(any("requires verification evidence" in e for e in errors))
+
+    def test_guarded_requires_operating_and_guard(self):
+        errors = MODULE.audit(
+            {
+                "items": [
+                    self._item(
+                        stage="GUARDED",
+                        implementation=["a.py"],
+                        integration_evidence=["runtime"],
+                        verification_evidence=["test"],
+                    )
+                ]
+            }
+        )
+        self.assertTrue(any("requires operating evidence" in e for e in errors))
+        self.assertTrue(any("requires regression guard" in e for e in errors))
+
+    def test_closed_cannot_keep_gaps(self):
+        errors = MODULE.audit(
+            {
+                "items": [
+                    self._item(
+                        stage="CLOSED",
+                        implementation=["a.py"],
+                        integration_evidence=["runtime"],
+                        verification_evidence=["test"],
+                        operating_evidence=["receipt"],
+                        regression_guard=["guard"],
+                    )
+                ]
+            }
+        )
+        self.assertTrue(any("cannot retain gaps" in e for e in errors))
+
+    def test_closed_with_complete_evidence_passes(self):
+        item = self._item(
+            stage="CLOSED",
+            implementation=["a.py"],
+            integration_evidence=["runtime"],
+            verification_evidence=["test"],
+            operating_evidence=["receipt"],
+            regression_guard=["guard"],
+            gaps=[],
+        )
+        self.assertEqual([], MODULE.audit({"items": [item]}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Turn the recurring idea-to-operation gap into a governed, machine-checkable lifecycle.

## Adds

- `.agent/closure/ledger.yaml` — canonical Closure Ledger with stages from `DISCOVERED` through `CLOSED`
- `scripts/closure_audit.py` — validates evidence gates and prevents unsupported stage claims
- `tests/test_closure_audit.py` — regression tests for stage requirements
- `.github/workflows/closure-audit.yml` — CI enforcement
- `docs/CLOSURE_REALITY.md` — Architecture Reality vs Closure Reality discipline

## Initial audit findings recorded

- role registry/inheritance exists, but Agent Employee Runtime is not closed
- per-agent durable memory is not proven; current memory routing remains project-scoped
- responsibility resolution is verified but does not guarantee employee activation
- Cognitive IR and Cognitive Thread/HEAD/Return Stack remain prototype/research-stage
- capability-learning closed loop still lacks durable end-to-end evidence
- Chronicler is proposed rather than operating
- Matters publishing skill exists but lacks current role-driven operating evidence
- Documentation Reality Guard and Protected Branch Authority are the strongest guarded examples

## Governance intent

A capability must not be called complete merely because it was discussed, specified, prototyped, or implemented once. Higher stages require integration, verification, operating evidence, and regression protection.

This PR does **not** merge itself. It should stop at `AWAITING_HUMAN_APPROVAL` after CI is green.