### PR TITLE
feat(agentos): publish execution heads and resolve freshness

### DIFF
--- a/.github/workflows/execution-head-tests.yml
+++ b/.github/workflows/execution-head-tests.yml
@@ -1,0 +1,33 @@
+name: Execution Head Tests
+
+on:
+  push:
+    branches:
+      - feature/execution-head-freshness
+    paths:
+      - 'scripts/execution_head.py'
+      - 'scripts/update_projects_pulse.py'
+      - 'scripts/project_overview.py'
+      - 'tests/test_execution_head.py'
+      - '.github/workflows/execution-head-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/execution_head.py'
+      - 'scripts/update_projects_pulse.py'
+      - 'scripts/project_overview.py'
+      - 'tests/test_execution_head.py'
+
+jobs:
+  execution-head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install minimal dependency
+        run: python -m pip install PyYAML
+      - name: Compile changed Python modules
+        run: python -m py_compile scripts/execution_head.py scripts/update_projects_pulse.py scripts/project_overview.py tests/test_execution_head.py
+      - name: Run execution-head regression tests
+        run: python -m unittest -v tests.test_execution_head

--- a/scripts/execution_head.py
+++ b/scripts/execution_head.py
@@ -177,7 +177,10 @@ def _parse_time(value: str | None) -> datetime:
     if not value:
         return datetime.fromtimestamp(0, tz=timezone.utc)
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
     except Exception:
         return datetime.fromtimestamp(0, tz=timezone.utc)
 

