### PR TITLE
feat(social): add governed AgentOS social capability

### DIFF
--- a/.agentos/commands/social-runtime-bootstrap.json
+++ b/.agentos/commands/social-runtime-bootstrap.json
@@ -1,0 +1,5 @@
+{
+  "schema": "agentos.social-runtime-command/v0.1",
+  "action": "social.runtime.bootstrap",
+  "nonce": "instagram-identity-discovery-20260827"
+}

--- a/.agentos/evidence/social-runtime-bootstrap-current.json
+++ b/.agentos/evidence/social-runtime-bootstrap-current.json
@@ -1,0 +1,57 @@
+{
+  "credential_refs": [
+    "facebook/default",
+    "instagram/default",
+    "threads/default"
+  ],
+  "credential_store": "/home/agentos-node/.agentos/social-credentials.json",
+  "credential_store_mode": "0o600",
+  "executor": "/home/agentos-node/.local/bin/agentos-social",
+  "executor_present": true,
+  "identity_probes": {
+    "facebook": {
+      "receipt": {
+        "credential_ref": "facebook/default",
+        "observed_at": "2026-08-27T05:14:20Z",
+        "ok": true,
+        "operation": "identity",
+        "platform": "facebook",
+        "platform_object_id": "814025338452355",
+        "result": {
+          "name": "\u65ed\u6f6d\u5e7b\u5883"
+        },
+        "schema": "agentos.social.publish-receipt/v0.1"
+      },
+      "returncode": 0
+    },
+    "instagram": {
+      "receipt": {
+        "credential_ref": "instagram/default",
+        "error_code": "invalid_request",
+        "error_message": "Instagram identity requires ig_id in args or credential metadata",
+        "observed_at": "2026-08-27T05:14:20Z",
+        "ok": false,
+        "operation": "identity",
+        "platform": "instagram",
+        "schema": "agentos.social.publish-receipt/v0.1"
+      },
+      "returncode": 2
+    },
+    "threads": {
+      "receipt": {
+        "credential_ref": "threads/default",
+        "error_code": "platform_http_error",
+        "error_message": "HTTP 400: {\"error\":{\"message\":\"Error validating access token: Session has expired on Tuesday, 23-Jun-26 01:33:13 PDT. The current time is Wednesday, 26-Aug-26 22:14:19 PDT.\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":0,\"fbtrace_id\":\"AmBOR7G_bLxUmABHje4KKBG\"}}",
+        "observed_at": "2026-08-27T05:14:19Z",
+        "ok": false,
+        "operation": "identity",
+        "platform": "threads",
+        "schema": "agentos.social.publish-receipt/v0.1"
+      },
+      "returncode": 2
+    }
+  },
+  "schema": "agentos.social-runtime-bootstrap/v0.1",
+  "secret_values_collected_in_evidence": false,
+  "write_operations_performed": false
+}

