### PR TITLE
fix(agentos): use the actual MCP SDK v2 server API

### DIFF
--- a/.github/workflows/distributed-agentos-ci.yml
+++ b/.github/workflows/distributed-agentos-ci.yml
@@ -21,6 +21,7 @@ on:
       - ".github/workflows/distributed-agentos-*.yml"
       - ".github/workflows/deploy-agentos-core.yml"
       - ".github/workflows/deploy-chatgpt-cloud-node.yml"
+      - "requirements-mcp.txt"
       - "pyproject.toml"
 
 permissions:
@@ -40,12 +41,23 @@ jobs:
           python-version: "3.11"
 
       - name: Install package and test dependencies
-        run: python -m pip install --upgrade -e . pytest
+        run: |
+          python -m pip install --upgrade -e . pytest
+          python -m pip install --upgrade -r requirements-mcp.txt
 
-      - name: Smoke-test installed CLIs
+      - name: Smoke-test installed CLIs and MCP server import
         run: |
           agentos --help >/dev/null
           agentos-node --help >/dev/null
+          python -c 'from mcp.server.mcpserver import MCPServer; assert MCPServer'
+          AGENTOS_CONTROL_PLANE_URL=https://one.invalid \
+          AGENTOS_CHATGPT_CLIENT_TOKEN=agc_ci_smoke \
+          AGENTOS_CHATGPT_PRINCIPAL_ID=ci-principal \
+          python - <<'PY'
+          import runpy
+          namespace = runpy.run_path('scripts/agentos_mcp_server.py', run_name='agentos_mcp_server_ci')
+          assert namespace['mcp'] is not None
+          PY
 
       - name: Validate Core service installers
         run: |

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import os
 
-from mcp.server import MCPServer
+from mcp.server.mcpserver import MCPServer
 
 from agentos_node.control_plane_client import ControlPlaneClient
 from agentos_node.mcp_read_tools import get_project_state, get_task, resume_project


### PR DESCRIPTION
Fixes the real Oracle startup crash: `MCPServer` in the installed v2 SDK lives at `mcp.server.mcpserver`, not `mcp.server`. Also makes deterministic CI install `requirements-mcp.txt` and import the actual ChatGPT MCP server module so SDK/API drift is caught before production deployment.