### PR TITLE
Fix Character Blueprint v0.4 release marker

### DIFF
--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -41,7 +41,7 @@ jobs:
           grep -q '丟一張角色圖，先把她立起來' "$PAGE"
           grep -q '3D Blueprint' "$PAGE"
           grep -q '技術細節 / Character IR' "$PAGE"
-          grep -q 'llm_tokens: 0' "$PAGE"
+          grep -q '"llm_tokens":0' "$PAGE"
           grep -q '/poc/character-blueprint/' "$DEPLOY"
           echo 'character_blueprint_v04_source=PASS'
 
@@ -101,11 +101,10 @@ jobs:
           grep -q '丟一張角色圖，先把她立起來' /tmp/character-blueprint-public
           grep -q '3D Blueprint' /tmp/character-blueprint-public
           grep -q '技術細節 / Character IR' /tmp/character-blueprint-public
+          grep -q '"llm_tokens":0' /tmp/character-blueprint-public
           ! grep -q '<title>Character Blueprint POC v0.3</title>' /tmp/character-blueprint-public
           if grep -q 'Milkcat Studio Portal' /tmp/character-blueprint-public && ! grep -q 'character-blueprint-poc' /tmp/character-blueprint-public; then
             echo 'ERROR: Studio homepage fallback detected' >&2; exit 1
           fi
           echo 'public_character_blueprint_v04_identity=PASS'
           echo 'interactive_3d_demo_contract=PASS'
-
-# v0.4 authoritative release trigger

--- a/scripts/deploy_character_blueprint_poc.py
+++ b/scripts/deploy_character_blueprint_poc.py
@@ -17,7 +17,7 @@ MARKERS = [
     'interactivePartLinking:true',
     '3D Blueprint',
     'OrbitControls',
-    'llm_tokens: 0',
+    '"llm_tokens":0',
 ]
 FORBIDDEN_FALLBACK = ['Milkcat Studio Portal', 'SERIALS', '連載作品']
 


### PR DESCRIPTION
The v0.4 demo source is correct; the release gate expected `llm_tokens: 0` while the emitted JSON marker is `"llm_tokens":0`. Align both deploy validation and public acceptance with the actual page output, without changing demo behavior.