### PR TITLE
Add Character Blueprint regression self-test

### DIFF
--- a/.github/workflows/character-blueprint-regression.yml
+++ b/.github/workflows/character-blueprint-regression.yml
@@ -1,0 +1,36 @@
+name: Character Blueprint Regression
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/character_blueprint_geometry_selftest.py'
+      - 'scripts/deploy_character_blueprint_poc.py'
+      - 'web_assets/character-blueprint-poc.html'
+      - '.github/workflows/character-blueprint-regression.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/character_blueprint_geometry_selftest.py'
+      - 'scripts/deploy_character_blueprint_poc.py'
+      - 'web_assets/character-blueprint-poc.html'
+
+permissions:
+  contents: read
+
+jobs:
+  geometry-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Character Blueprint geometry regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/character_blueprint_geometry_selftest.py | tee /tmp/character-blueprint-regression.json
+          grep -q '"ok": true' /tmp/character-blueprint-regression.json
+          grep -q 'portrait_upperbody_regression_01' /tmp/character-blueprint-regression.json
+          grep -q '"coverage": "upper_body"' /tmp/character-blueprint-regression.json
+          grep -q 'standing_fullbody_control_01' /tmp/character-blueprint-regression.json
+          echo 'character_blueprint_geometry_regression=PASS'

--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/oracle-release-character-blueprint.yml'
       - 'web_assets/character-blueprint-poc.html'
       - 'scripts/deploy_character_blueprint_poc.py'
+      - 'scripts/character_blueprint_geometry_selftest.py'
 
 permissions:
   contents: read
@@ -47,6 +48,16 @@ jobs:
           grep -q '/poc/character-blueprint/' "$DEPLOY"
           echo 'character_blueprint_v041_source=PASS'
 
+      - name: Geometry regression gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/character_blueprint_geometry_selftest.py | tee /tmp/character-blueprint-regression.json
+          grep -q '"ok": true' /tmp/character-blueprint-regression.json
+          grep -q 'portrait_upperbody_regression_01' /tmp/character-blueprint-regression.json
+          grep -q '"coverage": "upper_body"' /tmp/character-blueprint-regression.json
+          echo 'character_blueprint_geometry_regression=PASS'
+
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -58,7 +69,7 @@ jobs:
           set -euo pipefail
           test -n "${DEPLOY_USER:-}"
           STAGE=/tmp/character-blueprint-${GITHUB_RUN_ID}
-          tar czf - scripts/deploy_character_blueprint_poc.py web_assets/character-blueprint-poc.html \
+          tar czf - scripts/deploy_character_blueprint_poc.py scripts/character_blueprint_geometry_selftest.py web_assets/character-blueprint-poc.html \
           | ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
               "rm -rf '$STAGE' && mkdir -p '$STAGE' && tar xzf - -C '$STAGE'"
 
@@ -70,16 +81,19 @@ jobs:
           RECEIPT=/home/ubuntu/agent-data/runtime/action-relay/runtime-refresh-character-blueprint.json
           mkdir -p "$RUNTIME/scripts" "$RUNTIME/web_assets" "$(dirname "$RECEIPT")"
           install -m 0755 "$STAGE/scripts/deploy_character_blueprint_poc.py" "$RUNTIME/scripts/deploy_character_blueprint_poc.py"
+          install -m 0755 "$STAGE/scripts/character_blueprint_geometry_selftest.py" "$RUNTIME/scripts/character_blueprint_geometry_selftest.py"
           install -m 0644 "$STAGE/web_assets/character-blueprint-poc.html" "$RUNTIME/web_assets/character-blueprint-poc.html"
           python3 - "$RUNTIME" "$SHA" "$RECEIPT" <<'PY'
           import hashlib,json,sys
           from pathlib import Path
           root=Path(sys.argv[1]); sha=sys.argv[2]; receipt=Path(sys.argv[3])
-          rels=['scripts/deploy_character_blueprint_poc.py','web_assets/character-blueprint-poc.html']
+          rels=['scripts/deploy_character_blueprint_poc.py','scripts/character_blueprint_geometry_selftest.py','web_assets/character-blueprint-poc.html']
           data={'schema':'agentos.runtime-refresh-receipt/v1','ok':True,'scope':'character-blueprint-poc-v0.4.1','source_commit':sha,'runtime_root':str(root),'sha256':{r:hashlib.sha256((root/r).read_bytes()).hexdigest() for r in rels}}
           receipt.write_text(json.dumps(data,sort_keys=True,indent=2)+'\n'); print(json.dumps(data,sort_keys=True))
           PY
           cd "$RUNTIME"
