### PR TITLE
feat(agentos): connect account-scoped ChatGPT Cloud Node to ONE

### DIFF
--- a/agentos_node/chatgpt_web_node.py
+++ b/agentos_node/chatgpt_web_node.py
@@ -1,10 +1,7 @@
 """Bootstrap/resume contract for ChatGPT Web as an AgentOS web node.
 
-This module deliberately stays transport-neutral. It does not automate the
-ChatGPT UI and it never stores browser credentials. Its only job is to attach
-to the authoritative Control Plane, restore canonical project state, and
-compile that state into the immutable WebAgentAdapter request consumed by a
-browser-side bridge.
+The ChatGPT node is account/cloud scoped. Device, browser and conversation are
+transport details only and must never become the durable AgentOS identity.
 """
 
 from __future__ import annotations
@@ -20,6 +17,7 @@ from .web_agent_adapter import WebAgentAdapter
 
 BOOTSTRAP_PROTOCOL = "agentos.chatgpt-web-bootstrap/v1"
 DEFAULT_RUNTIME_ID = "chatgpt-web"
+DEFAULT_TRANSPORT = "mcp"
 
 
 @dataclass(frozen=True)
@@ -45,8 +43,6 @@ def build_bootstrap_from_attachment(
     *,
     runtime_id: str = DEFAULT_RUNTIME_ID,
 ) -> ChatGPTWebBootstrap:
-    """Compile a `/v1/attach` response into a deterministic resume packet."""
-
     project_id = str(attachment.get("project_id") or "").strip()
     if not project_id:
         raise ValueError("attachment is missing project_id")
@@ -111,14 +107,28 @@ def bootstrap_chatgpt_web(
     project_id: str,
     *,
     runtime_id: str = DEFAULT_RUNTIME_ID,
+    principal_id: str | None = None,
+    transport: str = DEFAULT_TRANSPORT,
 ) -> ChatGPTWebBootstrap:
-    """Attach ChatGPT Web to one AgentOS project and restore its current state."""
+    """Attach one account-scoped ChatGPT executor to AgentOS.
+
+    `principal_id` identifies the stable ChatGPT/account integration principal.
+    Device/browser/conversation identifiers intentionally do not participate in
+    the durable identity contract.
+    """
 
     project_id = str(project_id or "").strip()
     if not project_id:
         raise ValueError("project_id is required")
-    attachment = client.attach(
-        project_id,
-        agent={"runtime_id": runtime_id, "kind": "chatgpt_web", "transport": "browser"},
-    )
+    transport = str(transport or DEFAULT_TRANSPORT).strip() or DEFAULT_TRANSPORT
+    agent: dict[str, Any] = {
+        "runtime_id": runtime_id,
+        "kind": "chatgpt_web",
+        "transport": transport,
+        "identity_scope": "account",
+    }
+    if principal_id:
+        agent["principal_id"] = str(principal_id).strip()
+
+    attachment = client.attach(project_id, agent=agent)
     return build_bootstrap_from_attachment(attachment, runtime_id=runtime_id)

--- a/agentos_node/mcp_read_tools.py
+++ b/agentos_node/mcp_read_tools.py
@@ -1,9 +1,4 @@
-"""Read-only MCP-facing AgentOS helpers.
-
-These helpers stay independent of any MCP SDK so they can be unit-tested without
-pulling transport dependencies into the core test suite. They expose only the
-read/attach surface needed for ChatGPT custom-app / developer-mode experiments.
-"""
+"""Read-only MCP-facing AgentOS helpers."""
 
 from __future__ import annotations
 
@@ -18,19 +13,22 @@ def resume_project(
     project_id: str,
     *,
     runtime_id: str = "chatgpt-web",
+    principal_id: str | None = None,
 ) -> dict[str, Any]:
-    """Return the authoritative AgentOS bootstrap packet for one project."""
+    """Return the authoritative account-scoped AgentOS bootstrap packet."""
 
