### PR TITLE
feat(agentos): add official OpenAI Secure MCP Tunnel

### DIFF
--- a/.github/workflows/deploy-chatgpt-secure-mcp-tunnel.yml
+++ b/.github/workflows/deploy-chatgpt-secure-mcp-tunnel.yml
@@ -1,0 +1,66 @@
+name: Deploy ChatGPT Secure MCP Tunnel
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentos-chatgpt-secure-mcp-tunnel
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DEPLOY_HOST_SOURCE: ${{ secrets.AGENTOS_DEPLOY_HOST || secrets.N8N_BASE_URL || 'https://n8n.milkcat.org' }}
+      DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || 'ubuntu' }}
+      DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
+      RELEASE_ROOT: ${{ vars.AGENTOS_DISTRIBUTED_DEPLOY_ROOT || '/home/ubuntu/agentos-distributed' }}
+      OPENAI_MCP_TUNNEL_ID: ${{ vars.OPENAI_MCP_TUNNEL_ID }}
+      OPENAI_MCP_TUNNEL_API_KEY: ${{ secrets.OPENAI_MCP_TUNNEL_API_KEY }}
+
+    steps:
+      - name: Check tunnel credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$OPENAI_MCP_TUNNEL_ID" || { echo "blocked_missing_openai_tunnel_id"; exit 3; }
+          test -n "$OPENAI_MCP_TUNNEL_API_KEY" || { echo "blocked_missing_openai_tunnel_runtime_key"; exit 3; }
+
+      - name: Resolve deploy host
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEPLOY_HOST="${DEPLOY_HOST_SOURCE#*://}"
+          DEPLOY_HOST="${DEPLOY_HOST%%/*}"
+          DEPLOY_HOST="${DEPLOY_HOST%%:*}"
+          test -n "$DEPLOY_HOST"
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AGENTOS_DEPLOY_SSH_KEY || secrets.N8N_DEPLOY_SSH_KEY }}
+
+      - name: Install official OpenAI tunnel client
+        shell: bash
+        run: |
+          set -euo pipefail
+          TUNNEL_ID_B64="$(printf '%s' "$OPENAI_MCP_TUNNEL_ID" | base64 -w0)"
+          API_KEY_B64="$(printf '%s' "$OPENAI_MCP_TUNNEL_API_KEY" | base64 -w0)"
+          ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            bash -s -- "$RELEASE_ROOT" "$TUNNEL_ID_B64" "$API_KEY_B64" <<'REMOTE'
+          set -euo pipefail
+          RELEASE_ROOT="$1"
+          CONTROL_PLANE_TUNNEL_ID="$(printf '%s' "$2" | base64 -d)"
+          CONTROL_PLANE_API_KEY="$(printf '%s' "$3" | base64 -d)"
+          export CONTROL_PLANE_TUNNEL_ID CONTROL_PLANE_API_KEY
+          REF="feature/distributed-agentos-runtime"
+          git -C "$RELEASE_ROOT" fetch --prune origin "$REF"
+          git -C "$RELEASE_ROOT" checkout --detach "$(git -C "$RELEASE_ROOT" rev-parse FETCH_HEAD)"
+          systemctl --user is-active --quiet agentos-chatgpt-mcp.service
+          bash "$RELEASE_ROOT/scripts/install_chatgpt_secure_mcp_tunnel.sh"
+          REMOTE

