### PR TITLE
refactor(agentos): separate node runtime from desktop executor

### DIFF
--- a/.github/workflows/node-executor-runtime-ci.yml
+++ b/.github/workflows/node-executor-runtime-ci.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/install_thin_client_windows.ps1'
       - 'scripts/windows/install_node_runtime_service.ps1'
       - 'scripts/windows/install_desktop_executor_user.ps1'
+      - 'scripts/windows/migrate_split_node_executor_runtime.ps1'
       - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
@@ -28,6 +29,7 @@ on:
       - 'scripts/install_thin_client_windows.ps1'
       - 'scripts/windows/install_node_runtime_service.ps1'
       - 'scripts/windows/install_desktop_executor_user.ps1'
+      - 'scripts/windows/migrate_split_node_executor_runtime.ps1'
       - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
@@ -55,6 +57,7 @@ jobs:
 
           service = Path('scripts/windows/install_node_runtime_service.ps1').read_text(encoding='utf-8')
           desktop = Path('scripts/windows/install_desktop_executor_user.ps1').read_text(encoding='utf-8')
+          migration = Path('scripts/windows/migrate_split_node_executor_runtime.ps1').read_text(encoding='utf-8')
           bootstrap = Path('scripts/install_thin_client_windows.ps1').read_text(encoding='utf-8')
           host = Path('agentos_node/desktop_executor_host.py').read_text(encoding='utf-8')
           pyproject = Path('pyproject.toml').read_text(encoding='utf-8')
@@ -71,6 +74,10 @@ jobs:
           assert 'agentos-desktop-executor = "agentos_node.desktop_executor_cli:main"' in pyproject
           assert 'Register-ScheduledTask' not in bootstrap
           assert 'executor_bridge.py' in bootstrap and 'desktop_executor_host.py' in bootstrap
+          assert 'migration-backup-' in migration
+          assert 'Restore-LegacyRuntime' in migration
+          assert '[uri]::EscapeDataString($SourceRef)' in migration
+          assert 'client.json' in migration and 'policy.json' in migration
           print('node_desktop_carrier_boundary=PASS')
           PY
 
@@ -88,7 +95,8 @@ jobs:
           $files = @(
             'scripts/install_thin_client_windows.ps1',
             'scripts/windows/install_node_runtime_service.ps1',
-            'scripts/windows/install_desktop_executor_user.ps1'
+            'scripts/windows/install_desktop_executor_user.ps1',
+            'scripts/windows/migrate_split_node_executor_runtime.ps1'
           )
           foreach ($file in $files) {
             $tokens = $null

--- a/.github/workflows/node-executor-runtime-ci.yml
+++ b/.github/workflows/node-executor-runtime-ci.yml
@@ -5,15 +5,19 @@ on:
     branches:
       - feature/node-executor-runtime
     paths:
+      - 'agentos_node/executor_bridge.py'
       - 'agentos_node/executor_registry.py'
       - 'agentos_node/thin_client.py'
+      - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
       - '.github/workflows/node-executor-runtime-ci.yml'
   pull_request:
     paths:
+      - 'agentos_node/executor_bridge.py'
       - 'agentos_node/executor_registry.py'
       - 'agentos_node/thin_client.py'
+      - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
 
@@ -28,6 +32,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Run executor and thin client tests
+      - name: Run executor bridge and thin client tests
         run: |
-          python -m unittest tests.test_executor_registry tests.test_thin_client -v
+          python -m unittest tests.test_executor_bridge tests.test_executor_registry tests.test_thin_client -v

--- a/.github/workflows/node-executor-runtime-ci.yml
+++ b/.github/workflows/node-executor-runtime-ci.yml
@@ -1,0 +1,33 @@
+name: Node Executor Runtime CI
+
+on:
+  push:
+    branches:
+      - feature/node-executor-runtime
+    paths:
+      - 'agentos_node/executor_registry.py'
+      - 'agentos_node/thin_client.py'
+      - 'tests/test_executor_registry.py'
+      - 'tests/test_thin_client.py'
+      - '.github/workflows/node-executor-runtime-ci.yml'
+  pull_request:
+    paths:
+      - 'agentos_node/executor_registry.py'
+      - 'agentos_node/thin_client.py'
+      - 'tests/test_executor_registry.py'
+      - 'tests/test_thin_client.py'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run executor and thin client tests
+        run: |
+          python -m unittest tests.test_executor_registry tests.test_thin_client -v

--- a/.github/workflows/node-executor-runtime-ci.yml
+++ b/.github/workflows/node-executor-runtime-ci.yml
@@ -5,21 +5,33 @@ on:
     branches:
       - feature/node-executor-runtime
     paths:
+      - 'agentos_node/desktop_executor_cli.py'
+      - 'agentos_node/desktop_executor_host.py'
       - 'agentos_node/executor_bridge.py'
       - 'agentos_node/executor_registry.py'
       - 'agentos_node/thin_client.py'
+      - 'scripts/install_thin_client_windows.ps1'
+      - 'scripts/windows/install_node_runtime_service.ps1'
+      - 'scripts/windows/install_desktop_executor_user.ps1'
       - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
+      - 'pyproject.toml'
       - '.github/workflows/node-executor-runtime-ci.yml'
   pull_request:
     paths:
+      - 'agentos_node/desktop_executor_cli.py'
+      - 'agentos_node/desktop_executor_host.py'
       - 'agentos_node/executor_bridge.py'
       - 'agentos_node/executor_registry.py'
       - 'agentos_node/thin_client.py'
+      - 'scripts/install_thin_client_windows.ps1'
+      - 'scripts/windows/install_node_runtime_service.ps1'
+      - 'scripts/windows/install_desktop_executor_user.ps1'
       - 'tests/test_executor_bridge.py'
       - 'tests/test_executor_registry.py'
       - 'tests/test_thin_client.py'
+      - 'pyproject.toml'
 
 permissions:
   contents: read
@@ -35,3 +47,25 @@ jobs:
       - name: Run executor bridge and thin client tests
         run: |
           python -m unittest tests.test_executor_bridge tests.test_executor_registry tests.test_thin_client -v
+      - name: Validate node and desktop carrier boundaries
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          service = Path('scripts/windows/install_node_runtime_service.ps1').read_text(encoding='utf-8')
+          desktop = Path('scripts/windows/install_desktop_executor_user.ps1').read_text(encoding='utf-8')
+          host = Path('agentos_node/desktop_executor_host.py').read_text(encoding='utf-8')
+          pyproject = Path('pyproject.toml').read_text(encoding='utf-8')
+
+          assert 'sc.exe create $ServiceName' in service
+          assert 'ServiceName = RuntimeServiceName' in service
+          assert 'AGENTOS_DESKTOP_EXECUTOR_BRIDGE' in service
+          assert "Disable-ScheduledTask -TaskName $LegacyTaskName" in service
+          assert 'agentos_node.client_cli' not in desktop
+          assert 'agentos_node.desktop_executor_cli' in desktop
+          assert '-LogonType Interactive' in desktop
+          assert 'ThinClientTransport' not in host
+          assert 'node_token' not in host
+          assert 'agentos-desktop-executor = "agentos_node.desktop_executor_cli:main"' in pyproject
+          print('node_desktop_carrier_boundary=PASS')
+          PY

--- a/.github/workflows/node-executor-runtime-ci.yml
+++ b/.github/workflows/node-executor-runtime-ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Run executor bridge and thin client tests
         run: |
           python -m unittest tests.test_executor_bridge tests.test_executor_registry tests.test_thin_client -v
+          python -m py_compile agentos_node/desktop_executor_cli.py agentos_node/desktop_executor_host.py agentos_node/executor_bridge.py agentos_node/executor_registry.py agentos_node/thin_client.py
       - name: Validate node and desktop carrier boundaries
         run: |
           python - <<'PY'
@@ -54,6 +55,7 @@ jobs:
 
           service = Path('scripts/windows/install_node_runtime_service.ps1').read_text(encoding='utf-8')
           desktop = Path('scripts/windows/install_desktop_executor_user.ps1').read_text(encoding='utf-8')
+          bootstrap = Path('scripts/install_thin_client_windows.ps1').read_text(encoding='utf-8')
           host = Path('agentos_node/desktop_executor_host.py').read_text(encoding='utf-8')
           pyproject = Path('pyproject.toml').read_text(encoding='utf-8')
 
@@ -67,5 +69,38 @@ jobs:
           assert 'ThinClientTransport' not in host
           assert 'node_token' not in host
           assert 'agentos-desktop-executor = "agentos_node.desktop_executor_cli:main"' in pyproject
+          assert 'Register-ScheduledTask' not in bootstrap
+          assert 'executor_bridge.py' in bootstrap and 'desktop_executor_host.py' in bootstrap
           print('node_desktop_carrier_boundary=PASS')
           PY
+
+  windows-syntax:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Parse PowerShell carrier scripts
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = @(
+            'scripts/install_thin_client_windows.ps1',
+            'scripts/windows/install_node_runtime_service.ps1',
+            'scripts/windows/install_desktop_executor_user.ps1'
+          )
+          foreach ($file in $files) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path $file), [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors.Count -gt 0) {
+              $errors | ForEach-Object { Write-Error $_.Message }
+              throw "PowerShell parse failed: $file"
+            }
+            Write-Host "powershell_parse=PASS file=$file"
+          }
+      - name: Compile executor Python modules on Windows
+        shell: powershell
+        run: |
+          python -m py_compile agentos_node/desktop_executor_cli.py agentos_node/desktop_executor_host.py agentos_node/executor_bridge.py agentos_node/executor_registry.py agentos_node/interactive_desktop.py agentos_node/thin_client.py