-    return bootstrap_chatgpt_web(client, project_id, runtime_id=runtime_id).to_dict()
+    return bootstrap_chatgpt_web(
+        client,
+        project_id,
+        runtime_id=runtime_id,
+        principal_id=principal_id,
+        transport="mcp",
+    ).to_dict()
 
 
 def get_project_state(client: ControlPlaneClient, project_id: str) -> dict[str, Any]:
-    """Return the current durable project state without constructing new state."""
-
     return client.get_project_state(project_id)
 
 
 def get_task(client: ControlPlaneClient, task_id: str) -> dict[str, Any]:
-    """Read one AgentOS task by id."""
-
     return client.get_task(task_id)

--- a/docs/CHATGPT_CLOUD_NODE.md
+++ b/docs/CHATGPT_CLOUD_NODE.md
@@ -1,0 +1,66 @@
+# ChatGPT Cloud Node
+
+## Definition of done
+
+The authoritative ChatGPT AgentOS node is account/cloud scoped, not device scoped.
+
+A valid implementation must continue the same AgentOS project from any device where the same ChatGPT account has access to the configured remote app/MCP integration. Chrome extensions, localhost companions, browser profiles and machine identifiers are optional fallback transports only.
+
+## Preferred topology
+
+```text
+ChatGPT account
+    -> remote ChatGPT App / MCP
+    -> ONE Gateway
+    -> AgentOS canonical state
+```
+
+Durable identity:
+
+```text
+executor_type = chatgpt-web
+identity_scope = account
+principal_id = stable integration principal
+```
+
+Ephemeral and non-authoritative:
+
+```text
+device
+browser
+conversation id
+tab id
+local extension state
+```
+
+## ONE contract
+
+`agentos_resume(project_id)` calls the existing authenticated `/v1/attach` path. The attach metadata identifies the account-scoped ChatGPT principal and transport. ONE remains authoritative for canonical state, execution context, lineage and resume action.
+
+The remote MCP process uses:
+
+- `AGENTOS_CONTROL_PLANE_URL`
+- `AGENTOS_CONTROL_PLANE_TOKEN`
+- `AGENTOS_CHATGPT_PRINCIPAL_ID`
+- `AGENTOS_CHATGPT_RUNTIME_ID=chatgpt-web`
+
+No ONE bearer credential is stored on client devices.
+
+## Current ChatGPT product gate
+
+As of 2026-08-27, OpenAI documents remote custom MCP in ChatGPT Developer Mode for Pro read/fetch use, with full MCP currently available to Business and Enterprise/Edu. A Plus account therefore cannot yet complete the native account-scoped attachment through custom MCP.
+
+This is a product-surface gate, not an AgentOS architectural dependency. The remote MCP/ONE contract is the primary implementation; the previously built browser extension + localhost companion remains a fallback/debug transport and is not the definition of a completed ChatGPT Cloud Node.
+
+## Continuity Floor
+
+Once the account can connect the remote MCP app, acceptance is device-independent:
+
+1. ChatGPT on device A resumes the existing 3D Layout project.
+2. ONE returns the canonical state containing the existing `layoutlib`, demo/deployment identity, current revision, last verified result and next action.
+3. Open ChatGPT on device B or mobile using the same account.
+4. Start a fresh conversation and request continuation.
+5. ChatGPT calls `agentos_resume` and recovers the same operational state.
+6. No local extension, localhost service, copied prompt or previous conversation history is required.
+
+A generic 2D-to-3D redesign is a regression failure.

--- a/docs/CHATGPT_CLOUD_NODE.md
+++ b/docs/CHATGPT_CLOUD_NODE.md
@@ -37,27 +37,54 @@ local extension state
 
 `agentos_resume(project_id)` calls the existing authenticated `/v1/attach` path. The attach metadata identifies the account-scoped ChatGPT principal and transport. ONE remains authoritative for canonical state, execution context, lineage and resume action.
 
-The remote MCP process uses:
+The MCP process MUST NOT receive the ONE root bearer. ONE provisions a separate revocable client token with only the permissions required by the read-only ChatGPT node:
 
