### PR TITLE
Trigger Character Blueprint browser E2E release

### DIFF
--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -157,3 +157,5 @@ jobs:
           grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-browser-smoke.json
           grep -q '"coverage": "upper_body"' /tmp/character-blueprint-browser-smoke.json
           echo 'character_blueprint_browser_e2e=PASS'
+
+# Authoritative browser E2E release trigger.


### PR DESCRIPTION
Workflow-only trigger for the authoritative v0.4.1 release now that the real Chromium post-deploy E2E gate is installed. No demo source changes.