### PR TITLE
fix(agentos): route GitHub command bus through proven MCP workflow

### DIFF
--- a/.github/workflows/verify-chatgpt-mcp-protocol.yml
+++ b/.github/workflows/verify-chatgpt-mcp-protocol.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - "scripts/agentos_mcp_server.py"
       - "scripts/verify_chatgpt_mcp_protocol.py"
+      - "scripts/process_chatgpt_github_request.py"
       - "agentos_node/mcp_read_tools.py"
+      - "agentos-github-bus/requests/**"
       - ".github/workflows/verify-chatgpt-mcp-protocol.yml"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: agentos-chatgpt-mcp-protocol
@@ -29,6 +31,12 @@ jobs:
       RELEASE_ROOT: ${{ vars.AGENTOS_DISTRIBUTED_DEPLOY_ROOT || '/home/ubuntu/agentos-distributed' }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: feature/distributed-agentos-runtime
+          fetch-depth: 2
+
       - name: Resolve deploy host
         shell: bash
         run: |
@@ -62,3 +70,66 @@ jobs:
             --url http://127.0.0.1:8000/mcp \
             --project agentmanager
           REMOTE
+
+      - name: Resolve GitHub bus requests
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" -- agentos-github-bus/requests/ > /tmp/agentos_request_files
+          cat /tmp/agentos_request_files
+
+      - name: Process GitHub bus requests through ONE
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -s /tmp/agentos_request_files ] || exit 0
+          mkdir -p agentos-github-bus/responses
+          while IFS= read -r REQUEST_PATH; do
+            REQUEST_ID="$(basename "$REQUEST_PATH" .json)"
+            RESPONSE_PATH="agentos-github-bus/responses/${REQUEST_ID}.json"
+            RESPONSE="$(ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+              bash -s -- "$RELEASE_ROOT" "$REQUEST_PATH" <<'REMOTE'
+          set -euo pipefail
+          RELEASE_ROOT="$1"
+          REQUEST_PATH="$2"
+          REF="feature/distributed-agentos-runtime"
+          git -C "$RELEASE_ROOT" fetch --prune origin "$REF" >/dev/null
+          git -C "$RELEASE_ROOT" checkout --detach "$(git -C "$RELEASE_ROOT" rev-parse FETCH_HEAD)" >/dev/null
+          set -a
+          [ -f "$HOME/agentmanager/.env" ] && source "$HOME/agentmanager/.env"
+          [ -f "$HOME/.agentos.secrets" ] && source "$HOME/.agentos.secrets"
+          [ -f "$HOME/.config/agentos/distributed.env" ] && source "$HOME/.config/agentos/distributed.env"
+          set +a
+          export AGENTOS_CONTROL_PLANE_URL="http://127.0.0.1:8765"
+          export AGENTOS_CONTROL_PLANE_TOKEN="${AGENTOS_CHATGPT_CLIENT_TOKEN:?missing scoped ChatGPT client token}"
+          PYTHON_BIN="${AGENTOS_DISTRIBUTED_PYTHON:-$(command -v python3)}"
+          set +e
+          PYTHONPATH="$RELEASE_ROOT" "$PYTHON_BIN" "$RELEASE_ROOT/scripts/process_chatgpt_github_request.py" "$RELEASE_ROOT/$REQUEST_PATH"
+          exit 0
+          REMOTE
+            )"
+            test -n "$RESPONSE"
+            printf '%s\n' "$RESPONSE" > "$RESPONSE_PATH"
+            python3 -m json.tool "$RESPONSE_PATH" >/dev/null
+          done < /tmp/agentos_request_files
+
+      - name: Commit GitHub bus responses
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -d agentos-github-bus/responses ] || exit 0
+          git config user.name "agentos-command-bus"
+          git config user.email "agentos-command-bus@users.noreply.github.com"
+          git add agentos-github-bus/responses/
+          git diff --cached --quiet && exit 0
+          git commit -m "agentos(bus): respond to ChatGPT command"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:feature/distributed-agentos-runtime; then
+              exit 0
+            fi
+            git pull --rebase origin feature/distributed-agentos-runtime
+          done
+          exit 1


### PR DESCRIPTION
Moves the ChatGPT GitHub command-bus execution onto the already production-proven `Verify ChatGPT MCP Protocol to ONE` workflow. Request pushes now trigger that known workflow, which verifies MCP, processes request JSON on the ONE host with the scoped ChatGPT client token, and commits deterministic response JSON back to the distributed runtime branch.