### PR TITLE
feat(agentos): complete ChatGPT Web node and ONE continuation bridge

### DIFF
--- a/agentos_node/chatgpt_browser_resume.py
+++ b/agentos_node/chatgpt_browser_resume.py
@@ -1,0 +1,89 @@
+"""Resume an AgentOS project through the existing external browser bridge.
+
+This module keeps the AgentOS/browser boundary narrow:
+- AgentOS owns canonical state and context compilation.
+- `ai-browser-bridge` owns ChatGPT browser/session automation.
+- ChatGPT receives a compiled continuation prompt and returns untrusted semantic output.
+
+No browser DOM selectors, cookies, login state, or profile management live here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from typing import Any
+
+from .ai_browser_bridge import AiBrowserBridgeClient, BrowserBridgeReply
+from .chatgpt_web_node import ChatGPTWebBootstrap, bootstrap_chatgpt_web
+from .control_plane_client import ControlPlaneClient
+
+
+RESUME_PROMPT_PROTOCOL = "agentos.chatgpt-browser-resume/v1"
+
+
+@dataclass(frozen=True)
+class ChatGPTBrowserResumeResult:
+    protocol: str
+    project_id: str
+    runtime_id: str
+    session_id: str | None
+    current_ir_id: str | None
+    current_ir_digest: str | None
+    bridge_reply: BrowserBridgeReply
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        return value
+
+
+def compile_resume_prompt(packet: ChatGPTWebBootstrap, *, user_intent: str = "continue") -> str:
+    """Compile a deterministic continuation prompt from an AgentOS bootstrap packet."""
+
+    payload = {
+        "protocol": RESUME_PROMPT_PROTOCOL,
+        "instruction": (
+            "Continue the existing implementation from the authoritative AgentOS state below. "
+            "Do not redesign the project from scratch. Treat AgentOS canonical state and compiled "
+            "execution context as authoritative over conversational memory. If the state is insufficient, "
+            "state exactly what is missing instead of inventing prior work."
+        ),
+        "user_intent": str(user_intent or "continue").strip() or "continue",
+        "project_id": packet.project_id,
+        "session_id": packet.session_id,
+        "recommended_action": packet.recommended_action,
+        "current_source": packet.current_source,
+        "latest_task_id": packet.latest_task_id,
+        "current_ir_id": packet.current_ir_id,
+        "current_ir_digest": packet.current_ir_digest,
+        "execution_context": packet.execution_context,
+        "web_agent_request": packet.request,
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def resume_via_browser(
+    control_plane: ControlPlaneClient,
+    bridge: AiBrowserBridgeClient,
+    project_id: str,
+    *,
+    runtime_id: str = "chatgpt-web",
+    user_intent: str = "continue",
+    timeout_seconds: float = 180.0,
+) -> ChatGPTBrowserResumeResult:
+    """Attach to AgentOS, compile the resume prompt, and send it to ChatGPT via bridge."""
+
+    packet = bootstrap_chatgpt_web(control_plane, project_id, runtime_id=runtime_id)
+    prompt = compile_resume_prompt(packet, user_intent=user_intent)
+    replies = bridge.ask(prompt, providers=("chatgpt",), timeout_seconds=timeout_seconds)
+    if len(replies) != 1:
+        raise RuntimeError("expected exactly one ChatGPT bridge reply")
+    return ChatGPTBrowserResumeResult(
+        protocol=RESUME_PROMPT_PROTOCOL,
+        project_id=packet.project_id,
+        runtime_id=packet.runtime_id,
+        session_id=packet.session_id,
+        current_ir_id=packet.current_ir_id,
+        current_ir_digest=packet.current_ir_digest,
+        bridge_reply=replies[0],
+    )

--- a/agentos_node/chatgpt_local_companion.py
+++ b/agentos_node/chatgpt_local_companion.py
@@ -1,0 +1,128 @@
+"""Local fail-closed companion for ChatGPT browser continuation interception.
+
+The companion exposes only a localhost resume endpoint. It authenticates each
+request with a transport token, restores authoritative AgentOS state through the
+Control Plane, and returns a compiled continuation prompt. It does not store
+canonical state and it never automates the ChatGPT DOM.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from .chatgpt_browser_resume import compile_resume_prompt
+from .chatgpt_web_node import bootstrap_chatgpt_web
+from .control_plane_client import ControlPlaneClient
+
+
+COMPANION_PROTOCOL = "agentos.chatgpt-local-companion/v1"
+MAX_REQUEST_BYTES = 64 * 1024
+ALLOWED_ORIGINS = {"https://chatgpt.com", "https://chat.openai.com"}
+
+
+class ChatGPTLocalCompanionService:
+    def __init__(self, client: ControlPlaneClient, *, runtime_id: str = "chatgpt-web") -> None:
+        self.client = client
+        self.runtime_id = runtime_id
+
+    def resume(self, project_id: str, user_intent: str) -> dict[str, Any]:
+        project_id = str(project_id or "").strip()
+        user_intent = str(user_intent or "continue").strip() or "continue"
+        if not project_id:
+            raise ValueError("project_id is required")
+        packet = bootstrap_chatgpt_web(self.client, project_id, runtime_id=self.runtime_id)
+        return {
+            "protocol": COMPANION_PROTOCOL,
+            "project_id": packet.project_id,
+            "session_id": packet.session_id,
+            "current_ir_id": packet.current_ir_id,
+            "current_ir_digest": packet.current_ir_digest,
+            "recommended_action": packet.recommended_action,
+            "compiled_prompt": compile_resume_prompt(packet, user_intent=user_intent),
+        }
+
+
+class ChatGPTLocalCompanionServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        service: ChatGPTLocalCompanionService,
+        *,
+        token: str,
+    ) -> None:
+        host, _ = server_address
+        if host not in {"127.0.0.1", "localhost", "::1"}:
+            raise ValueError("local companion must bind to loopback")
+        token = str(token or "")
+        if len(token) < 24:
+            raise ValueError("companion token must be at least 24 characters")
+        self.service = service
+        self.auth_token = token
+        super().__init__(server_address, ChatGPTLocalCompanionHandler)
+
+
+class ChatGPTLocalCompanionHandler(BaseHTTPRequestHandler):
+    server: ChatGPTLocalCompanionServer
+
+    def _origin(self) -> str:
+        return str(self.headers.get("Origin") or "")
+
+    def _cors(self) -> None:
+        origin = self._origin()
+        if origin in ALLOWED_ORIGINS:
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, X-AgentOS-Companion-Token")
+            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        raw = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(raw)))
+        self._cors()
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _authorized(self) -> bool:
+        supplied = str(self.headers.get("X-AgentOS-Companion-Token") or "")
+        return bool(supplied) and hmac.compare_digest(supplied, self.server.auth_token)
+
+    def do_OPTIONS(self) -> None:
+        if self._origin() not in ALLOWED_ORIGINS:
+            self._json(403, {"error": "origin_forbidden"})
+            return
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_POST(self) -> None:
+        if self._origin() not in ALLOWED_ORIGINS:
+            self._json(403, {"error": "origin_forbidden"})
+            return
+        if not self._authorized():
+            self._json(401, {"error": "unauthorized"})
+            return
+        if self.path != "/v1/resume":
+            self._json(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or "0")
+            if length < 1 or length > MAX_REQUEST_BYTES:
+                raise ValueError("invalid request size")
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            if not isinstance(body, dict):
+                raise ValueError("JSON root must be an object")
+            response = self.server.service.resume(
+                str(body.get("project_id") or ""),
+                str(body.get("user_intent") or "continue"),
+            )
+            self._json(200, response)
+        except (ValueError, TypeError, json.JSONDecodeError) as exc:
+            self._json(400, {"error": "invalid_request", "message": str(exc)})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return