-- `AGENTOS_CONTROL_PLANE_URL`
-- `AGENTOS_CONTROL_PLANE_TOKEN`
-- `AGENTOS_CHATGPT_PRINCIPAL_ID`
+```text
+project.read
+task.read
+```
+
+Projects can be constrained at issuance time. The MCP process uses:
+
+- `AGENTOS_CONTROL_PLANE_URL=http://127.0.0.1:8765` on the ONE host
+- `AGENTOS_CHATGPT_CLIENT_TOKEN=<scoped agc_ token>`
+- `AGENTOS_CHATGPT_PRINCIPAL_ID=<stable account integration principal>`
 - `AGENTOS_CHATGPT_RUNTIME_ID=chatgpt-web`
 
-No ONE bearer credential is stored on client devices.
+No ONE bearer credential or canonical state is stored on client devices.
+
+## Provision on ONE
+
+Issue a ChatGPT Cloud principal on the ONE host:
+
+```bash
+python3 scripts/provision_chatgpt_cloud_principal.py \
+  --db "$AGENTOS_CONTROL_PLANE_DB" \
+  --principal-id '<stable-principal>' \
+  --project layout-3d
+```
+
+Store the returned `agc_...` token in the ONE secrets file as `AGENTOS_CHATGPT_CLIENT_TOKEN` and set `AGENTOS_CHATGPT_PRINCIPAL_ID` to the same stable principal. Then install the cloud service:
+
+```bash
+pip install -r requirements-mcp.txt
+bash scripts/install_chatgpt_cloud_node.sh
+```
+
+The service runs as `agentos-chatgpt-mcp.service`, binds only to loopback by default, and talks to ONE at `127.0.0.1:8765`. A reverse proxy / secure public ingress can expose the MCP path without exposing the Control Plane directly.
 
 ## Current ChatGPT product gate
 
-As of 2026-08-27, OpenAI documents remote custom MCP in ChatGPT Developer Mode for Pro read/fetch use, with full MCP currently available to Business and Enterprise/Edu. A Plus account therefore cannot yet complete the native account-scoped attachment through custom MCP.
+As of 2026-08-27, OpenAI documents remote custom MCP in ChatGPT Developer Mode for Pro read/fetch use, with full MCP currently available to Business and Enterprise/Edu. A Plus account therefore cannot yet complete the native account-scoped attachment through arbitrary custom MCP.
 
-This is a product-surface gate, not an AgentOS architectural dependency. The remote MCP/ONE contract is the primary implementation; the previously built browser extension + localhost companion remains a fallback/debug transport and is not the definition of a completed ChatGPT Cloud Node.
+The intended Plus path is a reviewed/published ChatGPT App/Plugin backed by this same remote MCP endpoint. This is a product-distribution gate, not an AgentOS architectural dependency. The browser extension + localhost companion remains a fallback/debug transport and is not the definition of a completed ChatGPT Cloud Node.
 
 ## Continuity Floor
 
-Once the account can connect the remote MCP app, acceptance is device-independent:
+Once the ChatGPT account can connect the remote app/MCP, acceptance is device-independent:
 
 1. ChatGPT on device A resumes the existing 3D Layout project.
