### PR TITLE
fix(agentos): deploy ChatGPT MCP without python3-venv

### DIFF
--- a/.github/workflows/deploy-chatgpt-cloud-node.yml
+++ b/.github/workflows/deploy-chatgpt-cloud-node.yml
@@ -71,11 +71,29 @@ jobs:
           TARGET_SHA="$(git -C "$RELEASE_ROOT" rev-parse FETCH_HEAD)"
           git -C "$RELEASE_ROOT" checkout --detach "$TARGET_SHA"
 
+          # Match the existing Core deployment policy: prefer the isolated venv,
+          # but do not require python3-venv/root package installation on Oracle.
           PYTHON_BIN="$RELEASE_ROOT/.venv/bin/python3"
           if [ ! -x "$PYTHON_BIN" ]; then
-            python3 -m venv "$RELEASE_ROOT/.venv"
+            rm -rf "$RELEASE_ROOT/.venv" 2>/dev/null || true
+            if python3 -m venv "$RELEASE_ROOT/.venv" >/dev/null 2>&1; then
+              PYTHON_BIN="$RELEASE_ROOT/.venv/bin/python3"
+              echo "Using isolated Python virtualenv"
+            else
+              rm -rf "$RELEASE_ROOT/.venv" 2>/dev/null || true
+              PYTHON_BIN="$(command -v python3)"
+              echo "python3-venv unavailable; using system Python user site"
+            fi
           fi
-          "$PYTHON_BIN" -m pip install --upgrade -r "$RELEASE_ROOT/requirements-mcp.txt"
+
+          if ! "$PYTHON_BIN" -c 'import mcp' >/dev/null 2>&1; then
+            if [ "$PYTHON_BIN" = "$(command -v python3)" ]; then
+              "$PYTHON_BIN" -m pip install --user --upgrade -r "$RELEASE_ROOT/requirements-mcp.txt"
+            else
+              "$PYTHON_BIN" -m pip install --upgrade -r "$RELEASE_ROOT/requirements-mcp.txt"
+            fi
+          fi
+          "$PYTHON_BIN" -c 'import mcp' >/dev/null
 
           DIST_ENV="$HOME/.config/agentos/distributed.env"
           python3 - "$DIST_ENV" "$CHATGPT_PRINCIPAL_ID" "$CHATGPT_PROJECTS" <<'PY'


### PR DESCRIPTION
Fixes the first real ONE deployment failure for the ChatGPT Cloud Node. Oracle does not have `python3-venv`, so the workflow now matches the existing Core deployment policy: prefer the isolated venv when available, otherwise use system Python user-site packages without sudo or apt changes. The workflow still verifies the MCP import before installing the service.