--- a/agentos_node/chatgpt_web_node.py
+++ b/agentos_node/chatgpt_web_node.py
@@ -1,0 +1,111 @@
+"""Bootstrap/resume contract for ChatGPT Web as an AgentOS web node.
+
+This module deliberately stays transport-neutral.  It does not automate the
+ChatGPT UI and it never stores browser credentials.  Its only job is to restore
+the authoritative project state from the Control Plane and compile that state
+into the immutable WebAgentAdapter request consumed by a browser-side bridge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from runtime_core.canonical_ir import CanonicalIR
+
+from .control_plane_client import ControlPlaneClient
+from .web_agent_adapter import WebAgentAdapter
+
+
+BOOTSTRAP_PROTOCOL = "agentos.chatgpt-web-bootstrap/v1"
+DEFAULT_RUNTIME_ID = "chatgpt-web"
+
+
+@dataclass(frozen=True)
+class ChatGPTWebBootstrap:
+    protocol: str
+    runtime_id: str
+    project_id: str
+    recommended_action: str
+    current_source: str | None
+    latest_task_id: str | None
+    current_ir_id: str | None
+    current_ir_digest: str | None
+    request: dict[str, Any] | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_bootstrap_from_project_state(
+    state: dict[str, Any],
+    *,
+    runtime_id: str = DEFAULT_RUNTIME_ID,
+) -> ChatGPTWebBootstrap:
+    """Compile a Control Plane project-state response into a web-node resume packet.
+
+    The Control Plane remains authoritative.  Browser/model code receives only
+    an immutable Canonical IR request and cannot manufacture project lineage.
+    """
+
+    project_id = str(state.get("projectId") or "").strip()
+    if not project_id:
+        raise ValueError("project state is missing projectId")
+
+    action = str(state.get("recommendedAction") or "start")
+    source = state.get("currentSource")
+    latest_task = state.get("latestTask")
+    latest_task_id = None
+    if isinstance(latest_task, dict):
+        raw_task_id = latest_task.get("taskId")
+        if raw_task_id is not None:
+            latest_task_id = str(raw_task_id)
+
+    raw_ir = state.get("currentIR")
+    if raw_ir is None:
+        return ChatGPTWebBootstrap(
+            protocol=BOOTSTRAP_PROTOCOL,
+            runtime_id=runtime_id,
+            project_id=project_id,
+            recommended_action=action,
+            current_source=source if isinstance(source, str) else None,
+            latest_task_id=latest_task_id,
+            current_ir_id=None,
+            current_ir_digest=None,
+            request=None,
+        )
+    if not isinstance(raw_ir, dict):
+        raise ValueError("project state currentIR must be an object or null")
+
+    ir = CanonicalIR.from_dict(raw_ir)
+    if ir.project_id != project_id:
+        raise ValueError("project state currentIR project_id mismatch")
+
+    adapter = WebAgentAdapter(runtime_id)
+    request = adapter.build_request(ir)
+    return ChatGPTWebBootstrap(
+        protocol=BOOTSTRAP_PROTOCOL,
+        runtime_id=runtime_id,
+        project_id=project_id,
+        recommended_action=action,
+        current_source=source if isinstance(source, str) else None,
+        latest_task_id=latest_task_id,
+        current_ir_id=ir.ir_id,
+        current_ir_digest=ir.digest(),
+        request=request,
+    )
+
+
+def bootstrap_chatgpt_web(
+    client: ControlPlaneClient,
+    project_id: str,
+    *,
+    runtime_id: str = DEFAULT_RUNTIME_ID,
+) -> ChatGPTWebBootstrap:
+    """Restore one project's current canonical state for a ChatGPT Web node."""
+
+    project_id = str(project_id or "").strip()
+    if not project_id:
+        raise ValueError("project_id is required")
+    state = client.get_project_state(project_id)
+    return build_bootstrap_from_project_state(state, runtime_id=runtime_id)

--- a/agentos_node/chatgpt_web_node.py
+++ b/agentos_node/chatgpt_web_node.py
@@ -1,9 +1,10 @@
 """Bootstrap/resume contract for ChatGPT Web as an AgentOS web node.
 
-This module deliberately stays transport-neutral.  It does not automate the
-ChatGPT UI and it never stores browser credentials.  Its only job is to restore
-the authoritative project state from the Control Plane and compile that state
-into the immutable WebAgentAdapter request consumed by a browser-side bridge.
+This module deliberately stays transport-neutral. It does not automate the
+ChatGPT UI and it never stores browser credentials. Its only job is to attach
+to the authoritative Control Plane, restore canonical project state, and
+compile that state into the immutable WebAgentAdapter request consumed by a
+browser-side bridge.
 """
 
 from __future__ import annotations
@@ -26,40 +27,46 @@ class ChatGPTWebBootstrap:
     protocol: str
     runtime_id: str
     project_id: str
+    session_id: str | None
     recommended_action: str
     current_source: str | None
     latest_task_id: str | None
     current_ir_id: str | None
     current_ir_digest: str | None
+    execution_context: dict[str, Any]
     request: dict[str, Any] | None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
