### PR TITLE
fix(agentos): upgrade stale MCP SDK on ONE

### DIFF
--- a/.github/workflows/deploy-chatgpt-cloud-node.yml
+++ b/.github/workflows/deploy-chatgpt-cloud-node.yml
@@ -94,14 +94,17 @@ jobs:
             fi
           fi
 
-          if ! "$PYTHON_BIN" -c 'import mcp' >/dev/null 2>&1; then
+          # Do not treat an arbitrary/old `mcp` package as sufficient. Verify the
+          # exact SDK v2 API used by our server and force an upgrade when absent.
+          if ! "$PYTHON_BIN" -c 'from mcp.server.mcpserver import MCPServer; assert MCPServer' >/dev/null 2>&1; then
+            echo "MCP SDK v2 server API missing; upgrading from requirements-mcp.txt"
             if [ "$PYTHON_BIN" = "$(command -v python3)" ]; then
               "$PYTHON_BIN" -m pip install --user --upgrade -r "$RELEASE_ROOT/requirements-mcp.txt"
             else
               "$PYTHON_BIN" -m pip install --upgrade -r "$RELEASE_ROOT/requirements-mcp.txt"
             fi
           fi
-          "$PYTHON_BIN" -c 'import mcp' >/dev/null
+          "$PYTHON_BIN" -c 'from mcp.server.mcpserver import MCPServer; assert MCPServer' >/dev/null
 
           DIST_ENV="$HOME/.config/agentos/distributed.env"
           python3 - "$DIST_ENV" "$CHATGPT_PRINCIPAL_ID" "$CHATGPT_PROJECTS" <<'PY'

--- a/scripts/install_chatgpt_cloud_node.sh
+++ b/scripts/install_chatgpt_cloud_node.sh
@@ -22,8 +22,8 @@ set +a
 if [ -z "$PYTHON_BIN" ] && [ -x "$LOGIC_ROOT/.venv/bin/python3" ]; then PYTHON_BIN="$LOGIC_ROOT/.venv/bin/python3"; fi
 if [ -z "$PYTHON_BIN" ]; then PYTHON_BIN="$(command -v python3)"; fi
 [ -x "$PYTHON_BIN" ] || { echo "No usable Python interpreter found" >&2; exit 2; }
-"$PYTHON_BIN" -c 'import mcp' >/dev/null 2>&1 || {
-  echo "Python MCP SDK is missing; install requirements-mcp.txt into $PYTHON_BIN environment" >&2
+"$PYTHON_BIN" -c 'from mcp.server.mcpserver import MCPServer; assert MCPServer' >/dev/null 2>&1 || {
+  echo "Python MCP SDK v2 server API is missing; install/upgrade requirements-mcp.txt into $PYTHON_BIN environment" >&2
   exit 2
 }
 


### PR DESCRIPTION
Fixes the fifth real ONE deployment failure. Oracle already had an older/unrelated `mcp` package, so `import mcp` falsely passed and skipped the required SDK upgrade. Deployment and installer now verify the exact v2 server API (`mcp.server.mcpserver.MCPServer`) and force an upgrade from `requirements-mcp.txt` when it is unavailable.