### PR TITLE
[MIGRATION CARRIER — DO NOT MERGE] Fix Character Blueprint v0.4 browser module startup

### DIFF
--- a/scripts/deploy_character_blueprint_poc.py
+++ b/scripts/deploy_character_blueprint_poc.py
@@ -20,6 +20,13 @@ MARKERS = [
     '"llm_tokens":0',
 ]
 FORBIDDEN_FALLBACK = ['Milkcat Studio Portal', 'SERIALS', '連載作品']
+THREE_DIRECT = "import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.179.1/build/three.module.js';"
+ORBIT_DIRECT = "import {OrbitControls} from 'https://cdn.jsdelivr.net/npm/three@0.179.1/examples/jsm/controls/OrbitControls.js';"
+IMPORT_MAP = '''<script type="importmap">
+{"imports":{"three":"https://cdn.jsdelivr.net/npm/three@0.179.1/build/three.module.js","three/addons/":"https://cdn.jsdelivr.net/npm/three@0.179.1/examples/jsm/"}}
+</script>'''
+THREE_MAPPED = "import * as THREE from 'three';"
+ORBIT_MAPPED = "import {OrbitControls} from 'three/addons/controls/OrbitControls.js';"
 
 
 def digest(path: Path) -> str:
@@ -34,19 +41,36 @@ def validate(text: str) -> None:
         raise SystemExit('character blueprint source unexpectedly contains Studio fallback identity')
 
 
+def make_browser_safe(text: str) -> str:
+    old = f'<script type="module">\n{THREE_DIRECT}\n{ORBIT_DIRECT}'
+    new = f'{IMPORT_MAP}\n<script type="module">\n{THREE_MAPPED}\n{ORBIT_MAPPED}'
+    if old not in text:
+        raise SystemExit('character blueprint deploy transform failed: expected Three.js direct imports not found')
+    text = text.replace(old, new, 1)
+    required = ['type="importmap"', '"three/addons/"', "from 'three'", "from 'three/addons/controls/OrbitControls.js'"]
+    missing = [m for m in required if m not in text]
+    if missing:
+        raise SystemExit(f'character blueprint browser import transform invalid: missing={missing}')
+    return text
+
+
 def main() -> int:
     if not SOURCE.is_file():
         raise SystemExit(f'missing source: {SOURCE}')
-    validate(SOURCE.read_text(encoding='utf-8'))
+    source_text = SOURCE.read_text(encoding='utf-8')
+    validate(source_text)
     TARGET.parent.mkdir(parents=True, exist_ok=True)
     TARGET.parent.chmod(0o755)
     tmp: Path | None = Path(tempfile.mkdtemp(prefix='.character-blueprint-', dir=str(TARGET.parent)))
     tmp.chmod(0o755)
     try:
         index = tmp / 'index.html'
-        shutil.copy2(SOURCE, index)
+        index.write_text(make_browser_safe(source_text), encoding='utf-8')
         index.chmod(0o644)
-        validate(index.read_text(encoding='utf-8'))
+        deployed_text = index.read_text(encoding='utf-8')
+        validate(deployed_text)
+        if 'type="importmap"' not in deployed_text or "from 'three/addons/controls/OrbitControls.js'" not in deployed_text:
+            raise SystemExit('character blueprint browser import wiring missing after transform')
         backup = TARGET.with_name(TARGET.name + '.previous')
         if backup.exists(): shutil.rmtree(backup)
         if TARGET.exists(): TARGET.rename(backup)
@@ -58,7 +82,10 @@ def main() -> int:
         if tmp is not None and tmp.exists(): shutil.rmtree(tmp)
 
     deployed = TARGET / 'index.html'
-    validate(deployed.read_text(encoding='utf-8'))
+    final_text = deployed.read_text(encoding='utf-8')
+    validate(final_text)
+    if 'type="importmap"' not in final_text:
+        raise SystemExit('character blueprint public artifact missing import map')
     print(json.dumps({
         'ok': True,
         'release': 'character-blueprint-poc-v0.4',
@@ -67,6 +94,7 @@ def main() -> int:
         'marker': 'character-blueprint-poc/v0.4.0',
         'three_d_proxy': True,
         'interactive_part_linking': True,
+        'browser_import_map': True,
         'llm_tokens': 0,
         'sha256': digest(deployed),
     }, ensure_ascii=False, sort_keys=True))


### PR DESCRIPTION
Fix the v0.4 public demo startup failure caused by OrbitControls importing the bare `three` specifier without a browser import map. The authoritative deployer now injects an import map into the published artifact, rewires Three.js and OrbitControls to mapped specifiers, and fails deployment if the browser-safe module wiring is missing. This preserves concurrent source changes while repairing the production artifact.