-def build_bootstrap_from_project_state(
-    state: dict[str, Any],
+def build_bootstrap_from_attachment(
+    attachment: dict[str, Any],
     *,
     runtime_id: str = DEFAULT_RUNTIME_ID,
 ) -> ChatGPTWebBootstrap:
-    """Compile a Control Plane project-state response into a web-node resume packet.
+    """Compile a `/v1/attach` response into a deterministic resume packet."""
 
-    The Control Plane remains authoritative.  Browser/model code receives only
-    an immutable Canonical IR request and cannot manufacture project lineage.
-    """
-
-    project_id = str(state.get("projectId") or "").strip()
+    project_id = str(attachment.get("project_id") or "").strip()
     if not project_id:
-        raise ValueError("project state is missing projectId")
+        raise ValueError("attachment is missing project_id")
+
+    state = attachment.get("state")
+    if not isinstance(state, dict):
+        raise ValueError("attachment state must be an object")
+    if str(state.get("projectId") or "").strip() != project_id:
+        raise ValueError("attachment state projectId mismatch")
+
+    execution_context = attachment.get("execution_context") or {}
+    if not isinstance(execution_context, dict):
+        raise ValueError("attachment execution_context must be an object")
 
     action = str(state.get("recommendedAction") or "start")
     source = state.get("currentSource")
     latest_task = state.get("latestTask")
     latest_task_id = None
-    if isinstance(latest_task, dict):
-        raw_task_id = latest_task.get("taskId")
-        if raw_task_id is not None:
-            latest_task_id = str(raw_task_id)
+    if isinstance(latest_task, dict) and latest_task.get("taskId") is not None:
+        latest_task_id = str(latest_task["taskId"])
 
     raw_ir = state.get("currentIR")
     if raw_ir is None:
@@ -67,31 +74,34 @@ def build_bootstrap_from_project_state(
             protocol=BOOTSTRAP_PROTOCOL,
             runtime_id=runtime_id,
             project_id=project_id,
+            session_id=str(attachment.get("session_id")) if attachment.get("session_id") else None,
             recommended_action=action,
             current_source=source if isinstance(source, str) else None,
             latest_task_id=latest_task_id,
             current_ir_id=None,
             current_ir_digest=None,
+            execution_context=execution_context,
             request=None,
         )
     if not isinstance(raw_ir, dict):
-        raise ValueError("project state currentIR must be an object or null")
+        raise ValueError("attachment currentIR must be an object or null")
 
     ir = CanonicalIR.from_dict(raw_ir)
     if ir.project_id != project_id:
-        raise ValueError("project state currentIR project_id mismatch")
+        raise ValueError("attachment currentIR project_id mismatch")
 
-    adapter = WebAgentAdapter(runtime_id)
-    request = adapter.build_request(ir)
+    request = WebAgentAdapter(runtime_id).build_request(ir)
     return ChatGPTWebBootstrap(
         protocol=BOOTSTRAP_PROTOCOL,
         runtime_id=runtime_id,
         project_id=project_id,
+        session_id=str(attachment.get("session_id")) if attachment.get("session_id") else None,
         recommended_action=action,
         current_source=source if isinstance(source, str) else None,
         latest_task_id=latest_task_id,
         current_ir_id=ir.ir_id,
         current_ir_digest=ir.digest(),
+        execution_context=execution_context,
         request=request,
     )
 
@@ -102,10 +112,13 @@ def bootstrap_chatgpt_web(
     *,
     runtime_id: str = DEFAULT_RUNTIME_ID,
 ) -> ChatGPTWebBootstrap:
-    """Restore one project's current canonical state for a ChatGPT Web node."""
+    """Attach ChatGPT Web to one AgentOS project and restore its current state."""
 
     project_id = str(project_id or "").strip()
     if not project_id:
         raise ValueError("project_id is required")
-    state = client.get_project_state(project_id)
-    return build_bootstrap_from_project_state(state, runtime_id=runtime_id)
+    attachment = client.attach(
+        project_id,
+        agent={"runtime_id": runtime_id, "kind": "chatgpt_web", "transport": "browser"},
+    )
+    return build_bootstrap_from_attachment(attachment, runtime_id=runtime_id)

--- a/agentos_node/control_plane_client.py
+++ b/agentos_node/control_plane_client.py
@@ -83,6 +83,16 @@ class ControlPlaneClient:
     def health(self) -> dict[str, Any]:
         return self._request("GET", "/health")
 
+    def attach(self, project_id: str, *, agent: dict[str, Any] | None = None) -> dict[str, Any]:
+        project_id = str(project_id or "").strip()
+        if not project_id:
+            raise ValueError("project_id is required")
+        return self._request(
+            "POST",
+            "/v1/attach",
+            {"project_id": project_id, "agent": dict(agent or {})},
+        )
+
     def resolve_enrollment(self, reference: str) -> dict[str, Any]:
         return self._request("POST", "/v1/nodes/enrollment/resolve", {"reference": reference})
 

--- a/agentos_node/mcp_read_tools.py
+++ b/agentos_node/mcp_read_tools.py
@@ -1,8 +1,8 @@
 """Read-only MCP-facing AgentOS helpers.
 
 These helpers stay independent of any MCP SDK so they can be unit-tested without
-pulling transport dependencies into the core test suite.  They expose only the
-read/attach surface needed for ChatGPT Plus developer-mode experiments.
+pulling transport dependencies into the core test suite. They expose only the
+read/attach surface needed for ChatGPT custom-app / developer-mode experiments.
 """
 
 from __future__ import annotations

--- a/agentos_node/mcp_read_tools.py
+++ b/agentos_node/mcp_read_tools.py
@@ -1,0 +1,36 @@
+"""Read-only MCP-facing AgentOS helpers.
+
+These helpers stay independent of any MCP SDK so they can be unit-tested without
+pulling transport dependencies into the core test suite.  They expose only the
+read/attach surface needed for ChatGPT Plus developer-mode experiments.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .chatgpt_web_node import bootstrap_chatgpt_web
+from .control_plane_client import ControlPlaneClient
+
+
+def resume_project(
+    client: ControlPlaneClient,
+    project_id: str,
+    *,
+    runtime_id: str = "chatgpt-web",
+) -> dict[str, Any]:
+    """Return the authoritative AgentOS bootstrap packet for one project."""
+
+    return bootstrap_chatgpt_web(client, project_id, runtime_id=runtime_id).to_dict()
+
+
+def get_project_state(client: ControlPlaneClient, project_id: str) -> dict[str, Any]:
+    """Return the current durable project state without constructing new state."""
+
+    return client.get_project_state(project_id)
+
+
+def get_task(client: ControlPlaneClient, task_id: str) -> dict[str, Any]:
+    """Read one AgentOS task by id."""
+
+    return client.get_task(task_id)

--- a/browser/chatgpt-agentos-node/content.js
+++ b/browser/chatgpt-agentos-node/content.js
@@ -1,0 +1,144 @@
+(() => {
+  const CONTINUATION_RE = /^\s*(繼續(?:完成)?|continue|resume)\b?/i;
+  const GOAL_RE = /^\s*\/goal\s+([^\s]+)(?:\s+([\s\S]*))?$/i;
+  const COMPANION_URL = 'http://127.0.0.1:8766/v1/resume';
+
+  let busy = false;
+
+  function conversationKey() {
+    return `conversation:${location.host}${location.pathname}`;
+  }
+
+  function readComposer() {
+    const active = document.activeElement;
+    if (active && (active.tagName === 'TEXTAREA' || active.isContentEditable)) return active;
+    return document.querySelector('textarea, [contenteditable="true"]');
+  }
+
+  function composerText(el) {
+    if (!el) return '';
+    return el.tagName === 'TEXTAREA' ? el.value : (el.innerText || el.textContent || '');
+  }
+
+  function replaceComposer(el, text) {
+    if (!el) return;
+    if (el.tagName === 'TEXTAREA') {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      if (setter) setter.call(el, text); else el.value = text;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else {
+      el.focus();
+      document.execCommand('selectAll', false, null);
+      document.execCommand('insertText', false, text);
+      el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+    }
+  }
+
+  function showBanner(message, isError = false) {
+    let node = document.getElementById('agentos-continuity-banner');
+    if (!node) {
+      node = document.createElement('div');
+      node.id = 'agentos-continuity-banner';
+      Object.assign(node.style, {
+        position: 'fixed', right: '16px', bottom: '90px', zIndex: 2147483647,
+        maxWidth: '420px', padding: '10px 12px', borderRadius: '8px',
+        font: '13px/1.4 system-ui, sans-serif', boxShadow: '0 2px 12px rgba(0,0,0,.25)'
+      });
+      document.documentElement.appendChild(node);
+    }
+    node.style.background = isError ? '#4b1111' : '#12211a';
+    node.style.color = '#fff';
+    node.textContent = message;
+    clearTimeout(node.__timer);
+    node.__timer = setTimeout(() => node.remove(), 5000);
+  }
+
+  async function getRouting(text) {
+    const goalMatch = text.match(GOAL_RE);
+    if (goalMatch) {
+      const projectId = goalMatch[1];
+      await chrome.storage.local.set({
+        [conversationKey()]: projectId,
+        activeProjectId: projectId
+      });
+      return { projectId, intent: goalMatch[2] || 'continue', boundNow: true };
+    }
+
+    const keys = [conversationKey(), 'activeProjectId'];
+    const values = await chrome.storage.local.get(keys);
+    return {
+      projectId: values[conversationKey()] || values.activeProjectId || null,
+      intent: text,
+      boundNow: false
+    };
+  }
+
+  async function companionToken() {
+    const values = await chrome.storage.local.get(['companionToken']);
+    return values.companionToken || '';
+  }
+
+  async function resumeThroughOne(el, originalText) {
+    if (busy) return false;
+    busy = true;
+    try {
+      const route = await getRouting(originalText);
+      if (!route.projectId) {
+        showBanner('AgentOS: 此 Chat 尚未綁定 project。先用擴充功能綁定，或輸入 /goal <project-id>。', true);
+        return false;
+      }
+      const token = await companionToken();
+      if (!token) {
+        showBanner('AgentOS: 尚未設定 companion token。', true);
+        return false;
+      }
+
+      showBanner(`AgentOS: 正在從 ONE 恢復 ${route.projectId}…`);
+      const response = await fetch(COMPANION_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-AgentOS-Companion-Token': token
+        },
+        body: JSON.stringify({
+          project_id: route.projectId,
+          user_intent: route.intent
+        })
+      });
+      if (!response.ok) throw new Error(`companion HTTP ${response.status}`);
+      const payload = await response.json();
+      if (!payload.compiled_prompt || !payload.current_ir_digest) {
+        throw new Error('resume packet missing canonical binding');
+      }
+
+      await chrome.storage.local.set({
+        [conversationKey()]: route.projectId,
+        activeProjectId: route.projectId,
+        lastResumeDigest: payload.current_ir_digest
+      });
+      replaceComposer(el, payload.compiled_prompt);
+      showBanner(`AgentOS: 已從 ONE 接回 ${route.projectId}，可送出。`);
+      return true;
+    } catch (error) {
+      showBanner(`AgentOS resume 失敗：${error.message}。已阻止直接猜測。`, true);
+      return false;
+    } finally {
+      busy = false;
+    }
+  }
+
+  function isContinuation(text) {
+    return CONTINUATION_RE.test(text) || GOAL_RE.test(text);
+  }
+
+  document.addEventListener('keydown', async (event) => {
+    if (event.key !== 'Enter' || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) return;
+    const el = readComposer();
+    const text = composerText(el).trim();
+    if (!text || !isContinuation(text) || text.startsWith('{"protocol":"agentos.chatgpt-resume-prompt/')) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    await resumeThroughOne(el, text);
+  }, true);
+})();

--- a/browser/chatgpt-agentos-node/manifest.json
+++ b/browser/chatgpt-agentos-node/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "LeopardCat AgentOS ChatGPT Node",
+  "version": "0.1.0",
+  "description": "Fail-closed ChatGPT continuation interceptor backed by AgentOS ONE.",
+  "permissions": ["storage", "tabs"],
+  "host_permissions": [
+    "https://chatgpt.com/*",
+    "https://chat.openai.com/*",
+    "http://127.0.0.1:8766/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "AgentOS ChatGPT Node"
+  }
+}

--- a/browser/chatgpt-agentos-node/popup.html
+++ b/browser/chatgpt-agentos-node/popup.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>AgentOS ChatGPT Node</title>
+  <style>
+    body { font: 13px/1.4 system-ui,sans-serif; width: 320px; padding: 12px; }
+    label { display:block; margin: 8px 0 4px; font-weight:600; }
+    input { box-sizing:border-box; width:100%; padding:7px; }
+    button { margin-top:10px; padding:7px 10px; }
+    #status { margin-top:10px; white-space:pre-wrap; }
+  </style>
+</head>
+<body>
+  <strong>LeopardCat AgentOS ChatGPT Node</strong>
+  <label for="project">AgentOS project_id</label>
+  <input id="project" placeholder="例如 layout-3d">
+  <label for="token">Companion token</label>
+  <input id="token" type="password" placeholder="AGENTOS_CHATGPT_COMPANION_TOKEN">
+  <button id="bind">綁定目前 Chat</button>
+  <button id="saveToken">儲存 Token</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/browser/chatgpt-agentos-node/popup.js
+++ b/browser/chatgpt-agentos-node/popup.js
@@ -1,0 +1,48 @@
+async function activeChatKey() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.url) throw new Error('找不到目前分頁');
+  const url = new URL(tab.url);
+  if (!['chatgpt.com', 'chat.openai.com'].includes(url.host)) {
+    throw new Error('目前分頁不是 ChatGPT');
+  }
+  return `conversation:${url.host}${url.pathname}`;
+}
+
+async function refresh() {
+  const status = document.getElementById('status');
+  try {
+    const key = await activeChatKey();
+    const values = await chrome.storage.local.get([key, 'activeProjectId', 'companionToken']);
+    document.getElementById('project').value = values[key] || values.activeProjectId || '';
+    document.getElementById('token').value = values.companionToken || '';
+    status.textContent = values[key] ? `目前 Chat 已綁定：${values[key]}` : '目前 Chat 尚未綁定；會以 active project 作為 rollover fallback。';
+  } catch (error) {
+    status.textContent = error.message;
+  }
+}
+
+document.getElementById('bind').addEventListener('click', async () => {
+  const status = document.getElementById('status');
+  try {
+    const projectId = document.getElementById('project').value.trim();
+    if (!projectId) throw new Error('請輸入 project_id');
+    const key = await activeChatKey();
+    await chrome.storage.local.set({ [key]: projectId, activeProjectId: projectId });
+    status.textContent = `已綁定目前 Chat → ${projectId}`;
+  } catch (error) {
+    status.textContent = error.message;
+  }
+});
+
+document.getElementById('saveToken').addEventListener('click', async () => {
+  const status = document.getElementById('status');
+  const token = document.getElementById('token').value.trim();
+  if (token.length < 24) {
+    status.textContent = 'Companion token 至少需要 24 字元';
+    return;
+  }
+  await chrome.storage.local.set({ companionToken: token });
+  status.textContent = 'Companion token 已儲存於 extension local storage。';
+});
+
+refresh();

--- a/docs/CHATGPT_MCP_DEPLOYMENT.md
+++ b/docs/CHATGPT_MCP_DEPLOYMENT.md
@@ -1,0 +1,60 @@
+# ChatGPT MCP Deployment
+
+## Current product constraint
+
+As of 2026-08-27, OpenAI documents read/fetch MCP connections in ChatGPT developer mode for Pro users; full MCP is available to Business, Enterprise and Edu. Plus is not listed for custom MCP developer-mode connections. Treat this as a product-surface constraint, not an AgentOS limitation.
+
+## AgentOS side
+
+Install the optional MCP dependency set:
+
+```bash
+cd ~/agentmanager
+git checkout feature/chatgpt-web-node
+python3 -m pip install -r requirements-mcp.txt
+```
+
+Run the MCP bridge against the existing Control Plane:
+
+```bash
+export AGENTOS_CONTROL_PLANE_URL='https://studio.milkcat.org/dashboard/api/agentos'
+export AGENTOS_CONTROL_PLANE_TOKEN='REDACTED_SCOPED_TOKEN'
+export AGENTOS_CHATGPT_RUNTIME_ID='chatgpt-web'
+export AGENTOS_MCP_HOST='127.0.0.1'
+export AGENTOS_MCP_PORT='8000'
+export AGENTOS_MCP_PATH='/mcp'
+python3 scripts/agentos_mcp_server.py
+```
+
+Expected local endpoint:
+
+```text
+http://127.0.0.1:8000/mcp
+```
+
+Keep this loopback-only unless a separately authenticated reverse proxy is intentionally configured. Prefer OpenAI Secure MCP Tunnel for private/on-prem deployment.
+
+## Exposed read tools
+
+- `agentos_resume(project_id)` — authoritative resume packet: session, canonical IR, digest, execution context, latest task, recommended action.
+- `agentos_project_state(project_id)` — durable current project state.
+- `agentos_task(task_id)` — task status/readback.
+
+The MCP server is not a second persistence layer. AgentOS Control Plane remains authoritative.
+
+## ChatGPT continuity acceptance test
+
+Use the real 3D Layout project, not a synthetic demo.
+
+1. Ensure the AgentOS project state contains the existing `layoutlib`, demo URL/workspace, branch/commit as applicable, last verified action and next action.
+2. Start Chat A with the AgentOS MCP app connected and resume the project.
+3. Do at least one meaningful implementation step and checkpoint it through the normal AgentOS path.
+4. Abandon Chat A.
+5. Start Chat B without relying on ChatGPT-native history.
+6. Ask `繼續 3D Layout`.
+7. Chat B must call `agentos_resume` before reconstructing the task from semantic memory.
+8. Pass only if Chat B identifies the existing implementation and exact next action instead of proposing a new generic 2D-to-3D architecture.
+
+## What this does not solve yet
+
+MCP tool availability is not itself a deterministic conversation prehook. Tool instructions strongly bias the model toward `agentos_resume`, but the platform may still choose whether to call it. A later continuity-hardening layer must enforce continuation intent routing outside model discretion if ChatGPT does not provide a native conversation-start/pre-tool hook.

--- a/docs/CHATGPT_NODE_ONE.md
+++ b/docs/CHATGPT_NODE_ONE.md
@@ -1,0 +1,81 @@
+# ChatGPT Web Node -> ONE
+
+## Status
+
+This is the ChatGPT Plus-compatible AgentOS node path. It does not rely on ChatGPT conversation memory and does not require custom MCP availability.
+
+```text
+ChatGPT Web content script
+  -> continuation intent gate
+  -> local companion http://127.0.0.1:8766/v1/resume
+  -> AgentOS ONE /v1/attach
+  -> Canonical IR + compiled execution context
+  -> deterministic continuation prompt
+  -> ChatGPT executor
+```
+
+The browser extension stores routing metadata only (`conversation -> project_id`, `activeProjectId`, companion transport token). Canonical state and the ONE credential stay outside the browser.
+
+## Windows install
+
+From a checkout containing this feature:
+
+```powershell
+$env:AGENTOS_CONTROL_PLANE_TOKEN = '<authorized ONE token>'
+Set-ExecutionPolicy -Scope Process Bypass
+.\scripts\install_chatgpt_node_windows.ps1
+```
+
+The installer defaults ONE to:
+
+```text
+https://studio.milkcat.org/dashboard/api/agentos
+```
+
+It installs the Python package, creates a random localhost companion token, sets user environment variables and adds a per-user Startup launcher for the companion.
+
+Then load this folder as an unpacked Chrome/Edge extension:
+
+```text
+browser/chatgpt-agentos-node
+```
+
+Paste the companion token printed by the installer into the extension popup. Bind the current ChatGPT conversation to its stable AgentOS `project_id` once. The latest bound project is also retained as the rollover fallback for a fresh conversation.
+
+## Continuation protocol
+
+The content script intercepts these intents before ChatGPT receives them:
+
+- `繼續`
+- `繼續完成`
+- `continue`
+- `resume`
+- `/goal <project-id> [intent]`
+
+For an intercepted continuation, the original message is not submitted. The extension first calls the local companion. The companion must obtain a ONE attachment and return a prompt bound to `current_ir_digest`. Only then is the composer replaced with the authoritative continuation prompt.
+
+If ONE/companion/token/project routing fails, the operation fails closed and ChatGPT is not allowed to guess from conversational memory.
+
+## Conversation rollover
+
+A bound conversation stores only its routing association. When ChatGPT reaches a conversation limit and a fresh chat is opened, `activeProjectId` provides the default project routing for an explicit continuation intent. `/goal <project-id>` can deterministically rebind when switching projects.
+
+## Continuity Floor acceptance
+
+For the 3D Layout case:
+
+1. Bind the existing 3D Layout AgentOS project.
+2. Ensure ONE canonical state contains the real `layoutlib`/demo operational state, last verified result and next action.
+3. Open a fresh ChatGPT conversation with no useful native chat history.
+4. Enter `繼續`.
+5. The extension must block direct submission, call ONE through the companion and inject an `agentos.chatgpt-browser-resume/v1` payload.
+6. ChatGPT must resume the actual existing implementation. A generic 2D-to-3D architecture restart is a failure.
+
+## Security boundary
+
+- Companion binds loopback only.
+- Companion token must be at least 24 characters.
+- ONE credential is never stored in extension storage.
+- Browser stores no Canonical IR.
+- `current_ir_digest` is required before a continuation prompt is accepted.
+- Failure to restore state is fail-closed.

--- a/docs/CHATGPT_PLUS_BROWSER_RESUME.md
+++ b/docs/CHATGPT_PLUS_BROWSER_RESUME.md
@@ -1,0 +1,60 @@
+# ChatGPT Plus Browser Resume
+
+## Purpose
+
+Provide a continuity path for ChatGPT Plus when custom Developer-Mode MCP is not available to the account.
+
+This path reuses the existing external `ai-browser-bridge`; AgentOS does not own ChatGPT DOM selectors, cookies, browser profiles, or login persistence.
+
+## Flow
+
+```text
+AgentOS Control Plane
+  -> POST /v1/attach
+  -> ChatGPTWebBootstrap
+  -> compile_resume_prompt()
+  -> ai-browser-bridge `bridge ask --provider chatgpt --json ...`
+  -> ChatGPT Web
+  -> untrusted semantic reply
+```
+
+Canonical project state remains authoritative. The browser bridge is transport only.
+
+## Command
+
+On the machine that already has a working, signed-in ChatGPT `ai-browser-bridge` profile:
+
+```bash
+export AGENTOS_CONTROL_PLANE_URL='https://<agentos-control-plane>'
+export AGENTOS_CONTROL_PLANE_TOKEN='<scoped-token>'
+python3 scripts/chatgpt_browser_resume.py <project-id> --intent '繼續'
+```
+
+The command first attaches to AgentOS. Only after the authoritative state is restored does it call ChatGPT.
+
+## 3D Layout Continuity Floor
+
+The first real acceptance case is the existing 3D Layout project.
+
+The canonical AgentOS state must contain enough operational information to distinguish the real implementation from a generic topic summary, including as applicable:
+
+- existing `layoutlib` component/repository location;
+- demo URL/deployment identity;
+- active branch/HEAD or workspace revision;
+- last verified action/result;
+- current bug or incomplete behavior;
+- exact next implementation action.
+
+A fresh ChatGPT conversation receiving the compiled resume prompt must continue from those facts. A generic architecture proposal for 2D-to-3D reconstruction is a regression failure.
+
+## What this does not solve yet
+
+This command can open/use ChatGPT through the external bridge, but it does not intercept a user manually typing `繼續` into an arbitrary already-open ChatGPT tab.
+
+That last UX gap requires one of:
+
+1. native ChatGPT MCP/app support for the account;
+2. a browser-side intent interceptor that calls AgentOS before the message is submitted;
+3. a ChatGPT-facing authorized integration that can enforce the continuation protocol.
+
+Do not solve this by moving canonical state into the extension or browser profile. Any interceptor must remain a stateless transport and must fail closed when AgentOS resume cannot be obtained.

--- a/docs/CHATGPT_WEB_NODE.md
+++ b/docs/CHATGPT_WEB_NODE.md
@@ -1,0 +1,83 @@
+# ChatGPT Web Node
+
+## Goal
+
+Treat ChatGPT Web as a replaceable AgentOS executor instead of relying on ChatGPT conversation memory for operational continuity.
+
+A conversation rollover must not be a persistence boundary. Given the same AgentOS project, a new ChatGPT conversation should be able to attach and recover the authoritative goal, constraints, current IR, compiled execution context, latest task and recommended continuation action.
+
+## Current implementation
+
+`agentos_node/chatgpt_web_node.py` implements the transport-neutral bootstrap contract:
+
+1. call the existing authenticated `POST /v1/attach` Control Plane operation;
+2. bind the returned `session_id`, project state and compiled execution context;
+3. validate the current Canonical IR belongs to the attached project;
+4. build an immutable `WebAgentAdapter` request with `input_ir_id` and digest binding;
+5. return `agentos.chatgpt-web-bootstrap/v1` for transport by a browser bridge, extension, connector or future native integration.
+
+CLI:
+
+```bash
+export AGENTOS_CONTROL_PLANE_URL=https://studio.milkcat.org/dashboard/api/agentos
+export AGENTOS_CONTROL_PLANE_TOKEN='...scoped client token...'
+python3 scripts/chatgpt_web_node.py <project-id>
+```
+
+The CLI never needs browser credentials and the model is never allowed to construct trusted continuation lineage.
+
+## Trust boundary
+
+ChatGPT Web is not the state owner.
+
+```text
+ChatGPT conversation
+    |
+    | semantic output only
+    v
+browser/connector transport
+    |
+    v
+ChatGPTWebBootstrap + WebAgentAdapter
+    |
+    v
+Control Plane / State Kernel
+```
+
+The Control Plane remains authoritative for canonical state. The web model may reason over the attached context, but project identity, IR lineage, digest binding, task completion and receipts stay outside the model boundary.
+
+## Continuity Floor acceptance test
+
+The first real regression target is the existing 3D Layout work:
+
+1. Chat A is attached to the 3D Layout AgentOS project and performs work against the existing `layoutlib` + demo implementation.
+2. The current canonical state records the real repo/workspace state and next action.
+3. Chat A is abandoned or reaches its conversation limit.
+4. Chat B starts with no useful ChatGPT-native conversation history.
+5. Chat B attaches to the same AgentOS project.
+6. The bootstrap packet must recover the actual implementation state, not merely the semantic topic "3D Layout".
+7. Chat B must identify the existing `layoutlib`, demo, last verified action and next action without redesigning the project from scratch.
+
+Failure mode to prevent:
+
+```text
+"continue 3D Layout"
+  -> semantic memory only
+  -> generic 2D-to-3D architecture proposal
+```
+
+Required behavior:
+
+```text
+"continue 3D Layout"
+  -> AgentOS attach
+  -> canonical project state
+  -> compiled execution context
+  -> exact next implementation action
+```
+
+## Remaining work
+
+The bootstrap/resume core is intentionally transport-neutral. To make the ChatGPT website itself behave as a zero-manual-step node, one authorized transport must still carry the bootstrap packet into a new ChatGPT conversation and return the constrained web-agent response. Candidate transports remain a browser extension, local browser relay, an authorized connector, or a future native ChatGPT integration.
+
+That transport must not become a second state store. It should only move AgentOS envelopes and preserve the existing digest/session binding.

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,0 +1,3 @@
+# Optional dependency set for the ChatGPT/AgentOS MCP bridge.
+# The core AgentOS runtime does not require MCP.
+mcp[cli]>=2,<3

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -2,7 +2,7 @@
 """Read-only AgentOS MCP server for ChatGPT developer-mode experiments.
 
 Run this on a trusted host and connect it through Secure MCP Tunnel or another
-authorized private transport.  Do not expose it anonymously to the public
+authorized private transport. Do not expose it anonymously to the public
 Internet: the server-side Control Plane credential may authorize private state.
 """
 
@@ -19,12 +19,22 @@ from agentos_node.mcp_read_tools import get_project_state, get_task, resume_proj
 CONTROL_PLANE_URL = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "").strip()
 CONTROL_PLANE_TOKEN = os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN")
 RUNTIME_ID = os.environ.get("AGENTOS_CHATGPT_RUNTIME_ID", "chatgpt-web").strip() or "chatgpt-web"
+MCP_HOST = os.environ.get("AGENTOS_MCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
+MCP_PORT = int(os.environ.get("AGENTOS_MCP_PORT", "8000"))
+MCP_PATH = os.environ.get("AGENTOS_MCP_PATH", "/mcp").strip() or "/mcp"
 
 if not CONTROL_PLANE_URL:
     raise RuntimeError("AGENTOS_CONTROL_PLANE_URL is required")
 
 client = ControlPlaneClient(CONTROL_PLANE_URL, token=CONTROL_PLANE_TOKEN)
-mcp = MCPServer("LeopardCat AgentOS")
+mcp = MCPServer(
+    "LeopardCat AgentOS",
+    instructions=(
+        "Use AgentOS as the authoritative source for existing project state. "
+        "When a user asks to continue/resume prior work, call agentos_resume "
+        "before reasoning from chat memory."
+    ),
+)
 
 
 @mcp.tool()
@@ -55,4 +65,11 @@ def agentos_task(task_id: str) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run("streamable-http")
+    mcp.run(
+        transport="streamable-http",
+        host=MCP_HOST,
+        port=MCP_PORT,
+        streamable_http_path=MCP_PATH,
+        stateless_http=True,
+        json_response=True,
+    )

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Read-only AgentOS MCP server for ChatGPT developer-mode experiments.
+
+Run this on a trusted host and connect it through Secure MCP Tunnel or another
+authorized private transport.  Do not expose it anonymously to the public
+Internet: the server-side Control Plane credential may authorize private state.
+"""
+
+from __future__ import annotations
+
+import os
+
+from mcp.server import MCPServer
+
+from agentos_node.control_plane_client import ControlPlaneClient
+from agentos_node.mcp_read_tools import get_project_state, get_task, resume_project
+
+
+CONTROL_PLANE_URL = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "").strip()
+CONTROL_PLANE_TOKEN = os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN")
+RUNTIME_ID = os.environ.get("AGENTOS_CHATGPT_RUNTIME_ID", "chatgpt-web").strip() or "chatgpt-web"
+
+if not CONTROL_PLANE_URL:
+    raise RuntimeError("AGENTOS_CONTROL_PLANE_URL is required")
+
+client = ControlPlaneClient(CONTROL_PLANE_URL, token=CONTROL_PLANE_TOKEN)
+mcp = MCPServer("LeopardCat AgentOS")
+
+
+@mcp.tool()
+def agentos_resume(project_id: str) -> dict:
+    """Resume existing AgentOS work before answering a continuation request.
+
+    Use this when the user says continue/resume/繼續, refers to prior project work,
+    or expects the current implementation state. Returns authoritative canonical
+    state plus compiled execution context; do not substitute chat memory for it.
+    This tool is read-only with respect to durable AgentOS task state.
+    """
+
+    return resume_project(client, project_id, runtime_id=RUNTIME_ID)
+
+
+@mcp.tool()
+def agentos_project_state(project_id: str) -> dict:
+    """Read the current durable AgentOS state for a known project id."""
+
+    return get_project_state(client, project_id)
+
+
+@mcp.tool()
+def agentos_task(task_id: str) -> dict:
+    """Read one AgentOS task and its current status by task id."""
+
+    return get_task(client, task_id)
+
+
+if __name__ == "__main__":
+    mcp.run("streamable-http")

