### PR TITLE
feat(agentos): bridge ChatGPT GitHub connector to ONE

### DIFF
--- a/.github/workflows/chatgpt-github-command-bus.yml
+++ b/.github/workflows/chatgpt-github-command-bus.yml
@@ -1,0 +1,121 @@
+name: ChatGPT GitHub Command Bus to ONE
+
+on:
+  push:
+    branches:
+      - feature/distributed-agentos-runtime
+    paths:
+      - "agentos-github-bus/requests/**.json"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: agentos-chatgpt-github-bus
+  cancel-in-progress: false
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DEPLOY_HOST_SOURCE: ${{ secrets.AGENTOS_DEPLOY_HOST || secrets.N8N_BASE_URL || 'https://n8n.milkcat.org' }}
+      DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || 'ubuntu' }}
+      DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
+      RELEASE_ROOT: ${{ vars.AGENTOS_DISTRIBUTED_DEPLOY_ROOT || '/home/ubuntu/agentos-distributed' }}
+
+    steps:
+      - name: Checkout command bus
+        uses: actions/checkout@v4
+        with:
+          ref: feature/distributed-agentos-runtime
+          fetch-depth: 2
+
+      - name: Resolve request files
+        id: requests
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" -- 'agentos-github-bus/requests/*.json' > /tmp/agentos_request_files
+          test -s /tmp/agentos_request_files || { echo 'No command request in triggering commit' >&2; exit 2; }
+          cat /tmp/agentos_request_files
+
+      - name: Resolve deploy host
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEPLOY_HOST="${DEPLOY_HOST_SOURCE#*://}"
+          DEPLOY_HOST="${DEPLOY_HOST%%/*}"
+          DEPLOY_HOST="${DEPLOY_HOST%%:*}"
+          test -n "$DEPLOY_HOST"
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AGENTOS_DEPLOY_SSH_KEY || secrets.N8N_DEPLOY_SSH_KEY }}
+
+      - name: Process requests against ONE
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p agentos-github-bus/responses
+          while IFS= read -r REQUEST_PATH; do
+            REQUEST_ID="$(basename "$REQUEST_PATH" .json)"
+            RESPONSE_PATH="agentos-github-bus/responses/${REQUEST_ID}.json"
+            RESPONSE="$({ ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+              bash -s -- "$RELEASE_ROOT" "$REQUEST_PATH" <<'REMOTE'
+          set -euo pipefail
+          RELEASE_ROOT="$1"
+          REQUEST_PATH="$2"
+          REF="feature/distributed-agentos-runtime"
+          git -C "$RELEASE_ROOT" fetch --prune origin "$REF" >/dev/null
+          git -C "$RELEASE_ROOT" checkout --detach "$(git -C "$RELEASE_ROOT" rev-parse FETCH_HEAD)" >/dev/null
+          set -a
+          [ -f "$HOME/agentmanager/.env" ] && source "$HOME/agentmanager/.env"
+          [ -f "$HOME/.agentos.secrets" ] && source "$HOME/.agentos.secrets"
+          [ -f "$HOME/.config/agentos/distributed.env" ] && source "$HOME/.config/agentos/distributed.env"
+          set +a
+          export AGENTOS_CONTROL_PLANE_URL="http://127.0.0.1:8765"
+          export AGENTOS_CONTROL_PLANE_TOKEN="${AGENTOS_CHATGPT_CLIENT_TOKEN:?missing scoped ChatGPT client token}"
+          PYTHON_BIN="${AGENTOS_DISTRIBUTED_PYTHON:-$(command -v python3)}"
+          set +e
+          PYTHONPATH="$RELEASE_ROOT" "$PYTHON_BIN" "$RELEASE_ROOT/scripts/process_chatgpt_github_request.py" "$RELEASE_ROOT/$REQUEST_PATH"
+          exit 0
+          REMOTE
+            } 2>/tmp/agentos_bus_err)"
+            test -n "$RESPONSE" || {
+              python3 - "$REQUEST_ID" /tmp/agentos_bus_err > "$RESPONSE_PATH" <<'PY'
+          import json, pathlib, sys
+          request_id = sys.argv[1]
+          err = pathlib.Path(sys.argv[2]).read_text(encoding='utf-8', errors='replace')[-4000:]
+          print(json.dumps({
+              'protocol': 'agentos.github-command-response/v1',
+              'request_id': request_id,
+              'ok': False,
+              'error': 'transport_failure',
+              'message': err,
+          }, ensure_ascii=False, sort_keys=True))
+          PY
+              continue
+            }
+            printf '%s\n' "$RESPONSE" > "$RESPONSE_PATH"
+            python3 -m json.tool "$RESPONSE_PATH" >/dev/null
+          done < /tmp/agentos_request_files
+
+      - name: Commit responses
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "agentos-command-bus"
+          git config user.email "agentos-command-bus@users.noreply.github.com"
+          git add agentos-github-bus/responses/
+          git diff --cached --quiet && exit 0
+          git commit -m "agentos(bus): respond to ChatGPT command"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:feature/distributed-agentos-runtime; then
+              exit 0
+            fi
+            git pull --rebase origin feature/distributed-agentos-runtime
+          done
+          exit 1

