### PR TITLE
feat(agentos): resolve active project for bare continuation

### DIFF
--- a/agent_core/distributed_gateway.py
+++ b/agent_core/distributed_gateway.py
@@ -67,6 +67,106 @@ class DistributedGatewayService:
             },
         }
 
+    def resolve_active_project(
+        self,
+        body: dict[str, Any],
+        *,
+        principal: ClientPrincipal | None = None,
+    ) -> dict[str, Any]:
+        """Resolve the most recently active readable project, optionally using a hint.
+
+        The durable source is the canonical task ledger.  Browser/device/session
+        metadata is intentionally excluded so the result is stable across ChatGPT
+        devices.  A scoped principal never learns project ids outside its scope.
+        """
+
+        hint = str(body.get("hint") or "").strip().casefold()
+        with self.store._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT project_id, MAX(updated_at) AS last_active_at
+                FROM tasks
+                WHERE project_id IS NOT NULL AND TRIM(project_id) <> ''
+                GROUP BY project_id
+                ORDER BY last_active_at DESC, project_id ASC
+                """
+            ).fetchall()
+
+        candidates: list[dict[str, Any]] = []
+        for row in rows:
+            project_id = str(row["project_id"] or "").strip()
+            if not project_id:
+                continue
+            if principal is not None and not principal.allows_project(project_id):
+                continue
+            state = read_project_state(self.store, project_id)
+            current_ir = state.get("currentIR") if isinstance(state.get("currentIR"), dict) else {}
+            goal = str(current_ir.get("goal") or "")
+            score = 0
+            if hint:
+                project_folded = project_id.casefold()
+                goal_folded = goal.casefold()
+                if hint == project_folded:
+                    score = 100
+                elif hint in project_folded:
+                    score = 80
+                elif hint in goal_folded:
+                    score = 60
+                else:
+                    hint_terms = [term for term in hint.replace("/", " ").replace("-", " ").split() if len(term) >= 2]
+                    score = sum(10 for term in hint_terms if term in project_folded or term in goal_folded)
+            candidates.append(
+                {
+                    "project_id": project_id,
+                    "last_active_at": row["last_active_at"],
+                    "recommended_action": state.get("recommendedAction"),
+                    "current_source": state.get("currentSource"),
+                    "goal": goal or None,
+                    "hint_score": score,
+                }
+            )
+
+        if not candidates:
+            return {
+                "protocol": "agentos.active-project/v1",
+                "resolution": "none",
+                "project_id": None,
+                "candidates": [],
+            }
+
+        ranked = candidates
+        if hint:
+            ranked = sorted(
+                candidates,
+                key=lambda item: (int(item["hint_score"]), str(item["last_active_at"] or ""), item["project_id"]),
+                reverse=True,
+            )
+            best_score = int(ranked[0]["hint_score"])
+            if best_score <= 0:
+                return {
+                    "protocol": "agentos.active-project/v1",
+                    "resolution": "no_hint_match",
+                    "project_id": None,
+                    "candidates": ranked[:5],
+                }
+            tied = [item for item in ranked if int(item["hint_score"]) == best_score]
+            if len(tied) > 1 and tied[0]["last_active_at"] == tied[1]["last_active_at"]:
+                return {
+                    "protocol": "agentos.active-project/v1",
+                    "resolution": "ambiguous",
+                    "project_id": None,
+                    "candidates": tied[:5],
+                }
+
+        selected = ranked[0]
+        return {
+            "protocol": "agentos.active-project/v1",
+            "resolution": "resolved",
+            "project_id": selected["project_id"],
+            "selected": selected,
+            "candidates": ranked[:5],
+        }
+
     def submit(self, body: dict[str, Any]) -> dict[str, Any]:
         raw_ir = body.get("canonical_ir")
         if not isinstance(raw_ir, dict):
@@ -264,6 +364,9 @@ class DistributedGatewayHandler(BaseHTTPRequestHandler):
                 project_id = str(body.get("project_id") or "")
                 if not self._require("project.read", project_id=project_id): return
                 self._json(200, self.server.service.attach(body)); return
+            if path == "/v1/projects/resolve-active":
+                if not self._require("project.read"): return
+                self._json(200, self.server.service.resolve_active_project(body, principal=self._principal())); return
             if path == "/v1/tasks":
                 project_id = str(body.get("project_id") or "")
                 capability = str(body.get("capability") or "")

--- a/agentos_node/control_plane_client.py
+++ b/agentos_node/control_plane_client.py
@@ -93,6 +93,12 @@ class ControlPlaneClient:
             {"project_id": project_id, "agent": dict(agent or {})},
         )
 
+    def resolve_active_project(self, *, hint: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if hint is not None and str(hint).strip():
+            payload["hint"] = str(hint).strip()
+        return self._request("POST", "/v1/projects/resolve-active", payload)
+
     def resolve_enrollment(self, reference: str) -> dict[str, Any]:
         return self._request("POST", "/v1/nodes/enrollment/resolve", {"reference": reference})
 

--- a/agentos_node/mcp_read_tools.py
+++ b/agentos_node/mcp_read_tools.py
@@ -8,6 +8,12 @@ from .chatgpt_web_node import bootstrap_chatgpt_web
 from .control_plane_client import ControlPlaneClient
 
 
+def resolve_active_project(client: ControlPlaneClient, *, hint: str | None = None) -> dict[str, Any]:
+    """Resolve the authoritative active readable project from ONE."""
+
+    return client.resolve_active_project(hint=hint)
+
+
 def resume_project(
     client: ControlPlaneClient,
     project_id: str,

--- a/scripts/agentos_mcp_server.py
+++ b/scripts/agentos_mcp_server.py
@@ -15,7 +15,7 @@ import os
 from mcp.server.mcpserver import MCPServer
 
 from agentos_node.control_plane_client import ControlPlaneClient
-from agentos_node.mcp_read_tools import get_project_state, get_task, resume_project
+from agentos_node.mcp_read_tools import get_project_state, get_task, resolve_active_project, resume_project
 
 
 CONTROL_PLANE_URL = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "").strip()
@@ -36,10 +36,25 @@ mcp = MCPServer(
     "LeopardCat AgentOS",
     instructions=(
         "AgentOS is authoritative for existing work. For continuation requests, "
-        "call agentos_resume before using conversational memory. This ChatGPT node "
-        "is account-scoped and must behave identically across devices."
+        "first call agentos_resolve_active when the project id is not already known, "
+        "then call agentos_resume before using conversational memory. This ChatGPT "
+        "node is account-scoped and must behave identically across devices."
     ),
 )
+
+
+@mcp.tool()
+def agentos_resolve_active(hint: str = "") -> dict:
+    """Resolve which existing AgentOS project should be resumed.
+
+    Use this before agentos_resume when the user says continue/resume/繼續 and the
+    current conversation does not already contain an authoritative project id.
+    The result is derived from ONE's canonical task ledger and is filtered by this
+    app principal's project scope. Pass a short user hint such as '3D layoutlib'
+    when available; pass an empty string for bare continuation intent.
+    """
+
+    return resolve_active_project(client, hint=hint or None)
 
 
 @mcp.tool()

--- a/tests/test_distributed_gateway.py
+++ b/tests/test_distributed_gateway.py
@@ -38,6 +38,54 @@ def test_gateway_service_submit_lease_complete(tmp_path: Path):
     assert completed["continuationIR"]["parent_ir_id"] == ir.ir_id
 
 
+def test_active_project_resolver_uses_latest_and_hint(tmp_path: Path):
+    store = DistributedControlPlane(tmp_path / "active.sqlite3")
+    service = DistributedGatewayService(store)
+    service.submit({
+        "canonical_ir": CanonicalIR(
+            goal="continue 3D layoutlib demo implementation",
+            project_id="layoutlib-3d",
+            capability="web.reason",
+        ).to_dict()
+    })
+    service.submit({
+        "canonical_ir": CanonicalIR(
+            goal="continue AgentOS runtime work",
+            project_id="agentmanager",
+            capability="web.reason",
+        ).to_dict()
+    })
+
+    latest = service.resolve_active_project({})
+    assert latest["resolution"] == "resolved"
+    assert latest["project_id"] == "agentmanager"
+
+    hinted = service.resolve_active_project({"hint": "3D layoutlib"})
+    assert hinted["resolution"] == "resolved"
+    assert hinted["project_id"] == "layoutlib-3d"
+
+
+def test_active_project_resolver_filters_principal_scope(tmp_path: Path):
+    store = DistributedControlPlane(tmp_path / "scoped.sqlite3")
+    service = DistributedGatewayService(store)
+    for project_id in ("private-a", "allowed-b"):
+        service.submit({
+            "canonical_ir": CanonicalIR(
+                goal=f"continue {project_id}",
+                project_id=project_id,
+                capability="web.reason",
+            ).to_dict()
+        })
+
+    class ScopedPrincipal:
+        def allows_project(self, project_id: str) -> bool:
+            return project_id == "allowed-b"
+
+    resolved = service.resolve_active_project({}, principal=ScopedPrincipal())
+    assert resolved["project_id"] == "allowed-b"
+    assert {item["project_id"] for item in resolved["candidates"]} == {"allowed-b"}
+
+
 def test_non_loopback_gateway_requires_token():
     with pytest.raises(ValueError, match="TOKEN"):
         validate_bind_security("0.0.0.0", None)


### PR DESCRIPTION
Adds an account-scoped ONE active-project resolver so a fresh ChatGPT session can resume without already knowing project_id. Resolution is derived from the canonical task ledger, filtered by client-token project scope, supports optional hints such as `3D layoutlib`, and is exposed as read-only MCP tool `agentos_resolve_active`. This closes the fresh-chat continuity gap before AgentOS App submission.