+          /usr/bin/python3 scripts/character_blueprint_geometry_selftest.py | tee /tmp/character-blueprint-regression-runtime.json
+          grep -q '"ok": true' /tmp/character-blueprint-regression-runtime.json
           /usr/bin/python3 scripts/deploy_character_blueprint_poc.py | tee /tmp/character-blueprint-release.json
           grep -q '"ok": true' /tmp/character-blueprint-release.json
           grep -q 'character-blueprint-poc-v0.4.1' /tmp/character-blueprint-release.json

--- a/scripts/character_blueprint_geometry_selftest.py
+++ b/scripts/character_blueprint_geometry_selftest.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOYER = ROOT / 'scripts' / 'deploy_character_blueprint_poc.py'
+
+
+@dataclass
+class P:
+    x: float
+    y: float
+    z: float = 0.0
+    visibility: float = 1.0
+
+
+def v(p: P) -> tuple[float, float, float]:
+    return ((p.x - 0.5) * 4.0, (0.5 - p.y) * 5.0, -(p.z or 0.0) * 2.2)
+
+
+def add(a, b): return tuple(x + y for x, y in zip(a, b))
+def sub(a, b): return tuple(x - y for x, y in zip(a, b))
+def mul(a, s): return tuple(x * s for x in a)
+def mean(a, b): return mul(add(a, b), 0.5)
+def norm(a): return math.sqrt(sum(x * x for x in a))
+def normalize(a):
+    n = norm(a)
+    return tuple(x / n for x in a) if n else (0.0, 0.0, 0.0)
+
+
+def reliable(p: P | None, threshold: float = 0.38) -> bool:
+    return bool(p and p.visibility >= threshold and -0.12 <= p.x <= 1.12 and -0.12 <= p.y <= 1.12)
+
+
+def coverage(lm: list[P]) -> str:
+    def ok(i: int, threshold: float = 0.4) -> bool:
+        p = lm[i]
+        return p.visibility >= threshold and -0.08 <= p.x <= 1.08 and -0.08 <= p.y <= 1.08
+    if ok(27) and ok(28): return 'full_body'
+    if ok(25) and ok(26): return 'three_quarter'
+    return 'upper_body'
+
+
+def proxy_spec(lm: list[P]) -> dict:
+    sh_l, sh_r = v(lm[11]), v(lm[12])
+    shoulder = mean(sh_l, sh_r)
+    sw = max(0.55, norm(sub(sh_l, sh_r)))
+    cov = coverage(lm)
+    if cov != 'upper_body' and reliable(lm[23], 0.42) and reliable(lm[24], 0.42):
+        raw_hip = mean(v(lm[23]), v(lm[24]))
+        d = sub(raw_hip, shoulder)
+        ratio = norm(d) / sw
+        if d[1] < -0.15 and 0.55 < ratio < 2.2:
+            hip, torso_len = raw_hip, norm(d)
+        else:
+            torso_len, hip = sw * 1.18, add(shoulder, (0.0, -sw * 1.18, 0.0))
+    else:
+        torso_len, hip = sw * 1.18, add(shoulder, (0.0, -sw * 1.18, 0.0))
+    torso_axis = normalize(sub(hip, shoulder))
+    torso_center = mean(shoulder, hip)
+    head_center = add(shoulder, (0.0, sw * 0.82, 0.0))
+    if reliable(lm[7], 0.28) and reliable(lm[8], 0.28):
+        ear_mid = mean(v(lm[7]), v(lm[8]))
+        delta = sub(ear_mid, shoulder)
+        if delta[1] > 0.1 and norm(delta) < sw * 1.6: head_center = ear_mid
+    elif reliable(lm[0], 0.3):
+        nose = v(lm[0]); delta = sub(nose, shoulder)
+        if delta[1] > 0.1 and norm(delta) < sw * 1.6: head_center = add(nose, (0.0, sw * 0.12, 0.0))
+    garment_r = max(0.21, sw * 0.285)
+    parts = ['head', 'hair', 'body', 'garment']
+    for label, a, b, c in [('left_arm',11,13,15),('right_arm',12,14,16)]:
+        if reliable(lm[b], 0.22): parts.append(label)
+    if cov != 'upper_body':
+        for label, a, b, c in [('left_leg',23,25,27),('right_leg',24,26,28)]:
+            if reliable(lm[a],0.35) and reliable(lm[b],0.3): parts.append(label)
+    return {'coverage':cov,'shoulder_width':sw,'shoulder':shoulder,'hip':hip,'torso_axis':torso_axis,'torso_center':torso_center,'torso_len':torso_len,'head_center':head_center,'garment_r':garment_r,'parts':parts}
+
+
+def base_landmarks() -> list[P]: return [P(0.5,0.5,visibility=0.0) for _ in range(33)]
+
+
+def fixture_upper_body_portrait() -> list[P]:
+    l=base_landmarks()
+    vals={0:P(.59,.24,-.06,.99),7:P(.53,.27,0,.93),8:P(.65,.26,-.03,.91),11:P(.47,.43,.02,.96),12:P(.68,.42,-.03,.96),13:P(.42,.60,.02,.82),14:P(.73,.57,-.02,.80),15:P(.46,.77,.01,.62),16:P(.76,.73,-.01,.60),23:P(.51,.88,1.4,.08),24:P(.69,.90,-1.1,.07),25:P(.25,.35,2,.04),26:P(.95,.31,-2,.03),27:P(.08,.22,2.4,.02),28:P(.98,.20,-2.4,.02)}
+    for i,p in vals.items(): l[i]=p
+    return l
+
+
+def fixture_full_body_standing() -> list[P]:
+    l=base_landmarks()
+    vals={0:P(.50,.12,0,.99),7:P(.46,.15,0,.95),8:P(.54,.15,0,.95),11:P(.42,.28,0,.99),12:P(.58,.28,0,.99),13:P(.36,.44,0,.95),14:P(.64,.44,0,.95),15:P(.34,.59,0,.92),16:P(.66,.59,0,.92),23:P(.45,.56,0,.98),24:P(.55,.56,0,.98),25:P(.45,.73,0,.96),26:P(.55,.73,0,.96),27:P(.45,.92,0,.94),28:P(.55,.92,0,.94)}
+    for i,p in vals.items(): l[i]=p
+    return l
+
+
+def assert_upper_body(spec: dict) -> None:
+    assert spec['coverage']=='upper_body', spec
+    assert 'left_leg' not in spec['parts'] and 'right_leg' not in spec['parts'], spec
+    verticality=abs(spec['torso_axis'][1])/max(1e-9,norm(spec['torso_axis']))
+    assert verticality>=.97, (verticality,spec)
+    assert spec['torso_axis'][1]<0, spec
+    head_above=spec['head_center'][1]-spec['torso_center'][1]
+    assert spec['shoulder_width']*.55 <= head_above <= spec['shoulder_width']*2.2, (head_above,spec)
+    assert .9 <= spec['torso_len']/spec['shoulder_width'] <= 1.5, spec
+    assert spec['garment_r']*2 < spec['torso_len']*.8, spec
+
+
+def assert_full_body(spec: dict) -> None:
+    assert spec['coverage']=='full_body', spec
+    assert 'left_leg' in spec['parts'] and 'right_leg' in spec['parts'], spec
+    assert spec['torso_axis'][1] < -.7, spec
+    assert spec['head_center'][1] > spec['torso_center'][1], spec
+
+
+def assert_deployer_contract() -> None:
+    text=DEPLOYER.read_text(encoding='utf-8')
+    required=["proxyBodyFrame='visibility-gated-v0.4.1'","cov!=='upper_body'","torsoLen=sw*1.18","character-blueprint-poc-v0.4.1"]
+    missing=[m for m in required if m not in text]
+    assert not missing, f'deployer/runtime contract drift: missing={missing}'
+
+
+def main() -> int:
+    assert_deployer_contract()
+    upper=proxy_spec(fixture_upper_body_portrait()); full=proxy_spec(fixture_full_body_standing())
+    assert_upper_body(upper); assert_full_body(full)
+    result={'ok':True,'suite':'character-blueprint-geometry-regression/v1','cases':{'portrait_upperbody_regression_01':{'coverage':upper['coverage'],'parts':upper['parts'],'torso_verticality':round(abs(upper['torso_axis'][1]),4),'torso_to_shoulder':round(upper['torso_len']/upper['shoulder_width'],4)},'standing_fullbody_control_01':{'coverage':full['coverage'],'parts':full['parts']}}}
+    print(json.dumps(result,ensure_ascii=False,sort_keys=True)); return 0
+
+
+if __name__=='__main__': raise SystemExit(main())


### PR DESCRIPTION
Rebased on the latest main. Adds a deterministic proxy-geometry regression suite for the half-body failure exposed in the public demo. The suite asserts upper-body coverage, no invented legs, near-vertical torso, sane torso/shoulder ratio, and head-above-torso geometry; a full-body control remains required. It runs on PRs and again inside the authoritative Oracle release before deployment.