### PR TITLE
Add Character Blueprint browser E2E gate

### DIFF
--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -9,6 +9,7 @@ on:
       - 'web_assets/character-blueprint-poc.html'
       - 'scripts/deploy_character_blueprint_poc.py'
       - 'scripts/character_blueprint_geometry_selftest.py'
+      - 'scripts/character_blueprint_browser_smoke.mjs'
 
 permissions:
   contents: read
@@ -45,6 +46,7 @@ jobs:
           grep -q '"llm_tokens":0' "$PAGE"
           grep -q 'visibility-gated-v0.4.1' "$DEPLOY"
           grep -q 'character-blueprint-poc-v0.4.1' "$DEPLOY"
+          grep -q 'browserSelfTest:true' "$DEPLOY"
           grep -q '/poc/character-blueprint/' "$DEPLOY"
           echo 'character_blueprint_v041_source=PASS'
 
@@ -98,6 +100,7 @@ jobs:
           grep -q '"ok": true' /tmp/character-blueprint-release.json
           grep -q 'character-blueprint-poc-v0.4.1' /tmp/character-blueprint-release.json
           grep -q '"three_d_proxy": true' /tmp/character-blueprint-release.json
+          grep -q '"browser_self_test": true' /tmp/character-blueprint-release.json
           grep -q '"visibility_gated_body_frame": true' /tmp/character-blueprint-release.json
           rm -rf "$STAGE"
           echo 'character_blueprint_v041_deploy=PASS'
@@ -114,6 +117,8 @@ jobs:
           grep -q 'character-blueprint-ir/v0.4' /tmp/character-blueprint-public
           grep -q 'threeDProxy:true' /tmp/character-blueprint-public
           grep -q 'interactivePartLinking:true' /tmp/character-blueprint-public
+          grep -q 'browserSelfTest:true' /tmp/character-blueprint-public
+          grep -q 'selfTestLandmarks' /tmp/character-blueprint-public
           grep -q 'OrbitControls' /tmp/character-blueprint-public
           grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-public
           grep -q '丟一張角色圖，先把她立起來' /tmp/character-blueprint-public
@@ -125,3 +130,30 @@ jobs:
           fi
           echo 'public_character_blueprint_v041_identity=PASS'
           echo 'upper_body_proxy_contract=PASS'
+
+  browser-e2e:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install Playwright Chromium
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+      - name: Run public Character Blueprint browser smoke
+        shell: bash
+        env:
+          CHARACTER_BLUEPRINT_URL: https://studio.milkcat.org/poc/character-blueprint/
+        run: |
+          set -euo pipefail
+          node scripts/character_blueprint_browser_smoke.mjs | tee /tmp/character-blueprint-browser-smoke.json
+          grep -q '"ok": true' /tmp/character-blueprint-browser-smoke.json
+          grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-browser-smoke.json
+          grep -q '"coverage": "upper_body"' /tmp/character-blueprint-browser-smoke.json
+          echo 'character_blueprint_browser_e2e=PASS'

--- a/scripts/character_blueprint_browser_smoke.mjs
+++ b/scripts/character_blueprint_browser_smoke.mjs
@@ -1,0 +1,48 @@
+import { chromium } from 'playwright';
+import assert from 'node:assert/strict';
+
+const url = process.env.CHARACTER_BLUEPRINT_URL || 'https://studio.milkcat.org/poc/character-blueprint/';
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+const pageErrors = [];
+page.on('pageerror', e => pageErrors.push(String(e)));
+
+try {
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  assert(response && response.ok(), `public page HTTP failed: ${response?.status()}`);
+  await page.waitForFunction(() => window.CharacterBlueprintPOC?.browserSelfTest === true, null, { timeout: 60_000 });
+
+  const result = await page.evaluate(() => {
+    const P=(x=.5,y=.5,z=0,visibility=0)=>({x,y,z,visibility});
+    const l=Array.from({length:33},()=>P());
+    Object.assign(l, {
+      0:P(.59,.24,-.06,.99), 7:P(.53,.27,0,.93), 8:P(.65,.26,-.03,.91),
+      11:P(.47,.43,.02,.96), 12:P(.68,.42,-.03,.96),
+      13:P(.42,.60,.02,.82), 14:P(.73,.57,-.02,.80),
+      15:P(.46,.77,.01,.62), 16:P(.76,.73,-.01,.60),
+      23:P(.51,.88,1.4,.08), 24:P(.69,.90,-1.1,.07),
+      25:P(.25,.35,2,.04), 26:P(.95,.31,-2,.03),
+      27:P(.08,.22,2.4,.02), 28:P(.98,.20,-2.4,.02),
+    });
+    return {
+      version: window.CharacterBlueprintPOC.version,
+      ...window.CharacterBlueprintPOC.selfTestLandmarks(l),
+    };
+  });
+
+  assert.equal(result.version, '0.4.1');
+  assert.equal(result.coverage, 'upper_body');
+  assert.equal(result.bodyFrame, 'visibility-gated-v0.4.1');
+  assert.equal(result.selected, 'head');
+  assert(result.canvasCount >= 1, `no Three.js canvas: ${JSON.stringify(result)}`);
+  assert(result.meshCount >= 6, `too few meshes: ${JSON.stringify(result)}`);
+  for (const required of ['head','hair','body','garment','left_arm','right_arm']) {
+    assert(result.parts.includes(required), `missing ${required}: ${JSON.stringify(result)}`);
+  }
+  assert(!result.parts.includes('left_leg') && !result.parts.includes('right_leg'), `upper-body fixture invented legs: ${JSON.stringify(result)}`);
+  assert.equal(pageErrors.length, 0, `browser page errors: ${pageErrors.join(' | ')}`);
+
+  console.log(JSON.stringify({ ok:true, suite:'character-blueprint-browser-smoke/v1', url, result }, null, 2));
+} finally {
+  await browser.close();
+}

