### PR TITLE
Fix Character Blueprint web permissions

### DIFF
--- a/scripts/deploy_character_blueprint_poc.py
+++ b/scripts/deploy_character_blueprint_poc.py
@@ -38,7 +38,9 @@ def main() -> int:
     validate(source_text)
 
     TARGET.parent.mkdir(parents=True, exist_ok=True)
+    TARGET.parent.chmod(0o755)
     tmp: Path | None = Path(tempfile.mkdtemp(prefix='.character-blueprint-', dir=str(TARGET.parent)))
+    tmp.chmod(0o755)
     try:
         index = tmp / 'index.html'
         shutil.copy2(SOURCE, index)
@@ -51,6 +53,7 @@ def main() -> int:
         if TARGET.exists():
             TARGET.rename(backup)
         tmp.rename(TARGET)
+        TARGET.chmod(0o755)
         tmp = None
         if backup.exists():
             shutil.rmtree(backup)


### PR DESCRIPTION
The deploy now succeeds locally but the public route returns 403 because tempfile.mkdtemp creates the published directory as mode 0700. Publish the route directory as 0755 so the web server can traverse it.