### PR TITLE
[LEGACY SOURCE — EXTRACT VIA #151] Recover minimal Agent Employee Runtime and closure wave 1

### DIFF
--- a/.agent/closure/ledger.yaml
+++ b/.agent/closure/ledger.yaml
@@ -55,7 +55,7 @@ items:
     regression_guard:
       - tests/test_protected_branch_authority.py
     gaps:
-      - "GitHub-native branch protection / required checks should remain independently enforced where available"
+      - "GitHub reports main as protected=false with no required checks; repository-native enforcement remains missing"
 
   - id: role-registry-and-inheritance
     owner: governance.spec_steward
@@ -76,33 +76,33 @@ items:
 
   - id: agent-employee-runtime
     owner: governance.spec_steward
-    stage: DISCOVERED
-    implementation: []
+    stage: IMPLEMENTED
+    implementation:
+      - agent_core/employee_runtime.py
+      - tests/test_employee_runtime.py
     integration_evidence: []
     verification_evidence: []
     operating_evidence: []
     regression_guard: []
     gaps:
-      - "durable AgentInstance identity"
-      - "per-agent memory namespace"
-      - "assignment and activation runtime"
-      - "agent-to-agent inbox/outbox messaging"
-      - "handoff and lifecycle closure"
-      - "executor binding independent of employee identity"
+      - "role inheritance is referenced by role_ids but not yet machine-hydrated into an effective employee contract"
+      - "skill_ids are durable references but skill loading/execution is not yet integrated"
+      - "first live Spec Steward assignment/receipt has not run"
+      - "agent-to-agent message transport is durable local storage only; Realm/cross-node transport not integrated"
+      - "Cognitive Thread return stack is not yet integrated into assignment state"
 
   - id: per-agent-durable-memory
     owner: governance.spec_steward
-    stage: SPECIFIED
+    stage: IMPLEMENTED
     implementation:
-      - .agent/roles/parents/
-    integration_evidence:
-      - agent_core/memory_router.py
+      - agent_core/employee_runtime.py
+    integration_evidence: []
     verification_evidence: []
     operating_evidence: []
     regression_guard: []
     gaps:
-      - "current memory router is project-scoped rather than employee-scoped"
-      - "role Memory Scope declarations are not equivalent to durable per-agent memory"
+      - "employee-scoped memory namespace now exists, but no memory consolidation/retrieval policy is integrated"
+      - "role Memory Scope declarations are not yet enforced against employee memory access"
 
   - id: responsibility-resolution
     owner: governance.keeper
@@ -143,7 +143,7 @@ items:
     operating_evidence: []
     regression_guard: []
     gaps:
-      - "not integrated into continuation_state runtime"
+      - "not integrated into EmployeeRuntime assignment state"
       - "cross-model thread-return experiment missing"
 
   - id: capability-learning-loop
@@ -187,16 +187,33 @@ items:
 
   - id: closure-audit
     owner: governance.spec_steward
-    stage: IMPLEMENTED
+    stage: GUARDED
     implementation:
       - .agent/closure/ledger.yaml
       - scripts/closure_audit.py
     integration_evidence:
       - docs/CLOSURE_REALITY.md
+      - .github/workflows/closure-audit.yml
     verification_evidence:
       - tests/test_closure_audit.py
-    operating_evidence: []
+      - "Closure Audit workflow run #1 on PR #16: success"
+    operating_evidence:
+      - "PR #16 closure ledger audit executed successfully in GitHub Actions"
     regression_guard:
       - tests/test_closure_audit.py
+      - .github/workflows/closure-audit.yml
     gaps:
-      - "promote to GUARDED only after CI evidence exists"
+      - "automatic recurring steward assignment generation is not yet implemented"
+
+  - id: repository-native-main-protection
+    owner: governance.keeper
+    stage: DISCOVERED
+    implementation: []
+    integration_evidence: []
+    verification_evidence:
+      - "GitHub branch metadata on 2026-08-27: main protected=false, required status checks empty"
+    operating_evidence: []
+    regression_guard: []
+    gaps:
+      - "enable native branch/ruleset protection for main"
+      - "require relevant CI checks independently of AgentOS policy"

--- a/.github/workflows/closure-audit.yml
+++ b/.github/workflows/closure-audit.yml
@@ -4,18 +4,24 @@ on:
   pull_request:
     paths:
       - '.agent/closure/**'
+      - 'agent_core/employee_runtime.py'
       - 'scripts/closure_audit.py'
       - 'tests/test_closure_audit.py'
+      - 'tests/test_employee_runtime.py'
       - 'docs/CLOSURE_REALITY.md'
+      - 'docs/closure/**'
       - '.github/workflows/closure-audit.yml'
   push:
     branches:
       - main
     paths:
       - '.agent/closure/**'
+      - 'agent_core/employee_runtime.py'
       - 'scripts/closure_audit.py'
       - 'tests/test_closure_audit.py'
+      - 'tests/test_employee_runtime.py'
       - 'docs/CLOSURE_REALITY.md'
+      - 'docs/closure/**'
       - '.github/workflows/closure-audit.yml'
 
 jobs:
@@ -31,3 +37,5 @@ jobs:
         run: python3 scripts/closure_audit.py --summary
       - name: Run closure audit regression tests
         run: python3 -m unittest tests.test_closure_audit -v
+      - name: Run employee runtime regression tests
+        run: python3 -m unittest tests.test_employee_runtime -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Before architecture or system-level changes:
 1. `README.md` — current product goal and public architecture.
 2. `docs/CURRENT_STATE.md` — canonical map of **Implemented / Verified / Research** capabilities.
 3. `docs/AGENTOS_NODE.md` — responsibility/resource discovery contract for cross-project work.
-4. `.agent/CONSTITUTION.yaml` and relevant governance/role sources when authority or policy is involved.
+4. `.agent/closure/ledger.yaml` — current Closure Reality for partially completed capabilities.
+5. `.agent/CONSTITUTION.yaml` and relevant governance/role sources when authority or policy is involved.
 
 Do not rely on older memory/pulse-era documents as current architecture if they disagree with `docs/CURRENT_STATE.md` and executable evidence.
 
@@ -24,7 +25,10 @@ AgentOS currently contains, among other components:
 - resource/world-state registry;
 - Realm cross-node execution surfaces;
 - platform runtime drivers;
-- operational evidence and drift guards.
+- operational evidence and drift guards;
+- a minimal employee-runtime slice for durable AgentInstance identity, employee-scoped memory namespace, assignment state, executor rebinding, and local durable agent messaging.
+
+The employee-runtime slice is **not yet a closed multi-agent organization runtime**. Role inheritance/skill hydration, live Spec Steward operation, cross-node messaging, and Cognitive Thread integration still require evidence.
 
 The model-independent **Cognitive IR / zero-cost arbitrary model switching** layer is still research unless and until a repeatable benchmark proves it.
 
@@ -36,6 +40,8 @@ The model-independent **Cognitive IR / zero-cost arbitrary model switching** lay
 - Evidence and tool results do not silently rewrite user intent.
 - Claims in documentation must be backed by implementation paths; verified claims also need tests/evidence.
 - **Capability does not imply authority.** A tool being available or a PR being mergeable does not authorize a protected-branch mutation.
+- **Implementation does not imply closure.** Use `.agent/closure/ledger.yaml`; do not describe a capability as operating/guarded/closed without the evidence required for that stage.
+- **No silent park.** Important deferred work must retain owner, stage, gaps, and a return/validation condition in durable state.
 
 ## Protected Branch Authority Rule
 
@@ -75,12 +81,28 @@ python3 scripts/documentation_reality_guard.py
 
 CI enforces the same rule. Treat a documentation-drift failure as an architecture regression, not optional cleanup.
 
+## Closure Reality Rule
+
+Run:
+
+```bash
+python3 scripts/closure_audit.py --summary
+```
+
+Lifecycle stages are:
+
+`DISCOVERED -> SPECIFIED -> PROTOTYPED -> IMPLEMENTED -> INTEGRATED -> VERIFIED -> OPERATING -> GUARDED -> CLOSED`
+
+Do not skip evidence gates. In particular, a unit test does not by itself prove `OPERATING`, and a successful live run does not by itself prove `GUARDED`.
+
 ## Useful verification
 
 ```bash
 python3 scripts/continuation_state.py --self-test
 python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
 python3 -m unittest tests.test_protected_branch_authority -v
+python3 -m unittest tests.test_employee_runtime -v
+python3 scripts/closure_audit.py --summary
 python3 scripts/documentation_reality_guard.py
 ```
 

--- a/agent_core/employee_runtime.py
+++ b/agent_core/employee_runtime.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+VALID_ASSIGNMENT_STATES = {"pending", "active", "blocked", "handoff", "completed", "cancelled"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_id(value: str) -> str:
+    value = value.strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError(f"unsafe id: {value!r}")
+    return value
+
+
+def _atomic_json_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return dict(default)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object in {path}")
+    return data
+
+
+@dataclass(slots=True)
+class ExecutorBinding:
+    provider: str = "unbound"
+    model: str = ""
+    session_id: str = ""
+    bound_at: str = ""
+
+
+@dataclass(slots=True)
+class AgentInstance:
+    agent_id: str
+    display_name: str
+    role_ids: list[str] = field(default_factory=list)
+    skill_ids: list[str] = field(default_factory=list)
+    memory_namespace: str = ""
+    executor: ExecutorBinding = field(default_factory=ExecutorBinding)
+    status: str = "available"
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class Assignment:
+    assignment_id: str
+    goal: str
+    employee_id: str
+    state: str = "pending"
+    parent_assignment_id: str | None = None
+    thread_head: str = ""
+    constraints: list[str] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class AgentMessage:
+    message_id: str
+    sender_id: str
+    recipient_id: str
+    subject: str
+    payload: dict[str, Any]
+    assignment_id: str | None = None
+    created_at: str = ""
+    read_at: str = ""
+
+
+class EmployeeRuntime:
+    """Minimal durable employee kernel.
+
+    Agent identity and working ownership live outside any LLM/provider. An executor
+    binding can be replaced without replacing the employee or its durable state.
+    This module intentionally implements mechanics only; role intelligence remains
+    in role/skill contracts and higher-level orchestrators.
+    """
+
+    def __init__(self, data_root: str | Path | None = None) -> None:
+        root = data_root or os.environ.get("AGENT_DATA_ROOT") or "/home/ubuntu/agent-data"
+        self.root = Path(root).expanduser().resolve() / "employees"
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _employee_dir(self, agent_id: str) -> Path:
+        return self.root / _safe_id(agent_id)
+
+    def _employee_path(self, agent_id: str) -> Path:
+        return self._employee_dir(agent_id) / "employee.json"
+
+    def _assignments_path(self, agent_id: str) -> Path:
+        return self._employee_dir(agent_id) / "assignments.json"
+
+    def _inbox_path(self, agent_id: str) -> Path:
+        return self._employee_dir(agent_id) / "inbox.json"
+
+    def _outbox_path(self, agent_id: str) -> Path:
+        return self._employee_dir(agent_id) / "outbox.json"
+
+    def memory_dir(self, agent_id: str) -> Path:
+        path = self._employee_dir(agent_id) / "memory"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def register_employee(self, agent_id: str, *, display_name: str, role_ids: list[str] | None = None, skill_ids: list[str] | None = None, replace: bool = False) -> AgentInstance:
+        agent_id = _safe_id(agent_id)
+        path = self._employee_path(agent_id)
+        if path.exists() and not replace:
+            raise ValueError(f"employee already exists: {agent_id}")
+        now = _now()
+        existing = self.get_employee(agent_id) if path.exists() else None
+        employee = AgentInstance(agent_id=agent_id, display_name=display_name, role_ids=list(role_ids or []), skill_ids=list(skill_ids or []), memory_namespace=f"employees/{agent_id}/memory", executor=existing.executor if existing else ExecutorBinding(), status=existing.status if existing else "available", created_at=existing.created_at if existing else now, updated_at=now)
+        _atomic_json_write(path, asdict(employee))
+        self.memory_dir(agent_id)
+        return employee
+
+    def get_employee(self, agent_id: str) -> AgentInstance | None:
+        path = self._employee_path(agent_id)
+        if not path.exists():
+            return None
+        data = _read_json(path, {})
+        executor = ExecutorBinding(**(data.pop("executor", {}) or {}))
+        return AgentInstance(executor=executor, **data)
+
+    def bind_executor(self, agent_id: str, *, provider: str, model: str = "", session_id: str = "") -> AgentInstance:
+        employee = self._require_employee(agent_id)
+        employee.executor = ExecutorBinding(provider=provider, model=model, session_id=session_id, bound_at=_now())
+        employee.updated_at = _now()
+        _atomic_json_write(self._employee_path(agent_id), asdict(employee))
+        return employee
+
+    def create_assignment(self, assignment_id: str, *, employee_id: str, goal: str, constraints: list[str] | None = None, parent_assignment_id: str | None = None, thread_head: str = "") -> Assignment:
+        employee_id = _safe_id(employee_id)
+        assignment_id = _safe_id(assignment_id)
+        self._require_employee(employee_id)
+        data = _read_json(self._assignments_path(employee_id), {"items": {}})
+        items = data.setdefault("items", {})
+        if assignment_id in items:
+            raise ValueError(f"assignment already exists: {assignment_id}")
+        now = _now()
+        assignment = Assignment(assignment_id=assignment_id, goal=goal, employee_id=employee_id, parent_assignment_id=parent_assignment_id, thread_head=thread_head, constraints=list(constraints or []), created_at=now, updated_at=now)
+        items[assignment_id] = asdict(assignment)
+        _atomic_json_write(self._assignments_path(employee_id), data)
+        return assignment
+
+    def get_assignment(self, employee_id: str, assignment_id: str) -> Assignment | None:
+        data = _read_json(self._assignments_path(employee_id), {"items": {}})
+        raw = data.get("items", {}).get(assignment_id)
+        return Assignment(**raw) if raw else None
+
+    def set_assignment_state(self, employee_id: str, assignment_id: str, state: str, *, thread_head: str | None = None, result: dict[str, Any] | None = None) -> Assignment:
+        if state not in VALID_ASSIGNMENT_STATES:
+            raise ValueError(f"invalid assignment state: {state}")
+        data = _read_json(self._assignments_path(employee_id), {"items": {}})
+        raw = data.get("items", {}).get(assignment_id)
+        if not raw:
+            raise KeyError(assignment_id)
+        raw["state"] = state
+        raw["updated_at"] = _now()
+        if thread_head is not None:
+            raw["thread_head"] = thread_head
+        if result is not None:
+            raw["result"] = result
+        data["items"][assignment_id] = raw
+        _atomic_json_write(self._assignments_path(employee_id), data)
+        return Assignment(**raw)
+
+    def send_message(self, message_id: str, *, sender_id: str, recipient_id: str, subject: str, payload: dict[str, Any], assignment_id: str | None = None) -> AgentMessage:
+        message_id = _safe_id(message_id)
+        self._require_employee(sender_id)
+        self._require_employee(recipient_id)
+        now = _now()
+        message = AgentMessage(message_id=message_id, sender_id=sender_id, recipient_id=recipient_id, subject=subject, payload=dict(payload), assignment_id=assignment_id, created_at=now)
+        self._append_message(self._outbox_path(sender_id), message)
+        self._append_message(self._inbox_path(recipient_id), message)
+        return message
+
+    def list_inbox(self, agent_id: str) -> list[AgentMessage]:
+        self._require_employee(agent_id)
+        data = _read_json(self._inbox_path(agent_id), {"items": []})
+        return [AgentMessage(**item) for item in data.get("items", [])]
+
+    def _append_message(self, path: Path, message: AgentMessage) -> None:
+        data = _read_json(path, {"items": []})
+        items = data.setdefault("items", [])
+        if any(item.get("message_id") == message.message_id for item in items):
+            raise ValueError(f"message already exists: {message.message_id}")
+        items.append(asdict(message))
+        _atomic_json_write(path, data)
+
+    def _require_employee(self, agent_id: str) -> AgentInstance:
+        employee = self.get_employee(agent_id)
+        if employee is None:
+            raise KeyError(agent_id)
+        return employee

--- a/docs/closure/RECOVERY_WAVE_1.md
+++ b/docs/closure/RECOVERY_WAVE_1.md
@@ -1,0 +1,86 @@
+# AgentOS Closure Recovery Wave 1
+
+Status: active audit / execution checkpoint
+Date: 2026-08-27
+
+## Why this wave exists
+
+The first Closure Ledger proved that AgentOS has a recurring pattern: architecture ideas, role contracts, skills, prototypes, and partial runtimes can survive in the repository while the final operating loop disappears or is never completed. This wave converts that inventory into an execution order.
+
+## Priority rule
+
+Prioritize gaps that unblock multiple other capabilities. Do not add another abstraction if an existing role, skill, resolver, or runtime can be recovered and completed instead.
+
+## P0 — Agent Organization / Employee Runtime
+
+Existing evidence already proves:
+
+- Root / parent-role inheritance exists.
+- Role contracts and role registry exist.
+- Skills exist, including publishing/deployment skills.
+- Governance Directory can resolve owners/providers.
+- Project-scoped durable memory exists.
+
+What is not yet closed:
+
+- durable `AgentInstance` identity;
+- employee-scoped memory namespace;
+- assignment and activation lifecycle;
+- agent-to-agent inbox/outbox or equivalent message transport;
+- handoff / completion receipts at employee scope;
+- executor binding that can change model/provider without changing employee identity.
+
+### Minimal acceptance loop
+
+Do not attempt a full multi-agent company first. Prove one employee:
+
+`assignment -> resolve employee -> hydrate inherited role + skills + employee state -> execute/handoff -> receipt -> assignment state update`
+
+Use `governance.spec_steward` as the first reference employee because the role already exists and naturally owns closure-gap tracking.
+
+## P0 — Closure Steward becomes operating
+
+The Closure Ledger must not become another passive document. `governance.spec_steward` should eventually consume it, identify non-terminal items, create/refresh assignments, and emit receipts showing what moved, remained blocked, or was explicitly deferred.
+
+Until that runtime exists, closure management is still human/LLM-triggered rather than continuously operating.
+
+## P1 — Cognitive Thread / HEAD / Return Stack
+
+Treat this as working-assignment state inside the Employee Runtime, not as a parallel organization system.
+
+Required later evidence:
+
+- nested topic diversion preserves parent HEAD;
+- explicit return restores the parent assignment position;
+- stale events cannot roll back a newer thread HEAD;
+- cross-model hydration preserves the same active thread and return path.
+
+## P1 — Chronicle / writing / publishing loop
+
+Do not invent duplicate Writer/Publisher infrastructure before recovering existing capabilities.
+
+Known pieces already exist:
+
+- Chronicler role contract is proposed;
+- Matters Publisher skill is implemented;
+- Zeus-writer has real three-projection content that needs chronicle synchronization.
+
+After the employee kernel exists, use Zeus-writer as the first multi-role collaboration case:
+
+`Chronicler -> Weaver/Writer responsibility -> Claw review -> publisher skill -> human authorization for public release`
+
+## P1 — Capability learning loop
+
+Keep LayoutLib as the first reference domain, but require the same Closure Ledger gates. The target is still one end-to-end receipt-backed loop from execution evidence through governed canonical learning and fresh-node reuse.
+
+## Repository-native governance gap
+
+After Closure Audit PR #16 was merged, `main` advanced to commit `ba31e3625f57b5b8bfb0ea1f506ed90beaad7555`. GitHub still reports `main` as `protected: false` with no required status checks.
+
+This does not prove the later commit was unauthorized, but it proves AgentOS policy is not backed by an independent repository-native enforcement layer. `protected-branch-authority` therefore remains `GUARDED`, not `CLOSED`.
+
+## Completion discipline for this wave
+
+A work item may move forward only with evidence for the new stage. No item becomes `OPERATING`, `GUARDED`, or `CLOSED` because a design document says it should.
+
+This wave should stop and ask for human authorization before any merge to `main`.

--- a/tests/test_employee_runtime.py
+++ b/tests/test_employee_runtime.py
@@ -1,0 +1,102 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+class EmployeeRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.runtime = EmployeeRuntime(Path(self.temp.name))
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_employee_identity_survives_executor_rebind(self):
+        employee = self.runtime.register_employee(
+            "spec-steward-1",
+            display_name="Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["task_architect"],
+        )
+        self.assertEqual(employee.memory_namespace, "employees/spec-steward-1/memory")
+
+        first = self.runtime.bind_executor(
+            "spec-steward-1",
+            provider="openai",
+            model="gpt-a",
+            session_id="session-a",
+        )
+        second = self.runtime.bind_executor(
+            "spec-steward-1",
+            provider="google",
+            model="gemini-b",
+            session_id="session-b",
+        )
+
+        self.assertEqual(first.agent_id, second.agent_id)
+        self.assertEqual(second.role_ids, ["governance.spec_steward"])
+        self.assertEqual(second.memory_namespace, "employees/spec-steward-1/memory")
+        self.assertEqual(second.executor.provider, "google")
+
+    def test_assignment_head_and_state_are_durable(self):
+        self.runtime.register_employee("spec-steward-1", display_name="Spec Steward")
+        self.runtime.create_assignment(
+            "closure-review",
+            employee_id="spec-steward-1",
+            goal="Review closure gaps",
+            thread_head="ledger loaded",
+        )
+        updated = self.runtime.set_assignment_state(
+            "spec-steward-1",
+            "closure-review",
+            "active",
+            thread_head="agent employee runtime selected as P0",
+        )
+
+        reloaded = EmployeeRuntime(Path(self.temp.name)).get_assignment("spec-steward-1", "closure-review")
+        self.assertEqual(updated.state, "active")
+        self.assertEqual(reloaded.thread_head, "agent employee runtime selected as P0")
+
+    def test_agent_to_agent_message_is_written_to_both_mailboxes(self):
+        self.runtime.register_employee("steward", display_name="Steward")
+        self.runtime.register_employee("paw", display_name="Paw")
+
+        self.runtime.send_message(
+            "msg-1",
+            sender_id="steward",
+            recipient_id="paw",
+            subject="Implement assignment",
+            payload={"goal": "Build employee runtime"},
+            assignment_id="employee-runtime",
+        )
+
+        inbox = self.runtime.list_inbox("paw")
+        self.assertEqual(len(inbox), 1)
+        self.assertEqual(inbox[0].sender_id, "steward")
+        self.assertEqual(inbox[0].assignment_id, "employee-runtime")
+
+    def test_assignment_can_close_with_receipt_like_result(self):
+        self.runtime.register_employee("paw", display_name="Paw")
+        self.runtime.create_assignment(
+            "impl-1",
+            employee_id="paw",
+            goal="Implement minimal runtime",
+        )
+        completed = self.runtime.set_assignment_state(
+            "paw",
+            "impl-1",
+            "completed",
+            result={"receipt": "tests-passed", "artifacts": ["agent_core/employee_runtime.py"]},
+        )
+        self.assertEqual(completed.state, "completed")
+        self.assertEqual(completed.result["receipt"], "tests-passed")
+
+    def test_unsafe_ids_are_rejected(self):
+        with self.assertRaises(ValueError):
+            self.runtime.register_employee("../escape", display_name="bad")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Use the new Closure Ledger to close the highest-leverage regression first: AgentOS still has role contracts, inheritance, skills and responsibility resolution, but lacked a durable employee lifecycle kernel.

## Adds

- `agent_core/employee_runtime.py`
  - durable `AgentInstance` identity independent of model/provider
  - employee-scoped memory namespace
  - durable assignments with state + thread head
  - executor rebinding without replacing employee identity
  - local durable inbox/outbox messaging
  - receipt-like assignment results
- `tests/test_employee_runtime.py`
- `docs/closure/RECOVERY_WAVE_1.md`
- Closure Audit CI now runs employee-runtime regression tests
- Closure Ledger advances `agent-employee-runtime` and `per-agent-durable-memory` only to `IMPLEMENTED`, not beyond the evidence
- Closure Audit itself advances to `GUARDED` based on successful PR #16 CI evidence
- records missing GitHub-native `main` protection as a separate discovered gap

## Explicit non-claims

This does **not** claim the multi-agent organization is restored or operating. Still missing: machine-hydrated role inheritance/skills, live Spec Steward assignments, cross-node messaging, role-scoped memory policy, Cognitive Thread return stack, and real operating receipts.

## Governance

This PR must stop at `AWAITING_HUMAN_APPROVAL` after CI is green. Do not merge on mergeability alone.