--- a/scripts/install_chatgpt_secure_mcp_tunnel.sh
+++ b/scripts/install_chatgpt_secure_mcp_tunnel.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="v0.0.13"
+INSTALL_ROOT="${AGENTOS_OPENAI_TUNNEL_INSTALL_ROOT:-$HOME/.local/lib/agentos/tunnel-client/$VERSION}"
+CONFIG_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/agentos"
+ENV_FILE="${AGENTOS_OPENAI_TUNNEL_ENV_FILE:-$CONFIG_ROOT/openai-tunnel.env}"
+USER_SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+MCP_URL="${AGENTOS_CHATGPT_MCP_URL:-http://127.0.0.1:8000/mcp}"
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    PLATFORM="linux-amd64"
+    EXPECTED_SHA256="e71f37b424126513173d5e3590687c0b5ccf6e8ef3fba900104d1f8c60dad906"
+    ;;
+  aarch64|arm64)
+    PLATFORM="linux-arm64"
+    EXPECTED_SHA256="9d214a805bec213a3a156dc2a4460a6dfe2f35b0c00ba20609d002bf5e6469f8"
+    ;;
+  *)
+    echo "Unsupported tunnel-client architecture: $(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+TUNNEL_ID="${CONTROL_PLANE_TUNNEL_ID:-${OPENAI_MCP_TUNNEL_ID:-}}"
+RUNTIME_KEY="${CONTROL_PLANE_API_KEY:-${OPENAI_MCP_TUNNEL_API_KEY:-}}"
+[ -n "$TUNNEL_ID" ] || { echo "blocked_missing_openai_tunnel_id" >&2; exit 3; }
+[ -n "$RUNTIME_KEY" ] || { echo "blocked_missing_openai_tunnel_runtime_key" >&2; exit 3; }
+case "$TUNNEL_ID" in
+  tunnel_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) echo "Invalid CONTROL_PLANE_TUNNEL_ID format" >&2; exit 3 ;;
+esac
+
+mkdir -p "$INSTALL_ROOT" "$CONFIG_ROOT" "$USER_SYSTEMD_DIR"
+chmod 700 "$CONFIG_ROOT"
+
+ARCHIVE="tunnel-client-${VERSION}-${PLATFORM}.zip"
+URL="https://github.com/openai/tunnel-client/releases/download/${VERSION}/${ARCHIVE}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+curl -fsSL "$URL" -o "$TMP_DIR/$ARCHIVE"
+printf '%s  %s\n' "$EXPECTED_SHA256" "$TMP_DIR/$ARCHIVE" | sha256sum -c - >/dev/null
+
+python3 - "$TMP_DIR/$ARCHIVE" "$INSTALL_ROOT" <<'PY'
+from pathlib import Path
+import stat, sys, zipfile
+archive=Path(sys.argv[1]); target=Path(sys.argv[2])
+with zipfile.ZipFile(archive) as zf:
+    for info in zf.infolist():
+        name=Path(info.filename)
+        if name.is_absolute() or ".." in name.parts:
+            raise SystemExit(f"unsafe archive member: {info.filename}")
+    zf.extractall(target)
+executables=[]
+for path in target.rglob("tunnel-client"):
+    if path.is_file():
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        executables.append(path)
+if len(executables) != 1:
+    raise SystemExit(f"expected exactly one tunnel-client executable, got {executables}")
+(target/"agentos-tunnel-client-path").write_text(str(executables[0])+"\n", encoding="utf-8")
+PY
+TUNNEL_BIN="$(cat "$INSTALL_ROOT/agentos-tunnel-client-path")"
+"$TUNNEL_BIN" --version
+
+# Keep the OpenAI runtime credential in a dedicated file. Never place an
+# OPENAI_ADMIN_KEY in this service: the daemon needs only Tunnels Read + Use.
+umask 077
+cat > "$ENV_FILE" <<EOF
+CONTROL_PLANE_TUNNEL_ID=$TUNNEL_ID
+CONTROL_PLANE_API_KEY=$RUNTIME_KEY
+EOF
+chmod 600 "$ENV_FILE"
+
+cat > "$USER_SYSTEMD_DIR/agentos-chatgpt-openai-tunnel.service" <<EOF
+[Unit]
+Description=AgentOS ChatGPT OpenAI Secure MCP Tunnel
+After=network-online.target agentos-chatgpt-mcp.service
+Requires=agentos-chatgpt-mcp.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=$ENV_FILE
+ExecStart=$TUNNEL_BIN run --control-plane.tunnel-id \${CONTROL_PLANE_TUNNEL_ID} --mcp.server-url $MCP_URL --health.listen-addr 127.0.0.1:8781
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable agentos-chatgpt-openai-tunnel.service >/dev/null
+systemctl --user restart agentos-chatgpt-openai-tunnel.service
+
+READY=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  if systemctl --user is-active --quiet agentos-chatgpt-openai-tunnel.service \
+    && curl -fsS http://127.0.0.1:8781/readyz >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [ "$READY" != "1" ]; then
+  echo "openai_secure_mcp_tunnel_not_ready" >&2
+  systemctl --user --no-pager --full status agentos-chatgpt-openai-tunnel.service >&2 || true
+  journalctl --user -u agentos-chatgpt-openai-tunnel.service -n 120 --no-pager >&2 || true
+  exit 7
+fi
+
+echo "openai_tunnel_binary_verified=ok"
+echo "openai_tunnel_service=active"
+echo "openai_tunnel_ready=ok"
+echo "openai_tunnel_mcp_target=$MCP_URL"
+echo "openai_tunnel_version=$VERSION"