--- a/agentos-github-bus/README.md
+++ b/agentos-github-bus/README.md
@@ -1,0 +1,39 @@
+# AgentOS GitHub Command Bus
+
+This directory is the account-scoped fallback transport from ChatGPT's official GitHub connector to ONE.
+
+## Request
+
+Create one immutable JSON file under `requests/`:
+
+```json
+{
+  "protocol": "agentos.github-command/v1",
+  "request_id": "chatgpt-<unique-id>",
+  "action": "resume",
+  "hint": "",
+  "principal": "chatgpt-github"
+}
+```
+
+Supported read-only actions:
+
+- `resume`: resolve the authoritative active project from ONE, then resume it.
+- `project_state`: read one explicit project state; requires `project_id`.
+
+The GitHub Actions workflow processes the request on the ONE host and writes one response under `responses/<request_id>.json`.
+
+## Response
+
+```json
+{
+  "protocol": "agentos.github-command-response/v1",
+  "request_id": "...",
+  "ok": true,
+  "action": "resume",
+  "project_id": "...",
+  "result": {"...": "ONE canonical response"}
+}
+```
+
+The GitHub repository is transport only. Canonical state remains in ONE. Device, browser and ChatGPT conversation identifiers must never become durable AgentOS identity.

--- a/agentos_node/mcp_read_tools.py
+++ b/agentos_node/mcp_read_tools.py
@@ -20,6 +20,7 @@ def resume_project(
     *,
     runtime_id: str = "chatgpt-web",
     principal_id: str | None = None,
+    transport: str = "mcp",
 ) -> dict[str, Any]:
     """Return the authoritative account-scoped AgentOS bootstrap packet."""
 
@@ -28,7 +29,7 @@ def resume_project(
         project_id,
         runtime_id=runtime_id,
         principal_id=principal_id,
-        transport="mcp",
+        transport=transport,
     ).to_dict()
 
 

