### PR TITLE
Release Character Blueprint v0.4.1

### DIFF
--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -42,8 +42,10 @@ jobs:
           grep -q '3D Blueprint' "$PAGE"
           grep -q '技術細節 / Character IR' "$PAGE"
           grep -q '"llm_tokens":0' "$PAGE"
+          grep -q 'visibility-gated-v0.4.1' "$DEPLOY"
+          grep -q 'character-blueprint-poc-v0.4.1' "$DEPLOY"
           grep -q '/poc/character-blueprint/' "$DEPLOY"
-          echo 'character_blueprint_v04_source=PASS'
+          echo 'character_blueprint_v041_source=PASS'
 
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -74,37 +76,38 @@ jobs:
           from pathlib import Path
           root=Path(sys.argv[1]); sha=sys.argv[2]; receipt=Path(sys.argv[3])
           rels=['scripts/deploy_character_blueprint_poc.py','web_assets/character-blueprint-poc.html']
-          data={'schema':'agentos.runtime-refresh-receipt/v1','ok':True,'scope':'character-blueprint-poc-v0.4','source_commit':sha,'runtime_root':str(root),'sha256':{r:hashlib.sha256((root/r).read_bytes()).hexdigest() for r in rels}}
+          data={'schema':'agentos.runtime-refresh-receipt/v1','ok':True,'scope':'character-blueprint-poc-v0.4.1','source_commit':sha,'runtime_root':str(root),'sha256':{r:hashlib.sha256((root/r).read_bytes()).hexdigest() for r in rels}}
           receipt.write_text(json.dumps(data,sort_keys=True,indent=2)+'\n'); print(json.dumps(data,sort_keys=True))
           PY
           cd "$RUNTIME"
           /usr/bin/python3 scripts/deploy_character_blueprint_poc.py | tee /tmp/character-blueprint-release.json
           grep -q '"ok": true' /tmp/character-blueprint-release.json
-          grep -q 'character-blueprint-poc-v0.4' /tmp/character-blueprint-release.json
+          grep -q 'character-blueprint-poc-v0.4.1' /tmp/character-blueprint-release.json
           grep -q '"three_d_proxy": true' /tmp/character-blueprint-release.json
+          grep -q '"visibility_gated_body_frame": true' /tmp/character-blueprint-release.json
           rm -rf "$STAGE"
-          echo 'character_blueprint_v04_deploy=PASS'
+          echo 'character_blueprint_v041_deploy=PASS'
           REMOTE
 
-      - name: Public v0.4 demo acceptance
+      - name: Public v0.4.1 demo acceptance
         shell: bash
         run: |
           set -euo pipefail
           URL=https://studio.milkcat.org/poc/character-blueprint/
           curl -fsS --retry 8 --retry-delay 2 --retry-all-errors "$URL" -o /tmp/character-blueprint-public
-          grep -q 'meta name="character-blueprint-poc" content="v0.4.0"' /tmp/character-blueprint-public
-          grep -q '<title>Character Blueprint POC v0.4</title>' /tmp/character-blueprint-public
+          grep -q 'meta name="character-blueprint-poc" content="v0.4.1"' /tmp/character-blueprint-public
+          grep -q '<title>Character Blueprint POC v0.4.1</title>' /tmp/character-blueprint-public
           grep -q 'character-blueprint-ir/v0.4' /tmp/character-blueprint-public
           grep -q 'threeDProxy:true' /tmp/character-blueprint-public
           grep -q 'interactivePartLinking:true' /tmp/character-blueprint-public
           grep -q 'OrbitControls' /tmp/character-blueprint-public
+          grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-public
           grep -q '丟一張角色圖，先把她立起來' /tmp/character-blueprint-public
           grep -q '3D Blueprint' /tmp/character-blueprint-public
           grep -q '技術細節 / Character IR' /tmp/character-blueprint-public
           grep -q '"llm_tokens":0' /tmp/character-blueprint-public
-          ! grep -q '<title>Character Blueprint POC v0.3</title>' /tmp/character-blueprint-public
           if grep -q 'Milkcat Studio Portal' /tmp/character-blueprint-public && ! grep -q 'character-blueprint-poc' /tmp/character-blueprint-public; then
             echo 'ERROR: Studio homepage fallback detected' >&2; exit 1
           fi
-          echo 'public_character_blueprint_v04_identity=PASS'
-          echo 'interactive_3d_demo_contract=PASS'
+          echo 'public_character_blueprint_v041_identity=PASS'
+          echo 'upper_body_proxy_contract=PASS'


### PR DESCRIPTION
Trigger and validate the visibility-gated upper-body proxy release. Public acceptance now requires v0.4.1 identity plus the visibility-gated body-frame marker, so the half-body regression cannot pass with the old artifact.