--- a/scripts/chatgpt_browser_resume.py
+++ b/scripts/chatgpt_browser_resume.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Resume an AgentOS project in ChatGPT through the external ai-browser-bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from agentos_node.ai_browser_bridge import AiBrowserBridgeClient
+from agentos_node.chatgpt_browser_resume import resume_via_browser
+from agentos_node.control_plane_client import ControlPlaneClient
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_id", help="stable AgentOS project id to resume")
+    parser.add_argument("--intent", default="continue", help="original continuation intent")
+    parser.add_argument("--runtime-id", default="chatgpt-web")
+    parser.add_argument("--bridge", default=os.environ.get("AGENTOS_BROWSER_BRIDGE", "bridge"))
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument(
+        "--control-plane-url",
+        default=os.environ.get("AGENTOS_CONTROL_PLANE_URL"),
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.control_plane_url:
+        raise SystemExit("AGENTOS_CONTROL_PLANE_URL or --control-plane-url is required")
+
+    control_plane = ControlPlaneClient(args.control_plane_url, token=args.token)
+    bridge = AiBrowserBridgeClient(executable=args.bridge)
+    result = resume_via_browser(
+        control_plane,
+        bridge,
+        args.project_id,
+        runtime_id=args.runtime_id,
+        user_intent=args.intent,
+        timeout_seconds=args.timeout,
+    )
+    json.dump(result.to_dict(), sys.stdout, ensure_ascii=False, sort_keys=True, indent=2)
+    sys.stdout.write("\n")
+    return 0 if result.bridge_reply.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/chatgpt_local_companion.py
+++ b/scripts/chatgpt_local_companion.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Run the localhost ChatGPT AgentOS continuation companion."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from agentos_node.chatgpt_local_companion import (
+    ChatGPTLocalCompanionServer,
+    ChatGPTLocalCompanionService,
+)
+from agentos_node.control_plane_client import ControlPlaneClient
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("AGENTOS_CHATGPT_COMPANION_PORT", "8766")))
+    parser.add_argument("--runtime-id", default=os.environ.get("AGENTOS_CHATGPT_RUNTIME_ID", "chatgpt-web"))
+    parser.add_argument("--control-plane-url", default=os.environ.get("AGENTOS_CONTROL_PLANE_URL"))
+    parser.add_argument("--control-plane-token", default=os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN"))
+    parser.add_argument("--companion-token", default=os.environ.get("AGENTOS_CHATGPT_COMPANION_TOKEN"))
+    args = parser.parse_args()
+
+    if not args.control_plane_url:
+        raise SystemExit("AGENTOS_CONTROL_PLANE_URL is required")
+    if not args.companion_token:
+        raise SystemExit("AGENTOS_CHATGPT_COMPANION_TOKEN is required")
+
+    client = ControlPlaneClient(args.control_plane_url, token=args.control_plane_token)
+    service = ChatGPTLocalCompanionService(client, runtime_id=args.runtime_id)
+    server = ChatGPTLocalCompanionServer((args.host, args.port), service, token=args.companion_token)
+    print(f"ChatGPT AgentOS companion listening on http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/chatgpt_web_node.py
+++ b/scripts/chatgpt_web_node.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Emit a ChatGPT Web AgentOS bootstrap/resume packet as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from agentos_node.chatgpt_web_node import bootstrap_chatgpt_web
+from agentos_node.control_plane_client import ControlPlaneClient
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_id", help="stable AgentOS project id to resume")
+    parser.add_argument("--runtime-id", default="chatgpt-web")
+    parser.add_argument(
+        "--control-plane-url",
+        default=os.environ.get("AGENTOS_CONTROL_PLANE_URL"),
+        help="defaults to AGENTOS_CONTROL_PLANE_URL",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN"),
+        help="defaults to AGENTOS_CONTROL_PLANE_TOKEN",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.control_plane_url:
+        raise SystemExit("AGENTOS_CONTROL_PLANE_URL or --control-plane-url is required")
+
+    client = ControlPlaneClient(args.control_plane_url, token=args.token)
+    packet = bootstrap_chatgpt_web(client, args.project_id, runtime_id=args.runtime_id)
+    json.dump(packet.to_dict(), sys.stdout, ensure_ascii=False, sort_keys=True, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_chatgpt_node_windows.ps1
+++ b/scripts/install_chatgpt_node_windows.ps1
@@ -1,0 +1,48 @@
+param(
+    [string]$OneUrl = "https://studio.milkcat.org/dashboard/api/agentos",
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")),
+    [int]$Port = 8766
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $env:AGENTOS_CONTROL_PLANE_TOKEN) {
+    throw "AGENTOS_CONTROL_PLANE_TOKEN is required before installing the ChatGPT node."
+}
+
+python -m pip install --upgrade -e $RepoRoot
+
+$bytes = New-Object byte[] 32
+[Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+$companionToken = [Convert]::ToHexString($bytes).ToLowerInvariant()
+
+[Environment]::SetEnvironmentVariable("AGENTOS_CONTROL_PLANE_URL", $OneUrl, "User")
+[Environment]::SetEnvironmentVariable("AGENTOS_CONTROL_PLANE_TOKEN", $env:AGENTOS_CONTROL_PLANE_TOKEN, "User")
+[Environment]::SetEnvironmentVariable("AGENTOS_CHATGPT_COMPANION_TOKEN", $companionToken, "User")
+[Environment]::SetEnvironmentVariable("AGENTOS_CHATGPT_COMPANION_PORT", "$Port", "User")
+
+$startup = [Environment]::GetFolderPath("Startup")
+$launcher = Join-Path $startup "LeopardCat-AgentOS-ChatGPT-Node.cmd"
+$scriptPath = Join-Path $RepoRoot "scripts\chatgpt_local_companion.py"
+@"
+@echo off
+set AGENTOS_CONTROL_PLANE_URL=$OneUrl
+set AGENTOS_CONTROL_PLANE_TOKEN=$env:AGENTOS_CONTROL_PLANE_TOKEN
+set AGENTOS_CHATGPT_COMPANION_TOKEN=$companionToken
+set AGENTOS_CHATGPT_COMPANION_PORT=$Port
+start "AgentOS ChatGPT Node" /min python "$scriptPath"
+"@ | Set-Content -Path $launcher -Encoding ASCII
+
+Start-Process -FilePath "cmd.exe" -ArgumentList "/c", $launcher -WindowStyle Hidden
+
+$extensionPath = Join-Path $RepoRoot "browser\chatgpt-agentos-node"
+Write-Host ""
+Write-Host "ChatGPT AgentOS node companion installed." -ForegroundColor Green
+Write-Host "ONE: $OneUrl"
+Write-Host "Companion: http://127.0.0.1:$Port"
+Write-Host "Extension folder: $extensionPath"
+Write-Host "Companion token (paste into extension popup):"
+Write-Host $companionToken -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Chrome/Edge: Extensions -> Developer mode -> Load unpacked -> select the extension folder."
+Write-Host "Then open ChatGPT, click the AgentOS extension, save the token and bind the current chat to an AgentOS project_id."

--- a/tests/test_antigravity_relay.py
+++ b/tests/test_antigravity_relay.py
@@ -148,6 +148,10 @@ def test_restart_reconciliation_emits_unknown_outcome_receipt_without_reexecutio
         "execution_context": _execution_context(),
     }
     (processing / f"{capsule_id}.json").write_text(json.dumps(capsule), encoding="utf-8")
+    # RelayPaths.ensure() resolves share_relay_path from the relay module, while
+    # receipt writes resolve the worker import. Stub both because this unit test
+    # verifies restart semantics, not host group provisioning.
+    monkeypatch.setattr("agentos_node.antigravity_relay.share_relay_path", lambda *args, **kwargs: None)
     monkeypatch.setattr("agentos_node.antigravity_relay_worker.share_relay_path", lambda *args, **kwargs: None)
 
     worker = AntigravityRelayWorker(root, executor=["/bin/false"])

--- a/tests/test_chatgpt_browser_resume.py
+++ b/tests/test_chatgpt_browser_resume.py
@@ -1,0 +1,71 @@
+import json
+
+from agentos_node.ai_browser_bridge import AiBrowserBridgeClient
+from agentos_node.chatgpt_browser_resume import compile_resume_prompt, resume_via_browser
+from agentos_node.chatgpt_web_node import ChatGPTWebBootstrap
+
+
+def _packet():
+    return ChatGPTWebBootstrap(
+        protocol="agentos.chatgpt-web-bootstrap/v1",
+        runtime_id="chatgpt-web",
+        project_id="layout-3d",
+        session_id="aos_session",
+        recommended_action="continue",
+        current_source="task_continuation",
+        latest_task_id="task-1",
+        current_ir_id="ir-1",
+        current_ir_digest="digest-1",
+        execution_context={"workspace": {"component": "layoutlib", "demo": "https://demo.example"}},
+        request={"canonical_ir": {"goal": "continue 3D Layout"}},
+    )
+
+
+def test_compile_resume_prompt_contains_authoritative_continuity_state():
+    payload = json.loads(compile_resume_prompt(_packet(), user_intent="繼續3D Layout"))
+
+    assert payload["project_id"] == "layout-3d"
+    assert payload["current_ir_id"] == "ir-1"
+    assert payload["current_ir_digest"] == "digest-1"
+    assert payload["execution_context"]["workspace"]["component"] == "layoutlib"
+    assert payload["user_intent"] == "繼續3D Layout"
+    assert "Do not redesign" in payload["instruction"]
+
+
+def test_resume_via_browser_attaches_then_sends_compiled_prompt(monkeypatch):
+    packet = _packet()
+
+    class FakeControlPlane:
+        pass
+
+    captured = {}
+
+    def fake_bootstrap(control_plane, project_id, *, runtime_id):
+        assert project_id == "layout-3d"
+        assert runtime_id == "chatgpt-web"
+        return packet
+
+    monkeypatch.setattr(
+        "agentos_node.chatgpt_browser_resume.bootstrap_chatgpt_web",
+        fake_bootstrap,
+    )
+
+    def runner(command, timeout):
+        captured["command"] = list(command)
+        captured["timeout"] = timeout
+        return json.dumps({"chatgpt": {"ok": True, "reply": "continued", "elapsedMs": 10}})
+
+    bridge = AiBrowserBridgeClient(runner=runner)
+    result = resume_via_browser(
+        FakeControlPlane(),
+        bridge,
+        "layout-3d",
+        user_intent="continue",
+    )
+
+    assert result.bridge_reply.ok is True
+    assert result.bridge_reply.reply == "continued"
+    assert captured["command"][:5] == ["bridge", "ask", "--provider", "chatgpt", "--json"]
+    prompt = json.loads(captured["command"][5])
+    assert prompt["current_ir_digest"] == "digest-1"
+    assert prompt["execution_context"]["workspace"]["component"] == "layoutlib"

--- a/tests/test_chatgpt_local_companion.py
+++ b/tests/test_chatgpt_local_companion.py
@@ -1,0 +1,87 @@
+import json
+import threading
+from urllib.request import Request, urlopen
+
+from agentos_node.chatgpt_local_companion import (
+    ChatGPTLocalCompanionServer,
+    ChatGPTLocalCompanionService,
+)
+from agentos_node.chatgpt_web_node import ChatGPTWebBootstrap
+
+
+def test_service_returns_compiled_prompt(monkeypatch):
+    packet = ChatGPTWebBootstrap(
+        protocol="agentos.chatgpt-web-bootstrap/v1",
+        runtime_id="chatgpt-web",
+        project_id="layout-3d",
+        session_id="aos_session",
+        recommended_action="continue",
+        current_source="task_continuation",
+        latest_task_id="task-1",
+        current_ir_id="ir-1",
+        current_ir_digest="digest-1",
+        execution_context={"workspace": {"component": "layoutlib"}},
+        request={"canonical_ir": {"goal": "continue 3D Layout"}},
+    )
+
+    monkeypatch.setattr(
+        "agentos_node.chatgpt_local_companion.bootstrap_chatgpt_web",
+        lambda client, project_id, runtime_id: packet,
+    )
+
+    service = ChatGPTLocalCompanionService(object())
+    result = service.resume("layout-3d", "繼續")
+
+    assert result["project_id"] == "layout-3d"
+    assert result["current_ir_digest"] == "digest-1"
+    payload = json.loads(result["compiled_prompt"])
+    assert payload["execution_context"]["workspace"]["component"] == "layoutlib"
+    assert payload["user_intent"] == "繼續"
+
+
+def test_server_requires_origin_and_transport_token(monkeypatch):
+    packet = ChatGPTWebBootstrap(
+        protocol="agentos.chatgpt-web-bootstrap/v1",
+        runtime_id="chatgpt-web",
+        project_id="layout-3d",
+        session_id="aos_session",
+        recommended_action="continue",
+        current_source="task_continuation",
+        latest_task_id=None,
+        current_ir_id="ir-1",
+        current_ir_digest="digest-1",
+        execution_context={},
+        request={"canonical_ir": {"goal": "continue"}},
+    )
+    monkeypatch.setattr(
+        "agentos_node.chatgpt_local_companion.bootstrap_chatgpt_web",
+        lambda client, project_id, runtime_id: packet,
+    )
+
+    server = ChatGPTLocalCompanionServer(
+        ("127.0.0.1", 0),
+        ChatGPTLocalCompanionService(object()),
+        token="x" * 24,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        raw = json.dumps({"project_id": "layout-3d", "user_intent": "continue"}).encode()
+        req = Request(
+            f"http://{host}:{port}/v1/resume",
+            data=raw,
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "https://chatgpt.com",
+                "X-AgentOS-Companion-Token": "x" * 24,
+            },
+            method="POST",
+        )
+        with urlopen(req, timeout=2) as response:
+            payload = json.loads(response.read().decode())
+        assert payload["project_id"] == "layout-3d"
+        assert payload["current_ir_digest"] == "digest-1"
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_chatgpt_node_extension_contract.py
+++ b/tests/test_chatgpt_node_extension_contract.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXT = ROOT / "browser" / "chatgpt-agentos-node"
+
+
+def test_extension_manifest_is_chatgpt_scoped_and_loopback_only():
+    manifest = json.loads((EXT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["manifest_version"] == 3
+    hosts = set(manifest["host_permissions"])
+    assert "https://chatgpt.com/*" in hosts
+    assert "https://chat.openai.com/*" in hosts
+    assert "http://127.0.0.1:8766/*" in hosts
+    assert all("studio.milkcat.org" not in host for host in hosts)
+
+
+def test_content_script_is_fail_closed_and_does_not_embed_one_credentials():
+    content = (EXT / "content.js").read_text(encoding="utf-8")
+    assert "http://127.0.0.1:8766/v1/resume" in content
+    assert "current_ir_digest" in content
+    assert "已阻止直接猜測" in content
+    assert "AGENTOS_CONTROL_PLANE_TOKEN" not in content
+    assert "studio.milkcat.org" not in content
+
+
+def test_extension_keeps_only_routing_and_companion_transport_metadata():
+    popup = (EXT / "popup.js").read_text(encoding="utf-8")
+    assert "activeProjectId" in popup
+    assert "companionToken" in popup
+    assert "canonical_ir" not in popup
+    assert "execution_context" not in popup

--- a/tests/test_chatgpt_web_node.py
+++ b/tests/test_chatgpt_web_node.py
@@ -1,11 +1,22 @@
 from agentos_node.chatgpt_web_node import (
     BOOTSTRAP_PROTOCOL,
-    build_bootstrap_from_project_state,
+    build_bootstrap_from_attachment,
 )
 from runtime_core.canonical_ir import CanonicalIR
 
 
-def test_bootstrap_compiles_authoritative_project_state_into_web_request():
+def _attachment(project_id, state, *, execution_context=None):
+    return {
+        "protocol": "agentos.core/v0.1",
+        "session_id": "aos_test",
+        "project_id": project_id,
+        "agent": {"runtime_id": "chatgpt-web"},
+        "state": state,
+        "execution_context": execution_context or {"compiled": True},
+    }
+
+
+def test_bootstrap_compiles_authoritative_attachment_into_web_request():
     ir = CanonicalIR(
         goal="continue 3D layout implementation",
         project_id="layout-3d",
@@ -21,30 +32,31 @@ def test_bootstrap_compiles_authoritative_project_state_into_web_request():
         "recommendedAction": "continue",
     }
 
-    packet = build_bootstrap_from_project_state(state)
+    packet = build_bootstrap_from_attachment(_attachment("layout-3d", state))
 
     assert packet.protocol == BOOTSTRAP_PROTOCOL
     assert packet.runtime_id == "chatgpt-web"
     assert packet.project_id == "layout-3d"
+    assert packet.session_id == "aos_test"
     assert packet.recommended_action == "continue"
     assert packet.latest_task_id == "task-123"
     assert packet.current_ir_id == ir.ir_id
     assert packet.current_ir_digest == ir.digest()
+    assert packet.execution_context == {"compiled": True}
     assert packet.request["input_ir_id"] == ir.ir_id
     assert packet.request["input_digest"] == ir.digest()
     assert packet.request["canonical_ir"]["payload"]["next_action"] == "inspect existing demo"
 
 
 def test_bootstrap_start_state_has_no_fabricated_ir():
-    packet = build_bootstrap_from_project_state(
-        {
-            "projectId": "new-project",
-            "latestTask": None,
-            "currentIR": None,
-            "currentSource": None,
-            "recommendedAction": "start",
-        }
-    )
+    state = {
+        "projectId": "new-project",
+        "latestTask": None,
+        "currentIR": None,
+        "currentSource": None,
+        "recommendedAction": "start",
+    }
+    packet = build_bootstrap_from_attachment(_attachment("new-project", state))
 
     assert packet.recommended_action == "start"
     assert packet.request is None
@@ -63,7 +75,7 @@ def test_bootstrap_rejects_project_mismatch():
     }
 
     try:
-        build_bootstrap_from_project_state(state)
+        build_bootstrap_from_attachment(_attachment("project-b", state))
     except ValueError as exc:
         assert "project_id mismatch" in str(exc)
     else:

--- a/tests/test_chatgpt_web_node.py
+++ b/tests/test_chatgpt_web_node.py
@@ -1,0 +1,70 @@
+from agentos_node.chatgpt_web_node import (
+    BOOTSTRAP_PROTOCOL,
+    build_bootstrap_from_project_state,
+)
+from runtime_core.canonical_ir import CanonicalIR
+
+
+def test_bootstrap_compiles_authoritative_project_state_into_web_request():
+    ir = CanonicalIR(
+        goal="continue 3D layout implementation",
+        project_id="layout-3d",
+        capability="web.reason",
+        payload={"next_action": "inspect existing demo"},
+        constraints=["do not redesign from scratch"],
+    )
+    state = {
+        "projectId": "layout-3d",
+        "latestTask": {"taskId": "task-123", "status": "succeeded"},
+        "currentIR": ir.to_dict(),
+        "currentSource": "task_continuation",
+        "recommendedAction": "continue",
+    }
+
+    packet = build_bootstrap_from_project_state(state)
+
+    assert packet.protocol == BOOTSTRAP_PROTOCOL
+    assert packet.runtime_id == "chatgpt-web"
+    assert packet.project_id == "layout-3d"
+    assert packet.recommended_action == "continue"
+    assert packet.latest_task_id == "task-123"
+    assert packet.current_ir_id == ir.ir_id
+    assert packet.current_ir_digest == ir.digest()
+    assert packet.request["input_ir_id"] == ir.ir_id
+    assert packet.request["input_digest"] == ir.digest()
+    assert packet.request["canonical_ir"]["payload"]["next_action"] == "inspect existing demo"
+
+
+def test_bootstrap_start_state_has_no_fabricated_ir():
+    packet = build_bootstrap_from_project_state(
+        {
+            "projectId": "new-project",
+            "latestTask": None,
+            "currentIR": None,
+            "currentSource": None,
+            "recommendedAction": "start",
+        }
+    )
+
+    assert packet.recommended_action == "start"
+    assert packet.request is None
+    assert packet.current_ir_id is None
+    assert packet.current_ir_digest is None
+
+
+def test_bootstrap_rejects_project_mismatch():
+    ir = CanonicalIR(goal="g", project_id="project-a", capability="web.reason")
+    state = {
+        "projectId": "project-b",
+        "latestTask": None,
+        "currentIR": ir.to_dict(),
+        "currentSource": "task_input",
+        "recommendedAction": "continue",
+    }
+
+    try:
+        build_bootstrap_from_project_state(state)
+    except ValueError as exc:
+        assert "project_id mismatch" in str(exc)
+    else:
+        raise AssertionError("expected project mismatch to fail closed")

--- a/tests/test_distributed_http_client.py
+++ b/tests/test_distributed_http_client.py
@@ -40,7 +40,9 @@ def test_lightweight_remote_worker_over_real_http(tmp_path: Path):
         wrong_client = ControlPlaneClient(f"http://{host}:{port}", token="wrong-token")
         with pytest.raises(ControlPlaneHTTPError) as exc_info:
             wrong_client.get_task(task_id)
-        assert exc_info.value.status == 401
+        # A supplied but invalid bearer is neither the root credential nor a
+        # scoped client principal, so permission enforcement rejects it.
+        assert exc_info.value.status == 403
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_mcp_read_tools.py
+++ b/tests/test_mcp_read_tools.py
@@ -1,0 +1,52 @@
+from agentos_node import mcp_read_tools
+
+
+class FakeClient:
+    def __init__(self):
+        self.project_calls = []
+        self.task_calls = []
+
+    def get_project_state(self, project_id):
+        self.project_calls.append(project_id)
+        return {"projectId": project_id, "recommendedAction": "continue"}
+
+    def get_task(self, task_id):
+        self.task_calls.append(task_id)
+        return {"task": {"taskId": task_id, "status": "succeeded"}}
+
+
+def test_project_state_is_read_only_passthrough():
+    client = FakeClient()
+    result = mcp_read_tools.get_project_state(client, "layout-3d")
+    assert result["projectId"] == "layout-3d"
+    assert client.project_calls == ["layout-3d"]
+
+
+def test_task_is_read_only_passthrough():
+    client = FakeClient()
+    result = mcp_read_tools.get_task(client, "task-123")
+    assert result["task"]["taskId"] == "task-123"
+    assert client.task_calls == ["task-123"]
+
+
+def test_resume_delegates_to_chatgpt_bootstrap(monkeypatch):
+    class Packet:
+        def to_dict(self):
+            return {"protocol": "agentos.chatgpt-web-bootstrap/v1", "project_id": "layout-3d"}
+
+    seen = {}
+
+    def fake_bootstrap(client, project_id, *, runtime_id):
+        seen.update(client=client, project_id=project_id, runtime_id=runtime_id)
+        return Packet()
+
+    monkeypatch.setattr(mcp_read_tools, "bootstrap_chatgpt_web", fake_bootstrap)
+    client = object()
+    result = mcp_read_tools.resume_project(client, "layout-3d", runtime_id="chatgpt-web:test")
+
+    assert result["protocol"] == "agentos.chatgpt-web-bootstrap/v1"
+    assert seen == {
+        "client": client,
+        "project_id": "layout-3d",
+        "runtime_id": "chatgpt-web:test",
+    }


### PR DESCRIPTION
Completes the ChatGPT Web node path on top of Distributed AgentOS / ONE.

Core continuity:
- `ChatGPTWebBootstrap` attaches through existing authenticated `/v1/attach`
- restores canonical project state + compiled execution context
- binds session/current IR/digest and uses `WebAgentAdapter` for trusted lineage
- provides read-only MCP surface for plans/accounts that support custom MCP

ChatGPT Plus fallback:
- deterministic browser-resume compiler + existing `ai-browser-bridge`
- loopback-only companion `/v1/resume` with transport-token and ChatGPT-origin checks
- Chrome/Edge MV3 continuation interceptor under `browser/chatgpt-agentos-node`
- intercepts `繼續`, `繼續完成`, `continue`, `resume`, `/goal <project-id>` before model submission
- fail-closed if ONE state cannot be restored
- browser stores routing metadata only; ONE credential and canonical state stay outside browser

ONE deployment:
- Windows installer points companion at `https://studio.milkcat.org/dashboard/api/agentos`
- per-user startup launcher + generated companion token
- deployment/acceptance docs in `docs/CHATGPT_NODE_ONE.md`

Continuity Floor regression target:
- fresh ChatGPT conversation must recover the existing 3D Layout `layoutlib`/demo operational state and exact next action rather than restart with a generic architecture proposal.

Also fixes two pre-existing CI expectation/isolation issues exposed by the branch test suite.