--- a/scripts/execution_head.py
+++ b/scripts/execution_head.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Collect and arbitrate per-project execution heads.
+
+Git remote state is evidence, not necessarily the newest project truth. A local
+workspace can legitimately be ahead of origin; AgentOS must publish that state
+so other nodes can resume from the freshest trustworthy execution head.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+SCHEMA = "agentos.execution-head/v1"
+DEFAULT_FRESH_SECONDS = 300
+
+
+@dataclass
+class ExecutionHead:
+    schema: str
+    project_id: str
+    source: str
+    node: str
+    workspace: str
+    branch: str | None
+    local_head: str | None
+    upstream: str | None
+    remote_head: str | None
+    ahead: int | None
+    behind: int | None
+    dirty: bool | None
+    version: str | None
+    version_source: str | None
+    latest_tag: str | None
+    observed_at: str
+    confidence: float = 1.0
+    error: str | None = None
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _run_git(workspace: Path, *args: str, check: bool = True) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=str(workspace), text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout.strip()
+
+
+def _read_json_version(path: Path) -> str | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    value = data.get("version") if isinstance(data, dict) else None
+    return str(value).strip() if value else None
+
+
+def discover_version(workspace: Path, project_yaml: dict[str, Any] | None = None) -> tuple[str | None, str | None]:
+    project_yaml = project_yaml or {}
+    configured = project_yaml.get("version_file") or project_yaml.get("version_path")
+    candidates: list[Path] = []
+    if configured:
+        candidates.append(workspace / str(configured))
+    candidates.extend([
+        workspace / "extension" / "manifest.json",
+        workspace / "package.json",
+        workspace / "pyproject.toml",
+        workspace / ".version",
+    ])
+    seen: set[Path] = set()
+    for path in candidates:
+        if path in seen or not path.exists() or not path.is_file():
+            continue
+        seen.add(path)
+        if path.suffix == ".json":
+            version = _read_json_version(path)
+            if version:
+                return version, str(path.relative_to(workspace))
+        elif path.name == ".version":
+            value = path.read_text(encoding="utf-8").strip()
+            if value:
+                return value, ".version"
+        elif path.name == "pyproject.toml":
+            in_project = False
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if line.startswith("["):
+                    in_project = line == "[project]"
+                    continue
+                if in_project and line.startswith("version") and "=" in line:
+                    value = line.split("=", 1)[1].strip().strip("\"'")
+                    if value:
+                        return value, "pyproject.toml"
+    return None, None
+
+
+def load_project_yaml(project_dir: Path) -> dict[str, Any]:
+    path = project_dir / "project.yaml"
+    if not path.exists() or yaml is None:
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def resolve_workspace(project_id: str, project_dir: Path, project_yaml: dict[str, Any]) -> Path | None:
+    candidates = [project_yaml.get("actual_code_path"), project_yaml.get("workspace"), project_yaml.get("code_path")]
+    for value in candidates:
+        if value:
+            path = Path(os.path.expandvars(os.path.expanduser(str(value))))
+            if path.exists():
+                return path.resolve()
+    agentmanager_root = Path(os.environ.get("AGENTMANAGER_ROOT", Path(__file__).resolve().parent.parent))
+    fallback = agentmanager_root / "workspace" / project_id
+    if fallback.exists():
+        return fallback.resolve()
+    return None
+
+
+def _node_id() -> str:
+    configured = os.environ.get("AGENTOS_NODE_ID")
+    if configured:
+        return configured
+    if hasattr(os, "uname"):
+        return os.uname().nodename
+    return os.environ.get("COMPUTERNAME", "unknown")
+
+
+def collect_execution_head(project_id: str, project_dir: Path, *, node: str | None = None) -> ExecutionHead:
+    project_yaml = load_project_yaml(project_dir)
+    workspace = resolve_workspace(project_id, project_dir, project_yaml)
+    now = utc_now().isoformat()
+    node = node or _node_id()
+    if workspace is None:
+        return ExecutionHead(SCHEMA, project_id, "local-git", node, "", None, None, None, None,
+                             None, None, None, None, None, None, now, 0.0, "workspace_not_found")
+    try:
+        local_head = _run_git(workspace, "rev-parse", "HEAD")
+        branch = _run_git(workspace, "branch", "--show-current", check=False) or None
+        upstream = _run_git(workspace, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}", check=False) or None
+        remote_head = (_run_git(workspace, "rev-parse", "@{u}", check=False) or None) if upstream else None
+        ahead = behind = None
+        if upstream:
+            counts = _run_git(workspace, "rev-list", "--left-right", "--count", f"{upstream}...HEAD", check=False)
+            parts = counts.split()
+            if len(parts) == 2 and all(p.isdigit() for p in parts):
+                behind, ahead = int(parts[0]), int(parts[1])
+        dirty = bool(_run_git(workspace, "status", "--porcelain", check=False))
+        latest_tag = _run_git(workspace, "describe", "--tags", "--abbrev=0", check=False) or None
+        version, version_source = discover_version(workspace, project_yaml)
+        return ExecutionHead(SCHEMA, project_id, "local-git", node, str(workspace), branch, local_head,
+                             upstream, remote_head, ahead, behind, dirty, version, version_source,
+                             latest_tag, now)
+    except Exception as exc:
+        return ExecutionHead(SCHEMA, project_id, "local-git", node, str(workspace), None, None, None, None,
+                             None, None, None, None, None, None, now, 0.2, str(exc))
+
+
+def _parse_time(value: str | None) -> datetime:
+    if not value:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except Exception:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def arbitrate_heads(heads: Iterable[dict[str, Any]], *, now: datetime | None = None,
+                    fresh_seconds: int = DEFAULT_FRESH_SECONDS) -> dict[str, Any]:
+    """Prefer fresh execution evidence and expose disagreements instead of hiding them."""
+    now = now or utc_now()
+    source_rank = {"local-git": 300, "execution-receipt": 290, "remote-git": 200, "release": 150, "status-md": 100}
+    normalized = [dict(h) for h in heads if isinstance(h, dict)]
+    if not normalized:
+        return {"winner": None, "fresh": False, "conflicts": [], "reason": "no_evidence"}
+    for h in normalized:
+        ts = _parse_time(h.get("observed_at") or h.get("timestamp") or h.get("updated_at"))
+        age = max(0.0, (now - ts).total_seconds())
+        h["age_seconds"] = age
+        h["fresh"] = age <= fresh_seconds
+        h["source_rank"] = source_rank.get(str(h.get("source")), 0)
+    fresh = [h for h in normalized if h["fresh"]]
+    pool = fresh or normalized
+    winner = max(pool, key=lambda h: (h["source_rank"], _parse_time(h.get("observed_at") or h.get("timestamp") or h.get("updated_at"))))
+    conflicts = []
+    winner_head = winner.get("local_head") or winner.get("remote_head")
+    winner_version = winner.get("version")
+    for h in normalized:
+        if h is winner:
+            continue
+        other_head = h.get("local_head") or h.get("remote_head")
+        if ((winner_head and other_head and winner_head != other_head) or
+                (winner_version and h.get("version") and winner_version != h.get("version"))):
+            conflicts.append({"source": h.get("source"), "node": h.get("node"), "head": other_head,
+                              "version": h.get("version"), "fresh": h.get("fresh"),
+                              "age_seconds": h.get("age_seconds")})
+    return {"winner": winner, "fresh": bool(winner.get("fresh")), "conflicts": conflicts,
+            "reason": "fresh_trust_rank" if fresh else "all_evidence_stale"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Collect AgentOS project execution head")
+    p.add_argument("project_dir")
+    p.add_argument("--project-id")
+    p.add_argument("--node")
+    p.add_argument("--out")
+    args = p.parse_args()
+    project_dir = Path(args.project_dir).resolve()
+    project_id = args.project_id or project_dir.name
+    payload = asdict(collect_execution_head(project_id, project_dir, node=args.node))
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0 if not payload.get("error") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/execution_head.py
+++ b/scripts/execution_head.py
@@ -184,25 +184,49 @@ def _parse_time(value: str | None) -> datetime:
 
 def arbitrate_heads(heads: Iterable[dict[str, Any]], *, now: datetime | None = None,
                     fresh_seconds: int = DEFAULT_FRESH_SECONDS) -> dict[str, Any]:
-    """Prefer fresh execution evidence and expose disagreements instead of hiding them."""
+    """Prefer fresh valid execution evidence and expose disagreements.
+
+    Evidence with a collection error is retained for diagnostics but is never
+    allowed to outrank valid project state merely because it was observed more
+    recently.
+    """
     now = now or utc_now()
     source_rank = {"local-git": 300, "execution-receipt": 290, "remote-git": 200, "release": 150, "status-md": 100}
     normalized = [dict(h) for h in heads if isinstance(h, dict)]
     if not normalized:
-        return {"winner": None, "fresh": False, "conflicts": [], "reason": "no_evidence"}
+        return {"winner": None, "fresh": False, "conflicts": [], "invalid_evidence": [], "reason": "no_evidence"}
+
+    valid: list[dict[str, Any]] = []
+    invalid: list[dict[str, Any]] = []
     for h in normalized:
         ts = _parse_time(h.get("observed_at") or h.get("timestamp") or h.get("updated_at"))
         age = max(0.0, (now - ts).total_seconds())
         h["age_seconds"] = age
         h["fresh"] = age <= fresh_seconds
         h["source_rank"] = source_rank.get(str(h.get("source")), 0)
-    fresh = [h for h in normalized if h["fresh"]]
-    pool = fresh or normalized
-    winner = max(pool, key=lambda h: (h["source_rank"], _parse_time(h.get("observed_at") or h.get("timestamp") or h.get("updated_at"))))
+        h["confidence"] = float(h.get("confidence", 1.0) or 0.0)
+        if h.get("error"):
+            h["source_rank"] = -1
+            invalid.append(h)
+        else:
+            valid.append(h)
+
+    pool_base = valid or normalized
+    fresh = [h for h in pool_base if h.get("fresh") and not h.get("error")]
+    pool = fresh or pool_base
+    winner = max(
+        pool,
+        key=lambda h: (
+            h.get("source_rank", -1),
+            h.get("confidence", 0.0),
+            _parse_time(h.get("observed_at") or h.get("timestamp") or h.get("updated_at")),
+        ),
+    )
+
     conflicts = []
     winner_head = winner.get("local_head") or winner.get("remote_head")
     winner_version = winner.get("version")
-    for h in normalized:
+    for h in valid:
         if h is winner:
             continue
         other_head = h.get("local_head") or h.get("remote_head")
@@ -211,8 +235,14 @@ def arbitrate_heads(heads: Iterable[dict[str, Any]], *, now: datetime | None = N
             conflicts.append({"source": h.get("source"), "node": h.get("node"), "head": other_head,
                               "version": h.get("version"), "fresh": h.get("fresh"),
                               "age_seconds": h.get("age_seconds")})
-    return {"winner": winner, "fresh": bool(winner.get("fresh")), "conflicts": conflicts,
-            "reason": "fresh_trust_rank" if fresh else "all_evidence_stale"}
+
+    return {
+        "winner": winner,
+        "fresh": bool(winner.get("fresh")),
+        "conflicts": conflicts,
+        "invalid_evidence": invalid,
+        "reason": "fresh_trust_rank" if fresh else ("all_valid_evidence_stale" if valid else "no_valid_evidence"),
+    }
 
 
 def main() -> int:

--- a/scripts/project_overview.py
+++ b/scripts/project_overview.py
@@ -1,15 +1,31 @@
 #!/usr/bin/env python3
+import json
 import os
 import sys
 from pathlib import Path
 
 import yaml
 
+
 def read_file(path):
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
     return ""
+
+
+def read_json(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def short_sha(value):
+    return str(value)[:12] if value else "-"
+
 
 def main():
     if len(sys.argv) < 2:
@@ -20,6 +36,7 @@ def main():
     project_yaml_path = Path(project_dir) / "project.yaml"
     status_path = os.path.join(project_dir, "STATUS.md")
     short_term_path = os.path.join(project_dir, "memory", "SHORT_TERM.md")
+    execution_head_path = os.path.join(project_dir, "execution-head.json")
 
     if not os.path.exists(status_path):
         print(f"❌ Error: Not a project directory (STATUS.md missing at {project_dir})")
@@ -27,6 +44,7 @@ def main():
 
     status_content = read_file(status_path)
     short_term_content = read_file(short_term_path)
+    execution = read_json(execution_head_path)
     project_yaml = {}
     if project_yaml_path.exists():
         try:
@@ -38,7 +56,6 @@ def main():
     print("🎯 PROJECT MISSION BRIEF")
     print("="*40)
 
-    # 提取 Summary
     summary = "No summary found."
     if "## 📍 Summary" in status_content:
         summary_section = status_content.split("## 📍 Summary")[1].split("##")[0].strip()
@@ -51,19 +68,36 @@ def main():
     if isinstance(required, str):
         required = [required]
 
-    # 提取 Todo List (Pending only)
     todos = []
     if "## 📅 Todo List" in status_content:
         todo_section = status_content.split("## 📅 Todo List")[1].split("##")[0].strip()
         todos = [line.strip() for line in todo_section.split("\n") if "[ ]" in line]
 
-    # 提取 Pending Tasks from short-term
     active_tasks = []
     if "## 🚧 Pending Tasks" in short_term_content:
         active_section = short_term_content.split("## 🚧 Pending Tasks")[1].split("##")[0].strip()
         active_tasks = [line.strip() for line in active_section.split("\n") if "[ ]" in line or line.startswith("-")]
 
     print(f"\n📍 STATUS SUMMARY:\n{summary}")
+
+    if execution:
+        print("\n⚙️ EXECUTION HEAD (runtime evidence):")
+        print(f"  Node:        {execution.get('node') or '-'}")
+        print(f"  Workspace:   {execution.get('workspace') or '-'}")
+        print(f"  Branch:      {execution.get('branch') or '-'}")
+        print(f"  Version:     {execution.get('version') or '-'}")
+        print(f"  Local HEAD:  {short_sha(execution.get('local_head'))}")
+        print(f"  Upstream:    {execution.get('upstream') or '-'}")
+        print(f"  Remote HEAD: {short_sha(execution.get('remote_head'))}")
+        print(f"  Ahead/Behind:{execution.get('ahead')} / {execution.get('behind')}")
+        print(f"  Dirty:       {execution.get('dirty')}")
+        print(f"  Latest Tag:  {execution.get('latest_tag') or '-'}")
+        print(f"  Observed:    {execution.get('observed_at') or '-'}")
+        if execution.get("error"):
+            print(f"  ⚠ Collector error: {execution.get('error')}")
+        if isinstance(execution.get("ahead"), int) and execution["ahead"] > 0:
+            print(f"  ⚠ LOCAL EXECUTION IS {execution['ahead']} COMMIT(S) AHEAD OF REMOTE.")
+            print("    Do not treat the remote branch or STATUS.md as the current implementation head.")
 
     if provided or required:
         print("\n🧩 CAPABILITY DECLARATIONS:")
@@ -75,18 +109,27 @@ def main():
             print("  Required:")
             for item in required:
                 print(f"    - {item}")
-    
+
     print("\n📅 CORE ROADMAP (from STATUS.md):")
-    for t in todos[:5]: print(f"  {t}")
-    
+    for t in todos[:5]:
+        print(f"  {t}")
+
     print("\n🚧 ACTIVE SESSION TASKS (from SHORT_TERM.md):")
-    for t in active_tasks[:5]: print(f"  {t}")
+    for t in active_tasks[:5]:
+        print(f"  {t}")
 
     print("\n💡 ADVICE FOR THE AGENT:")
-    print("  1. Focus on the first [ ] task in the 'Active Session' list.")
-    print("  2. Update the 'Activity Log' in STATUS.md after every major success.")
-    print("  3. Run '/report' before leaving to ensure context is passed to the next agent.")
+    if execution and execution.get("local_head"):
+        print("  1. Treat the fresh execution receipt as implementation evidence; surface any drift from remote/STATUS.")
+        print("  2. Continue from the active local workspace unless a fresher trusted receipt supersedes it.")
+        print("  3. Update STATUS.md after major success; do not use it to overwrite a newer execution head.")
+    else:
+        print("  1. No valid execution receipt is available; inspect the registered workspace before assuming GitHub is current.")
+        print("  2. Focus on the first [ ] task in the 'Active Session' list.")
+        print("  3. Update the 'Activity Log' in STATUS.md after every major success.")
+    print("  4. Run '/report' before leaving to ensure context is passed to the next agent.")
     print("="*40 + "\n")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/project_overview.py
+++ b/scripts/project_overview.py
@@ -6,26 +6,21 @@ from pathlib import Path
 
 import yaml
 
-
 def read_file(path):
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
     return ""
 
-
 def read_json(path):
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
-
-
-def short_sha(value):
-    return str(value)[:12] if value else "-"
-
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                value = json.load(f)
+            return value if isinstance(value, dict) else {}
+        except Exception:
+            return {}
+    return {}
 
 def main():
     if len(sys.argv) < 2:
@@ -36,7 +31,7 @@ def main():
     project_yaml_path = Path(project_dir) / "project.yaml"
     status_path = os.path.join(project_dir, "STATUS.md")
     short_term_path = os.path.join(project_dir, "memory", "SHORT_TERM.md")
-    execution_head_path = os.path.join(project_dir, "execution-head.json")
+    execution_path = os.path.join(project_dir, "execution-head.json")
 
     if not os.path.exists(status_path):
         print(f"❌ Error: Not a project directory (STATUS.md missing at {project_dir})")
@@ -44,7 +39,7 @@ def main():
 
     status_content = read_file(status_path)
     short_term_content = read_file(short_term_path)
-    execution = read_json(execution_head_path)
+    execution = read_json(execution_path)
     project_yaml = {}
     if project_yaml_path.exists():
         try:
@@ -80,24 +75,23 @@ def main():
 
     print(f"\n📍 STATUS SUMMARY:\n{summary}")
 
-    if execution:
-        print("\n⚙️ EXECUTION HEAD (runtime evidence):")
-        print(f"  Node:        {execution.get('node') or '-'}")
-        print(f"  Workspace:   {execution.get('workspace') or '-'}")
-        print(f"  Branch:      {execution.get('branch') or '-'}")
-        print(f"  Version:     {execution.get('version') or '-'}")
-        print(f"  Local HEAD:  {short_sha(execution.get('local_head'))}")
-        print(f"  Upstream:    {execution.get('upstream') or '-'}")
-        print(f"  Remote HEAD: {short_sha(execution.get('remote_head'))}")
-        print(f"  Ahead/Behind:{execution.get('ahead')} / {execution.get('behind')}")
-        print(f"  Dirty:       {execution.get('dirty')}")
-        print(f"  Latest Tag:  {execution.get('latest_tag') or '-'}")
-        print(f"  Observed:    {execution.get('observed_at') or '-'}")
-        if execution.get("error"):
-            print(f"  ⚠ Collector error: {execution.get('error')}")
-        if isinstance(execution.get("ahead"), int) and execution["ahead"] > 0:
-            print(f"  ⚠ LOCAL EXECUTION IS {execution['ahead']} COMMIT(S) AHEAD OF REMOTE.")
-            print("    Do not treat the remote branch or STATUS.md as the current implementation head.")
+    if execution.get("local_head"):
+        print("\n🧭 RESOLVED EXECUTION HEAD:")
+        print(f"  Source: {execution.get('source') or 'execution-receipt'}")
+        if execution.get("receipt_kind"):
+            print(f"  Receipt: {execution.get('receipt_kind')}")
+        print(f"  Branch: {execution.get('branch') or 'unknown'}")
+        print(f"  Head: {execution.get('local_head')}")
+        if execution.get("version"):
+            print(f"  Version: {execution.get('version')}")
+        if execution.get("latest_tag"):
+            print(f"  Latest tag: {execution.get('latest_tag')}")
+        if execution.get("ahead") is not None:
+            print(f"  Ahead of upstream: {execution.get('ahead')}")
+        if execution.get("verification_state"):
+            print(f"  Verification: {execution.get('verification_state')}")
+        if execution.get("observed_at"):
+            print(f"  Observed: {execution.get('observed_at')}")
 
     if provided or required:
         print("\n🧩 CAPABILITY DECLARATIONS:")
@@ -111,25 +105,21 @@ def main():
                 print(f"    - {item}")
 
     print("\n📅 CORE ROADMAP (from STATUS.md):")
-    for t in todos[:5]:
-        print(f"  {t}")
+    for t in todos[:5]: print(f"  {t}")
 
     print("\n🚧 ACTIVE SESSION TASKS (from SHORT_TERM.md):")
-    for t in active_tasks[:5]:
-        print(f"  {t}")
+    for t in active_tasks[:5]: print(f"  {t}")
 
     print("\n💡 ADVICE FOR THE AGENT:")
-    if execution and execution.get("local_head"):
-        print("  1. Treat the fresh execution receipt as implementation evidence; surface any drift from remote/STATUS.")
-        print("  2. Continue from the active local workspace unless a fresher trusted receipt supersedes it.")
-        print("  3. Update STATUS.md after major success; do not use it to overwrite a newer execution head.")
+    if execution.get("local_head"):
+        print("  1. Treat the execution-head receipt as fresher execution evidence than an older STATUS.md summary.")
+        print("  2. If verification is pending-node-attestation, replace it with a node-collected receipt before risky writes/releases.")
+        print("  3. Continue from active session tasks; update STATUS.md after major successes.")
     else:
-        print("  1. No valid execution receipt is available; inspect the registered workspace before assuming GitHub is current.")
-        print("  2. Focus on the first [ ] task in the 'Active Session' list.")
-        print("  3. Update the 'Activity Log' in STATUS.md after every major success.")
-    print("  4. Run '/report' before leaving to ensure context is passed to the next agent.")
+        print("  1. Focus on the first [ ] task in the 'Active Session' list.")
+        print("  2. Update the 'Activity Log' in STATUS.md after every major success.")
+        print("  3. Run '/report' before leaving to ensure context is passed to the next agent.")
     print("="*40 + "\n")
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/update_projects_pulse.py
+++ b/scripts/update_projects_pulse.py
@@ -78,14 +78,37 @@ def parse_status_md(status_path: Path) -> dict:
     return data
 
 
-def status_evidence(status_path: Path, status: dict) -> dict:
+def _status_observed_at(status_path: Path, status: dict) -> str:
+    """Use the semantic STATUS timestamp, never checkout/file mtime when available.
+
+    Git checkout/sync can refresh filesystem mtimes without changing project state,
+    which would incorrectly make stale STATUS.md evidence look fresh.
+    """
+    raw = str(status.get("last_updated") or "").strip()
+    if raw and raw.lower() not in {"unknown", "none", "n/a"}:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            try:
+                parsed = datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
+                return parsed.isoformat()
+            except ValueError:
+                pass
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc).isoformat()
+        except ValueError:
+            pass
     try:
-        observed = datetime.fromtimestamp(status_path.stat().st_mtime, tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(status_path.stat().st_mtime, tz=timezone.utc).isoformat()
     except OSError:
-        observed = datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
+
+
+def status_evidence(status_path: Path, status: dict) -> dict:
     return {
         "source": "status-md",
-        "observed_at": observed,
+        "observed_at": _status_observed_at(status_path, status),
         "version": None,
         "status": status.get("last_status"),
         "updated_label": status.get("last_updated"),

--- a/scripts/update_projects_pulse.py
+++ b/scripts/update_projects_pulse.py
@@ -78,14 +78,33 @@ def parse_status_md(status_path: Path) -> dict:
     return data
 
 
-def status_evidence(status: dict, timestamp: str) -> dict:
+def status_evidence(status_path: Path, status: dict) -> dict:
+    try:
+        observed = datetime.fromtimestamp(status_path.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        observed = datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
     return {
         "source": "status-md",
-        "observed_at": timestamp,
+        "observed_at": observed,
         "version": None,
         "status": status.get("last_status"),
         "updated_label": status.get("last_updated"),
     }
+
+
+def load_execution_receipt(project_dir: Path) -> dict | None:
+    target = project_dir / EXECUTION_HEAD_FILENAME
+    if not target.exists():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or not data.get("local_head"):
+            return None
+        data = dict(data)
+        data["source"] = "execution-receipt"
+        return data
+    except Exception:
+        return None
 
 
 def publish_execution_receipt(project_dir: Path, execution: dict) -> None:
@@ -120,14 +139,23 @@ def main():
                 continue
 
             status = parse_status_md(status_file)
+            persisted_receipt = load_execution_receipt(proj_dir)
             execution = asdict(collect_execution_head(proj_dir.name, proj_dir))
             publish_execution_receipt(proj_dir, execution)
-            arbitration = arbitrate_heads([execution, status_evidence(status, timestamp)])
+
+            evidence = [execution]
+            if persisted_receipt:
+                evidence.append(persisted_receipt)
+            evidence.append(status_evidence(status_file, status))
+            arbitration = arbitrate_heads(evidence)
+
             pulse_data["projects"][proj_dir.name] = {
                 **status,
                 "execution": execution,
+                "persisted_execution_receipt": persisted_receipt,
                 "resolved_head": arbitration.get("winner"),
                 "state_conflicts": arbitration.get("conflicts", []),
+                "invalid_evidence": arbitration.get("invalid_evidence", []),
                 "resolution_reason": arbitration.get("reason"),
             }
 
@@ -137,9 +165,9 @@ def main():
 
     valid_heads = sum(
         1 for item in pulse_data["projects"].values()
-        if (item.get("execution") or {}).get("local_head")
+        if (item.get("resolved_head") or {}).get("local_head")
     )
-    print(f"✅ Pulse updated: {len(pulse_data['projects'])} projects cached; {valid_heads} execution heads published.")
+    print(f"✅ Pulse updated: {len(pulse_data['projects'])} projects cached; {valid_heads} resolved execution heads available.")
 
 
 if __name__ == "__main__":

--- a/scripts/update_projects_pulse.py
+++ b/scripts/update_projects_pulse.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """
-update_projects_pulse.py - Aggregates project states from STATUS.md into a high-speed JSON cache.
-Writes to volatile RAM disk and persistent fallback.
+update_projects_pulse.py - Aggregates project states into a high-speed JSON cache.
+
+STATUS.md remains descriptive evidence. When a project has a reachable local
+workspace, the pulse also publishes an execution-head receipt so a newer local
+Git head is not hidden by an older remote branch or STATUS.md summary.
 """
 
-import os
 import json
 import re
 import sys
+from dataclasses import asdict
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -17,6 +20,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from agent_core.memory_router import resolve_memory_route
 from agent_core.platform import get_platform_driver
+from scripts.execution_head import collect_execution_head, arbitrate_heads
 
 route = resolve_memory_route()
 AGENT_DATA_ROOT = route.data_root
@@ -26,6 +30,8 @@ PLATFORM_DRIVER = get_platform_driver(project_root=PROJECT_ROOT, data_root=AGENT
 SHM_ROOT = PLATFORM_DRIVER.volatile_state_dir()
 SHM_PULSE = SHM_ROOT / "projects_pulse.json"
 PERSISTENT_PULSE = PLATFORM_DRIVER.persistent_state_dir() / "projects_pulse_snapshot.json"
+EXECUTION_HEAD_FILENAME = "execution-head.json"
+
 
 def parse_status_md(status_path: Path) -> dict:
     data = {
@@ -35,28 +41,26 @@ def parse_status_md(status_path: Path) -> dict:
         "tags": [],
         "last_status": "Unknown",
         "last_updated": "Unknown",
-        "pending_todos": 0
+        "pending_todos": 0,
     }
-    
     if not status_path.exists():
         return data
-        
+
     content = status_path.read_text(encoding="utf-8")
-    
-    # Parse frontmatter
     fm_match = re.search(r"^---\n(.*?)\n---", content, re.DOTALL)
     if fm_match:
         fm = fm_match.group(1)
         for line in fm.split("\n"):
             if line.startswith("priority:"):
-                try: data["priority"] = int(line.split(":")[1].strip())
-                except: pass
+                try:
+                    data["priority"] = int(line.split(":", 1)[1].strip())
+                except Exception:
+                    pass
             elif line.startswith("category:"):
-                data["category"] = line.split(":")[1].strip()
+                data["category"] = line.split(":", 1)[1].strip()
             elif line.startswith("lifecycle_stage:"):
-                data["lifecycle_stage"] = line.split(":")[1].strip()
-                
-    # Parse metrics
+                data["lifecycle_stage"] = line.split(":", 1)[1].strip()
+
     for line in content.split("\n"):
         if "| **Last Status**" in line:
             parts = line.split("|")
@@ -66,37 +70,77 @@ def parse_status_md(status_path: Path) -> dict:
             parts = line.split("|")
             if len(parts) >= 3:
                 data["last_updated"] = parts[2].strip()
-                
-    # Count pending TODOs
+
     todo_match = re.search(r"## 📅 Todo List\n(.*)", content, re.DOTALL)
     if todo_match:
         todos = todo_match.group(1).split("\n")
         data["pending_todos"] = len([t for t in todos if t.strip().startswith("- [ ]")])
-        
     return data
+
+
+def status_evidence(status: dict, timestamp: str) -> dict:
+    return {
+        "source": "status-md",
+        "observed_at": timestamp,
+        "version": None,
+        "status": status.get("last_status"),
+        "updated_label": status.get("last_updated"),
+    }
+
+
+def publish_execution_receipt(project_dir: Path, execution: dict) -> None:
+    """Publish only meaningful local evidence into the project data layer.
+
+    Workspace-not-found is still present in the aggregate pulse but does not
+    overwrite a previously valid execution receipt.
+    """
+    if execution.get("error") or not execution.get("local_head"):
+        return
+    target = project_dir / EXECUTION_HEAD_FILENAME
+    target.write_text(json.dumps(execution, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
 
 def main():
     SHM_ROOT.mkdir(parents=True, exist_ok=True)
     PERSISTENT_PULSE.parent.mkdir(parents=True, exist_ok=True)
-    
+
+    timestamp = datetime.now(timezone.utc).isoformat()
     pulse_data = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "projects": {}
+        "schema": "agentos.projects-pulse/v2",
+        "timestamp": timestamp,
+        "projects": {},
     }
-    
+
     if PROJECTS_DIR.exists():
         for proj_dir in PROJECTS_DIR.iterdir():
-            if proj_dir.is_dir():
-                status_file = proj_dir / "STATUS.md"
-                if status_file.exists():
-                    pulse_data["projects"][proj_dir.name] = parse_status_md(status_file)
-                    
-    json_data = json.dumps(pulse_data, indent=2)
-    
+            if not proj_dir.is_dir():
+                continue
+            status_file = proj_dir / "STATUS.md"
+            if not status_file.exists():
+                continue
+
+            status = parse_status_md(status_file)
+            execution = asdict(collect_execution_head(proj_dir.name, proj_dir))
+            publish_execution_receipt(proj_dir, execution)
+            arbitration = arbitrate_heads([execution, status_evidence(status, timestamp)])
+            pulse_data["projects"][proj_dir.name] = {
+                **status,
+                "execution": execution,
+                "resolved_head": arbitration.get("winner"),
+                "state_conflicts": arbitration.get("conflicts", []),
+                "resolution_reason": arbitration.get("reason"),
+            }
+
+    json_data = json.dumps(pulse_data, ensure_ascii=False, indent=2)
     SHM_PULSE.write_text(json_data, encoding="utf-8")
     PERSISTENT_PULSE.write_text(json_data, encoding="utf-8")
-    
-    print(f"✅ Pulse updated: {len(pulse_data['projects'])} projects cached.")
+
+    valid_heads = sum(
+        1 for item in pulse_data["projects"].values()
+        if (item.get("execution") or {}).get("local_head")
+    )
+    print(f"✅ Pulse updated: {len(pulse_data['projects'])} projects cached; {valid_heads} execution heads published.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_execution_head.py
+++ b/tests/test_execution_head.py
@@ -145,6 +145,28 @@ class ExecutionHeadTests(unittest.TestCase):
             observed = _status_observed_at(path, {"last_updated": "2026-08-20 10:25"})
             self.assertTrue(observed.startswith("2026-08-20T10:25:00"))
 
+    def test_operator_bootstrap_receipt_is_valid_execution_evidence(self):
+        now = datetime(2026, 8, 28, 2, 0, tzinfo=timezone.utc)
+        bootstrap = {
+            "source": "execution-receipt",
+            "receipt_kind": "operator-confirmed-bootstrap",
+            "verification_state": "pending-node-attestation",
+            "local_head": "0b37627",
+            "version": "1.0.59",
+            "latest_tag": "v1.0.55",
+            "ahead": 40,
+            "observed_at": (now - timedelta(minutes=10)).isoformat(),
+            "confidence": 0.95,
+        }
+        stale_status = {
+            "source": "status-md",
+            "status": "v1.0.20 released",
+            "observed_at": "2026-08-20T02:25:00+00:00",
+        }
+        result = arbitrate_heads([stale_status, bootstrap], now=now)
+        self.assertEqual(result["winner"]["receipt_kind"], "operator-confirmed-bootstrap")
+        self.assertEqual(result["winner"]["version"], "1.0.59")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_execution_head.py
+++ b/tests/test_execution_head.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from scripts.execution_head import arbitrate_heads, collect_execution_head, discover_version
+from scripts.update_projects_pulse import _status_observed_at
 
 
 class ExecutionHeadTests(unittest.TestCase):
@@ -111,6 +112,38 @@ class ExecutionHeadTests(unittest.TestCase):
         result = arbitrate_heads([failed_local, remote], now=now)
         self.assertEqual(result["winner"]["source"], "remote-git")
         self.assertEqual(len(result["invalid_evidence"]), 1)
+
+    def test_persisted_receipt_survives_missing_workspace_and_stale_status(self):
+        now = datetime(2026, 8, 28, 2, 0, tzinfo=timezone.utc)
+        failed_local = {
+            "source": "local-git",
+            "error": "workspace_not_found",
+            "observed_at": (now - timedelta(seconds=1)).isoformat(),
+            "confidence": 0.0,
+        }
+        persisted = {
+            "source": "execution-receipt",
+            "local_head": "0b37627",
+            "version": "1.0.59",
+            "observed_at": (now - timedelta(hours=1)).isoformat(),
+            "confidence": 0.95,
+        }
+        stale_status = {
+            "source": "status-md",
+            "status": "v1.0.20 released",
+            "observed_at": "2026-08-20T02:25:00+00:00",
+            "confidence": 1.0,
+        }
+        result = arbitrate_heads([failed_local, stale_status, persisted], now=now)
+        self.assertEqual(result["winner"]["source"], "execution-receipt")
+        self.assertEqual(result["winner"]["version"], "1.0.59")
+
+    def test_status_semantic_timestamp_beats_checkout_mtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "STATUS.md"
+            path.write_text("status", encoding="utf-8")
+            observed = _status_observed_at(path, {"last_updated": "2026-08-20 10:25"})
+            self.assertTrue(observed.startswith("2026-08-20T10:25:00"))
 
 
 if __name__ == "__main__":

--- a/tests/test_execution_head.py
+++ b/tests/test_execution_head.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from scripts.execution_head import arbitrate_heads, collect_execution_head, discover_version
+
+
+class ExecutionHeadTests(unittest.TestCase):
+    def test_discovers_extension_manifest_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = root / "extension" / "manifest.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"version": "1.0.59"}), encoding="utf-8")
+            version, source = discover_version(root)
+            self.assertEqual(version, "1.0.59")
+            self.assertEqual(source, "extension/manifest.json")
+
+    def test_collects_local_git_head_and_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            workspace = base / "repo"
+            project_dir = base / "project"
+            workspace.mkdir()
+            project_dir.mkdir()
+            subprocess.run(["git", "init", "-b", "develop"], cwd=workspace, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.email", "agentos@example.invalid"], cwd=workspace, check=True)
+            subprocess.run(["git", "config", "user.name", "AgentOS Test"], cwd=workspace, check=True)
+            manifest = workspace / "extension" / "manifest.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"version": "1.0.59"}), encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+            subprocess.run(["git", "commit", "-m", "test head"], cwd=workspace, check=True, capture_output=True)
+            subprocess.run(["git", "tag", "v1.0.55"], cwd=workspace, check=True)
+            (project_dir / "project.yaml").write_text(
+                f"project_id: metashield-protocol\nactual_code_path: {workspace}\n",
+                encoding="utf-8",
+            )
+
+            head = collect_execution_head("metashield-protocol", project_dir, node="test-node")
+            self.assertIsNone(head.error)
+            self.assertEqual(head.branch, "develop")
+            self.assertEqual(head.version, "1.0.59")
+            self.assertEqual(head.latest_tag, "v1.0.55")
+            self.assertEqual(head.node, "test-node")
+            self.assertFalse(head.dirty)
+            self.assertTrue(head.local_head)
+
+    def test_fresh_local_execution_wins_over_remote_drift(self):
+        now = datetime(2026, 8, 28, 1, 30, tzinfo=timezone.utc)
+        local = {
+            "source": "local-git",
+            "node": "oracle",
+            "local_head": "0b37627",
+            "version": "1.0.59",
+            "ahead": 40,
+            "latest_tag": "v1.0.55",
+            "observed_at": (now - timedelta(seconds=30)).isoformat(),
+            "confidence": 1.0,
+        }
+        remote = {
+            "source": "remote-git",
+            "node": "github",
+            "remote_head": "e71e85c",
+            "version": "1.0.36",
+            "observed_at": (now - timedelta(seconds=20)).isoformat(),
+            "confidence": 1.0,
+        }
+        result = arbitrate_heads([remote, local], now=now)
+        self.assertEqual(result["winner"]["source"], "local-git")
+        self.assertEqual(result["winner"]["version"], "1.0.59")
+        self.assertEqual(result["winner"]["ahead"], 40)
+        self.assertEqual(len(result["conflicts"]), 1)
+
+    def test_fresh_remote_wins_when_local_receipt_is_stale(self):
+        now = datetime(2026, 8, 28, 1, 30, tzinfo=timezone.utc)
+        local = {
+            "source": "local-git",
+            "local_head": "local",
+            "version": "2.0.0",
+            "observed_at": (now - timedelta(minutes=10)).isoformat(),
+        }
+        remote = {
+            "source": "remote-git",
+            "remote_head": "remote",
+            "version": "1.9.0",
+            "observed_at": (now - timedelta(seconds=30)).isoformat(),
+        }
+        result = arbitrate_heads([local, remote], now=now)
+        self.assertEqual(result["winner"]["source"], "remote-git")
+
+    def test_failed_fresh_local_evidence_cannot_win(self):
+        now = datetime(2026, 8, 28, 1, 30, tzinfo=timezone.utc)
+        failed_local = {
+            "source": "local-git",
+            "error": "workspace_not_found",
+            "observed_at": (now - timedelta(seconds=1)).isoformat(),
+            "confidence": 0.0,
+        }
+        remote = {
+            "source": "remote-git",
+            "remote_head": "remote",
+            "version": "1.0.36",
+            "observed_at": (now - timedelta(seconds=20)).isoformat(),
+        }
+        result = arbitrate_heads([failed_local, remote], now=now)
+        self.assertEqual(result["winner"]["source"], "remote-git")
+        self.assertEqual(len(result["invalid_evidence"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
This is a downstream continuity patch for project execution state. It does **not** change the ChatGPT Web → ONE → AgentOS Core query path; that belongs to the canonical AgentOS Core development thread.

## What changes
- add `scripts/execution_head.py` to collect local Git execution head evidence
- discover project version from configured/default version files
- record local/upstream heads, ahead/behind, dirty state, latest tag, node/workspace
- arbitrate fresh evidence with trust ordering instead of treating STATUS/Git remote as canonical by default
- make `update_projects_pulse.py` publish valid `execution-head.json` receipts and reuse persisted receipts cross-node when local workspace is unavailable
- expose resolved execution head/conflict data in `project_overview.py`
- add regression coverage for MetaShield-style local v1.0.59 vs remote/status v1.0.36 drift
- add focused GitHub Actions test workflow

## Validation
Dedicated `Execution Head Tests` workflow passed on branch head `4f2cf25`.

## Important boundary
This PR should be integrated/reviewed from the canonical AgentOS Core engineering authority. It intentionally does not implement or modify the higher-level ONE query/bootstrap path.