--- a/scripts/process_chatgpt_github_request.py
+++ b/scripts/process_chatgpt_github_request.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Process one read-only ChatGPT GitHub command against ONE.
+
+The script is intended to run on the ONE host. GitHub is transport only;
+canonical state is always read from ONE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from agentos_node.control_plane_client import ControlPlaneClient
+from agentos_node.mcp_read_tools import get_project_state, resolve_active_project, resume_project
+
+PROTOCOL = "agentos.github-command/v1"
+RESPONSE_PROTOCOL = "agentos.github-command-response/v1"
+
+
+def _load_request(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("protocol") != PROTOCOL:
+        raise ValueError("unsupported protocol")
+    request_id = str(payload.get("request_id") or "").strip()
+    if not request_id or "/" in request_id or ".." in request_id:
+        raise ValueError("invalid request_id")
+    action = str(payload.get("action") or "").strip()
+    if action not in {"resume", "project_state"}:
+        raise ValueError("unsupported action")
+    return payload
+
+
+def _client() -> ControlPlaneClient:
+    url = os.environ.get("AGENTOS_CONTROL_PLANE_URL", "http://127.0.0.1:8765").strip()
+    token = os.environ.get("AGENTOS_CONTROL_PLANE_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("AGENTOS_CONTROL_PLANE_TOKEN is required")
+    return ControlPlaneClient(url, token=token)
+
+
+def process(payload: dict) -> dict:
+    client = _client()
+    action = payload["action"]
+    request_id = payload["request_id"]
+
+    if action == "resume":
+        hint = str(payload.get("hint") or "").strip() or None
+        resolved = resolve_active_project(client, hint=hint)
+        if resolved.get("resolution") != "resolved" or not resolved.get("project_id"):
+            return {
+                "protocol": RESPONSE_PROTOCOL,
+                "request_id": request_id,
+                "ok": False,
+                "action": action,
+                "error": "active_project_not_resolved",
+                "resolution": resolved,
+            }
+        project_id = str(resolved["project_id"])
+        resumed = resume_project(
+            client,
+            project_id,
+            runtime_id="chatgpt-github",
+            principal_id="chatgpt-github",
+            transport="github",
+        )
+        return {
+            "protocol": RESPONSE_PROTOCOL,
+            "request_id": request_id,
+            "ok": True,
+            "action": action,
+            "project_id": project_id,
+            "resolution": resolved,
+            "result": resumed,
+        }
+
+    project_id = str(payload.get("project_id") or "").strip()
+    if not project_id:
+        raise ValueError("project_id is required for project_state")
+    state = get_project_state(client, project_id)
+    return {
+        "protocol": RESPONSE_PROTOCOL,
+        "request_id": request_id,
+        "ok": True,
+        "action": action,
+        "project_id": project_id,
+        "result": state,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("request")
+    args = parser.parse_args()
+    try:
+        payload = _load_request(Path(args.request))
+        response = process(payload)
+    except Exception as exc:  # fail closed but return machine-readable evidence
+        response = {
+            "protocol": RESPONSE_PROTOCOL,
+            "request_id": None,
+            "ok": False,
+            "error": type(exc).__name__,
+            "message": str(exc),
+        }
+    json.dump(response, sys.stdout, ensure_ascii=False, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if response.get("ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/process_chatgpt_github_request.py
+++ b/scripts/process_chatgpt_github_request.py
@@ -27,6 +27,8 @@ def _load_request(path: Path) -> dict:
     request_id = str(payload.get("request_id") or "").strip()
     if not request_id or "/" in request_id or ".." in request_id:
         raise ValueError("invalid request_id")
+    if path.stem != request_id:
+        raise ValueError("request filename must match request_id")
     action = str(payload.get("action") or "").strip()
     if action not in {"resume", "project_state"}:
         raise ValueError("unsupported action")
@@ -94,13 +96,15 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("request")
     args = parser.parse_args()
+    request_path = Path(args.request)
+    request_id = request_path.stem
     try:
-        payload = _load_request(Path(args.request))
+        payload = _load_request(request_path)
         response = process(payload)
     except Exception as exc:  # fail closed but return machine-readable evidence
         response = {
             "protocol": RESPONSE_PROTOCOL,
-            "request_id": None,
+            "request_id": request_id,
             "ok": False,
             "error": type(exc).__name__,
             "message": str(exc),


### PR DESCRIPTION
Adds a device-independent GitHub command bus for ChatGPT Plus. ChatGPT can create an immutable request JSON through the official GitHub connector; a GitHub Actions worker forwards the request to the ONE host using the existing scoped ChatGPT client principal, then commits a deterministic response JSON for ChatGPT to read. Canonical state remains exclusively in ONE. Includes bare resume via resolve_active -> resume and explicit project_state reads.