--- a/tests/test_chatgpt_secure_mcp_tunnel_installer.py
+++ b/tests/test_chatgpt_secure_mcp_tunnel_installer.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = (ROOT / "scripts" / "install_chatgpt_secure_mcp_tunnel.sh").read_text(encoding="utf-8")
+
+
+def test_tunnel_client_release_is_pinned_and_verified():
+    assert 'VERSION="v0.0.13"' in INSTALLER
+    assert "sha256sum -c -" in INSTALLER
+    assert "e71f37b424126513173d5e3590687c0b5ccf6e8ef3fba900104d1f8c60dad906" in INSTALLER
+    assert "9d214a805bec213a3a156dc2a4460a6dfe2f35b0c00ba20609d002bf5e6469f8" in INSTALLER
+    assert "openai/tunnel-client/releases/download" in INSTALLER
+
+
+def test_tunnel_is_outbound_only_to_local_mcp():
+    assert 'MCP_URL="${AGENTOS_CHATGPT_MCP_URL:-http://127.0.0.1:8000/mcp}"' in INSTALLER
+    assert "--mcp.server-url $MCP_URL" in INSTALLER
+    assert "--health.listen-addr 127.0.0.1:8781" in INSTALLER
+    assert "iptables" not in INSTALLER
+    assert "ufw" not in INSTALLER
+    assert "nginx" not in INSTALLER
+
+
+def test_runtime_credentials_are_required_and_admin_key_not_used_by_service():
+    assert "blocked_missing_openai_tunnel_id" in INSTALLER
+    assert "blocked_missing_openai_tunnel_runtime_key" in INSTALLER
+    assert "CONTROL_PLANE_API_KEY=$RUNTIME_KEY" in INSTALLER
+    service_block = INSTALLER.split("cat > \"$USER_SYSTEMD_DIR/agentos-chatgpt-openai-tunnel.service\"", 1)[1]
+    assert "OPENAI_ADMIN_KEY" not in service_block
+
+
+def test_tunnel_depends_on_private_chatgpt_mcp_service():
+    assert "After=network-online.target agentos-chatgpt-mcp.service" in INSTALLER
+    assert "Requires=agentos-chatgpt-mcp.service" in INSTALLER
+    assert "openai_tunnel_ready=ok" in INSTALLER


### PR DESCRIPTION
Adds a fail-closed, user-level systemd deployment for OpenAI's official `openai/tunnel-client` pinned at v0.0.13. The installer detects linux amd64/arm64, verifies the official release SHA256, keeps the AgentOS MCP target on 127.0.0.1:8000/mcp, stores only the runtime tunnel key in a dedicated permission-600 env file, and never exposes an inbound MCP port or uses OPENAI_ADMIN_KEY in the daemon. A manual deployment workflow requires a Platform tunnel ID and runtime API key before mutating the host.