### PR TITLE
test(agentos): prove live MCP tool path reaches ONE

### DIFF
--- a/.github/workflows/verify-chatgpt-mcp-protocol.yml
+++ b/.github/workflows/verify-chatgpt-mcp-protocol.yml
@@ -1,0 +1,64 @@
+name: Verify ChatGPT MCP Protocol to ONE
+
+on:
+  push:
+    branches:
+      - feature/distributed-agentos-runtime
+    paths:
+      - "scripts/agentos_mcp_server.py"
+      - "scripts/verify_chatgpt_mcp_protocol.py"
+      - "agentos_node/mcp_read_tools.py"
+      - ".github/workflows/verify-chatgpt-mcp-protocol.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentos-chatgpt-mcp-protocol
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DEPLOY_HOST_SOURCE: ${{ secrets.AGENTOS_DEPLOY_HOST || secrets.N8N_BASE_URL || 'https://n8n.milkcat.org' }}
+      DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || 'ubuntu' }}
+      DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
+      RELEASE_ROOT: ${{ vars.AGENTOS_DISTRIBUTED_DEPLOY_ROOT || '/home/ubuntu/agentos-distributed' }}
+
+    steps:
+      - name: Resolve deploy host
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEPLOY_HOST="${DEPLOY_HOST_SOURCE#*://}"
+          DEPLOY_HOST="${DEPLOY_HOST%%/*}"
+          DEPLOY_HOST="${DEPLOY_HOST%%:*}"
+          test -n "$DEPLOY_HOST"
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AGENTOS_DEPLOY_SSH_KEY || secrets.N8N_DEPLOY_SSH_KEY }}
+
+      - name: Verify live MCP to ONE
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            bash -s -- "$RELEASE_ROOT" <<'REMOTE'
+          set -euo pipefail
+          RELEASE_ROOT="$1"
+          REF="feature/distributed-agentos-runtime"
+          git -C "$RELEASE_ROOT" fetch --prune origin "$REF"
+          git -C "$RELEASE_ROOT" checkout --detach "$(git -C "$RELEASE_ROOT" rev-parse FETCH_HEAD)"
+          PYTHON_BIN="$(command -v python3)"
+          "$PYTHON_BIN" -c 'from mcp import ClientSession; from mcp.client.streamable_http import streamable_http_client'
+          systemctl --user is-active --quiet agentos-chatgpt-mcp.service
+          "$PYTHON_BIN" "$RELEASE_ROOT/scripts/verify_chatgpt_mcp_protocol.py" \
+            --url http://127.0.0.1:8000/mcp \
+            --project agentmanager
+          REMOTE

--- a/scripts/verify_chatgpt_mcp_protocol.py
+++ b/scripts/verify_chatgpt_mcp_protocol.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Live Streamable HTTP acceptance probe for the ChatGPT Cloud MCP node.
+
+This proves the actual MCP protocol path, not just TCP readiness or a separate
+Control Plane REST request: initialize -> list tools -> call AgentOS tool -> ONE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+
+EXPECTED_TOOLS = {"agentos_resume", "agentos_project_state", "agentos_task"}
+
+
+def _content_text(result: object) -> str:
+    content = getattr(result, "content", None) or []
+    texts = [getattr(item, "text", "") for item in content if getattr(item, "type", None) == "text"]
+    return "\n".join(text for text in texts if text)
+
+
+async def verify(url: str, project_id: str) -> None:
+    async with streamable_http_client(url) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            initialized = await session.initialize()
+            tools = await session.list_tools()
+            names = {tool.name for tool in tools.tools}
+            missing = EXPECTED_TOOLS - names
+            if missing:
+                raise RuntimeError(f"missing MCP tools: {sorted(missing)}")
+
+            result = await session.call_tool("agentos_project_state", {"project_id": project_id})
+            if getattr(result, "is_error", False):
+                raise RuntimeError(f"agentos_project_state returned MCP error: {_content_text(result)}")
+
+            structured = getattr(result, "structured_content", None)
+            payload = structured if isinstance(structured, dict) else None
+            if payload is None:
+                text = _content_text(result)
+                try:
+                    payload = json.loads(text)
+                except (TypeError, json.JSONDecodeError) as exc:
+                    raise RuntimeError(f"MCP tool result is not JSON/structured content: {text!r}") from exc
+
+            if payload.get("projectId") != project_id:
+                raise RuntimeError(
+                    f"MCP tool reached unexpected project: {payload.get('projectId')!r} != {project_id!r}"
+                )
+
+            server_info = getattr(initialized, "server_info", None)
+            server_name = getattr(server_info, "name", "unknown")
+            print("mcp_initialize=ok")
+            print(f"mcp_server={server_name}")
+            print("mcp_tools=ok")
+            print("mcp_tool_call_one=ok")
+            print(f"mcp_project={project_id}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8000/mcp")
+    parser.add_argument("--project", default="agentmanager")
+    args = parser.parse_args()
+    asyncio.run(verify(args.url, args.project))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a live Streamable HTTP MCP acceptance probe and a production-side verification workflow. The probe performs initialize, lists the three AgentOS MCP tools, calls agentos_project_state(agentmanager), and requires the returned durable ONE state to identify the expected project. This upgrades acceptance from socket + separate REST checks to an actual MCP tool round-trip into ONE.