-2. ONE returns the canonical state containing the existing `layoutlib`, demo/deployment identity, current revision, last verified result and next action.
+2. ONE returns canonical state containing the existing `layoutlib`, demo/deployment identity, current revision, last verified result and next action.
 3. Open ChatGPT on device B or mobile using the same account.
 4. Start a fresh conversation and request continuation.
 5. ChatGPT calls `agentos_resume` and recovers the same operational state.

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Read-only AgentOS MCP server for ChatGPT developer-mode experiments.
+"""Remote read-only AgentOS MCP server for an account-scoped ChatGPT node.
 
-Run this on a trusted host and connect it through Secure MCP Tunnel or another
-authorized private transport. Do not expose it anonymously to the public
-Internet: the server-side Control Plane credential may authorize private state.
+This is the preferred cross-device transport. ChatGPT connects to the remote MCP
+server; the server attaches to ONE and restores canonical state. No device,
+browser profile, or conversation id participates in durable node identity.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from agentos_node.mcp_read_tools import get_project_state, get_task, resume_proj
 CONTROL_PLANE_URL = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "").strip()
 CONTROL_PLANE_TOKEN = os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN")
 RUNTIME_ID = os.environ.get("AGENTOS_CHATGPT_RUNTIME_ID", "chatgpt-web").strip() or "chatgpt-web"
+PRINCIPAL_ID = os.environ.get("AGENTOS_CHATGPT_PRINCIPAL_ID", "").strip() or None
 MCP_HOST = os.environ.get("AGENTOS_MCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
 MCP_PORT = int(os.environ.get("AGENTOS_MCP_PORT", "8000"))
 MCP_PATH = os.environ.get("AGENTOS_MCP_PATH", "/mcp").strip() or "/mcp"
@@ -30,37 +31,33 @@ client = ControlPlaneClient(CONTROL_PLANE_URL, token=CONTROL_PLANE_TOKEN)
 mcp = MCPServer(
     "LeopardCat AgentOS",
     instructions=(
-        "Use AgentOS as the authoritative source for existing project state. "
-        "When a user asks to continue/resume prior work, call agentos_resume "
-        "before reasoning from chat memory."
+        "AgentOS is authoritative for existing work. For continuation requests, "
+        "call agentos_resume before using conversational memory. This ChatGPT node "
+        "is account-scoped and must behave identically across devices."
     ),
 )
 
 
 @mcp.tool()
 def agentos_resume(project_id: str) -> dict:
-    """Resume existing AgentOS work before answering a continuation request.
-
-    Use this when the user says continue/resume/繼續, refers to prior project work,
-    or expects the current implementation state. Returns authoritative canonical
-    state plus compiled execution context; do not substitute chat memory for it.
-    This tool is read-only with respect to durable AgentOS task state.
-    """
-
-    return resume_project(client, project_id, runtime_id=RUNTIME_ID)
+    """Restore an existing AgentOS project before answering continuation intent."""
+    return resume_project(
+        client,
+        project_id,
+        runtime_id=RUNTIME_ID,
+        principal_id=PRINCIPAL_ID,
+    )
 
 
 @mcp.tool()
 def agentos_project_state(project_id: str) -> dict:
-    """Read the current durable AgentOS state for a known project id."""
-
+    """Read current durable AgentOS state for a known project."""
     return get_project_state(client, project_id)
 
 
 @mcp.tool()
 def agentos_task(task_id: str) -> dict:
-    """Read one AgentOS task and its current status by task id."""
-
+    """Read one AgentOS task and status by id."""
     return get_task(client, task_id)
 
 

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -4,6 +4,8 @@
 This is the preferred cross-device transport. ChatGPT connects to the remote MCP
 server; the server attaches to ONE and restores canonical state. No device,
 browser profile, or conversation id participates in durable node identity.
+
+The MCP process MUST use a scoped AgentOS client token, never the ONE root bearer.
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ from agentos_node.mcp_read_tools import get_project_state, get_task, resume_proj
 
 
 CONTROL_PLANE_URL = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "").strip()
-CONTROL_PLANE_TOKEN = os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN")
+CHATGPT_CLIENT_TOKEN = os.environ.get("AGENTOS_CHATGPT_CLIENT_TOKEN", "").strip()
 RUNTIME_ID = os.environ.get("AGENTOS_CHATGPT_RUNTIME_ID", "chatgpt-web").strip() or "chatgpt-web"
 PRINCIPAL_ID = os.environ.get("AGENTOS_CHATGPT_PRINCIPAL_ID", "").strip() or None
 MCP_HOST = os.environ.get("AGENTOS_MCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
@@ -26,8 +28,10 @@ MCP_PATH = os.environ.get("AGENTOS_MCP_PATH", "/mcp").strip() or "/mcp"
 
 if not CONTROL_PLANE_URL:
     raise RuntimeError("AGENTOS_CONTROL_PLANE_URL is required")
+if not CHATGPT_CLIENT_TOKEN:
+    raise RuntimeError("AGENTOS_CHATGPT_CLIENT_TOKEN is required; do not use the ONE root token")
 
-client = ControlPlaneClient(CONTROL_PLANE_URL, token=CONTROL_PLANE_TOKEN)
+client = ControlPlaneClient(CONTROL_PLANE_URL, token=CHATGPT_CLIENT_TOKEN)
 mcp = MCPServer(
     "LeopardCat AgentOS",
     instructions=(

--- a/scripts/install_chatgpt_cloud_node.sh
+++ b/scripts/install_chatgpt_cloud_node.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGIC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${AGENTOS_CONFIG_ENV_FILE:-$HOME/agentmanager/.env}"
+DIST_ENV_FILE="${AGENTOS_DISTRIBUTED_ENV_FILE:-$HOME/.config/agentos/distributed.env}"
+SECRETS_FILE="${AGENTOS_SECRETS_FILE:-$HOME/.agentos.secrets}"
+USER_SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
+PYTHON_BIN="${AGENTOS_DISTRIBUTED_PYTHON:-}"
+
+[ -f "$ENV_FILE" ] || { echo "Missing AgentOS env: $ENV_FILE" >&2; exit 2; }
+[ -f "$DIST_ENV_FILE" ] || { echo "Missing distributed env: $DIST_ENV_FILE" >&2; exit 2; }
+
+set -a
+source "$ENV_FILE"
+source "$DIST_ENV_FILE"
+[ -f "$SECRETS_FILE" ] && source "$SECRETS_FILE"
+set +a
+
+if [ -z "$PYTHON_BIN" ] && [ -x "$LOGIC_ROOT/.venv/bin/python3" ]; then PYTHON_BIN="$LOGIC_ROOT/.venv/bin/python3"; fi
+if [ -z "$PYTHON_BIN" ]; then PYTHON_BIN="$(command -v python3)"; fi
+[ -x "$PYTHON_BIN" ] || { echo "No usable Python interpreter found" >&2; exit 2; }
+
+[ -n "${AGENTOS_CHATGPT_CLIENT_TOKEN:-}" ] || { echo "AGENTOS_CHATGPT_CLIENT_TOKEN is required" >&2; exit 2; }
+[ -n "${AGENTOS_CHATGPT_PRINCIPAL_ID:-}" ] || { echo "AGENTOS_CHATGPT_PRINCIPAL_ID is required" >&2; exit 2; }
+
+mkdir -p "$USER_SYSTEMD_DIR" "$DATA_ROOT/logs"
+
+cat > "$USER_SYSTEMD_DIR/agentos-chatgpt-mcp.service" <<EOF
+[Unit]
+Description=AgentOS ChatGPT Cloud Node MCP
+After=network-online.target agentos-control-plane.service
+Requires=agentos-control-plane.service
+
+[Service]
+Type=simple
+WorkingDirectory=$LOGIC_ROOT
+Environment=PYTHONPATH=$LOGIC_ROOT
+Environment=AGENTOS_CONTROL_PLANE_URL=http://127.0.0.1:8765
+Environment=AGENTOS_CHATGPT_RUNTIME_ID=chatgpt-web
+Environment=AGENTOS_MCP_HOST=127.0.0.1
+Environment=AGENTOS_MCP_PORT=${AGENTOS_MCP_PORT:-8000}
+Environment=AGENTOS_MCP_PATH=${AGENTOS_MCP_PATH:-/mcp}
+EnvironmentFile=-$ENV_FILE
+EnvironmentFile=-$DIST_ENV_FILE
+EnvironmentFile=-$SECRETS_FILE
+ExecStart=$PYTHON_BIN scripts/agentos_mcp_server.py
+Restart=always
+RestartSec=5
+StandardOutput=append:$DATA_ROOT/logs/chatgpt_mcp.log
+StandardError=append:$DATA_ROOT/logs/chatgpt_mcp.log
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable agentos-chatgpt-mcp.service >/dev/null
+systemctl --user restart agentos-chatgpt-mcp.service
+systemctl --user is-active --quiet agentos-chatgpt-mcp.service
+
+echo "Installed AgentOS ChatGPT Cloud Node"
+echo "ONE: http://127.0.0.1:8765"
+echo "MCP: http://127.0.0.1:${AGENTOS_MCP_PORT:-8000}${AGENTOS_MCP_PATH:-/mcp}"
+echo "Identity scope: account"
+echo "Principal: ${AGENTOS_CHATGPT_PRINCIPAL_ID}"

--- a/scripts/provision_chatgpt_cloud_principal.py
+++ b/scripts/provision_chatgpt_cloud_principal.py
@@ -6,6 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from pathlib import Path
+import sys
+
+# When executed as ``python scripts/...``, Python puts ``scripts`` on sys.path.
+# Add the repository root explicitly so the Control Plane modules remain importable
+# without requiring agent_core to be installed as a site package.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from agent_core.client_auth import ClientTokenStore
 from agent_core.distributed_control_plane import DistributedControlPlane

--- a/scripts/provision_chatgpt_cloud_principal.py
+++ b/scripts/provision_chatgpt_cloud_principal.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Issue a least-privilege ONE client token for the account-scoped ChatGPT node."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from agent_core.client_auth import ClientTokenStore
+from agent_core.distributed_control_plane import DistributedControlPlane
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default=os.environ.get("AGENTOS_CONTROL_PLANE_DB"))
+    parser.add_argument("--principal-id", required=True)
+    parser.add_argument("--project", action="append", dest="projects")
+    parser.add_argument("--ttl-days", type=int, default=90)
+    args = parser.parse_args()
+
+    if not args.db:
+        raise SystemExit("--db or AGENTOS_CONTROL_PLANE_DB is required")
+    projects = tuple(args.projects or ["*"])
+    store = DistributedControlPlane(args.db)
+    issued = ClientTokenStore(store).issue(
+        f"chatgpt:{args.principal_id}",
+        label="ChatGPT Cloud Node",
+        permissions=("project.read", "task.read"),
+        projects=projects,
+        capabilities=("*",),
+        ttl_days=args.ttl_days,
+    )
+    print(json.dumps(issued, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chatgpt_cloud_principal.py
+++ b/tests/test_chatgpt_cloud_principal.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+
+from agent_core.client_auth import ClientTokenStore
+from agent_core.distributed_control_plane import DistributedControlPlane
+
+
+def test_provisioned_chatgpt_principal_is_read_only_and_project_scoped(tmp_path):
+    db = tmp_path / "one.sqlite3"
+    command = [
+        sys.executable,
+        "scripts/provision_chatgpt_cloud_principal.py",
+        "--db",
+        str(db),
+        "--principal-id",
+        "acct-test",
+        "--project",
+        "layout-3d",
+        "--ttl-days",
+        "30",
+    ]
+    output = subprocess.check_output(command, text=True)
+    issued = json.loads(output)
+
+    assert issued["subject"] == "chatgpt:acct-test"
+    assert issued["permissions"] == ["project.read", "task.read"]
+    assert issued["projects"] == ["layout-3d"]
+
+    principal = ClientTokenStore(DistributedControlPlane(db)).principal(issued["token"])
+    assert principal is not None
+    assert principal.allows_permission("project.read")
+    assert principal.allows_permission("task.read")
+    assert not principal.allows_permission("task.submit")
+    assert principal.allows_project("layout-3d")
+    assert not principal.allows_project("other-project")

--- a/tests/test_chatgpt_web_node.py
+++ b/tests/test_chatgpt_web_node.py
@@ -1,5 +1,6 @@
 from agentos_node.chatgpt_web_node import (
     BOOTSTRAP_PROTOCOL,
+    bootstrap_chatgpt_web,
     build_bootstrap_from_attachment,
 )
 from runtime_core.canonical_ir import CanonicalIR
@@ -46,6 +47,43 @@ def test_bootstrap_compiles_authoritative_attachment_into_web_request():
     assert packet.request["input_ir_id"] == ir.ir_id
     assert packet.request["input_digest"] == ir.digest()
     assert packet.request["canonical_ir"]["payload"]["next_action"] == "inspect existing demo"
+
+
+def test_account_scoped_attach_excludes_device_identity():
+    class FakeClient:
+        def __init__(self):
+            self.agent = None
+
+        def attach(self, project_id, *, agent=None):
+            self.agent = agent
+            return _attachment(
+                project_id,
+                {
+                    "projectId": project_id,
+                    "latestTask": None,
+                    "currentIR": None,
+                    "currentSource": None,
+                    "recommendedAction": "start",
+                },
+            )
+
+    client = FakeClient()
+    bootstrap_chatgpt_web(
+        client,
+        "layout-3d",
+        principal_id="chatgpt-principal-1",
+        transport="mcp",
+    )
+
+    assert client.agent == {
+        "runtime_id": "chatgpt-web",
+        "kind": "chatgpt_web",
+        "transport": "mcp",
+        "identity_scope": "account",
+        "principal_id": "chatgpt-principal-1",
+    }
+    assert "device" not in client.agent
+    assert "conversation" not in client.agent
 
 
 def test_bootstrap_start_state_has_no_fabricated_ir():

--- a/tests/test_mcp_read_tools.py
+++ b/tests/test_mcp_read_tools.py
@@ -29,24 +29,37 @@ def test_task_is_read_only_passthrough():
     assert client.task_calls == ["task-123"]
 
 
-def test_resume_delegates_to_chatgpt_bootstrap(monkeypatch):
+def test_resume_delegates_to_account_scoped_chatgpt_bootstrap(monkeypatch):
     class Packet:
         def to_dict(self):
             return {"protocol": "agentos.chatgpt-web-bootstrap/v1", "project_id": "layout-3d"}
 
     seen = {}
 
-    def fake_bootstrap(client, project_id, *, runtime_id):
-        seen.update(client=client, project_id=project_id, runtime_id=runtime_id)
+    def fake_bootstrap(client, project_id, *, runtime_id, principal_id=None, transport="mcp"):
+        seen.update(
+            client=client,
+            project_id=project_id,
+            runtime_id=runtime_id,
+            principal_id=principal_id,
+            transport=transport,
+        )
         return Packet()
 
     monkeypatch.setattr(mcp_read_tools, "bootstrap_chatgpt_web", fake_bootstrap)
     client = object()
-    result = mcp_read_tools.resume_project(client, "layout-3d", runtime_id="chatgpt-web:test")
+    result = mcp_read_tools.resume_project(
+        client,
+        "layout-3d",
+        runtime_id="chatgpt-web:test",
+        principal_id="acct-test",
+    )
 
     assert result["protocol"] == "agentos.chatgpt-web-bootstrap/v1"
     assert seen == {
         "client": client,
         "project_id": "layout-3d",
         "runtime_id": "chatgpt-web:test",
+        "principal_id": "acct-test",
+        "transport": "mcp",
     }


### PR DESCRIPTION
Promotes ChatGPT integration from a device-local fallback to the intended account/cloud-scoped ONE node model.

Identity / continuity:
- durable identity is `identity_scope=account`
- stable `principal_id`, `executor_type=chatgpt-web`, `transport=mcp`
- device/browser/conversation ids are excluded from durable identity
- browser extension + localhost companion remain fallback/debug only

ONE integration:
- remote MCP calls the existing ONE `/v1/attach` path
- adds `provision_chatgpt_cloud_principal.py` to issue a dedicated revocable `agc_` client token
- ChatGPT principal is read-only by default: `project.read` + `task.read`, with project allowlisting
- MCP server now refuses to start without `AGENTOS_CHATGPT_CLIENT_TOKEN`; ONE root bearer is not accepted as the Cloud Node credential
- adds `install_chatgpt_cloud_node.sh` for `agentos-chatgpt-mcp.service` on the ONE host
- MCP talks to ONE over loopback `127.0.0.1:8765`; only the MCP ingress needs public exposure
- adds regression coverage for scoped principal issuance and account-scoped attach metadata

Plus path:
- arbitrary custom MCP remains a ChatGPT plan/product gate
- intended Plus distribution is a reviewed/published ChatGPT App/Plugin backed by this same remote MCP endpoint
- no architecture or device-specific bridge is required when that account-side surface is available

Continuity Floor remains: a fresh ChatGPT conversation on any device must recover the existing 3D Layout `layoutlib`/demo operational state and exact next action from ONE instead of restarting with a generic 2D-to-3D proposal.