--- a/.agentos/evidence/social-runtime-bootstrap-current.json
+++ b/.agentos/evidence/social-runtime-bootstrap-current.json
@@ -12,7 +12,7 @@
     "facebook": {
       "receipt": {
         "credential_ref": "facebook/default",
-        "observed_at": "2026-08-27T05:14:20Z",
+        "observed_at": "2026-08-27T05:17:33Z",
         "ok": true,
         "operation": "identity",
         "platform": "facebook",
@@ -27,22 +27,25 @@
     "instagram": {
       "receipt": {
         "credential_ref": "instagram/default",
-        "error_code": "invalid_request",
-        "error_message": "Instagram identity requires ig_id in args or credential metadata",
-        "observed_at": "2026-08-27T05:14:20Z",
-        "ok": false,
+        "observed_at": "2026-08-27T05:17:34Z",
+        "ok": true,
         "operation": "identity",
         "platform": "instagram",
+        "platform_object_id": "17841451767627377",
+        "result": {
+          "discovery": "facebook_page",
+          "username": "oursong_alstonhuang"
+        },
         "schema": "agentos.social.publish-receipt/v0.1"
       },
-      "returncode": 2
+      "returncode": 0
     },
     "threads": {
       "receipt": {
         "credential_ref": "threads/default",
         "error_code": "platform_http_error",
-        "error_message": "HTTP 400: {\"error\":{\"message\":\"Error validating access token: Session has expired on Tuesday, 23-Jun-26 01:33:13 PDT. The current time is Wednesday, 26-Aug-26 22:14:19 PDT.\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":0,\"fbtrace_id\":\"AmBOR7G_bLxUmABHje4KKBG\"}}",
-        "observed_at": "2026-08-27T05:14:19Z",
+        "error_message": "HTTP 400: {\"error\":{\"message\":\"Error validating access token: Session has expired on Tuesday, 23-Jun-26 01:33:13 PDT. The current time is Wednesday, 26-Aug-26 22:17:33 PDT.\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":0,\"fbtrace_id\":\"AheB5OnsTkO49v8HdEKkuHJ\"}}",
+        "observed_at": "2026-08-27T05:17:33Z",
         "ok": false,
         "operation": "identity",
         "platform": "threads",

--- a/.agentos/evidence/social-runtime-inventory-current.json
+++ b/.agentos/evidence/social-runtime-inventory-current.json
@@ -23,5 +23,21 @@
   "schema": "agentos.social-runtime-inventory/v0.1",
   "secret_values_collected": false,
   "zeus_directories": [],
-  "zeus_env_files": []
+  "zeus_env_files": [
+    {
+      "exists": true,
+      "mode": "0o664",
+      "owner": {
+        "gid": 1005,
+        "uid": 1001
+      },
+      "path": "/home/ubuntu/agent-data/secrets/zeus-writer.env",
+      "relevant_key_names": [
+        "SOC_FB_PAGE_ID",
+        "SOC_FB_TOKEN",
+        "SOC_IG_TOKEN",
+        "SOC_THREADS_TOKEN"
+      ]
+    }
+  ]
 }

--- a/.agentos/evidence/social-runtime-inventory-current.json
+++ b/.agentos/evidence/social-runtime-inventory-current.json
@@ -1,0 +1,27 @@
+{
+  "agentos_social": null,
+  "credential_stores": [
+    {
+      "credential_refs": null,
+      "exists": false,
+      "mode": null,
+      "owner": null,
+      "path": "/home/ubuntu/.agentos/social-credentials.json"
+    },
+    {
+      "credential_refs": null,
+      "exists": false,
+      "mode": null,
+      "owner": null,
+      "path": "/home/agentos-node/.agentos/social-credentials.json"
+    }
+  ],
+  "runner": {
+    "home": "/home/agentos-node",
+    "user": "agentos-node"
+  },
+  "schema": "agentos.social-runtime-inventory/v0.1",
+  "secret_values_collected": false,
+  "zeus_directories": [],
+  "zeus_env_files": []
+}

--- a/.agentos/evidence/threads-oauth-inventory-current.json
+++ b/.agentos/evidence/threads-oauth-inventory-current.json
@@ -1,0 +1,8 @@
+{
+  "matching_key_names": [
+    "SOC_THREADS_TOKEN"
+  ],
+  "schema": "agentos.threads-oauth-inventory/v0.1",
+  "source_exists": true,
+  "values_collected": false
+}

--- a/.agentos/evidence/threads-oauth-secret-scan-current.json
+++ b/.agentos/evidence/threads-oauth-secret-scan-current.json
@@ -1,0 +1,21 @@
+{
+  "matches": [
+    {
+      "file": "global.env",
+      "matching_key_names": [
+        "SOC_THREADS_TOKEN"
+      ],
+      "mode": "0o664"
+    },
+    {
+      "file": "zeus-writer.env",
+      "matching_key_names": [
+        "SOC_THREADS_TOKEN"
+      ],
+      "mode": "0o664"
+    }
+  ],
+  "schema": "agentos.threads-oauth-secret-scan/v0.1",
+  "secret_root_exists": true,
+  "values_collected": false
+}

--- a/.github/workflows/social-capability-ci.yml
+++ b/.github/workflows/social-capability-ci.yml
@@ -1,0 +1,46 @@
+name: Social Capability CI
+
+on:
+  push:
+    branches:
+      - feature/social-capability
+    paths:
+      - 'agentos_node/social_capability.py'
+      - 'agentos_node/social_cli.py'
+      - 'tests/test_social_capability.py'
+      - 'pyproject.toml'
+      - '.github/workflows/social-capability-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'agentos_node/social_capability.py'
+      - 'agentos_node/social_cli.py'
+      - 'tests/test_social_capability.py'
+      - 'pyproject.toml'
+      - '.github/workflows/social-capability-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install package and test dependency
+        run: python -m pip install -e . pytest
+      - name: Verify CLI is installed
+        run: agentos-social --help >/dev/null
+      - name: Run social capability tests
+        run: python -m pytest -q tests/test_social_capability.py
+      - name: Secret boundary static guard
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          text = Path('agentos_node/social_capability.py').read_text(encoding='utf-8')
+          assert 'receipt["access_token"]' not in text
+          assert "receipt['access_token']" not in text
+          assert 'raw credential' in text
+          PY

--- a/.github/workflows/social-capability-ci.yml
+++ b/.github/workflows/social-capability-ci.yml
@@ -38,9 +38,25 @@ jobs:
       - name: Secret boundary static guard
         run: |
           python - <<'PY'
+          import ast
           from pathlib import Path
-          text = Path('agentos_node/social_capability.py').read_text(encoding='utf-8')
-          assert 'receipt["access_token"]' not in text
-          assert "receipt['access_token']" not in text
-          assert 'raw credential' in text
+
+          path = Path('agentos_node/social_capability.py')
+          source = path.read_text(encoding='utf-8')
+          tree = ast.parse(source)
+
+          # The receipt constructor itself must not expose a secret-bearing argument.
+          receipt = next(
+              node for node in ast.walk(tree)
+              if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == '_receipt'
+          )
+          argument_names = {
+              arg.arg for arg in [*receipt.args.posonlyargs, *receipt.args.args, *receipt.args.kwonlyargs]
+          }
+          forbidden_arguments = {'access_token', 'token', 'client_secret', 'app_secret', 'credential_values'}
+          assert argument_names.isdisjoint(forbidden_arguments), argument_names & forbidden_arguments
+
+          # No direct assignment of access_token into a receipt mapping is allowed.
+          assert 'receipt["access_token"]' not in source
+          assert "receipt['access_token']" not in source
           PY

--- a/.github/workflows/social-runtime-bootstrap.yml
+++ b/.github/workflows/social-runtime-bootstrap.yml
@@ -1,0 +1,193 @@
+name: Social Runtime Bootstrap
+
+on:
+  push:
+    branches:
+      - feature/social-capability
+    paths:
+      - '.agentos/commands/social-runtime-bootstrap.json'
+      - '.github/workflows/social-runtime-bootstrap.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: social-runtime-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    if: github.actor == 'alstonhuang'
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feature/social-capability
+
+      - name: Install feature executor without exposing credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT=/home/agentos-node/.local/share/agentos-social
+          BIN=/home/agentos-node/.local/bin
+          install -d -m 0755 "$ROOT/src" "$BIN"
+          rm -rf "$ROOT/src/agentos_node"
+          cp -a agentos_node "$ROOT/src/agentos_node"
+          cat > "$BIN/agentos-social" <<'SH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export PYTHONPATH=/home/agentos-node/.local/share/agentos-social/src${PYTHONPATH:+:$PYTHONPATH}
+          exec python3 -m agentos_node.social_cli "$@"
+          SH
+          chmod 0755 "$BIN/agentos-social"
+          "$BIN/agentos-social" --help >/dev/null
+
+      - name: Migrate legacy values to executor-local credential references
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          source = Path('/home/ubuntu/agent-data/secrets/zeus-writer.env')
+          target = Path('/home/agentos-node/.agentos/social-credentials.json')
+          if not source.is_file():
+              raise SystemExit('legacy Zeus credential source is missing')
+
+          values = {}
+          for raw in source.read_text(encoding='utf-8', errors='replace').splitlines():
+              line = raw.strip()
+              if not line or line.startswith('#') or '=' not in line:
+                  continue
+              key, value = line.split('=', 1)
+              values[key.strip()] = value.strip().strip('"').strip("'")
+
+          refs = {}
+          threads = values.get('SOC_THREADS_TOKEN') or values.get('THREADS_ACCESS_TOKEN')
+          if threads:
+              refs['threads/default'] = {'platform': 'threads', 'access_token': threads}
+
+          fb = values.get('SOC_FB_TOKEN')
+          if fb:
+              item = {'platform': 'facebook', 'access_token': fb}
+              if values.get('SOC_FB_PAGE_ID'):
+                  item['page_id'] = values['SOC_FB_PAGE_ID']
+              refs['facebook/default'] = item
+
+          ig = values.get('SOC_IG_TOKEN')
+          if ig:
+              item = {'platform': 'instagram', 'access_token': ig}
+              if values.get('SOC_FB_PAGE_ID'):
+                  item['page_id'] = values['SOC_FB_PAGE_ID']
+              if values.get('SOC_IG_ID'):
+                  item['ig_id'] = values['SOC_IG_ID']
+              refs['instagram/default'] = item
+
+          if not refs:
+              raise SystemExit('no supported social credentials found in legacy source')
+
+          target.parent.mkdir(parents=True, exist_ok=True)
+          tmp = target.with_suffix('.tmp')
+          fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+          with os.fdopen(fd, 'w', encoding='utf-8') as f:
+              json.dump(refs, f, indent=2, sort_keys=True)
+              f.write('\n')
+          os.chmod(tmp, 0o600)
+          os.replace(tmp, target)
+          os.chmod(target, 0o600)
+
+          print('credential_store_created=true')
+          print('credential_refs=' + ','.join(sorted(refs)))
+          print('secret_values_printed=false')
+          PY
+
+      - name: Run read-only identity probes
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          python3 - <<'PY'
+          import json
+          import os
+          import stat
+          import subprocess
+          from pathlib import Path
+
+          store = Path('/home/agentos-node/.agentos/social-credentials.json')
+          refs = json.loads(store.read_text(encoding='utf-8'))
+          secrets = [str(v.get('access_token') or '') for v in refs.values() if isinstance(v, dict)]
+          exe = '/home/agentos-node/.local/bin/agentos-social'
+
+          def probe(platform, ref, extra=None):
+              cmd = [exe, platform, 'identity', '--credential', ref]
+              if extra:
+                  cmd += extra
+              p = subprocess.run(cmd, text=True, capture_output=True, timeout=40, check=False)
+              raw = (p.stdout.strip().splitlines() or ['{}'])[-1]
+              for secret in secrets:
+                  if secret:
+                      raw = raw.replace(secret, '[REDACTED]')
+              try:
+                  receipt = json.loads(raw)
+              except json.JSONDecodeError:
+                  receipt = {
+                      'schema': 'agentos.social.publish-receipt/v0.1',
+                      'ok': False,
+                      'platform': platform,
+                      'operation': 'identity',
+                      'credential_ref': ref,
+                      'error_code': 'invalid_executor_output',
+                  }
+              # Do not persist stderr; a third-party failure body is unnecessary evidence.
+              return {'returncode': p.returncode, 'receipt': receipt}
+
+          results = {}
+          if 'threads/default' in refs:
+              results['threads'] = probe('threads', 'threads/default')
+          if 'facebook/default' in refs:
+              extra = []
+              page_id = refs['facebook/default'].get('page_id')
+              if page_id:
+                  extra = ['--page-id', str(page_id)]
+              results['facebook'] = probe('facebook', 'facebook/default', extra)
+          if 'instagram/default' in refs:
+              extra = []
+              page_id = refs['instagram/default'].get('page_id')
+              ig_id = refs['instagram/default'].get('ig_id')
+              if page_id:
+                  extra += ['--page-id', str(page_id)]
+              if ig_id:
+                  extra += ['--ig-id', str(ig_id)]
+              results['instagram'] = probe('instagram', 'instagram/default', extra)
+
+          mode = oct(stat.S_IMODE(store.stat().st_mode))
+          payload = {
+              'schema': 'agentos.social-runtime-bootstrap/v0.1',
+              'executor': exe,
+              'executor_present': Path(exe).is_file(),
+              'credential_store': str(store),
+              'credential_store_mode': mode,
+              'credential_refs': sorted(refs),
+              'identity_probes': results,
+              'write_operations_performed': False,
+              'secret_values_collected_in_evidence': False,
+          }
+          Path('.agentos/evidence/social-runtime-bootstrap-current.json').write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Publish secret-free evidence to feature branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .agentos/evidence/social-runtime-bootstrap-current.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'evidence(social): record executor bootstrap identities'
+          git push origin HEAD:feature/social-capability

--- a/.github/workflows/social-runtime-inventory.yml
+++ b/.github/workflows/social-runtime-inventory.yml
@@ -65,7 +65,6 @@ jobs:
                           keys.append(key)
               except (OSError, PermissionError):
                   return None
-              # Deliberately return names only, never values.
               interesting = {
                   'SOC_THREADS_TOKEN', 'THREADS_ACCESS_TOKEN', 'SOC_FB_TOKEN',
                   'SOC_IG_TOKEN', 'AGENTOS_SOCIAL_CREDENTIAL_STORE',
@@ -135,25 +134,29 @@ jobs:
                   'credential_refs': credential_refs(p) if p.exists() else None,
               })
 
-          env_files = []
+          env_candidates = [Path('/home/ubuntu/agent-data/secrets/zeus-writer.env')]
           for d in zeus_dirs:
               base = Path(d)
-              for name in ('.env', '.env.local', '.env.production'):
-                  p = base / name
-                  if p.is_file():
-                      env_files.append({
-                          'path': str(p),
-                          'mode': mode_of(p),
-                          'owner': owner_of(p),
-                          'relevant_key_names': env_key_names(p),
-                      })
+              env_candidates.extend(base / name for name in ('.env', '.env.local', '.env.production'))
+
+          env_files = []
+          seen_env = set()
+          for p in env_candidates:
+              key = str(p)
+              if key in seen_env:
+                  continue
+              seen_env.add(key)
+              env_files.append({
+                  'path': key,
+                  'exists': p.is_file(),
+                  'mode': mode_of(p) if p.is_file() else None,
+                  'owner': owner_of(p) if p.is_file() else None,
+                  'relevant_key_names': env_key_names(p) if p.is_file() else None,
+              })
 
           payload = {
               'schema': 'agentos.social-runtime-inventory/v0.1',
-              'runner': {
-                  'user': os.environ.get('USER'),
-                  'home': str(Path.home()),
-              },
+              'runner': {'user': os.environ.get('USER'), 'home': str(Path.home())},
               'agentos_social': exe_info,
               'zeus_directories': sorted(zeus_dirs),
               'credential_stores': stores,

--- a/.github/workflows/social-runtime-inventory.yml
+++ b/.github/workflows/social-runtime-inventory.yml
@@ -1,0 +1,178 @@
+name: Social Runtime Inventory
+
+on:
+  push:
+    branches:
+      - feature/social-capability
+    paths:
+      - '.agentos/commands/social-runtime-inventory.json'
+      - '.github/workflows/social-runtime-inventory.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: social-runtime-inventory
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    if: github.actor == 'alstonhuang'
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feature/social-capability
+
+      - name: Collect non-secret runtime inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import shutil
+          import stat
+          import subprocess
+          from pathlib import Path
+
+          def mode_of(path: Path):
+              try:
+                  return oct(stat.S_IMODE(path.stat().st_mode))
+              except OSError:
+                  return None
+
+          def owner_of(path: Path):
+              try:
+                  s = path.stat()
+                  return {'uid': s.st_uid, 'gid': s.st_gid}
+              except OSError:
+                  return None
+
+          def env_key_names(path: Path):
+              keys = []
+              try:
+                  for raw in path.read_text(encoding='utf-8', errors='replace').splitlines():
+                      line = raw.strip()
+                      if not line or line.startswith('#') or '=' not in line:
+                          continue
+                      key = line.split('=', 1)[0].strip()
+                      if key and key.replace('_', '').isalnum():
+                          keys.append(key)
+              except (OSError, PermissionError):
+                  return None
+              # Deliberately return names only, never values.
+              interesting = {
+                  'SOC_THREADS_TOKEN', 'THREADS_ACCESS_TOKEN', 'SOC_FB_TOKEN',
+                  'SOC_IG_TOKEN', 'AGENTOS_SOCIAL_CREDENTIAL_STORE',
+                  'AGENTOS_THREADS_CREDENTIAL_REF', 'AGENTOS_FB_CREDENTIAL_REF',
+                  'AGENTOS_IG_CREDENTIAL_REF', 'SOC_FB_PAGE_ID', 'SOC_IG_ID',
+              }
+              return sorted(k for k in set(keys) if k in interesting)
+
+          def credential_refs(path: Path):
+              try:
+                  data = json.loads(path.read_text(encoding='utf-8'))
+              except (OSError, PermissionError, json.JSONDecodeError):
+                  return None
+              if not isinstance(data, dict):
+                  return None
+              out = []
+              for ref, payload in data.items():
+                  platform = payload.get('platform') if isinstance(payload, dict) else None
+                  out.append({'ref': str(ref), 'platform': str(platform) if platform else None})
+              return sorted(out, key=lambda x: x['ref'])
+
+          roots = [Path('/home/ubuntu'), Path('/home/agentos-node')]
+          zeus_dirs = []
+          for root in roots:
+              if not root.exists():
+                  continue
+              try:
+                  proc = subprocess.run(
+                      ['find', str(root), '-maxdepth', '5', '-type', 'd', '-iname', '*zeus*'],
+                      text=True, capture_output=True, timeout=20, check=False,
+                  )
+                  for line in proc.stdout.splitlines():
+                      p = Path(line.strip())
+                      if p.exists() and str(p) not in zeus_dirs:
+                          zeus_dirs.append(str(p))
+              except Exception:
+                  pass
+
+          executable = shutil.which('agentos-social')
+          exe_info = None
+          if executable:
+              p = Path(executable)
+              exe_info = {'path': executable, 'mode': mode_of(p), 'owner': owner_of(p)}
+              try:
+                  help_run = subprocess.run([executable, '--help'], text=True, capture_output=True, timeout=10, check=False)
+                  exe_info['help_returncode'] = help_run.returncode
+              except Exception as exc:
+                  exe_info['help_error_type'] = type(exc).__name__
+
+          candidate_stores = [
+              Path('/home/ubuntu/.agentos/social-credentials.json'),
+              Path('/home/agentos-node/.agentos/social-credentials.json'),
+              Path.home() / '.agentos' / 'social-credentials.json',
+          ]
+          stores = []
+          seen = set()
+          for p in candidate_stores:
+              key = str(p)
+              if key in seen:
+                  continue
+              seen.add(key)
+              stores.append({
+                  'path': key,
+                  'exists': p.exists(),
+                  'mode': mode_of(p) if p.exists() else None,
+                  'owner': owner_of(p) if p.exists() else None,
+                  'credential_refs': credential_refs(p) if p.exists() else None,
+              })
+
+          env_files = []
+          for d in zeus_dirs:
+              base = Path(d)
+              for name in ('.env', '.env.local', '.env.production'):
+                  p = base / name
+                  if p.is_file():
+                      env_files.append({
+                          'path': str(p),
+                          'mode': mode_of(p),
+                          'owner': owner_of(p),
+                          'relevant_key_names': env_key_names(p),
+                      })
+
+          payload = {
+              'schema': 'agentos.social-runtime-inventory/v0.1',
+              'runner': {
+                  'user': os.environ.get('USER'),
+                  'home': str(Path.home()),
+              },
+              'agentos_social': exe_info,
+              'zeus_directories': sorted(zeus_dirs),
+              'credential_stores': stores,
+              'zeus_env_files': env_files,
+              'secret_values_collected': False,
+          }
+          Path('.agentos/evidence/social-runtime-inventory-current.json').write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Publish non-secret evidence to feature branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .agentos/evidence/social-runtime-inventory-current.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'evidence(social): record Core runtime inventory'
+          git push origin HEAD:feature/social-capability

--- a/.github/workflows/threads-oauth-inventory.yml
+++ b/.github/workflows/threads-oauth-inventory.yml
@@ -1,0 +1,66 @@
+name: Threads OAuth Inventory
+
+on:
+  push:
+    branches:
+      - feature/social-capability
+    paths:
+      - '.github/workflows/threads-oauth-inventory.yml'
+      - '.agentos/commands/threads-oauth-inventory.json'
+
+permissions:
+  contents: write
+
+jobs:
+  inventory:
+    if: github.actor == 'alstonhuang'
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feature/social-capability
+      - name: Inspect key names only
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          python3 - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          source = Path('/home/ubuntu/agent-data/secrets/zeus-writer.env')
+          names = []
+          if source.is_file():
+              for raw in source.read_text(encoding='utf-8', errors='replace').splitlines():
+                  line = raw.strip()
+                  if not line or line.startswith('#') or '=' not in line:
+                      continue
+                  key = line.split('=', 1)[0].strip()
+                  upper = key.upper()
+                  if ('THREAD' in upper or 'META' in upper or 'FACEBOOK' in upper) and any(
+                      word in upper for word in ('APP', 'CLIENT', 'SECRET', 'REDIRECT', 'CALLBACK', 'TOKEN')
+                  ):
+                      names.append(key)
+          payload = {
+              'schema': 'agentos.threads-oauth-inventory/v0.1',
+              'source_exists': source.is_file(),
+              'matching_key_names': sorted(set(names)),
+              'values_collected': False,
+          }
+          Path('.agentos/evidence/threads-oauth-inventory-current.json').write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+      - name: Publish secret-free evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .agentos/evidence/threads-oauth-inventory-current.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'evidence(social): record Threads OAuth key inventory'
+          git push origin HEAD:feature/social-capability

--- a/.github/workflows/threads-oauth-secret-scan.yml
+++ b/.github/workflows/threads-oauth-secret-scan.yml
@@ -1,0 +1,97 @@
+name: Threads OAuth Secret Scan
+
+on:
+  push:
+    branches:
+      - feature/social-capability
+    paths:
+      - '.github/workflows/threads-oauth-secret-scan.yml'
+      - '.agentos/commands/threads-oauth-secret-scan.json'
+
+permissions:
+  contents: write
+
+jobs:
+  scan:
+    if: github.actor == 'alstonhuang'
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feature/social-capability
+
+      - name: Scan secret file names and key names only
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import re
+          import stat
+          from pathlib import Path
+
+          root = Path('/home/ubuntu/agent-data/secrets')
+          keyword = re.compile(r'(THREAD|META|FACEBOOK|INSTAGRAM)', re.I)
+          oauthish = re.compile(r'(APP|CLIENT|SECRET|REDIRECT|CALLBACK|OAUTH|TOKEN)', re.I)
+
+          files = []
+          if root.is_dir():
+              for path in sorted(p for p in root.rglob('*') if p.is_file()):
+                  try:
+                      rel = str(path.relative_to(root))
+                  except ValueError:
+                      rel = path.name
+                  entry = {
+                      'file': rel,
+                      'mode': oct(stat.S_IMODE(path.stat().st_mode)),
+                      'matching_key_names': [],
+                  }
+                  # Parse only simple env/json/yaml/text-like files. Never persist values.
+                  if path.suffix.lower() in {'.env', '.json', '.yaml', '.yml', '.txt', '.conf', ''} or path.name.startswith('.env'):
+                      try:
+                          text = path.read_text(encoding='utf-8', errors='replace')
+                      except (OSError, PermissionError):
+                          text = ''
+                      names = set()
+                      for line in text.splitlines():
+                          stripped = line.strip()
+                          if not stripped or stripped.startswith('#'):
+                              continue
+                          candidates = []
+                          if '=' in stripped:
+                              candidates.append(stripped.split('=', 1)[0].strip().strip('"\''))
+                          if ':' in stripped:
+                              candidates.append(stripped.split(':', 1)[0].strip().strip('"\''))
+                          for name in candidates:
+                              if keyword.search(name) and oauthish.search(name):
+                                  names.add(name)
+                      entry['matching_key_names'] = sorted(names)
+                  if keyword.search(rel) or entry['matching_key_names']:
+                      files.append(entry)
+
+          payload = {
+              'schema': 'agentos.threads-oauth-secret-scan/v0.1',
+              'secret_root_exists': root.is_dir(),
+              'matches': files,
+              'values_collected': False,
+          }
+          Path('.agentos/evidence/threads-oauth-secret-scan-current.json').write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Publish secret-free evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .agentos/evidence/threads-oauth-secret-scan-current.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'evidence(social): record Threads OAuth secret scan'
+          git push origin HEAD:feature/social-capability

--- a/agentos_node/social_capability.py
+++ b/agentos_node/social_capability.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+RECEIPT_SCHEMA = "agentos.social.publish-receipt/v0.1"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class SocialCapabilityError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class Credential:
+    ref: str
+    platform: str
+    values: Mapping[str, str]
+
+    def require(self, name: str) -> str:
+        value = str(self.values.get(name) or "").strip()
+        if not value:
+            raise SocialCapabilityError("credential_incomplete", f"credential {self.ref!r} has no {name}")
+        return value
+
+
+class CredentialStore:
+    """Executor-local credential references.
+
+    The file is never returned to callers. On POSIX, group/world-readable stores are
+    rejected so a reusable capability does not silently widen secret exposure.
+    """
+
+    def __init__(self, path: Path | None = None):
+        self.path = path or Path(
+            os.environ.get("AGENTOS_SOCIAL_CREDENTIAL_STORE")
+            or Path.home() / ".agentos" / "social-credentials.json"
+        )
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            raise SocialCapabilityError("credential_store_missing", f"credential store not found: {self.path}")
+        if os.name == "posix":
+            mode = stat.S_IMODE(self.path.stat().st_mode)
+            if mode & 0o077:
+                raise SocialCapabilityError("credential_store_permissions", "credential store must not be group/world readable")
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SocialCapabilityError("credential_store_invalid", str(exc)) from exc
+        if not isinstance(data, dict):
+            raise SocialCapabilityError("credential_store_invalid", "credential store root must be an object")
+        return data
+
+    def resolve(self, ref: str, platform: str) -> Credential:
+        raw = self._load().get(ref)
+        if not isinstance(raw, dict):
+            raise SocialCapabilityError("credential_not_found", f"credential reference not found: {ref}")
+        declared = str(raw.get("platform") or platform).lower()
+        if declared != platform.lower():
+            raise SocialCapabilityError("credential_platform_mismatch", f"credential {ref!r} belongs to {declared}")
+        values = {str(k): str(v) for k, v in raw.items() if k != "platform" and v is not None}
+        return Credential(ref=ref, platform=declared, values=values)
+
+
+class HttpTransport:
+    def request(self, method: str, url: str, *, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        encoded = urllib.parse.urlencode({k: v for k, v in (params or {}).items() if v is not None})
+        if method.upper() == "GET":
+            target = url + (("&" if "?" in url else "?") + encoded if encoded else "")
+            req = urllib.request.Request(target, method="GET")
+        else:
+            req = urllib.request.Request(url, data=encoded.encode("utf-8"), method=method.upper())
+            req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                payload = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise SocialCapabilityError("platform_http_error", f"HTTP {exc.code}: {body[:1000]}") from exc
+        except urllib.error.URLError as exc:
+            raise SocialCapabilityError("platform_transport_error", str(exc.reason)) from exc
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise SocialCapabilityError("platform_invalid_response", payload[:1000]) from exc
+        if isinstance(data, dict) and data.get("error"):
+            raise SocialCapabilityError("platform_error", json.dumps(data["error"], ensure_ascii=False)[:1000])
+        if not isinstance(data, dict):
+            raise SocialCapabilityError("platform_invalid_response", "platform response must be an object")
+        return data
+
+
+class SocialCapability:
+    def __init__(self, store: CredentialStore | None = None, transport: HttpTransport | None = None):
+        self.store = store or CredentialStore()
+        self.transport = transport or HttpTransport()
+
+    def _receipt(
+        self,
+        *,
+        platform: str,
+        operation: str,
+        credential_ref: str,
+        ok: bool,
+        platform_object_id: str | None = None,
+        permalink: str | None = None,
+        result: Mapping[str, Any] | None = None,
+        error: SocialCapabilityError | None = None,
+    ) -> dict[str, Any]:
+        receipt: dict[str, Any] = {
+            "schema": RECEIPT_SCHEMA,
+            "ok": ok,
+            "platform": platform,
+            "operation": operation,
+            "credential_ref": credential_ref,
+            "observed_at": _utc_now(),
+        }
+        if platform_object_id:
+            receipt["platform_object_id"] = platform_object_id
+        if permalink:
+            receipt["permalink"] = permalink
+        if result:
+            # Only caller-safe identity/operation metadata belongs here. Never merge
+            # raw credential or request dictionaries into receipts.
+            receipt["result"] = dict(result)
+        if error:
+            receipt["error_code"] = error.code
+            receipt["error_message"] = error.message
+        return receipt
+
+    def execute(self, platform: str, operation: str, credential_ref: str, args: Mapping[str, Any]) -> dict[str, Any]:
+        platform = platform.lower()
+        operation = operation.lower()
+        try:
+            credential = self.store.resolve(credential_ref, platform)
+            if operation in {"publish", "reply"} and not bool(args.get("allow_write")):
+                raise SocialCapabilityError("write_not_approved", "write operation requires --allow-write")
+            if platform == "threads":
+                return self._threads(operation, credential, args)
+            if platform == "facebook":
+                return self._facebook(operation, credential, args)
+            if platform == "instagram":
+                return self._instagram(operation, credential, args)
+            raise SocialCapabilityError("unsupported_platform", platform)
+        except SocialCapabilityError as exc:
+            return self._receipt(
+                platform=platform,
+                operation=operation,
+                credential_ref=credential_ref,
+                ok=False,
+                error=exc,
+            )
+
+    def _threads(self, operation: str, cred: Credential, args: Mapping[str, Any]) -> dict[str, Any]:
+        base = "https://graph.threads.net/v1.0"
+        token = cred.require("access_token")
+        if operation == "identity":
+            data = self.transport.request("GET", f"{base}/me", params={"fields": "id,username", "access_token": token})
+            uid = str(data.get("id") or "")
+            if not uid:
+                raise SocialCapabilityError("identity_unverified", "Threads identity response has no id")
+            return self._receipt(platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
+                                 platform_object_id=uid, result={"username": data.get("username")})
+
+        text = str(args.get("text") or "")
+        if not text:
+            raise SocialCapabilityError("invalid_request", "text is required")
+        identity = self.transport.request("GET", f"{base}/me", params={"fields": "id", "access_token": token})
+        uid = str(identity.get("id") or "")
+        if not uid:
+            raise SocialCapabilityError("identity_unverified", "Threads identity response has no id")
+        payload: dict[str, Any] = {
+            "media_type": "IMAGE" if args.get("image_url") else "TEXT",
+            "text": text,
+            "access_token": token,
+        }
+        if args.get("image_url"):
+            payload["image_url"] = str(args["image_url"])
+        if operation == "reply":
+            reply_to = str(args.get("reply_to") or "")
+            if not reply_to:
+                raise SocialCapabilityError("invalid_request", "reply operation requires --reply-to")
+            payload["reply_to_id"] = reply_to
+        elif operation != "publish":
+            raise SocialCapabilityError("unsupported_operation", operation)
+        container = self.transport.request("POST", f"{base}/{uid}/threads", params=payload)
+        creation_id = str(container.get("id") or "")
+        if not creation_id:
+            raise SocialCapabilityError("publish_container_failed", "Threads did not return creation id")
+        published = self.transport.request("POST", f"{base}/{uid}/threads_publish", params={"creation_id": creation_id, "access_token": token})
+        object_id = str(published.get("id") or "")
+        if not object_id:
+            raise SocialCapabilityError("publish_failed", "Threads did not return published id")
+        permalink: str | None = None
+        try:
+            item = self.transport.request("GET", f"{base}/{object_id}", params={"fields": "permalink", "access_token": token})
+            permalink = str(item.get("permalink") or "") or None
+        except SocialCapabilityError:
+            pass
+        return self._receipt(platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
+                             platform_object_id=object_id, permalink=permalink)
+
+    def _facebook(self, operation: str, cred: Credential, args: Mapping[str, Any]) -> dict[str, Any]:
+        token = cred.require("access_token")
+        page_id = str(args.get("page_id") or cred.values.get("page_id") or "")
+        if operation != "identity":
+            raise SocialCapabilityError("operation_not_yet_verified", "Facebook write path is not enabled until controlled-publish verification")
+        target = page_id or "me"
+        data = self.transport.request("GET", f"https://graph.facebook.com/v23.0/{target}", params={"fields": "id,name", "access_token": token})
+        object_id = str(data.get("id") or "")
+        if not object_id:
+            raise SocialCapabilityError("identity_unverified", "Facebook identity response has no id")
+        return self._receipt(platform="facebook", operation=operation, credential_ref=cred.ref, ok=True,
+                             platform_object_id=object_id, result={"name": data.get("name")})
+
+    def _instagram(self, operation: str, cred: Credential, args: Mapping[str, Any]) -> dict[str, Any]:
+        token = cred.require("access_token")
+        ig_id = str(args.get("ig_id") or cred.values.get("ig_id") or "")
+        if operation != "identity":
+            raise SocialCapabilityError("operation_not_yet_verified", "Instagram write path is not enabled until controlled-publish verification")
+        if not ig_id:
+            raise SocialCapabilityError("invalid_request", "Instagram identity requires ig_id in args or credential metadata")
+        data = self.transport.request("GET", f"https://graph.facebook.com/v23.0/{ig_id}", params={"fields": "id,username", "access_token": token})
+        object_id = str(data.get("id") or "")
+        if not object_id:
+            raise SocialCapabilityError("identity_unverified", "Instagram identity response has no id")
+        return self._receipt(platform="instagram", operation=operation, credential_ref=cred.ref, ok=True,
+                             platform_object_id=object_id, result={"username": data.get("username")})

--- a/agentos_node/social_capability.py
+++ b/agentos_node/social_capability.py
@@ -136,8 +136,6 @@ class SocialCapability:
         if permalink:
             receipt["permalink"] = permalink
         if result:
-            # Only caller-safe identity/operation metadata belongs here. Never merge
-            # raw credential or request dictionaries into receipts.
             receipt["result"] = dict(result)
         if error:
             receipt["error_code"] = error.code
@@ -175,8 +173,10 @@ class SocialCapability:
             uid = str(data.get("id") or "")
             if not uid:
                 raise SocialCapabilityError("identity_unverified", "Threads identity response has no id")
-            return self._receipt(platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
-                                 platform_object_id=uid, result={"username": data.get("username")})
+            return self._receipt(
+                platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
+                platform_object_id=uid, result={"username": data.get("username")},
+            )
 
         text = str(args.get("text") or "")
         if not text:
@@ -203,42 +203,86 @@ class SocialCapability:
         creation_id = str(container.get("id") or "")
         if not creation_id:
             raise SocialCapabilityError("publish_container_failed", "Threads did not return creation id")
-        published = self.transport.request("POST", f"{base}/{uid}/threads_publish", params={"creation_id": creation_id, "access_token": token})
+        published = self.transport.request(
+            "POST", f"{base}/{uid}/threads_publish",
+            params={"creation_id": creation_id, "access_token": token},
+        )
         object_id = str(published.get("id") or "")
         if not object_id:
             raise SocialCapabilityError("publish_failed", "Threads did not return published id")
         permalink: str | None = None
         try:
-            item = self.transport.request("GET", f"{base}/{object_id}", params={"fields": "permalink", "access_token": token})
+            item = self.transport.request(
+                "GET", f"{base}/{object_id}", params={"fields": "permalink", "access_token": token}
+            )
             permalink = str(item.get("permalink") or "") or None
         except SocialCapabilityError:
             pass
-        return self._receipt(platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
-                             platform_object_id=object_id, permalink=permalink)
+        return self._receipt(
+            platform="threads", operation=operation, credential_ref=cred.ref, ok=True,
+            platform_object_id=object_id, permalink=permalink,
+        )
 
     def _facebook(self, operation: str, cred: Credential, args: Mapping[str, Any]) -> dict[str, Any]:
         token = cred.require("access_token")
         page_id = str(args.get("page_id") or cred.values.get("page_id") or "")
         if operation != "identity":
-            raise SocialCapabilityError("operation_not_yet_verified", "Facebook write path is not enabled until controlled-publish verification")
+            raise SocialCapabilityError(
+                "operation_not_yet_verified",
+                "Facebook write path is not enabled until controlled-publish verification",
+            )
         target = page_id or "me"
-        data = self.transport.request("GET", f"https://graph.facebook.com/v23.0/{target}", params={"fields": "id,name", "access_token": token})
+        data = self.transport.request(
+            "GET", f"https://graph.facebook.com/v23.0/{target}",
+            params={"fields": "id,name", "access_token": token},
+        )
         object_id = str(data.get("id") or "")
         if not object_id:
             raise SocialCapabilityError("identity_unverified", "Facebook identity response has no id")
-        return self._receipt(platform="facebook", operation=operation, credential_ref=cred.ref, ok=True,
-                             platform_object_id=object_id, result={"name": data.get("name")})
+        return self._receipt(
+            platform="facebook", operation=operation, credential_ref=cred.ref, ok=True,
+            platform_object_id=object_id, result={"name": data.get("name")},
+        )
 
     def _instagram(self, operation: str, cred: Credential, args: Mapping[str, Any]) -> dict[str, Any]:
         token = cred.require("access_token")
         ig_id = str(args.get("ig_id") or cred.values.get("ig_id") or "")
+        page_id = str(args.get("page_id") or cred.values.get("page_id") or "")
         if operation != "identity":
-            raise SocialCapabilityError("operation_not_yet_verified", "Instagram write path is not enabled until controlled-publish verification")
+            raise SocialCapabilityError(
+                "operation_not_yet_verified",
+                "Instagram write path is not enabled until controlled-publish verification",
+            )
+
+        discovery = "explicit"
         if not ig_id:
-            raise SocialCapabilityError("invalid_request", "Instagram identity requires ig_id in args or credential metadata")
-        data = self.transport.request("GET", f"https://graph.facebook.com/v23.0/{ig_id}", params={"fields": "id,username", "access_token": token})
+            if not page_id:
+                raise SocialCapabilityError(
+                    "invalid_request",
+                    "Instagram identity requires ig_id or a connected Facebook page_id",
+                )
+            page = self.transport.request(
+                "GET", f"https://graph.facebook.com/v23.0/{page_id}",
+                params={"fields": "instagram_business_account", "access_token": token},
+            )
+            linked = page.get("instagram_business_account")
+            if not isinstance(linked, dict) or not linked.get("id"):
+                raise SocialCapabilityError(
+                    "identity_unverified",
+                    "Facebook Page has no discoverable instagram_business_account",
+                )
+            ig_id = str(linked["id"])
+            discovery = "facebook_page"
+
+        data = self.transport.request(
+            "GET", f"https://graph.facebook.com/v23.0/{ig_id}",
+            params={"fields": "id,username", "access_token": token},
+        )
         object_id = str(data.get("id") or "")
         if not object_id:
             raise SocialCapabilityError("identity_unverified", "Instagram identity response has no id")
-        return self._receipt(platform="instagram", operation=operation, credential_ref=cred.ref, ok=True,
-                             platform_object_id=object_id, result={"username": data.get("username")})
+        return self._receipt(
+            platform="instagram", operation=operation, credential_ref=cred.ref, ok=True,
+            platform_object_id=object_id,
+            result={"username": data.get("username"), "discovery": discovery},
+        )

--- a/agentos_node/social_cli.py
+++ b/agentos_node/social_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from agentos_node.social_capability import SocialCapability
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agentos-social")
+    parser.add_argument("platform", choices=("threads", "facebook", "instagram"))
+    parser.add_argument("operation", choices=("identity", "publish", "reply"))
+    parser.add_argument("--credential", required=True, help="executor-local credential reference, never a token")
+    parser.add_argument("--text")
+    parser.add_argument("--title")
+    parser.add_argument("--image-url")
+    parser.add_argument("--image-path")
+    parser.add_argument("--reply-to")
+    parser.add_argument("--page-id")
+    parser.add_argument("--ig-id")
+    parser.add_argument("--allow-write", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    request: dict[str, Any] = {
+        "text": args.text,
+        "title": args.title,
+        "image_url": args.image_url,
+        "image_path": args.image_path,
+        "reply_to": args.reply_to,
+        "page_id": args.page_id,
+        "ig_id": args.ig_id,
+        "allow_write": args.allow_write,
+    }
+    receipt = SocialCapability().execute(args.platform, args.operation, args.credential, request)
+    print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+    return 0 if receipt.get("ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -26,6 +26,11 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Resource registry / world-state lookup | Implemented + tested | `agent_core/resource_registry.py` | `tests/test_resource_registry.py` |
 | Realm / cross-node fabric | Implemented slices + tested | `agent_core/realm_fabric.py`, `agent_core/realm_server.py`, `agent_core/realm_cli.py` | `tests/test_realm_fabric.py`, `.agentos/commands/` |
 | Platform driver abstraction | Implemented + tested | `agent_core/platform/`, `scripts/platform_runtime.py` | `tests/test_platform_runtime.py` |
+| Governed social capability executor | Implemented + unit-tested on feature branch | `agentos_node/social_capability.py`, `agentos_node/social_cli.py` | `tests/test_social_capability.py`, Social Capability CI |
+| Facebook social identity via credential reference | Verified read-only on Core | `agentos_node/social_capability.py` | `.agentos/evidence/social-runtime-bootstrap-current.json` |
+| Instagram social identity via connected Facebook Page discovery | Verified read-only on Core | `agentos_node/social_capability.py` | `.agentos/evidence/social-runtime-bootstrap-current.json` |
+| Threads social identity | Implemented, credential currently invalid | `agentos_node/social_capability.py` | Core identity probe reports the legacy token expired on 2026-06-23; reauthorization is required before any real write verification |
+| Social publish/reply governance | Implemented gate; real-world Threads write not yet re-verified | `agentos_node/social_capability.py`, `agentos_node/social_cli.py` | unit tests require explicit `--allow-write`; no post-migration real write has been performed |
 | Governance drift guard | Implemented + tested | `scripts/drift_guard.py`, constitution/role registries | `tests/test_drift_guard.py` |
 | Protected-branch authority guard | Implemented on governance branch | `.agent/governance/protected_branches.yaml`, `scripts/protected_branch_authority.py` | `tests/test_protected_branch_authority.py`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md` |
 | Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows |
@@ -47,6 +52,10 @@ Tool results and execution evidence can inform decisions, but they do not silent
 
 The presence of a mutation tool, a mergeable pull request, or passing CI does not authorize a protected-branch mutation. Agents must stop at `AWAITING_HUMAN_APPROVAL` until an explicit human authorization exists. See `.agent/governance/protected_branches.yaml` and `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md`.
 
+### Social credentials belong to the executor boundary
+
+Product code such as Zeus Writer or Vendor Reputation may request a social capability by credential reference, but must not own, print, or resolve platform access tokens. AgentOS social receipts may contain a credential reference and verified platform identity metadata, but never the underlying secret value. Real social writes require an explicit write gate and platform-specific controlled-write evidence before a product fallback can be removed.
+
 ### Discover before invent
 
 Reusable/cross-project work should resolve existing responsibility and resources before creating parallel implementations. See `docs/AGENTOS_NODE.md` and the Governance Directory.
@@ -64,9 +73,21 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, and explicit authority boundaries for protected mutations.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, and a governed reusable social-capability boundary under feature validation.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
+
+## Current social-capability boundary
+
+The social capability is intentionally asymmetric while migration evidence is incomplete:
+
+- Facebook identity is verified through an executor-local credential reference.
+- Instagram identity is verified and can discover the connected Instagram Business Account from the configured Facebook Page.
+- Threads execution code exists, but the migrated legacy credential is expired; identity therefore fails closed until reauthorization.
+- Facebook and Instagram write paths remain disabled until each receives its own controlled-publish evidence.
+- Threads publish/reply requires explicit write approval and must receive a new real controlled-publish PASS before Zeus Writer's temporary direct Threads fallback is removed.
+
+The executor-local credential store is deployed with mode `0600`. Legacy Zeus secret files remain temporarily intact for reversible migration; they are not evidence that product code is allowed to continue owning social credentials indefinitely.
 
 ## Current research boundary: Cognitive IR
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 agentos-node = "agentos_node.cli:main"
 agentos-client = "agentos_node.client_cli:main"
 agentos-one = "agent_core.realm_cli:main"
+agentos-social = "agentos_node.social_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_social_capability.py
+++ b/tests/test_social_capability.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+from agentos_node.social_capability import CredentialStore, SocialCapability
+
+
+class FakeTransport:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, *, params=None):
+        params = dict(params or {})
+        self.calls.append((method, url, params))
+        if url.endswith('/me'):
+            return {'id': 'threads-user-1', 'username': 'tester'}
+        if url.endswith('/threads'):
+            return {'id': 'creation-1'}
+        if url.endswith('/threads_publish'):
+            return {'id': 'thread-1'}
+        if url.endswith('/thread-1'):
+            return {'permalink': 'https://www.threads.net/@tester/post/example'}
+        if 'graph.facebook.com' in url:
+            if 'ig-1' in url:
+                return {'id': 'ig-1', 'username': 'igtester'}
+            return {'id': 'page-1', 'name': 'Page Tester'}
+        raise AssertionError((method, url, params))
+
+
+def _store(tmp_path: Path) -> CredentialStore:
+    path = tmp_path / 'social-credentials.json'
+    path.write_text(json.dumps({
+        'threads/default': {'platform': 'threads', 'access_token': 'THREADS_SECRET'},
+        'facebook/default': {'platform': 'facebook', 'access_token': 'FB_SECRET', 'page_id': 'page-1'},
+        'instagram/default': {'platform': 'instagram', 'access_token': 'IG_SECRET', 'ig_id': 'ig-1'},
+    }), encoding='utf-8')
+    path.chmod(0o600)
+    return CredentialStore(path)
+
+
+def test_threads_identity_receipt_never_contains_secret(tmp_path):
+    cap = SocialCapability(_store(tmp_path), FakeTransport())
+    receipt = cap.execute('threads', 'identity', 'threads/default', {})
+    assert receipt['ok'] is True
+    assert receipt['platform_object_id'] == 'threads-user-1'
+    assert 'THREADS_SECRET' not in json.dumps(receipt)
+    assert receipt['credential_ref'] == 'threads/default'
+
+
+def test_write_requires_explicit_approval(tmp_path):
+    cap = SocialCapability(_store(tmp_path), FakeTransport())
+    receipt = cap.execute('threads', 'publish', 'threads/default', {'text': 'hello'})
+    assert receipt['ok'] is False
+    assert receipt['error_code'] == 'write_not_approved'
+
+
+def test_threads_controlled_publish_returns_secret_free_receipt(tmp_path):
+    transport = FakeTransport()
+    cap = SocialCapability(_store(tmp_path), transport)
+    receipt = cap.execute('threads', 'publish', 'threads/default', {'text': 'hello', 'allow_write': True})
+    assert receipt['ok'] is True
+    assert receipt['platform_object_id'] == 'thread-1'
+    assert receipt['permalink'].startswith('https://www.threads.net/')
+    assert 'THREADS_SECRET' not in json.dumps(receipt)
+    assert any(call[2].get('access_token') == 'THREADS_SECRET' for call in transport.calls)
+
+
+def test_facebook_and_instagram_are_identity_only_until_verified(tmp_path):
+    cap = SocialCapability(_store(tmp_path), FakeTransport())
+    fb = cap.execute('facebook', 'identity', 'facebook/default', {})
+    ig = cap.execute('instagram', 'identity', 'instagram/default', {})
+    assert fb['ok'] is True and fb['platform_object_id'] == 'page-1'
+    assert ig['ok'] is True and ig['platform_object_id'] == 'ig-1'
+
+    fb_write = cap.execute('facebook', 'publish', 'facebook/default', {'text': 'x', 'allow_write': True})
+    ig_write = cap.execute('instagram', 'publish', 'instagram/default', {'text': 'x', 'allow_write': True})
+    assert fb_write['error_code'] == 'operation_not_yet_verified'
+    assert ig_write['error_code'] == 'operation_not_yet_verified'

--- a/tests/test_social_capability.py
+++ b/tests/test_social_capability.py
@@ -20,6 +20,10 @@ class FakeTransport:
         if url.endswith('/thread-1'):
             return {'permalink': 'https://www.threads.net/@tester/post/example'}
         if 'graph.facebook.com' in url:
+            if 'page-discovery' in url and params.get('fields') == 'instagram_business_account':
+                return {'instagram_business_account': {'id': 'ig-discovered'}}
+            if 'ig-discovered' in url:
+                return {'id': 'ig-discovered', 'username': 'discoveredtester'}
             if 'ig-1' in url:
                 return {'id': 'ig-1', 'username': 'igtester'}
             return {'id': 'page-1', 'name': 'Page Tester'}
@@ -32,6 +36,7 @@ def _store(tmp_path: Path) -> CredentialStore:
         'threads/default': {'platform': 'threads', 'access_token': 'THREADS_SECRET'},
         'facebook/default': {'platform': 'facebook', 'access_token': 'FB_SECRET', 'page_id': 'page-1'},
         'instagram/default': {'platform': 'instagram', 'access_token': 'IG_SECRET', 'ig_id': 'ig-1'},
+        'instagram/discovery': {'platform': 'instagram', 'access_token': 'IG_SECRET', 'page_id': 'page-discovery'},
     }), encoding='utf-8')
     path.chmod(0o600)
     return CredentialStore(path)
@@ -70,8 +75,21 @@ def test_facebook_and_instagram_are_identity_only_until_verified(tmp_path):
     ig = cap.execute('instagram', 'identity', 'instagram/default', {})
     assert fb['ok'] is True and fb['platform_object_id'] == 'page-1'
     assert ig['ok'] is True and ig['platform_object_id'] == 'ig-1'
+    assert ig['result']['discovery'] == 'explicit'
 
     fb_write = cap.execute('facebook', 'publish', 'facebook/default', {'text': 'x', 'allow_write': True})
     ig_write = cap.execute('instagram', 'publish', 'instagram/default', {'text': 'x', 'allow_write': True})
     assert fb_write['error_code'] == 'operation_not_yet_verified'
     assert ig_write['error_code'] == 'operation_not_yet_verified'
+
+
+def test_instagram_identity_can_be_discovered_from_connected_facebook_page(tmp_path):
+    transport = FakeTransport()
+    cap = SocialCapability(_store(tmp_path), transport)
+    receipt = cap.execute('instagram', 'identity', 'instagram/discovery', {})
+    assert receipt['ok'] is True
+    assert receipt['platform_object_id'] == 'ig-discovered'
+    assert receipt['result'] == {'username': 'discoveredtester', 'discovery': 'facebook_page'}
+    assert 'IG_SECRET' not in json.dumps(receipt)
+    assert any('page-discovery' in url and params.get('fields') == 'instagram_business_account'
+               for _, url, params in transport.calls)


### PR DESCRIPTION
Introduce a reproducible `agentos-social` executor as an AgentOS capability rather than relying on an untracked runtime script.

Current implementation:
- executor-local credential references via `~/.agentos/social-credentials.json` or `AGENTOS_SOCIAL_CREDENTIAL_STORE`
- POSIX secret-store permission guard
- secret-free receipt contract
- explicit `--allow-write` governance gate
- Threads identity / publish / reply implementation
- Facebook identity verification
- Instagram identity verification with automatic IG Business Account discovery from a connected Facebook Page
- Facebook / Instagram writes fail closed as `operation_not_yet_verified` until controlled-publish evidence exists
- CLI entry point through `pyproject.toml`
- unit tests and branch CI

Live Core evidence (2026-08-27, read-only only):
- `agentos-social` deployed from this feature branch
- credential store created at `/home/agentos-node/.agentos/social-credentials.json`, mode `0600`
- `facebook/default` identity PASS for Page `旭潼幻境`
- `instagram/default` identity PASS via Facebook Page discovery for `oursong_alstonhuang`
- `threads/default` identity FAIL with OAuth error 190 because the legacy token expired on 2026-06-23
- no publish/reply write operations were performed
- no secret values were persisted into evidence

Threads reauthorization finding:
- the Zeus shared secret currently exposes only the existing Threads access-token key; no Threads app/client/redirect OAuth configuration was found in that file
- a broader secret-key-name-only scan is in progress to determine whether OAuth app configuration exists elsewhere on Core without exposing any values

This PR remains intentionally draft. Do not merge until:
1. Social capability tests/CI are green for the latest implementation.
2. Threads credential is re-authorized and identity PASS is recorded through `threads/default`.
3. One explicitly approved controlled Threads publish returns a secret-free PASS receipt.
4. Zeus Writer PR #3 is tested against this executor and its temporary direct Threads fallback is removed only after the controlled publish passes.
5. Facebook/Instagram write paths remain disabled until each receives separate controlled-publish evidence.

No platform secrets belong in this repository or in receipts.