### PR TITLE
security(agentos): sanitize ChatGPT GitHub bus responses

### DIFF
--- a/scripts/process_chatgpt_github_request.py
+++ b/scripts/process_chatgpt_github_request.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Process one read-only ChatGPT GitHub command against ONE.
 
-The script is intended to run on the ONE host. GitHub is transport only;
-canonical state is always read from ONE.
+GitHub is transport only. Canonical state remains in ONE, and only an explicit
+continuity-safe allowlist may cross the GitHub transport boundary.
 """
 
 from __future__ import annotations
@@ -12,12 +12,139 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 from agentos_node.control_plane_client import ControlPlaneClient
 from agentos_node.mcp_read_tools import get_project_state, resolve_active_project, resume_project
 
 PROTOCOL = "agentos.github-command/v1"
 RESPONSE_PROTOCOL = "agentos.github-command-response/v1"
+
+
+def _pick(source: dict[str, Any], *keys: str) -> dict[str, Any]:
+    return {key: source.get(key) for key in keys if key in source}
+
+
+def _safe_ir(raw: object) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    return _pick(
+        raw,
+        "schema_version",
+        "ir_id",
+        "parent_ir_id",
+        "project_id",
+        "goal",
+        "capability",
+        "constraints",
+        "decisions",
+        "pending_tasks",
+        "continuation",
+        "hop_count",
+        "created_at",
+    )
+
+
+def _safe_task(raw: object) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    return _pick(raw, "taskId", "projectId", "status", "capability", "targetNodeId", "createdAt", "updatedAt")
+
+
+def _safe_resolution(raw: object) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    safe = _pick(raw, "protocol", "resolution", "project_id")
+    selected = raw.get("selected")
+    if isinstance(selected, dict):
+        safe["selected"] = _pick(
+            selected,
+            "project_id",
+            "goal",
+            "recommended_action",
+            "current_source",
+            "last_active_at",
+            "hint_score",
+        )
+    candidates = raw.get("candidates")
+    if isinstance(candidates, list):
+        safe["candidates"] = [
+            _pick(
+                item,
+                "project_id",
+                "goal",
+                "recommended_action",
+                "current_source",
+                "last_active_at",
+                "hint_score",
+            )
+            for item in candidates[:5]
+            if isinstance(item, dict)
+        ]
+    return safe
+
+
+def _safe_execution_context(raw: object) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    safe = _pick(
+        raw,
+        "schema",
+        "project_id",
+        "active_goal",
+        "recommended_action",
+        "next_action",
+        "next_actions",
+        "current_findings",
+        "integration_branch",
+        "source_revision",
+        "write_policy",
+        "context_freshness",
+    )
+    safe_ir = _safe_ir(raw.get("current_ir"))
+    if safe_ir is not None:
+        safe["current_ir"] = safe_ir
+    safe_task = _safe_task(raw.get("latest_task"))
+    if safe_task is not None:
+        safe["latest_task"] = safe_task
+    agent = raw.get("agent")
+    if isinstance(agent, dict):
+        safe["agent"] = _pick(agent, "identity_scope", "kind", "principal_id", "runtime_id", "transport")
+    return safe
+
+
+def _safe_resume(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    safe = _pick(
+        raw,
+        "protocol",
+        "runtime_id",
+        "project_id",
+        "session_id",
+        "recommended_action",
+        "current_source",
+        "latest_task_id",
+        "current_ir_id",
+        "current_ir_digest",
+    )
+    context = _safe_execution_context(raw.get("execution_context"))
+    if context is not None:
+        safe["execution_context"] = context
+    return safe
+
+
+def _safe_project_state(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    safe = _pick(raw, "protocol", "projectId", "recommendedAction", "currentSource")
+    ir = _safe_ir(raw.get("currentIR"))
+    if ir is not None:
+        safe["currentIR"] = ir
+    task = _safe_task(raw.get("latestTask"))
+    if task is not None:
+        safe["latestTask"] = task
+    return safe
 
 
 def _load_request(path: Path) -> dict:
@@ -58,7 +185,7 @@ def process(payload: dict) -> dict:
                 "ok": False,
                 "action": action,
                 "error": "active_project_not_resolved",
-                "resolution": resolved,
+                "resolution": _safe_resolution(resolved),
             }
         project_id = str(resolved["project_id"])
         resumed = resume_project(
@@ -74,8 +201,8 @@ def process(payload: dict) -> dict:
             "ok": True,
             "action": action,
             "project_id": project_id,
-            "resolution": resolved,
-            "result": resumed,
+            "resolution": _safe_resolution(resolved),
+            "result": _safe_resume(resumed),
         }
 
     project_id = str(payload.get("project_id") or "").strip()
@@ -88,7 +215,7 @@ def process(payload: dict) -> dict:
         "ok": True,
         "action": action,
         "project_id": project_id,
-        "result": state,
+        "result": _safe_project_state(state),
     }
 
 
@@ -101,7 +228,7 @@ def main() -> int:
     try:
         payload = _load_request(request_path)
         response = process(payload)
-    except Exception as exc:  # fail closed but return machine-readable evidence
+    except Exception as exc:
         response = {
             "protocol": RESPONSE_PROTOCOL,
             "request_id": request_id,

--- a/tests/test_chatgpt_github_bus_security.py
+++ b/tests/test_chatgpt_github_bus_security.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+
+
+def _module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "process_chatgpt_github_request.py"
+    spec = importlib.util.spec_from_file_location("process_chatgpt_github_request", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_safe_resume_drops_payload_remote_path_and_credentials():
+    module = _module()
+    raw = {
+        "protocol": "agentos.chatgpt-web-bootstrap/v1",
+        "project_id": "demo",
+        "current_ir_id": "ir_1",
+        "current_ir_digest": "abc",
+        "execution_context": {
+            "active_goal": "continue demo",
+            "current_ir": {
+                "schema_version": "agentos.ir/v1",
+                "ir_id": "ir_1",
+                "project_id": "demo",
+                "goal": "continue demo",
+                "capability": "agentos.project.inspect",
+                "payload": {
+                    "remote": "https://x-access-token:SECRET@example.invalid/repo.git",
+                    "path": "/home/user/private",
+                    "token": "SECRET",
+                },
+            },
+            "latest_task": {
+                "taskId": "task_1",
+                "status": "succeeded",
+                "payload": {"token": "SECRET"},
+                "result": {"remote": "https://SECRET@example.invalid/repo.git"},
+            },
+        },
+        "request": {"canonical_ir": {"payload": {"token": "SECRET"}}},
+    }
+
+    safe = module._safe_resume(raw)
+    text = repr(safe)
+    assert "SECRET" not in text
+    assert "remote" not in text
+    assert "payload" not in text
+    assert "/home/user/private" not in text
+    assert safe["execution_context"]["current_ir"]["goal"] == "continue demo"
+    assert safe["execution_context"]["latest_task"]["taskId"] == "task_1"


### PR DESCRIPTION
Hardens the ChatGPT GitHub command bus after the live E2E exposed that raw canonical payloads can contain credential-bearing repository remotes. Responses now use a strict continuity allowlist and never return arbitrary payload/result/path/remote fields. Adds a regression test proving embedded credentials cannot cross the GitHub transport boundary.