--- a/agentos_node/desktop_executor_cli.py
+++ b/agentos_node/desktop_executor_cli.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agentos_node.desktop_executor_host import DesktopExecutorHost
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog='agentos-desktop-executor')
+    parser.add_argument('--bridge', type=Path, required=True)
+    parser.add_argument('--poll-seconds', type=float, default=0.2)
+    sub = parser.add_subparsers(dest='command', required=True)
+    sub.add_parser('once', help='publish executor state and process queued requests once')
+    sub.add_parser('run', help='run the interactive desktop executor host')
+    args = parser.parse_args()
+
+    host = DesktopExecutorHost(bridge_root=args.bridge, poll_seconds=args.poll_seconds)
+    if args.command == 'once':
+        processed = host.serve_once()
+        print(f'desktop_executor_processed={processed}')
+        return 0
+    host.run_forever()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/agentos_node/desktop_executor_host.py
+++ b/agentos_node/desktop_executor_host.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from agentos_node import interactive_desktop
+from agentos_node.executor_bridge import FileExecutorHost
+from agentos_node.executor_registry import DESKTOP_CAPABILITIES, ExecutorRegistry
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+_RECEIPT_FIELDS = {
+    'schema', 'realm_id', 'node_id', 'task_id', 'action', 'started_at',
+    'completed_at', 'ok', 'cognition_ids_used', 'error',
+}
+
+
+class DesktopExecutorHost:
+    """User-session host for the desktop executor.
+
+    It intentionally owns no ONE transport and no Realm credential. Existing
+    ThinClient desktop dispatch is reused with an empty local policy, and the host
+    rejects every non-desktop task before execution.
+    """
+
+    def __init__(self, *, bridge_root: str | Path, poll_seconds: float = 0.2):
+        registry = ExecutorRegistry()
+        self.client = ThinClient(
+            NodeIdentity('local-executor', 'desktop-executor-host'),
+            ThinClientPolicy(),
+            executor_registry=registry,
+        )
+        self.poll_seconds = max(0.05, float(poll_seconds))
+        self.host = FileExecutorHost(
+            'desktop',
+            bridge_root,
+            capabilities=DESKTOP_CAPABILITIES,
+            details_provider=interactive_desktop.session_info,
+        )
+
+    def _handle(self, task: dict[str, Any]) -> dict[str, Any]:
+        action = str(task.get('action') or '')
+        if not action.startswith('desktop.') or action not in DESKTOP_CAPABILITIES:
+            raise PermissionError(f'desktop executor rejects action: {action}')
+        receipt = self.client.execute(task)
+        if not receipt.get('ok'):
+            raise RuntimeError(str(receipt.get('error') or 'desktop execution failed'))
+        return {key: value for key, value in receipt.items() if key not in _RECEIPT_FIELDS}
+
+    def serve_once(self) -> int:
+        info = interactive_desktop.session_info()
+        if not info.get('interactive'):
+            self.host.publish_descriptor(ready=False)
+            return 0
+        return self.host.serve_once(self._handle)
+
+    def run_forever(self) -> None:
+        while True:
+            self.serve_once()
+            time.sleep(self.poll_seconds)

--- a/agentos_node/desktop_executor_host.py
+++ b/agentos_node/desktop_executor_host.py
@@ -55,7 +55,20 @@ class DesktopExecutorHost:
             return 0
         return self.host.serve_once(self._handle)
 
+    def _publish_unavailable(self, exc: Exception) -> None:
+        original = self.host.details_provider
+        try:
+            self.host.details_provider = lambda: {'error': f'{type(exc).__name__}: {exc}'}
+            self.host.publish_descriptor(ready=False)
+        except Exception:
+            pass
+        finally:
+            self.host.details_provider = original
+
     def run_forever(self) -> None:
         while True:
-            self.serve_once()
+            try:
+                self.serve_once()
+            except Exception as exc:
+                self._publish_unavailable(exc)
             time.sleep(self.poll_seconds)

--- a/agentos_node/executor_bridge.py
+++ b/agentos_node/executor_bridge.py
@@ -189,6 +189,8 @@ class FileExecutorHost:
         self.receipts.mkdir(parents=True, exist_ok=True)
         processed = 0
         for target in sorted(self.requests.glob('executor-*.json')):
+            request_id = target.stem
+            task: dict[str, Any] = {}
             try:
                 request = json.loads(target.read_text(encoding='utf-8-sig'))
                 if request.get('schema') != REQUEST_SCHEMA:
@@ -196,9 +198,10 @@ class FileExecutorHost:
                 if str(request.get('executor_id') or '') != self.executor_id:
                     raise ValueError('executor request targets another executor')
                 request_id = str(request.get('request_id') or '')
-                task = request.get('task')
-                if not request_id or not isinstance(task, dict):
+                task_raw = request.get('task')
+                if not request_id or not isinstance(task_raw, dict):
                     raise ValueError('invalid executor request')
+                task = task_raw
                 result = handler(task)
                 if not isinstance(result, dict):
                     raise ValueError('executor handler must return an object')
@@ -212,8 +215,6 @@ class FileExecutorHost:
                     'completed_at': _utc_now(),
                 }
             except Exception as exc:
-                request_id = locals().get('request_id') or target.stem
-                task = locals().get('task') if isinstance(locals().get('task'), dict) else {}
                 receipt = {
                     'schema': RECEIPT_SCHEMA,
                     'request_id': request_id,

--- a/agentos_node/executor_bridge.py
+++ b/agentos_node/executor_bridge.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+BRIDGE_SCHEMA = 'agentos.executor-bridge/v0.1'
+REQUEST_SCHEMA = 'agentos.executor-request/v0.1'
+RECEIPT_SCHEMA = 'agentos.executor-receipt/v0.1'
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def _parse_utc(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def executor_bridge_root(executor_id: str) -> Path | None:
+    key = 'AGENTOS_' + executor_id.upper().replace('-', '_') + '_EXECUTOR_BRIDGE'
+    raw = os.environ.get(key)
+    return Path(raw).expanduser() if raw else None
+
+
+def describe_executor_bridge(
+    executor_id: str,
+    root: str | Path | None = None,
+    *,
+    stale_after_seconds: int = 15,
+) -> dict[str, Any] | None:
+    resolved = Path(root).expanduser() if root is not None else executor_bridge_root(executor_id)
+    if resolved is None:
+        return None
+    descriptor = resolved / 'bridge.json'
+    if not descriptor.exists():
+        return {
+            'schema': BRIDGE_SCHEMA,
+            'executor_id': executor_id,
+            'root': str(resolved),
+            'ready': False,
+            'status': 'unavailable',
+            'reason': 'descriptor_missing',
+            'capabilities': [],
+        }
+    try:
+        payload = json.loads(descriptor.read_text(encoding='utf-8-sig'))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if payload.get('schema') != BRIDGE_SCHEMA or str(payload.get('executor_id') or '') != executor_id:
+        return None
+    observed_at = str(payload.get('observed_at') or '')
+    age_seconds: int | None = None
+    stale = True
+    if observed_at:
+        try:
+            age_seconds = max(0, int((datetime.now(timezone.utc) - _parse_utc(observed_at)).total_seconds()))
+            stale = age_seconds > max(1, int(stale_after_seconds))
+        except ValueError:
+            stale = True
+    ready = bool(payload.get('ready')) and not stale
+    return {
+        **payload,
+        'root': str(resolved),
+        'ready': ready,
+        'status': 'available' if ready else 'unavailable',
+        'reason': None if ready else ('heartbeat_stale' if stale else 'not_ready'),
+        'heartbeat_age_seconds': age_seconds,
+        'capabilities': sorted({str(x) for x in (payload.get('capabilities') or []) if str(x)}),
+    }
+
+
+class FileExecutorBridge:
+    """Local file-backed request/receipt bridge between a Node Runtime and executor host.
+
+    The filesystem ACL of the bridge root is the authority boundary. No network
+    listener is opened. The executor host owns bridge.json and receipt production;
+    the Node Runtime owns request production.
+    """
+
+    def __init__(self, executor_id: str, root: str | Path):
+        self.executor_id = executor_id
+        self.root = Path(root).expanduser()
+        self.requests = self.root / 'requests'
+        self.receipts = self.root / 'receipts'
+
+    @classmethod
+    def from_environment(cls, executor_id: str) -> 'FileExecutorBridge':
+        root = executor_bridge_root(executor_id)
+        if root is None:
+            raise RuntimeError(f'no {executor_id} executor bridge configured')
+        descriptor = describe_executor_bridge(executor_id, root)
+        if not descriptor or not descriptor.get('ready'):
+            reason = descriptor.get('reason') if descriptor else 'invalid_descriptor'
+            raise RuntimeError(f'{executor_id} executor bridge is not ready: {reason}')
+        return cls(executor_id, root)
+
+    def request(self, task: dict[str, Any]) -> dict[str, Any]:
+        if task.get('schema') != 'agentos.node-task/v0.1':
+            raise ValueError('invalid node task schema')
+        task_id = str(task.get('task_id') or '')
+        if not task_id:
+            raise ValueError('task_id is required')
+        self.requests.mkdir(parents=True, exist_ok=True)
+        request_id = 'executor-' + uuid.uuid4().hex
+        request = {
+            'schema': REQUEST_SCHEMA,
+            'request_id': request_id,
+            'executor_id': self.executor_id,
+            'task': dict(task),
+            'created_at': _utc_now(),
+        }
+        target = self.requests / f'{request_id}.json'
+        tmp = target.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(request, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+        os.replace(tmp, target)
+        return request
+
+    def receipt(self, request_id: str) -> dict[str, Any] | None:
+        target = self.receipts / f'{request_id}.json'
+        if not target.exists():
+            return None
+        payload = json.loads(target.read_text(encoding='utf-8-sig'))
+        if payload.get('schema') != RECEIPT_SCHEMA or str(payload.get('request_id') or '') != request_id:
+            raise ValueError('invalid executor bridge receipt')
+        if str(payload.get('executor_id') or '') != self.executor_id:
+            raise ValueError('executor bridge receipt belongs to another executor')
+        return payload
+
+    def execute(self, task: dict[str, Any], *, timeout_seconds: float = 30.0, poll_seconds: float = 0.1) -> dict[str, Any]:
+        request = self.request(task)
+        deadline = time.monotonic() + max(0.5, float(timeout_seconds))
+        while time.monotonic() < deadline:
+            receipt = self.receipt(str(request['request_id']))
+            if receipt is not None:
+                if not receipt.get('ok'):
+                    raise RuntimeError(str(receipt.get('error') or 'executor failed'))
+                result = receipt.get('result')
+                if not isinstance(result, dict):
+                    raise RuntimeError('executor result must be an object')
+                return result
+            time.sleep(max(0.02, float(poll_seconds)))
+        raise TimeoutError(f'executor request timed out: {request["request_id"]}')
+
+
+class FileExecutorHost:
+    """Executor-side helper that publishes health and consumes bridge requests."""
+
+    def __init__(
+        self,
+        executor_id: str,
+        root: str | Path,
+        *,
+        capabilities: list[str] | tuple[str, ...],
+        details_provider: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        self.executor_id = executor_id
+        self.root = Path(root).expanduser()
+        self.requests = self.root / 'requests'
+        self.receipts = self.root / 'receipts'
+        self.capabilities = sorted(set(capabilities))
+        self.details_provider = details_provider
+
+    def publish_descriptor(self, *, ready: bool = True) -> dict[str, Any]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        details = dict(self.details_provider() if self.details_provider else {})
+        payload = {
+            'schema': BRIDGE_SCHEMA,
+            'executor_id': self.executor_id,
+            'ready': bool(ready),
+            'observed_at': _utc_now(),
+            'capabilities': self.capabilities,
+            'security_boundary': 'filesystem_acl',
+            'details': details,
+        }
+        target = self.root / 'bridge.json'
+        tmp = target.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+        os.replace(tmp, target)
+        return payload
+
+    def serve_once(self, handler: Callable[[dict[str, Any]], dict[str, Any]]) -> int:
+        self.publish_descriptor(ready=True)
+        self.requests.mkdir(parents=True, exist_ok=True)
+        self.receipts.mkdir(parents=True, exist_ok=True)
+        processed = 0
+        for target in sorted(self.requests.glob('executor-*.json')):
+            try:
+                request = json.loads(target.read_text(encoding='utf-8-sig'))
+                if request.get('schema') != REQUEST_SCHEMA:
+                    raise ValueError('invalid executor request schema')
+                if str(request.get('executor_id') or '') != self.executor_id:
+                    raise ValueError('executor request targets another executor')
+                request_id = str(request.get('request_id') or '')
+                task = request.get('task')
+                if not request_id or not isinstance(task, dict):
+                    raise ValueError('invalid executor request')
+                result = handler(task)
+                if not isinstance(result, dict):
+                    raise ValueError('executor handler must return an object')
+                receipt = {
+                    'schema': RECEIPT_SCHEMA,
+                    'request_id': request_id,
+                    'executor_id': self.executor_id,
+                    'task_id': task.get('task_id'),
+                    'ok': True,
+                    'result': result,
+                    'completed_at': _utc_now(),
+                }
+            except Exception as exc:
+                request_id = locals().get('request_id') or target.stem
+                task = locals().get('task') if isinstance(locals().get('task'), dict) else {}
+                receipt = {
+                    'schema': RECEIPT_SCHEMA,
+                    'request_id': request_id,
+                    'executor_id': self.executor_id,
+                    'task_id': task.get('task_id'),
+                    'ok': False,
+                    'error': f'{type(exc).__name__}: {exc}',
+                    'completed_at': _utc_now(),
+                }
+            receipt_target = self.receipts / f'{receipt["request_id"]}.json'
+            tmp = receipt_target.with_suffix('.json.tmp')
+            tmp.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+            os.replace(tmp, receipt_target)
+            target.unlink(missing_ok=True)
+            processed += 1
+        return processed

--- a/agentos_node/executor_registry.py
+++ b/agentos_node/executor_registry.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from agentos_node import interactive_desktop
+
+
+DESKTOP_CAPABILITIES = (
+    'desktop.session.inspect',
+    'desktop.windows.inspect',
+    'desktop.screenshot',
+    'desktop.open_url',
+    'desktop.mouse',
+    'desktop.keyboard',
+)
+
+
+@dataclass(frozen=True)
+class ExecutorDescriptor:
+    executor_id: str
+    kind: str
+    status: str
+    capabilities: tuple[str, ...]
+    reason: str | None = None
+    details: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            'executor_id': self.executor_id,
+            'kind': self.kind,
+            'status': self.status,
+            'capabilities': list(self.capabilities),
+        }
+        if self.reason:
+            payload['reason'] = self.reason
+        if self.details:
+            payload['details'] = self.details
+        return payload
+
+
+class ExecutorRegistry:
+    """Discover runtime executors independently from the Node transport lifecycle.
+
+    The Node Runtime may stay online in a non-interactive service session while the
+    desktop executor is unavailable. Desktop capabilities are only advertised when
+    the current process is actually attached to the active interactive session.
+    """
+
+    def __init__(
+        self,
+        *,
+        platform_name: str | None = None,
+        desktop_probe: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        self.platform_name = platform_name or platform.system()
+        self.desktop_probe = desktop_probe or interactive_desktop.session_info
+
+    def desktop(self) -> ExecutorDescriptor:
+        if self.platform_name != 'Windows':
+            return ExecutorDescriptor(
+                executor_id='desktop',
+                kind='interactive-desktop',
+                status='unavailable',
+                capabilities=(),
+                reason='unsupported_platform',
+                details={'platform': self.platform_name},
+            )
+        try:
+            info = dict(self.desktop_probe())
+        except Exception as exc:
+            return ExecutorDescriptor(
+                executor_id='desktop',
+                kind='interactive-desktop',
+                status='unavailable',
+                capabilities=(),
+                reason='probe_failed',
+                details={'error': f'{type(exc).__name__}: {exc}'},
+            )
+        if not bool(info.get('interactive')):
+            return ExecutorDescriptor(
+                executor_id='desktop',
+                kind='interactive-desktop',
+                status='unavailable',
+                capabilities=(),
+                reason='not_interactive_session',
+                details=info,
+            )
+        return ExecutorDescriptor(
+            executor_id='desktop',
+            kind='interactive-desktop',
+            status='available',
+            capabilities=DESKTOP_CAPABILITIES,
+            details=info,
+        )
+
+    def inventory(self, *, local_capabilities: list[str] | tuple[str, ...]) -> list[dict[str, Any]]:
+        local = ExecutorDescriptor(
+            executor_id='local',
+            kind='node-local',
+            status='available',
+            capabilities=tuple(sorted(set(local_capabilities))),
+        )
+        return [local.as_dict(), self.desktop().as_dict()]
+
+    def available_capabilities(self, *, local_capabilities: list[str] | tuple[str, ...]) -> list[str]:
+        caps = set(local_capabilities)
+        desktop = self.desktop()
+        if desktop.status == 'available':
+            caps.update(desktop.capabilities)
+        return sorted(caps)
+
+    def require_desktop(self) -> ExecutorDescriptor:
+        desktop = self.desktop()
+        if desktop.status != 'available':
+            raise RuntimeError(f'desktop executor unavailable: {desktop.reason}')
+        return desktop

--- a/agentos_node/executor_registry.py
+++ b/agentos_node/executor_registry.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from agentos_node import interactive_desktop
+from agentos_node.executor_bridge import describe_executor_bridge
 
 
 DESKTOP_CAPABILITIES = (
@@ -43,9 +44,10 @@ class ExecutorDescriptor:
 class ExecutorRegistry:
     """Discover runtime executors independently from the Node transport lifecycle.
 
-    The Node Runtime may stay online in a non-interactive service session while the
-    desktop executor is unavailable. Desktop capabilities are only advertised when
-    the current process is actually attached to the active interactive session.
+    A Node Runtime may stay online in a non-interactive service session while an
+    interactive desktop executor lives in another user-session process. Desktop
+    capabilities are advertised only when either the local process is interactive
+    or a fresh local executor bridge reports them available.
     """
 
     def __init__(
@@ -53,9 +55,37 @@ class ExecutorRegistry:
         *,
         platform_name: str | None = None,
         desktop_probe: Callable[[], dict[str, Any]] | None = None,
+        desktop_bridge_probe: Callable[[], dict[str, Any] | None] | None = None,
     ) -> None:
         self.platform_name = platform_name or platform.system()
         self.desktop_probe = desktop_probe or interactive_desktop.session_info
+        self.desktop_bridge_probe = desktop_bridge_probe or (lambda: describe_executor_bridge('desktop'))
+
+    def _bridged_desktop(self) -> ExecutorDescriptor | None:
+        try:
+            bridge = self.desktop_bridge_probe()
+        except Exception:
+            return None
+        if not bridge or not bridge.get('ready'):
+            return None
+        advertised = {str(x) for x in (bridge.get('capabilities') or [])}
+        allowed = tuple(cap for cap in DESKTOP_CAPABILITIES if cap in advertised)
+        if not allowed:
+            return None
+        safe_details = {
+            'execution_mode': 'local_executor_bridge',
+            'heartbeat_age_seconds': bridge.get('heartbeat_age_seconds'),
+            'root': bridge.get('root'),
+            'security_boundary': bridge.get('security_boundary'),
+            'details': bridge.get('details'),
+        }
+        return ExecutorDescriptor(
+            executor_id='desktop',
+            kind='interactive-desktop-bridge',
+            status='available',
+            capabilities=allowed,
+            details=safe_details,
+        )
 
     def desktop(self) -> ExecutorDescriptor:
         if self.platform_name != 'Windows':
@@ -70,6 +100,9 @@ class ExecutorRegistry:
         try:
             info = dict(self.desktop_probe())
         except Exception as exc:
+            bridged = self._bridged_desktop()
+            if bridged:
+                return bridged
             return ExecutorDescriptor(
                 executor_id='desktop',
                 kind='interactive-desktop',
@@ -78,20 +111,23 @@ class ExecutorRegistry:
                 reason='probe_failed',
                 details={'error': f'{type(exc).__name__}: {exc}'},
             )
-        if not bool(info.get('interactive')):
+        if bool(info.get('interactive')):
             return ExecutorDescriptor(
                 executor_id='desktop',
                 kind='interactive-desktop',
-                status='unavailable',
-                capabilities=(),
-                reason='not_interactive_session',
-                details=info,
+                status='available',
+                capabilities=DESKTOP_CAPABILITIES,
+                details={'execution_mode': 'in_process', **info},
             )
+        bridged = self._bridged_desktop()
+        if bridged:
+            return bridged
         return ExecutorDescriptor(
             executor_id='desktop',
             kind='interactive-desktop',
-            status='available',
-            capabilities=DESKTOP_CAPABILITIES,
+            status='unavailable',
+            capabilities=(),
+            reason='not_interactive_session',
             details=info,
         )
 

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agentos_node import interactive_desktop
 from agentos_node.agent_surfaces import discover_surfaces
+from agentos_node.executor_registry import ExecutorRegistry
 from agentos_node.session_bridge import FileSessionBridge
 
 
@@ -71,11 +72,18 @@ class ThinClient:
         'code', 'cursor', 'antigravity', 'claude', 'codex', 'gemini',
     )
 
-    def __init__(self, identity: NodeIdentity, policy: ThinClientPolicy):
+    def __init__(
+        self,
+        identity: NodeIdentity,
+        policy: ThinClientPolicy,
+        *,
+        executor_registry: ExecutorRegistry | None = None,
+    ):
         self.identity = identity
         self.policy = policy
         self.hostname = socket.gethostname()
         self.started_at = _utc_now()
+        self.executors = executor_registry or ExecutorRegistry()
 
     def discover_tools(self) -> dict[str, str]:
         found: dict[str, str] = {}
@@ -88,10 +96,8 @@ class ThinClient:
     def surface_inventory(self) -> dict[str, Any]:
         return discover_surfaces()
 
-    def capability_manifest(self) -> dict[str, Any]:
-        tools = self.discover_tools()
-        surface_inventory = self.surface_inventory()
-        caps = ['context.harvest', 'process.inspect', 'tool.presence', 'agent.surface.inspect']
+    def _local_capabilities(self, surface_inventory: dict[str, Any]) -> list[str]:
+        caps = ['context.harvest', 'process.inspect', 'tool.presence', 'agent.surface.inspect', 'executor.inspect']
         caps.extend(surface_inventory.get('capabilities') or [])
         if self.policy.allowed_executables:
             caps.append('shell.exec')
@@ -99,11 +105,14 @@ class ThinClient:
             caps.append('filesystem.read')
         if self.policy.writable_roots:
             caps.append('filesystem.write')
-        if platform.system() == 'Windows':
-            caps.extend([
-                'desktop.session.inspect', 'desktop.windows.inspect', 'desktop.screenshot',
-                'desktop.open_url', 'desktop.mouse', 'desktop.keyboard',
-            ])
+        return sorted(set(caps))
+
+    def capability_manifest(self) -> dict[str, Any]:
+        tools = self.discover_tools()
+        surface_inventory = self.surface_inventory()
+        local_caps = self._local_capabilities(surface_inventory)
+        caps = self.executors.available_capabilities(local_capabilities=local_caps)
+        executor_inventory = self.executors.inventory(local_capabilities=local_caps)
         return {
             'schema': 'agentos.node-manifest/v0.1',
             'realm_id': self.identity.realm_id,
@@ -114,7 +123,8 @@ class ThinClient:
             'platform_release': platform.release(),
             'python_version': platform.python_version(),
             'observed_at': _utc_now(),
-            'capabilities': sorted(set(caps)),
+            'capabilities': caps,
+            'executors': executor_inventory,
             'tool_presence': tools,
             'surface_inventory': surface_inventory,
             'workspace_roots': {
@@ -134,6 +144,7 @@ class ThinClient:
             'observed_at': _utc_now(),
             'uptime_seconds': max(0, int(time.time() - datetime.fromisoformat(self.started_at.replace('Z', '+00:00')).timestamp())),
             'capability_count': len(manifest['capabilities']),
+            'executor_count': len(manifest.get('executors') or []),
             'surface_count': int((manifest.get('surface_inventory') or {}).get('surface_count') or 0),
             'manifest': manifest,
         }
@@ -167,6 +178,10 @@ class ThinClient:
                 result = self._read_file(task)
             elif action == 'filesystem.write':
                 result = self._write_file(task)
+            elif action == 'executor.inspect':
+                surface_inventory = self.surface_inventory()
+                local_caps = self._local_capabilities(surface_inventory)
+                result = {'executors': self.executors.inventory(local_capabilities=local_caps)}
             elif action == 'agent.surface.inspect':
                 result = {'surface_inventory': self.surface_inventory()}
             elif action == 'agent.session.discover':
@@ -190,19 +205,23 @@ class ThinClient:
                 if not request_id:
                     raise ValueError('request_id is required')
                 result = {'session_receipt': self._session_bridge(task).receipt(request_id)}
-            elif action == 'desktop.session.inspect':
-                result = {'desktop': interactive_desktop.session_info()}
-            elif action == 'desktop.windows.inspect':
-                result = interactive_desktop.inspect_windows()
-            elif action == 'desktop.open_url':
-                result = interactive_desktop.open_url(str(task.get('url') or ''))
-            elif action == 'desktop.screenshot':
-                workspace = self.policy.writable_roots[0] if self.policy.writable_roots else Path.cwd()
-                result = interactive_desktop.screenshot(workspace, quality=int(task.get('quality') or 55))
-            elif action == 'desktop.mouse':
-                result = interactive_desktop.mouse(task)
-            elif action == 'desktop.keyboard':
-                result = interactive_desktop.keyboard(task)
+            elif str(action).startswith('desktop.'):
+                self.executors.require_desktop()
+                if action == 'desktop.session.inspect':
+                    result = {'desktop': interactive_desktop.session_info()}
+                elif action == 'desktop.windows.inspect':
+                    result = interactive_desktop.inspect_windows()
+                elif action == 'desktop.open_url':
+                    result = interactive_desktop.open_url(str(task.get('url') or ''))
+                elif action == 'desktop.screenshot':
+                    workspace = self.policy.writable_roots[0] if self.policy.writable_roots else Path.cwd()
+                    result = interactive_desktop.screenshot(workspace, quality=int(task.get('quality') or 55))
+                elif action == 'desktop.mouse':
+                    result = interactive_desktop.mouse(task)
+                elif action == 'desktop.keyboard':
+                    result = interactive_desktop.keyboard(task)
+                else:
+                    raise ValueError(f'unsupported desktop action: {action}')
             else:
                 raise ValueError(f'unsupported action: {action}')
             receipt.update(result)

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agentos_node import interactive_desktop
 from agentos_node.agent_surfaces import discover_surfaces
+from agentos_node.executor_bridge import FileExecutorBridge
 from agentos_node.executor_registry import ExecutorRegistry
 from agentos_node.session_bridge import FileSessionBridge
 
@@ -206,8 +207,13 @@ class ThinClient:
                     raise ValueError('request_id is required')
                 result = {'session_receipt': self._session_bridge(task).receipt(request_id)}
             elif str(action).startswith('desktop.'):
-                self.executors.require_desktop()
-                if action == 'desktop.session.inspect':
+                desktop = self.executors.require_desktop()
+                if desktop.kind == 'interactive-desktop-bridge':
+                    result = FileExecutorBridge.from_environment('desktop').execute(
+                        task,
+                        timeout_seconds=min(float(task.get('timeout_seconds') or 30), float(self.policy.max_timeout_seconds)),
+                    )
+                elif action == 'desktop.session.inspect':
                     result = {'desktop': interactive_desktop.session_info()}
                 elif action == 'desktop.windows.inspect':
                     result = interactive_desktop.inspect_windows()

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -22,6 +22,9 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Continuation-state monotonicity | Implemented + tested | `scripts/continuation_state.py` | `tests/test_continuation_state.py` |
 | Persistent control plane | Implemented + tested | `agent_core/control_plane.py` | `tests/test_control_plane.py`, `.agentos/evidence/bootstrap-control-plane.txt` |
 | Node registry / capability discovery | Implemented + tested | `agent_core/node_registry.py`, `scripts/agentos_node.py` | `tests/test_agentos_node.py`, `tests/test_node_registry_v01.py` |
+| Node / executor separation | Implemented + tested on feature branch | `agentos_node/executor_registry.py`, `agentos_node/executor_bridge.py`, `agentos_node/thin_client.py` | `tests/test_executor_registry.py`, `tests/test_executor_bridge.py`, `Node Executor Runtime CI` |
+| Windows always-on Node Runtime carrier | Implemented, not yet live-verified | `scripts/windows/install_node_runtime_service.ps1` | Windows-native syntax CI; requires live `vopc5750` heartbeat acceptance |
+| Windows interactive Desktop executor carrier | Implemented, not yet live-verified | `agentos_node/desktop_executor_host.py`, `agentos_node/desktop_executor_cli.py`, `scripts/windows/install_desktop_executor_user.ps1` | bridge/unit tests + Windows-native syntax CI; requires live desktop acceptance |
 | Governance responsibility resolution | Implemented + tested | `agent_core/governance_directory.py` | `tests/test_governance_directory.py`, governance audit workflow/evidence |
 | Resource registry / world-state lookup | Implemented + tested | `agent_core/resource_registry.py` | `tests/test_resource_registry.py` |
 | Realm / cross-node fabric | Implemented slices + tested | `agent_core/realm_fabric.py`, `agent_core/realm_server.py`, `agent_core/realm_cli.py` | `tests/test_realm_fabric.py`, `.agentos/commands/` |
@@ -42,6 +45,12 @@ Compaction, replay, stale tool results, or executor switching must not replace a
 ### Evidence is not intent
 
 Tool results and execution evidence can inform decisions, but they do not silently rewrite the user's active goal.
+
+### Node identity is not executor availability
+
+A Node is the durable transport/control-plane participant. Executors are capability providers attached to that Node and may independently become available or unavailable. In particular, Windows being online must not imply that an interactive desktop is available. A Session 0 Node Runtime must remain able to heartbeat, receive work, report executor status, and recover even when the Desktop executor is absent.
+
+The Windows Desktop executor is intentionally hosted in the logged-in user session. Its interactive Scheduled Task is an executor carrier only; it must not own the Realm transport credential or become the Node's liveness boundary. The always-on Node Runtime belongs to the Windows Service carrier.
 
 ### Capability does not imply authority
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [project.scripts]
 agentos-node = "agentos_node.cli:main"
 agentos-client = "agentos_node.client_cli:main"
+agentos-desktop-executor = "agentos_node.desktop_executor_cli:main"
 agentos-one = "agent_core.realm_cli:main"
 
 [tool.setuptools.packages.find]

--- a/scripts/install_thin_client_windows.ps1
+++ b/scripts/install_thin_client_windows.ps1
@@ -29,10 +29,17 @@ if ($major -lt 3) { throw "Python 3 is required; found $version" }
 
 $files = @(
   'agentos_node/__init__.py',
-  'agentos_node/thin_client.py',
+  'agentos_node/agent_surfaces.py',
+  'agentos_node/client_cli.py',
+  'agentos_node/desktop_executor_cli.py',
+  'agentos_node/desktop_executor_host.py',
+  'agentos_node/executor_bridge.py',
+  'agentos_node/executor_registry.py',
   'agentos_node/interactive_desktop.py',
-  'agentos_node/thin_client_transport.py',
-  'agentos_node/client_cli.py'
+  'agentos_node/onboarding.py',
+  'agentos_node/session_bridge.py',
+  'agentos_node/thin_client.py',
+  'agentos_node/thin_client_transport.py'
 )
 foreach ($rel in $files) {
   $dest = Join-Path $InstallRoot ($rel -replace '/', '\')
@@ -45,8 +52,10 @@ $clientCliText = Get-Content -Raw $clientCli
 if ($clientCliText -notmatch "encoding='utf-8-sig'") {
   throw "Downloaded client_cli.py failed BOM-compatibility guard (ref=$Ref)"
 }
-if (-not (Test-Path (Join-Path $Pkg 'interactive_desktop.py'))) {
-  throw "Interactive Desktop Adapter missing (ref=$Ref)"
+foreach ($required in @('interactive_desktop.py','executor_bridge.py','executor_registry.py','desktop_executor_host.py','desktop_executor_cli.py')) {
+  if (-not (Test-Path (Join-Path $Pkg $required))) {
+    throw "Required AgentOS runtime module missing: $required (ref=$Ref)"
+  }
 }
 
 $policy = @{
@@ -68,24 +77,21 @@ $launcherPath = Join-Path $InstallRoot 'agentos-client.cmd'
 $launcher | Set-Content -Encoding ASCII $launcherPath
 
 if ($EnableAutostart) {
-  if (-not (Test-Path (Join-Path $State 'client.json'))) {
-    throw 'Client is not enrolled yet. Run agentos-client.cmd join first, then rerun installer with -EnableAutostart.'
-  }
-  $taskName = 'AgentOS Thin Client'
-  $action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument "/d /c `"$launcherPath`" run" -WorkingDirectory $InstallRoot
-  $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
-  $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -RestartCount 5 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit ([TimeSpan]::Zero)
-  Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description 'AgentOS Thin Client user-session daemon' -Force | Out-Null
-  Start-ScheduledTask -TaskName $taskName
-  Write-Host "Autostart enabled: $taskName"
+  throw @'
+-EnableAutostart no longer installs the combined interactive Thin Client task.
+AgentOS now separates the always-on Node Runtime from user-session executors.
+Install the Node Runtime Windows Service with scripts/windows/install_node_runtime_service.ps1,
+then install the interactive desktop executor with scripts/windows/install_desktop_executor_user.ps1.
+'@
 }
 
-Write-Host "AgentOS Thin Client installed: $InstallRoot"
+Write-Host "AgentOS Thin Client runtime installed: $InstallRoot"
 Write-Host "Source commit: $Ref"
 Write-Host "Python: $version"
 Write-Host "Policy workspace: $WorkspaceRoot"
 Write-Host "Launcher: $launcherPath"
-Write-Host "Interactive Desktop Adapter: installed"
+Write-Host "Executor bridge runtime: installed"
 Write-Host ''
-Write-Host 'Next command:'
+Write-Host 'Next command for a new node:'
 Write-Host "  & '$launcherPath' join --one https://studio.milkcat.org/dashboard/api/agentos"
+Write-Host 'After enrollment, install the split Node Service and user-session Desktop Executor carriers.'

--- a/scripts/windows/install_desktop_executor_user.ps1
+++ b/scripts/windows/install_desktop_executor_user.ps1
@@ -1,0 +1,68 @@
+param(
+  [string]$TaskName = 'AgentOS Desktop Executor',
+  [string]$InstallRoot = "$env:LOCALAPPDATA\AgentOS",
+  [string]$BridgeRoot = "$env:ProgramData\AgentOS\executor-bridges\desktop-$env:USERNAME"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$required = @(
+  'agentos_node\desktop_executor_cli.py',
+  'agentos_node\desktop_executor_host.py',
+  'agentos_node\executor_bridge.py',
+  'agentos_node\executor_registry.py',
+  'agentos_node\interactive_desktop.py',
+  'agentos_node\thin_client.py'
+)
+foreach ($rel in $required) {
+  $path = Join-Path $InstallRoot $rel
+  if (-not (Test-Path $path)) { throw "Missing desktop executor runtime file: $path" }
+}
+if (-not (Test-Path $BridgeRoot)) {
+  throw "Desktop executor bridge does not exist: $BridgeRoot. Install the AgentOS Node Runtime service first."
+}
+
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) { throw 'Python 3 is required for the AgentOS Desktop Executor.' }
+
+$launcherPath = Join-Path $InstallRoot 'agentos-desktop-executor.cmd'
+$launcher = @"
+@echo off
+set "PYTHONPATH=$InstallRoot"
+"$($python.Source)" -m agentos_node.desktop_executor_cli %*
+"@
+$launcher | Set-Content -Encoding ASCII $launcherPath
+
+$action = New-ScheduledTaskAction `
+  -Execute 'cmd.exe' `
+  -Argument "/d /c `"$launcherPath`" --bridge `"$BridgeRoot`" run" `
+  -WorkingDirectory $InstallRoot
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -StartWhenAvailable `
+  -RestartCount 10 `
+  -RestartInterval (New-TimeSpan -Minutes 1) `
+  -ExecutionTimeLimit ([TimeSpan]::Zero)
+$principal = New-ScheduledTaskPrincipal `
+  -UserId "$env:USERDOMAIN\$env:USERNAME" `
+  -LogonType Interactive `
+  -RunLevel Limited
+
+Register-ScheduledTask `
+  -TaskName $TaskName `
+  -Action $action `
+  -Trigger $trigger `
+  -Settings $settings `
+  -Principal $principal `
+  -Description 'AgentOS interactive desktop executor host; no Realm transport credential' `
+  -Force | Out-Null
+
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 1
+$task = Get-ScheduledTask -TaskName $TaskName
+Write-Host "Desktop executor task: $TaskName"
+Write-Host "Task state: $($task.State)"
+Write-Host "Bridge: $BridgeRoot"
+Write-Host 'This task hosts desktop capabilities only; it does not own the AgentOS Realm transport.'

--- a/scripts/windows/install_node_runtime_service.ps1
+++ b/scripts/windows/install_node_runtime_service.ps1
@@ -1,0 +1,174 @@
+param(
+  [string]$ServiceName = 'AgentOSNodeRuntime',
+  [string]$DisplayName = 'AgentOS Node Runtime',
+  [string]$InstallRoot = "$env:LOCALAPPDATA\AgentOS",
+  [string]$LegacyTaskName = 'AgentOS Thin Client',
+  [string]$BridgeRoot = "$env:ProgramData\AgentOS\executor-bridges\desktop-$env:USERNAME"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = New-Object Security.Principal.WindowsPrincipal($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+  throw 'Administrator privileges are required to install the AgentOS Node Runtime Windows Service.'
+}
+
+$launcher = Join-Path $InstallRoot 'agentos-client.cmd'
+$stateRoot = Join-Path $InstallRoot 'state'
+if (-not (Test-Path $launcher)) { throw "Missing AgentOS launcher: $launcher" }
+if (-not (Test-Path (Join-Path $stateRoot 'client.json'))) { throw "Missing enrolled node config under $stateRoot" }
+if (-not (Test-Path (Join-Path $stateRoot 'policy.json'))) { throw "Missing node policy under $stateRoot" }
+
+$runtimeRoot = Join-Path $env:ProgramData 'AgentOS\node-runtime'
+New-Item -ItemType Directory -Force -Path $runtimeRoot, $BridgeRoot | Out-Null
+
+# The bridge is a local authority boundary shared only by SYSTEM/Administrators and
+# the currently logged-in user that hosts the interactive desktop executor.
+$currentUser = $identity.Name
+& icacls.exe $BridgeRoot /inheritance:r | Out-Null
+& icacls.exe $BridgeRoot /grant:r 'SYSTEM:(OI)(CI)F' 'BUILTIN\Administrators:(OI)(CI)F' "$currentUser`:(OI)(CI)M" | Out-Null
+
+$serviceExe = Join-Path $runtimeRoot 'AgentOSNodeRuntimeService.exe'
+$escapedLauncher = $launcher.Replace('"', '""')
+$escapedInstall = $InstallRoot.Replace('"', '""')
+$escapedBridge = $BridgeRoot.Replace('"', '""')
+
+$source = @'
+using System;
+using System.Diagnostics;
+using System.ServiceProcess;
+using System.Threading;
+
+public sealed class AgentOSNodeRuntimeService : ServiceBase
+{
+    private readonly object gate = new object();
+    private Timer timer;
+    private Process child;
+    private bool stopping;
+
+    private const string Launcher = @"__LAUNCHER__";
+    private const string WorkingRoot = @"__INSTALL_ROOT__";
+    private const string DesktopBridge = @"__BRIDGE_ROOT__";
+
+    public AgentOSNodeRuntimeService()
+    {
+        ServiceName = "AgentOSNodeRuntime";
+        CanStop = true;
+        CanShutdown = true;
+        AutoLog = true;
+    }
+
+    protected override void OnStart(string[] args)
+    {
+        stopping = false;
+        timer = new Timer(EnsureChild, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    protected override void OnStop()
+    {
+        stopping = true;
+        if (timer != null) timer.Dispose();
+        lock (gate)
+        {
+            StopChild();
+        }
+    }
+
+    protected override void OnShutdown()
+    {
+        OnStop();
+        base.OnShutdown();
+    }
+
+    private void EnsureChild(object state)
+    {
+        if (stopping) return;
+        lock (gate)
+        {
+            if (stopping) return;
+            if (child != null && !child.HasExited) return;
+            if (child != null)
+            {
+                child.Dispose();
+                child = null;
+            }
+            var psi = new ProcessStartInfo();
+            psi.FileName = "cmd.exe";
+            psi.Arguments = "/d /c \"\"" + Launcher + "\" run\"";
+            psi.WorkingDirectory = WorkingRoot;
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            psi.EnvironmentVariables["AGENTOS_DESKTOP_EXECUTOR_BRIDGE"] = DesktopBridge;
+            child = Process.Start(psi);
+        }
+    }
+
+    private void StopChild()
+    {
+        if (child == null) return;
+        try
+        {
+            if (!child.HasExited)
+            {
+                child.Kill();
+                child.WaitForExit(5000);
+            }
+        }
+        catch { }
+        finally
+        {
+            child.Dispose();
+            child = null;
+        }
+    }
+
+    public static void Main()
+    {
+        ServiceBase.Run(new AgentOSNodeRuntimeService());
+    }
+}
+'@
+$source = $source.Replace('__LAUNCHER__', $escapedLauncher).Replace('__INSTALL_ROOT__', $escapedInstall).Replace('__BRIDGE_ROOT__', $escapedBridge)
+
+$existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($existing) {
+  if ($existing.Status -ne 'Stopped') {
+    Stop-Service -Name $ServiceName -Force
+    $existing.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(15))
+  }
+  & sc.exe delete $ServiceName | Out-Null
+  Start-Sleep -Seconds 1
+}
+if (Test-Path $serviceExe) { Remove-Item -Force $serviceExe }
+
+Add-Type -TypeDefinition $source -Language CSharp -ReferencedAssemblies 'System.ServiceProcess.dll' -OutputAssembly $serviceExe -OutputType WindowsApplication
+if (-not (Test-Path $serviceExe)) { throw 'Windows Service wrapper compilation failed.' }
+
+& sc.exe create $ServiceName "binPath= `"$serviceExe`"" 'start= auto' "DisplayName= $DisplayName" | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "sc.exe create failed for $ServiceName" }
+& sc.exe failure $ServiceName 'reset= 86400' 'actions= restart/5000/restart/5000/restart/10000' | Out-Null
+& sc.exe failureflag $ServiceName 1 | Out-Null
+
+$legacyTask = Get-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue
+if ($legacyTask) {
+  Stop-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue
+}
+
+Start-Service -Name $ServiceName
+$service = Get-Service -Name $ServiceName
+$service.WaitForStatus('Running', [TimeSpan]::FromSeconds(15))
+if ($service.Status -ne 'Running') {
+  if ($legacyTask) { Start-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue }
+  throw "$ServiceName did not reach Running state; legacy task was restarted when available."
+}
+
+if ($legacyTask) {
+  Disable-ScheduledTask -TaskName $LegacyTaskName | Out-Null
+}
+
+Write-Host "AgentOS Node Runtime Windows Service: $($service.Status)"
+Write-Host "Service name: $ServiceName"
+Write-Host "Desktop executor bridge: $BridgeRoot"
+if ($legacyTask) { Write-Host "Legacy task retained but disabled for rollback: $LegacyTaskName" }
+Write-Host 'No Realm credential value was printed or copied by this installer.'

--- a/scripts/windows/install_node_runtime_service.ps1
+++ b/scripts/windows/install_node_runtime_service.ps1
@@ -30,6 +30,7 @@ $currentUser = $identity.Name
 & icacls.exe $BridgeRoot /grant:r 'SYSTEM:(OI)(CI)F' 'BUILTIN\Administrators:(OI)(CI)F' "$currentUser`:(OI)(CI)M" | Out-Null
 
 $serviceExe = Join-Path $runtimeRoot 'AgentOSNodeRuntimeService.exe'
+$escapedServiceName = $ServiceName.Replace('"', '""')
 $escapedLauncher = $launcher.Replace('"', '""')
 $escapedInstall = $InstallRoot.Replace('"', '""')
 $escapedBridge = $BridgeRoot.Replace('"', '""')
@@ -47,13 +48,14 @@ public sealed class AgentOSNodeRuntimeService : ServiceBase
     private Process child;
     private bool stopping;
 
+    private const string RuntimeServiceName = @"__SERVICE_NAME__";
     private const string Launcher = @"__LAUNCHER__";
     private const string WorkingRoot = @"__INSTALL_ROOT__";
     private const string DesktopBridge = @"__BRIDGE_ROOT__";
 
     public AgentOSNodeRuntimeService()
     {
-        ServiceName = "AgentOSNodeRuntime";
+        ServiceName = RuntimeServiceName;
         CanStop = true;
         CanShutdown = true;
         AutoLog = true;
@@ -129,7 +131,7 @@ public sealed class AgentOSNodeRuntimeService : ServiceBase
     }
 }
 '@
-$source = $source.Replace('__LAUNCHER__', $escapedLauncher).Replace('__INSTALL_ROOT__', $escapedInstall).Replace('__BRIDGE_ROOT__', $escapedBridge)
+$source = $source.Replace('__SERVICE_NAME__', $escapedServiceName).Replace('__LAUNCHER__', $escapedLauncher).Replace('__INSTALL_ROOT__', $escapedInstall).Replace('__BRIDGE_ROOT__', $escapedBridge)
 
 $existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
 if ($existing) {

--- a/scripts/windows/migrate_split_node_executor_runtime.ps1
+++ b/scripts/windows/migrate_split_node_executor_runtime.ps1
@@ -1,0 +1,137 @@
+param(
+  [string]$SourceRef = 'feature/node-executor-runtime',
+  [string]$InstallRoot = "$env:LOCALAPPDATA\AgentOS",
+  [string]$LegacyTaskName = 'AgentOS Thin Client',
+  [string]$NodeServiceName = 'AgentOSNodeRuntime',
+  [string]$DesktopTaskName = 'AgentOS Desktop Executor'
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = 'alston-personal/agentmanager'
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = New-Object Security.Principal.WindowsPrincipal($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+  throw 'Run this migration from an elevated PowerShell window (Run as administrator).'
+}
+
+$launcher = Join-Path $InstallRoot 'agentos-client.cmd'
+$stateRoot = Join-Path $InstallRoot 'state'
+if (-not (Test-Path $launcher)) { throw "Existing AgentOS launcher not found: $launcher" }
+if (-not (Test-Path (Join-Path $stateRoot 'client.json'))) { throw 'Existing node enrollment is required; client.json was not found.' }
+if (-not (Test-Path (Join-Path $stateRoot 'policy.json'))) { throw 'Existing node policy is required; policy.json was not found.' }
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$backupRoot = Join-Path $InstallRoot "migration-backup-$timestamp"
+New-Item -ItemType Directory -Force -Path $backupRoot | Out-Null
+if (Test-Path (Join-Path $InstallRoot 'agentos_node')) {
+  Copy-Item -Recurse -Force (Join-Path $InstallRoot 'agentos_node') (Join-Path $backupRoot 'agentos_node')
+}
+Copy-Item -Force $launcher (Join-Path $backupRoot 'agentos-client.cmd')
+
+$legacyTask = Get-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue
+$legacyWasEnabled = $false
+$legacyWasRunning = $false
+if ($legacyTask) {
+  $legacyWasEnabled = ($legacyTask.State -ne 'Disabled')
+  $legacyWasRunning = ($legacyTask.State -eq 'Running')
+}
+
+function Restore-LegacyRuntime {
+  Write-Warning 'Migration failed; restoring prior AgentOS runtime.'
+  Stop-Service -Name $NodeServiceName -Force -ErrorAction SilentlyContinue
+  & sc.exe delete $NodeServiceName 2>$null | Out-Null
+  Unregister-ScheduledTask -TaskName $DesktopTaskName -Confirm:$false -ErrorAction SilentlyContinue
+
+  $currentPkg = Join-Path $InstallRoot 'agentos_node'
+  if (Test-Path $currentPkg) { Remove-Item -Recurse -Force $currentPkg }
+  $backupPkg = Join-Path $backupRoot 'agentos_node'
+  if (Test-Path $backupPkg) { Copy-Item -Recurse -Force $backupPkg $currentPkg }
+  Copy-Item -Force (Join-Path $backupRoot 'agentos-client.cmd') $launcher
+
+  if ($legacyTask) {
+    if ($legacyWasEnabled) { Enable-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue | Out-Null }
+    if ($legacyWasRunning -or $legacyWasEnabled) { Start-ScheduledTask -TaskName $LegacyTaskName -ErrorAction SilentlyContinue }
+  }
+}
+
+try {
+  $headers = @{
+    'Accept' = 'application/vnd.github+json'
+    'User-Agent' = 'AgentOS-NodeRuntime-Migration/0.1'
+    'Cache-Control' = 'no-cache'
+  }
+  $encodedRef = [uri]::EscapeDataString($SourceRef)
+  $head = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri "https://api.github.com/repos/$Repo/commits/$encodedRef?ts=$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())"
+  $Ref = [string]$head.sha
+  if ($Ref -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve immutable source commit: $SourceRef" }
+  $Base = "https://raw.githubusercontent.com/$Repo/$Ref"
+
+  $files = @(
+    'agentos_node/__init__.py',
+    'agentos_node/agent_surfaces.py',
+    'agentos_node/client_cli.py',
+    'agentos_node/desktop_executor_cli.py',
+    'agentos_node/desktop_executor_host.py',
+    'agentos_node/executor_bridge.py',
+    'agentos_node/executor_registry.py',
+    'agentos_node/interactive_desktop.py',
+    'agentos_node/onboarding.py',
+    'agentos_node/session_bridge.py',
+    'agentos_node/thin_client.py',
+    'agentos_node/thin_client_transport.py'
+  )
+  foreach ($rel in $files) {
+    $dest = Join-Path $InstallRoot ($rel -replace '/', '\')
+    New-Item -ItemType Directory -Force -Path (Split-Path $dest -Parent) | Out-Null
+    Invoke-WebRequest -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } -Uri "$Base/$rel" -OutFile $dest
+  }
+
+  $serviceInstaller = Join-Path $InstallRoot 'install_node_runtime_service.ps1'
+  $desktopInstaller = Join-Path $InstallRoot 'install_desktop_executor_user.ps1'
+  Invoke-WebRequest -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } -Uri "$Base/scripts/windows/install_node_runtime_service.ps1" -OutFile $serviceInstaller
+  Invoke-WebRequest -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } -Uri "$Base/scripts/windows/install_desktop_executor_user.ps1" -OutFile $desktopInstaller
+
+  # Local import/manifest preflight before changing any carrier.
+  $manifestOutput = & $launcher manifest 2>&1
+  if ($LASTEXITCODE -ne 0) { throw "Updated runtime manifest preflight failed: $manifestOutput" }
+  $manifestText = ($manifestOutput | Out-String)
+  if ($manifestText -notmatch '"executors"') { throw 'Updated runtime manifest does not expose executor inventory.' }
+  if ($manifestText -notmatch '"executor.inspect"') { throw 'Updated runtime manifest is missing executor.inspect.' }
+  Write-Host "runtime_preflight=PASS ref=$Ref"
+
+  & $serviceInstaller -ServiceName $NodeServiceName -InstallRoot $InstallRoot -LegacyTaskName $LegacyTaskName
+  if ($LASTEXITCODE -ne 0) { throw 'Node Runtime Service installer returned a non-zero exit code.' }
+
+  $service = Get-Service -Name $NodeServiceName -ErrorAction Stop
+  $service.WaitForStatus('Running', [TimeSpan]::FromSeconds(15))
+  if ($service.Status -ne 'Running') { throw 'Node Runtime Service did not remain Running.' }
+  Write-Host 'node_service=PASS'
+
+  & $desktopInstaller -TaskName $DesktopTaskName -InstallRoot $InstallRoot
+  if ($LASTEXITCODE -ne 0) { throw 'Desktop Executor installer returned a non-zero exit code.' }
+
+  Start-Sleep -Seconds 2
+  $desktopTask = Get-ScheduledTask -TaskName $DesktopTaskName -ErrorAction Stop
+  if ($desktopTask.State -notin @('Running','Ready')) { throw "Unexpected Desktop Executor task state: $($desktopTask.State)" }
+  Write-Host "desktop_executor_task=PASS state=$($desktopTask.State)"
+
+  $result = [ordered]@{
+    schema = 'agentos.windows-node-migration/v0.1'
+    ok = $true
+    source_ref = $SourceRef
+    source_commit = $Ref
+    node_service = $NodeServiceName
+    node_service_status = $service.Status.ToString()
+    desktop_task = $DesktopTaskName
+    desktop_task_status = $desktopTask.State.ToString()
+    legacy_task_retained = [bool]$legacyTask
+    backup_root = $backupRoot
+    credential_values_printed = $false
+  }
+  $result | ConvertTo-Json -Depth 5
+}
+catch {
+  Restore-LegacyRuntime
+  throw
+}

--- a/tests/test_executor_bridge.py
+++ b/tests/test_executor_bridge.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentos_node.executor_bridge import FileExecutorBridge, FileExecutorHost, describe_executor_bridge
+from agentos_node.executor_registry import DESKTOP_CAPABILITIES, ExecutorRegistry
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+class TestExecutorBridge(unittest.TestCase):
+    def test_descriptor_reports_fresh_executor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            host = FileExecutorHost('desktop', tmp, capabilities=['desktop.open_url'])
+            host.publish_descriptor(ready=True)
+            descriptor = describe_executor_bridge('desktop', tmp)
+            self.assertIsNotNone(descriptor)
+            self.assertTrue(descriptor['ready'])
+            self.assertEqual(descriptor['status'], 'available')
+            self.assertIn('desktop.open_url', descriptor['capabilities'])
+
+    def test_request_receipt_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bridge = FileExecutorBridge('desktop', tmp)
+            host = FileExecutorHost('desktop', tmp, capabilities=['desktop.open_url'])
+            host.publish_descriptor(ready=True)
+            task = {
+                'schema': 'agentos.node-task/v0.1',
+                'task_id': 'bridge-roundtrip',
+                'action': 'desktop.open_url',
+                'url': 'https://example.com',
+            }
+            request = bridge.request(task)
+            self.assertEqual(host.serve_once(lambda item: {'echo_action': item['action']}), 1)
+            receipt = bridge.receipt(request['request_id'])
+            self.assertTrue(receipt['ok'])
+            self.assertEqual(receipt['result']['echo_action'], 'desktop.open_url')
+
+    def test_node_service_routes_to_bridged_desktop_executor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            host = FileExecutorHost('desktop', root, capabilities=DESKTOP_CAPABILITIES)
+            host.publish_descriptor(ready=True)
+            registry = ExecutorRegistry(
+                platform_name='Windows',
+                desktop_probe=lambda: {
+                    'process_session_id': 0,
+                    'active_console_session_id': 2,
+                    'interactive': False,
+                },
+                desktop_bridge_probe=lambda: describe_executor_bridge('desktop', root),
+            )
+            client = ThinClient(
+                NodeIdentity('realm-test', 'node-service-test'),
+                ThinClientPolicy(max_timeout_seconds=2),
+                executor_registry=registry,
+            )
+            manifest = client.capability_manifest()
+            executors = {item['executor_id']: item for item in manifest['executors']}
+            self.assertEqual(executors['desktop']['kind'], 'interactive-desktop-bridge')
+            self.assertIn('desktop.open_url', manifest['capabilities'])
+
+            stop = threading.Event()
+
+            def worker():
+                while not stop.is_set():
+                    host.serve_once(lambda task: {'bridged': True, 'url': task.get('url')})
+                    time.sleep(0.02)
+
+            thread = threading.Thread(target=worker, daemon=True)
+            thread.start()
+            try:
+                with patch.dict(os.environ, {'AGENTOS_DESKTOP_EXECUTOR_BRIDGE': str(root)}):
+                    receipt = client.execute({
+                        'schema': 'agentos.node-task/v0.1',
+                        'task_id': 'bridged-open-url',
+                        'action': 'desktop.open_url',
+                        'url': 'https://example.com',
+                    })
+                self.assertTrue(receipt['ok'], receipt)
+                self.assertTrue(receipt['bridged'])
+                self.assertEqual(receipt['url'], 'https://example.com')
+            finally:
+                stop.set()
+                thread.join(timeout=1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_executor_registry.py
+++ b/tests/test_executor_registry.py
@@ -1,0 +1,92 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentos_node.executor_registry import DESKTOP_CAPABILITIES, ExecutorRegistry
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+class TestExecutorRegistry(unittest.TestCase):
+    def test_non_windows_keeps_desktop_unavailable(self):
+        registry = ExecutorRegistry(platform_name='Linux')
+        desktop = registry.desktop()
+        self.assertEqual(desktop.status, 'unavailable')
+        self.assertEqual(desktop.reason, 'unsupported_platform')
+        self.assertEqual(desktop.capabilities, ())
+
+    def test_windows_service_session_does_not_advertise_desktop(self):
+        registry = ExecutorRegistry(
+            platform_name='Windows',
+            desktop_probe=lambda: {
+                'process_session_id': 0,
+                'active_console_session_id': 2,
+                'interactive': False,
+            },
+        )
+        desktop = registry.desktop()
+        self.assertEqual(desktop.status, 'unavailable')
+        self.assertEqual(desktop.reason, 'not_interactive_session')
+        self.assertEqual(desktop.capabilities, ())
+
+    def test_windows_interactive_session_advertises_desktop(self):
+        registry = ExecutorRegistry(
+            platform_name='Windows',
+            desktop_probe=lambda: {
+                'process_session_id': 2,
+                'active_console_session_id': 2,
+                'interactive': True,
+            },
+        )
+        desktop = registry.desktop()
+        self.assertEqual(desktop.status, 'available')
+        self.assertEqual(set(desktop.capabilities), set(DESKTOP_CAPABILITIES))
+
+    def test_manifest_separates_node_from_desktop_executor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = ExecutorRegistry(
+                platform_name='Windows',
+                desktop_probe=lambda: {
+                    'process_session_id': 0,
+                    'active_console_session_id': 2,
+                    'interactive': False,
+                },
+            )
+            client = ThinClient(
+                NodeIdentity('realm-test', 'node-service-test'),
+                ThinClientPolicy(readable_roots=(root,), writable_roots=(root,)),
+                executor_registry=registry,
+            )
+            manifest = client.capability_manifest()
+            self.assertIn('filesystem.read', manifest['capabilities'])
+            self.assertNotIn('desktop.screenshot', manifest['capabilities'])
+            executors = {item['executor_id']: item for item in manifest['executors']}
+            self.assertEqual(executors['local']['status'], 'available')
+            self.assertEqual(executors['desktop']['status'], 'unavailable')
+
+    def test_desktop_dispatch_fails_closed_when_executor_unavailable(self):
+        registry = ExecutorRegistry(
+            platform_name='Windows',
+            desktop_probe=lambda: {
+                'process_session_id': 0,
+                'active_console_session_id': 2,
+                'interactive': False,
+            },
+        )
+        client = ThinClient(
+            NodeIdentity('realm-test', 'node-service-test'),
+            ThinClientPolicy(),
+            executor_registry=registry,
+        )
+        receipt = client.execute({
+            'schema': 'agentos.node-task/v0.1',
+            'task_id': 'desktop-fail-closed',
+            'action': 'desktop.open_url',
+            'url': 'https://example.com',
+        })
+        self.assertFalse(receipt['ok'])
+        self.assertIn('desktop executor unavailable', receipt['error'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Split Windows AgentOS Node liveness from interactive desktop execution.

- Model executors independently from Node identity/liveness.
- Advertise desktop capabilities only when an interactive executor is actually available.
- Add a local file-backed executor request/receipt bridge.
- Route `desktop.*` tasks through a bridged desktop executor when the Node Runtime is in a non-interactive service session.
- Add an isolated Desktop Executor host/CLI with no Realm transport credential.
- Add a real SCM Windows Service carrier for the always-on Node Runtime.
- Keep the interactive Scheduled Task only as the Desktop Executor carrier.
- Retain the old `AgentOS Thin Client` task disabled for rollback after successful service installation.
- Add reversible one-time Windows migration with runtime backup and rollback.
- Prevent the generic Windows bootstrap installer from recreating the old combined user-session daemon.
- Document the Node/executor liveness boundary in `docs/CURRENT_STATE.md`.

## Architecture invariant

A Node is the durable Realm transport/control-plane participant. Executors are capability providers attached to the Node and may independently become available/unavailable.

In particular:

- Session 0 Node Runtime must remain online without Desktop.
- Desktop executor may run only in the interactive user session.
- Desktop executor does not own the Realm transport credential.
- Windows being online does not imply Desktop is available.

## Verification so far

- Executor registry/unit tests: PASS.
- Local executor bridge request/receipt round trip: PASS.
- Simulated Session-0 Node -> bridged Desktop executor -> Node receipt: PASS without touching a real GUI.
- Carrier boundary static guard: PASS.
- PowerShell carrier/migration scripts parse on a native Windows GitHub runner: PASS.
- Executor Python modules compile on Windows: PASS.

## Live gate before ready/merge

Still required on `vopc5750`:

1. Run reversible split-runtime migration.
2. Verify `AgentOSNodeRuntime` remains Running and Core receives persistent heartbeats for >60 seconds.
3. Verify manifest reports Node online independently of Desktop availability.
4. Verify logged-in Desktop executor appears as available through the local bridge.
5. Run read-only Meta acceptance: `desktop.open_url -> desktop.windows.inspect -> desktop.screenshot`.
6. Confirm no Realm credential is present in the Desktop Executor process boundary.

Do not merge based only on CI; live Windows acceptance is still outstanding.