--- a/scripts/deploy_character_blueprint_poc.py
+++ b/scripts/deploy_character_blueprint_poc.py
@@ -80,7 +80,6 @@ def make_proxy_stable(text: str) -> str:
     m = pattern.search(text)
     if not m:
         raise SystemExit('character blueprint geometry transform failed: coverage/buildIR boundary missing')
-    # Preserve buildIR; replace coverage and inject reliability helper.
     prefix = STABLE_PROXY_FUNCTIONS.split('function rebuild3D', 1)[0]
     text = text[:m.start()] + prefix + 'function buildIR(l)' + text[m.end():]
     rebuild_pattern = re.compile(r"function rebuild3D\(l\)\{.*?viewerEmpty\.style\.display='none';fitCamera\(\);selectPart\(selected\)\}", re.S)
@@ -91,8 +90,20 @@ def make_proxy_stable(text: str) -> str:
     text = text.replace('POC v0.4 · browser-local', 'POC v0.4.1 · browser-local', 1)
     text = text.replace('<title>Character Blueprint POC v0.4</title>', '<title>Character Blueprint POC v0.4.1</title>', 1)
     text = text.replace('meta name="character-blueprint-poc" content="v0.4.0"', 'meta name="character-blueprint-poc" content="v0.4.1"', 1)
+    text = text.replace("const VERSION='0.4.0'", "const VERSION='0.4.1'", 1)
     if "proxyBodyFrame='visibility-gated-v0.4.1'" not in text:
         raise SystemExit('character blueprint stable body-frame marker missing')
+    return text
+
+
+def make_browser_testable(text: str) -> str:
+    old = "window.CharacterBlueprintPOC={version:VERSION,schema:SCHEMA,threeDProxy:true,interactivePartLinking:true,llmTokens:0};"
+    new = """window.CharacterBlueprintPOC={version:VERSION,schema:SCHEMA,threeDProxy:true,interactivePartLinking:true,llmTokens:0,browserSelfTest:true,selfTestLandmarks:(l)=>{currentLm=l;currentIR=buildIR(l);selected='body';rebuild3D(l);const parts=[...new Set(meshParts.map(x=>x.userData.part))];selectPart('head');return{coverage:coverage(l),parts,selected,meshCount:meshParts.length,canvasCount:viewer.querySelectorAll('canvas').length,bodyFrame:root?.userData?.proxyBodyFrame||null}}};"""
+    if old not in text:
+        raise SystemExit('character blueprint browser self-test transform failed: public API marker missing')
+    text = text.replace(old, new, 1)
+    if 'browserSelfTest:true' not in text or 'selfTestLandmarks' not in text:
+        raise SystemExit('character blueprint browser self-test hook missing')
     return text
 
 
@@ -107,12 +118,12 @@ def main() -> int:
     tmp.chmod(0o755)
     try:
         index = tmp / 'index.html'
-        published_text = make_proxy_stable(make_browser_safe(source_text))
+        published_text = make_browser_testable(make_proxy_stable(make_browser_safe(source_text)))
         index.write_text(published_text, encoding='utf-8')
         index.chmod(0o644)
         deployed_text = index.read_text(encoding='utf-8')
         validate(deployed_text)
-        required = ['type="importmap"', "from 'three/addons/controls/OrbitControls.js'", 'v0.4.1', "proxyBodyFrame='visibility-gated-v0.4.1'"]
+        required = ['type="importmap"', "from 'three/addons/controls/OrbitControls.js'", 'v0.4.1', "proxyBodyFrame='visibility-gated-v0.4.1'", 'browserSelfTest:true', 'selfTestLandmarks']
         missing = [m for m in required if m not in deployed_text]
         if missing:
             raise SystemExit(f'character blueprint published artifact invalid: missing={missing}')
@@ -129,7 +140,7 @@ def main() -> int:
     deployed = TARGET / 'index.html'
     final_text = deployed.read_text(encoding='utf-8')
     validate(final_text)
-    if 'type="importmap"' not in final_text or "proxyBodyFrame='visibility-gated-v0.4.1'" not in final_text:
+    if 'type="importmap"' not in final_text or "proxyBodyFrame='visibility-gated-v0.4.1'" not in final_text or 'browserSelfTest:true' not in final_text:
         raise SystemExit('character blueprint public artifact missing runtime safety markers')
     print(json.dumps({
         'ok': True,
@@ -140,6 +151,7 @@ def main() -> int:
         'three_d_proxy': True,
         'interactive_part_linking': True,
         'browser_import_map': True,
+        'browser_self_test': True,
         'visibility_gated_body_frame': True,
         'llm_tokens': 0,
         'sha256': digest(deployed),


### PR DESCRIPTION
Add a production-only browser self-test hook to the published Character Blueprint artifact and a real Chromium post-deploy E2E. The browser test loads the public URL, executes the actual Three.js rebuild3D path with the half-body regression landmarks, verifies canvas creation, body-frame marker, required parts, no invented legs, and part-selection logic.