### PR TITLE
Character Blueprint v0.5: silhouette-driven 3D envelope

### DIFF
--- a/.github/workflows/oracle-release-character-blueprint.yml
+++ b/.github/workflows/oracle-release-character-blueprint.yml
@@ -29,12 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate image-to-3D Character Blueprint source
+      - name: Validate Character Blueprint v0.5 source contract
         shell: bash
         run: |
           set -euo pipefail
           PAGE=web_assets/character-blueprint-poc.html
           DEPLOY=scripts/deploy_character_blueprint_poc.py
+          # The checked-in page remains the stable v0.4 base; the authoritative deployer publishes v0.5.
           grep -q 'data-version="0.4.0"' "$PAGE"
           grep -q 'character-blueprint-ir/v0.4' "$PAGE"
           grep -q 'threeDProxy:true' "$PAGE"
@@ -44,11 +45,15 @@ jobs:
           grep -q '3D Blueprint' "$PAGE"
           grep -q '技術細節 / Character IR' "$PAGE"
           grep -q '"llm_tokens":0' "$PAGE"
-          grep -q 'visibility-gated-v0.4.1' "$DEPLOY"
-          grep -q 'character-blueprint-poc-v0.4.1' "$DEPLOY"
-          grep -q 'browserSelfTest:true' "$DEPLOY"
+          grep -q 'silhouette-envelope-v0.5' "$DEPLOY"
+          grep -q 'border-evidence-silhouette/v0.5' "$DEPLOY"
+          grep -q 'threejs-silhouette-envelope/v0.5' "$DEPLOY"
+          grep -q 'function envelopeGeometry' "$DEPLOY"
+          grep -q 'extractSilhouetteProfile' "$DEPLOY"
+          grep -q 'character-blueprint-poc-v0.5.0' "$DEPLOY"
+          grep -q 'silhouetteEnvelope:true' "$DEPLOY"
           grep -q '/poc/character-blueprint/' "$DEPLOY"
-          echo 'character_blueprint_v041_source=PASS'
+          echo 'character_blueprint_v050_source=PASS'
 
       - name: Geometry regression gate
         shell: bash
@@ -56,9 +61,11 @@ jobs:
           set -euo pipefail
           python3 scripts/character_blueprint_geometry_selftest.py | tee /tmp/character-blueprint-regression.json
           grep -q '"ok": true' /tmp/character-blueprint-regression.json
+          grep -q 'character-blueprint-geometry-regression/v2' /tmp/character-blueprint-regression.json
+          grep -q 'silhouette-envelope-v0.5' /tmp/character-blueprint-regression.json
           grep -q 'portrait_upperbody_regression_01' /tmp/character-blueprint-regression.json
           grep -q '"coverage": "upper_body"' /tmp/character-blueprint-regression.json
-          echo 'character_blueprint_geometry_regression=PASS'
+          echo 'character_blueprint_geometry_regression_v05=PASS'
 
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -90,46 +97,49 @@ jobs:
           from pathlib import Path
           root=Path(sys.argv[1]); sha=sys.argv[2]; receipt=Path(sys.argv[3])
           rels=['scripts/deploy_character_blueprint_poc.py','scripts/character_blueprint_geometry_selftest.py','web_assets/character-blueprint-poc.html']
-          data={'schema':'agentos.runtime-refresh-receipt/v1','ok':True,'scope':'character-blueprint-poc-v0.4.1','source_commit':sha,'runtime_root':str(root),'sha256':{r:hashlib.sha256((root/r).read_bytes()).hexdigest() for r in rels}}
+          data={'schema':'agentos.runtime-refresh-receipt/v1','ok':True,'scope':'character-blueprint-poc-v0.5.0','source_commit':sha,'runtime_root':str(root),'sha256':{r:hashlib.sha256((root/r).read_bytes()).hexdigest() for r in rels}}
           receipt.write_text(json.dumps(data,sort_keys=True,indent=2)+'\n'); print(json.dumps(data,sort_keys=True))
           PY
           cd "$RUNTIME"
           /usr/bin/python3 scripts/character_blueprint_geometry_selftest.py | tee /tmp/character-blueprint-regression-runtime.json
           grep -q '"ok": true' /tmp/character-blueprint-regression-runtime.json
+          grep -q 'silhouette-envelope-v0.5' /tmp/character-blueprint-regression-runtime.json
           /usr/bin/python3 scripts/deploy_character_blueprint_poc.py | tee /tmp/character-blueprint-release.json
           grep -q '"ok": true' /tmp/character-blueprint-release.json
-          grep -q 'character-blueprint-poc-v0.4.1' /tmp/character-blueprint-release.json
-          grep -q '"three_d_proxy": true' /tmp/character-blueprint-release.json
+          grep -q 'character-blueprint-poc-v0.5.0' /tmp/character-blueprint-release.json
+          grep -q '"three_d_envelope": true' /tmp/character-blueprint-release.json
+          grep -q 'border-evidence-silhouette/v0.5' /tmp/character-blueprint-release.json
           grep -q '"browser_self_test": true' /tmp/character-blueprint-release.json
-          grep -q '"visibility_gated_body_frame": true' /tmp/character-blueprint-release.json
           rm -rf "$STAGE"
-          echo 'character_blueprint_v041_deploy=PASS'
+          echo 'character_blueprint_v050_deploy=PASS'
           REMOTE
 
-      - name: Public v0.4.1 demo acceptance
+      - name: Public v0.5 demo acceptance
         shell: bash
         run: |
           set -euo pipefail
           URL=https://studio.milkcat.org/poc/character-blueprint/
           curl -fsS --retry 8 --retry-delay 2 --retry-all-errors "$URL" -o /tmp/character-blueprint-public
-          grep -q 'meta name="character-blueprint-poc" content="v0.4.1"' /tmp/character-blueprint-public
-          grep -q '<title>Character Blueprint POC v0.4.1</title>' /tmp/character-blueprint-public
-          grep -q 'character-blueprint-ir/v0.4' /tmp/character-blueprint-public
-          grep -q 'threeDProxy:true' /tmp/character-blueprint-public
-          grep -q 'interactivePartLinking:true' /tmp/character-blueprint-public
+          grep -q 'data-version="0.5.0"' /tmp/character-blueprint-public
+          grep -q 'meta name="character-blueprint-poc" content="v0.5.0"' /tmp/character-blueprint-public
+          grep -q '<title>Character Blueprint POC v0.5</title>' /tmp/character-blueprint-public
+          grep -q 'character-blueprint-ir/v0.5' /tmp/character-blueprint-public
+          grep -q 'threejs-silhouette-envelope/v0.5' /tmp/character-blueprint-public
+          grep -q 'border-evidence-silhouette/v0.5' /tmp/character-blueprint-public
+          grep -q 'silhouetteEnvelope:true' /tmp/character-blueprint-public
           grep -q 'browserSelfTest:true' /tmp/character-blueprint-public
           grep -q 'selfTestLandmarks' /tmp/character-blueprint-public
           grep -q 'OrbitControls' /tmp/character-blueprint-public
-          grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-public
-          grep -q '丟一張角色圖，先把她立起來' /tmp/character-blueprint-public
+          grep -q 'silhouette-envelope-v0.5' /tmp/character-blueprint-public
+          grep -q 'CHARACTER BLUEPRINT · IMAGE → 3D ENVELOPE' /tmp/character-blueprint-public
           grep -q '3D Blueprint' /tmp/character-blueprint-public
           grep -q '技術細節 / Character IR' /tmp/character-blueprint-public
           grep -q '"llm_tokens":0' /tmp/character-blueprint-public
           if grep -q 'Milkcat Studio Portal' /tmp/character-blueprint-public && ! grep -q 'character-blueprint-poc' /tmp/character-blueprint-public; then
             echo 'ERROR: Studio homepage fallback detected' >&2; exit 1
           fi
-          echo 'public_character_blueprint_v041_identity=PASS'
-          echo 'upper_body_proxy_contract=PASS'
+          echo 'public_character_blueprint_v050_identity=PASS'
+          echo 'silhouette_envelope_contract=PASS'
 
   browser-e2e:
     needs: release
@@ -166,10 +176,11 @@ jobs:
           set -euo pipefail
           node scripts/character_blueprint_browser_smoke.mjs | tee /tmp/character-blueprint-browser-smoke.json
           grep -q '"ok": true' /tmp/character-blueprint-browser-smoke.json
-          grep -q 'character-blueprint-browser-smoke/v2' /tmp/character-blueprint-browser-smoke.json
-          grep -q 'visibility-gated-v0.4.1' /tmp/character-blueprint-browser-smoke.json
+          grep -q 'character-blueprint-browser-smoke/v3' /tmp/character-blueprint-browser-smoke.json
+          grep -q 'silhouette-envelope-v0.5' /tmp/character-blueprint-browser-smoke.json
+          grep -q 'border-evidence-silhouette/v0.5' /tmp/character-blueprint-browser-smoke.json
           grep -q '"statusClass": "status ok"' /tmp/character-blueprint-browser-smoke.json
-          grep -q '"schema": "character-blueprint-ir/v0.4"' /tmp/character-blueprint-browser-smoke.json
-          echo 'character_blueprint_real_image_e2e=PASS'
+          grep -q '"schema": "character-blueprint-ir/v0.5"' /tmp/character-blueprint-browser-smoke.json
+          echo 'character_blueprint_v05_real_image_e2e=PASS'
 
-# Real-image public-domain E2E release gate.
+# Silhouette-driven 3D envelope release gate.

--- a/scripts/character_blueprint_browser_smoke.mjs
+++ b/scripts/character_blueprint_browser_smoke.mjs
@@ -33,13 +33,16 @@ async function runSyntheticGeometrySmoke() {
     });
     return {
       version: window.CharacterBlueprintPOC.version,
+      silhouetteEnvelope: window.CharacterBlueprintPOC.silhouetteEnvelope,
       ...window.CharacterBlueprintPOC.selfTestLandmarks(l),
     };
   });
 
-  assert.equal(result.version, '0.4.1');
+  assert.equal(result.version, '0.5.0');
+  assert.equal(result.silhouetteEnvelope, true);
   assert.equal(result.coverage, 'upper_body');
-  assert.equal(result.bodyFrame, 'visibility-gated-v0.4.1');
+  assert.equal(result.bodyFrame, 'silhouette-envelope-v0.5');
+  assert.equal(result.silhouetteEngine, 'pose-fallback');
   assert.equal(result.selected, 'head');
   assert(result.canvasCount >= 1, `no Three.js canvas: ${JSON.stringify(result)}`);
   assert(result.meshCount >= 6, `too few meshes: ${JSON.stringify(result)}`);
@@ -76,17 +79,27 @@ async function runRealImageUploadSmoke() {
       partsMetric: Number(document.getElementById('mParts')?.textContent || 0),
       partButtons: [...document.querySelectorAll('#parts .part')].map(x => x.dataset.part),
       canvasCount: document.querySelectorAll('#viewer canvas').length,
+      publicApi: {
+        version: window.CharacterBlueprintPOC?.version,
+        silhouetteEnvelope: window.CharacterBlueprintPOC?.silhouetteEnvelope,
+      },
       ir,
     };
   });
 
   assert(result.statusClass.includes('ok'), `real-image analysis failed: ${JSON.stringify(result)}`);
   assert(result.statusText.includes('完成'), `unexpected success state: ${JSON.stringify(result)}`);
+  assert.equal(result.publicApi.version, '0.5.0');
+  assert.equal(result.publicApi.silhouetteEnvelope, true);
   assert(result.canvasCount >= 1, `real-image flow created no Three.js canvas: ${JSON.stringify(result)}`);
   assert(result.partsMetric >= 4, `real-image flow created too few 3D parts: ${JSON.stringify(result)}`);
   assert(result.ir, `real-image flow emitted invalid Character IR: ${JSON.stringify(result)}`);
-  assert.equal(result.ir.schema, 'character-blueprint-ir/v0.4');
+  assert.equal(result.ir.schema, 'character-blueprint-ir/v0.5');
   assert.equal(result.ir.llm_tokens, 0);
+  assert.equal(result.ir.proxy_3d?.renderer, 'threejs-silhouette-envelope/v0.5');
+  assert.equal(result.ir.observed?.silhouette?.engine, 'border-evidence-silhouette/v0.5');
+  assert(result.ir.observed?.silhouette?.torso_rows >= 5, `too few silhouette torso rows: ${JSON.stringify(result.ir.observed?.silhouette)}`);
+  assert(result.ir.observed?.silhouette?.hair_rows >= 4, `too few silhouette hair rows: ${JSON.stringify(result.ir.observed?.silhouette)}`);
   assert(result.ir.observed?.pose?.mean_visibility > 0.1, `pose visibility too low: ${JSON.stringify(result.ir.observed?.pose)}`);
   assert(['full_body','three_quarter','upper_body'].includes(result.ir.observed?.pose?.coverage), `invalid coverage: ${JSON.stringify(result.ir.observed?.pose)}`);
   for (const required of ['head','hair','body','garment']) {
@@ -103,7 +116,7 @@ try {
 
   console.log(JSON.stringify({
     ok: true,
-    suite: 'character-blueprint-browser-smoke/v2',
+    suite: 'character-blueprint-browser-smoke/v3',
     url,
     synthetic,
     realImage,

--- a/scripts/character_blueprint_geometry_selftest.py
+++ b/scripts/character_blueprint_geometry_selftest.py
@@ -70,14 +70,13 @@ def proxy_spec(lm: list[P]) -> dict:
     elif reliable(lm[0], 0.3):
         nose = v(lm[0]); delta = sub(nose, shoulder)
         if delta[1] > 0.1 and norm(delta) < sw * 1.6: head_center = add(nose, (0.0, sw * 0.12, 0.0))
-    garment_r = max(0.21, sw * 0.285)
     parts = ['head', 'hair', 'body', 'garment']
     for label, a, b, c in [('left_arm',11,13,15),('right_arm',12,14,16)]:
         if reliable(lm[b], 0.22): parts.append(label)
     if cov != 'upper_body':
         for label, a, b, c in [('left_leg',23,25,27),('right_leg',24,26,28)]:
             if reliable(lm[a],0.35) and reliable(lm[b],0.3): parts.append(label)
-    return {'coverage':cov,'shoulder_width':sw,'shoulder':shoulder,'hip':hip,'torso_axis':torso_axis,'torso_center':torso_center,'torso_len':torso_len,'head_center':head_center,'garment_r':garment_r,'parts':parts}
+    return {'coverage':cov,'shoulder_width':sw,'shoulder':shoulder,'hip':hip,'torso_axis':torso_axis,'torso_center':torso_center,'torso_len':torso_len,'head_center':head_center,'parts':parts}
 
 
 def base_landmarks() -> list[P]: return [P(0.5,0.5,visibility=0.0) for _ in range(33)]
@@ -106,7 +105,6 @@ def assert_upper_body(spec: dict) -> None:
     head_above=spec['head_center'][1]-spec['torso_center'][1]
     assert spec['shoulder_width']*.55 <= head_above <= spec['shoulder_width']*2.2, (head_above,spec)
     assert .9 <= spec['torso_len']/spec['shoulder_width'] <= 1.5, spec
-    assert spec['garment_r']*2 < spec['torso_len']*.8, spec
 
 
 def assert_full_body(spec: dict) -> None:
@@ -118,7 +116,16 @@ def assert_full_body(spec: dict) -> None:
 
 def assert_deployer_contract() -> None:
     text=DEPLOYER.read_text(encoding='utf-8')
-    required=["proxyBodyFrame='visibility-gated-v0.4.1'","cov!=='upper_body'","torsoLen=sw*1.18","character-blueprint-poc-v0.4.1"]
+    required=[
+        "proxyBodyFrame='silhouette-envelope-v0.5'",
+        "border-evidence-silhouette/v0.5",
+        "threejs-silhouette-envelope/v0.5",
+        "function envelopeGeometry",
+        "extractSilhouetteProfile",
+        "cov!=='upper_body'",
+        "torsoLen=sw*1.18",
+        "character-blueprint-poc-v0.5.0",
+    ]
     missing=[m for m in required if m not in text]
     assert not missing, f'deployer/runtime contract drift: missing={missing}'
 
@@ -127,7 +134,7 @@ def main() -> int:
     assert_deployer_contract()
     upper=proxy_spec(fixture_upper_body_portrait()); full=proxy_spec(fixture_full_body_standing())
     assert_upper_body(upper); assert_full_body(full)
-    result={'ok':True,'suite':'character-blueprint-geometry-regression/v1','cases':{'portrait_upperbody_regression_01':{'coverage':upper['coverage'],'parts':upper['parts'],'torso_verticality':round(abs(upper['torso_axis'][1]),4),'torso_to_shoulder':round(upper['torso_len']/upper['shoulder_width'],4)},'standing_fullbody_control_01':{'coverage':full['coverage'],'parts':full['parts']}}}
+    result={'ok':True,'suite':'character-blueprint-geometry-regression/v2','envelope':'silhouette-envelope-v0.5','cases':{'portrait_upperbody_regression_01':{'coverage':upper['coverage'],'parts':upper['parts'],'torso_verticality':round(abs(upper['torso_axis'][1]),4),'torso_to_shoulder':round(upper['torso_len']/upper['shoulder_width'],4)},'standing_fullbody_control_01':{'coverage':full['coverage'],'parts':full['parts']}}}
     print(json.dumps(result,ensure_ascii=False,sort_keys=True)); return 0
 
 

--- a/scripts/deploy_character_blueprint_poc.py
+++ b/scripts/deploy_character_blueprint_poc.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / 'web_assets' / 'character-blueprint-poc.html'
 TARGET = Path('/home/ubuntu/zeus-writer/website/dist/poc/character-blueprint')
-MARKERS = [
+SOURCE_MARKERS = [
     'data-version="0.4.0"',
     'character-blueprint-ir/v0.4',
     'threeDProxy:true',
@@ -29,33 +29,27 @@ IMPORT_MAP = '''<script type="importmap">
 THREE_MAPPED = "import * as THREE from 'three';"
 ORBIT_MAPPED = "import {OrbitControls} from 'three/addons/controls/OrbitControls.js';"
 
-STABLE_PROXY_FUNCTIONS = r'''function coverage(l){const ok=(i,t=.4)=>{const p=l[i];return !!p&&(p.visibility??0)>=t&&p.x>=-.08&&p.x<=1.08&&p.y>=-.08&&p.y<=1.08};return ok(27)&&ok(28)?'full_body':ok(25)&&ok(26)?'three_quarter':'upper_body'}
+ENVELOPE_FUNCTIONS = r'''let lastSilhouetteProfile=null;
+function coverage(l){const ok=(i,t=.4)=>{const p=l[i];return !!p&&(p.visibility??0)>=t&&p.x>=-.08&&p.x<=1.08&&p.y>=-.08&&p.y<=1.08};return ok(27)&&ok(28)?'full_body':ok(25)&&ok(26)?'three_quarter':'upper_body'}
 function reliablePoint(l,i,t=.38){const p=l[i];return !!p&&(p.visibility??0)>=t&&p.x>=-.12&&p.x<=1.12&&p.y>=-.12&&p.y<=1.12}
-function rebuild3D(l){init3D();if(root)scene.remove(root);root=new THREE.Group();scene.add(root);meshParts=[];
- const shL=v(l,11),shR=v(l,12),shoulder=mean(shL,shR),sw=Math.max(.55,shL.distanceTo(shR)),cov=coverage(l);
- let hip,torsoLen;
- if(cov!=='upper_body'&&reliablePoint(l,23,.42)&&reliablePoint(l,24,.42)){const rawHip=mean(v(l,23),v(l,24)),d=rawHip.clone().sub(shoulder),ratio=d.length()/sw;if(d.y<-.15&&ratio>.55&&ratio<2.2){hip=rawHip;torsoLen=d.length()}else{torsoLen=sw*1.18;hip=shoulder.clone().add(new THREE.Vector3(0,-torsoLen,0))}}
- else{torsoLen=sw*1.18;hip=shoulder.clone().add(new THREE.Vector3(0,-torsoLen,0))}
- const torsoAxis=hip.clone().sub(shoulder).normalize(),torsoCenter=mean(shoulder,hip);
- let headCenter=shoulder.clone().add(new THREE.Vector3(0,sw*.82,0));
- if(reliablePoint(l,7,.28)&&reliablePoint(l,8,.28)){const earMid=mean(v(l,7),v(l,8)),delta=earMid.clone().sub(shoulder);if(delta.y>.1&&delta.length()<sw*1.6)headCenter=earMid}
- else if(reliablePoint(l,0,.3)){const nose=v(l,0),delta=nose.clone().sub(shoulder);if(delta.y>.1&&delta.length()<sw*1.6)headCenter=nose.clone().add(new THREE.Vector3(0,sw*.12,0))}
- const headR=Math.max(.24,sw*.31);
- addMesh(new THREE.SphereGeometry(1,28,20),'head',headCenter,new THREE.Vector3(headR*.82,headR,headR*.72));
- addMesh(new THREE.SphereGeometry(1,24,18),'hair',headCenter.clone().add(new THREE.Vector3(0,headR*.12,-headR*.04)),new THREE.Vector3(headR*.98,headR*1.12,headR*.88));
- const bodyR=Math.max(.18,sw*.24),bodyLen=Math.max(.08,torsoLen-bodyR*2),torso=addMesh(new THREE.CapsuleGeometry(bodyR,bodyLen,8,18),'body',torsoCenter,new THREE.Vector3(1,1,.72));torso.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0),torsoAxis);
- const garmentR=Math.max(.21,sw*.285),garmentLen=Math.max(.08,torsoLen-garmentR*1.7),garment=addMesh(new THREE.CapsuleGeometry(garmentR,garmentLen,8,18),'garment',torsoCenter.clone().add(new THREE.Vector3(0,-sw*.03,0)),new THREE.Vector3(1.04,1,.84));garment.quaternion.copy(torso.quaternion);
- const armChains=[['left_arm',11,13,15],['right_arm',12,14,16]];for(const [part,a,b,c] of armChains){if(!reliablePoint(l,b,.22))continue;const A=v(l,a),B=v(l,b);cylinderBetween(A,B,Math.max(.055,sw*.095),part);if(reliablePoint(l,c,.2))cylinderBetween(B,v(l,c),Math.max(.05,sw*.085),part)}
- if(cov!=='upper_body'){const legChains=[['left_leg',23,25,27],['right_leg',24,26,28]];for(const [part,a,b,c] of legChains){if(!reliablePoint(l,a,.35)||!reliablePoint(l,b,.3))continue;const A=v(l,a),B=v(l,b);cylinderBetween(A,B,Math.max(.07,sw*.12),part);if(reliablePoint(l,c,.28))cylinderBetween(B,v(l,c),Math.max(.06,sw*.1),part)}}
- root.userData.proxyBodyFrame='visibility-gated-v0.4.1';viewerEmpty.style.display='none';fitCamera();selectPart(selected)}'''
+function clamp01(x){return Math.max(0,Math.min(1,x))}
+function rgbDistance(d,i,bg){const dr=d[i]-bg[0],dg=d[i+1]-bg[1],db=d[i+2]-bg[2];return Math.sqrt(dr*dr+dg*dg+db*db)}
+function estimateBorderBackground(data,w,h){let r=0,g=0,b=0,n=0;const step=Math.max(1,Math.floor(Math.min(w,h)/40));const take=(x,y)=>{const i=(y*w+x)*4;r+=data[i];g+=data[i+1];b+=data[i+2];n++};for(let x=0;x<w;x+=step){take(x,0);take(x,h-1)}for(let y=step;y<h-step;y+=step){take(0,y);take(w-1,y)}return n?[r/n,g/n,b/n]:[255,255,255]}
+function rowForegroundRun(data,w,h,yn,cxn,halfNorm,bg,threshold=46){const y=Math.max(0,Math.min(h-1,Math.round(clamp01(yn)*(h-1)))),cx=Math.round(clamp01(cxn)*(w-1)),x0=Math.max(0,Math.floor((cxn-halfNorm)*w)),x1=Math.min(w-1,Math.ceil((cxn+halfNorm)*w));let runs=[],start=-1;for(let x=x0;x<=x1;x++){const fg=rgbDistance(data,(y*w+x)*4,bg)>threshold;if(fg&&start<0)start=x;if((!fg||x===x1)&&start>=0){const end=fg&&x===x1?x:x-1;if(end-start>=2)runs.push([start,end]);start=-1}}if(!runs.length)return null;runs.sort((a,b)=>{const ac=(a[0]+a[1])/2,bc=(b[0]+b[1])/2,ad=cx>=a[0]&&cx<=a[1]?0:Math.abs(ac-cx),bd=cx>=b[0]&&cx<=b[1]?0:Math.abs(bc-cx);return ad-bd||(b[1]-b[0])-(a[1]-a[0])});const q=runs[0],left=q[0]/w,right=q[1]/w;return{left_norm:left,right_norm:right,width_norm:Math.max(1/w,right-left),center_norm:(left+right)/2}}
+function fallbackRows(widthNorm,centerNorm,count=7){return Array.from({length:count},(_,i)=>{const t=i/(count-1),shape=.88+.18*Math.sin(Math.PI*t);return{t,width_norm:widthNorm*shape,center_norm:centerNorm,source:'pose-fallback'}})}
+function extractSilhouetteProfile(l){if(!img?.naturalWidth||!img?.naturalHeight)return null;const maxDim=320,scale=Math.min(1,maxDim/Math.max(img.naturalWidth,img.naturalHeight)),c=document.createElement('canvas');c.width=Math.max(32,Math.round(img.naturalWidth*scale));c.height=Math.max(32,Math.round(img.naturalHeight*scale));const ctx=c.getContext('2d',{willReadFrequently:true});ctx.drawImage(img,0,0,c.width,c.height);const im=ctx.getImageData(0,0,c.width,c.height),data=im.data,bg=estimateBorderBackground(data,c.width,c.height),cov=coverage(l);const shoulderNorm=Math.max(.035,Math.abs(l[12].x-l[11].x)),shoulderY=(l[11].y+l[12].y)/2,shoulderX=(l[11].x+l[12].x)/2;let hipY=shoulderY+shoulderNorm*1.18,hipX=shoulderX;if(cov!=='upper_body'&&reliablePoint(l,23,.35)&&reliablePoint(l,24,.35)){hipY=(l[23].y+l[24].y)/2;hipX=(l[23].x+l[24].x)/2;if(hipY<=shoulderY+.08||hipY>shoulderY+shoulderNorm*2.1){hipY=shoulderY+shoulderNorm*1.18;hipX=shoulderX}}else hipY=Math.min(.98,shoulderY+Math.max(.20,shoulderNorm*1.35));const torso=[];for(let i=0;i<8;i++){const t=i/7,yn=shoulderY+(hipY-shoulderY)*t,cxn=shoulderX+(hipX-shoulderX)*t,run=rowForegroundRun(data,c.width,c.height,yn,cxn,shoulderNorm*.95,bg,46);if(run)torso.push({t,...run,source:'image-silhouette'})}const torsoRows=torso.length>=5?torso:fallbackRows(shoulderNorm*1.12,shoulderX,8);const earX=reliablePoint(l,7,.2)&&reliablePoint(l,8,.2)?(l[7].x+l[8].x)/2:(l[0]?.x??shoulderX),faceY=l[0]?.y??Math.max(.05,shoulderY-shoulderNorm*.9),hairTop=Math.max(0,faceY-shoulderNorm*.78),hairBottom=Math.min(shoulderY+shoulderNorm*.08,faceY+shoulderNorm*1.05),hair=[];for(let i=0;i<8;i++){const t=i/7,yn=hairTop+(hairBottom-hairTop)*t,run=rowForegroundRun(data,c.width,c.height,yn,earX,shoulderNorm*.82,bg,42);if(run)hair.push({t,...run,source:'image-silhouette'})}const hairRows=hair.length>=4?hair:fallbackRows(shoulderNorm*.92,earX,8);return{engine:'border-evidence-silhouette/v0.5',canvas:{width:c.width,height:c.height},background_rgb:bg.map(x=>Math.round(x)),shoulder_width_norm:+shoulderNorm.toFixed(4),torso:{rows:torsoRows,confidence:+Math.min(1,torso.length/8).toFixed(3)},hair:{rows:hairRows,confidence:+Math.min(1,hair.length/8).toFixed(3)}}}
+function envelopeGeometry(rows,length,sw,shoulderNorm,depthRatio,refCenterNorm,widthScale=1,segments=20){const verts=[],idx=[],safeShoulder=Math.max(.035,shoulderNorm);for(let i=0;i<rows.length;i++){const p=rows[i],ratio=Math.max(.52,Math.min(1.75,p.width_norm/safeShoulder)),rx=Math.max(.10,sw*ratio*.5*widthScale),rz=Math.max(.08,rx*depthRatio),y=length*(.5-p.t),xo=(p.center_norm-refCenterNorm)*4*.72;for(let j=0;j<segments;j++){const a=2*Math.PI*j/segments;verts.push(xo+rx*Math.cos(a),y,rz*Math.sin(a))}}for(let i=0;i<rows.length-1;i++)for(let j=0;j<segments;j++){const n=(j+1)%segments,a=i*segments+j,b=i*segments+n,c=(i+1)*segments+j,d=(i+1)*segments+n;idx.push(a,c,b,b,c,d)}const top=verts.length/3,bottom=top+1;verts.push(0,length*.5,0,0,-length*.5,0);for(let j=0;j<segments;j++){const n=(j+1)%segments;idx.push(top,n,j);const a=(rows.length-1)*segments+j,b=(rows.length-1)*segments+n;idx.push(bottom,a,b)}const geo=new THREE.BufferGeometry();geo.setAttribute('position',new THREE.Float32BufferAttribute(verts,3));geo.setIndex(idx);geo.computeVertexNormals();return geo}
+function rebuild3D(l){init3D();if(root)scene.remove(root);root=new THREE.Group();scene.add(root);meshParts=[];const shL=v(l,11),shR=v(l,12),shoulder=mean(shL,shR),sw=Math.max(.55,shL.distanceTo(shR)),cov=coverage(l),shoulderNorm=Math.max(.035,Math.abs(l[12].x-l[11].x)),shoulderCenterNorm=(l[11].x+l[12].x)/2;let hip,torsoLen,hipCenterNorm=shoulderCenterNorm;if(cov!=='upper_body'&&reliablePoint(l,23,.42)&&reliablePoint(l,24,.42)){const rawHip=mean(v(l,23),v(l,24)),d=rawHip.clone().sub(shoulder),ratio=d.length()/sw;if(d.y<-.15&&ratio>.55&&ratio<2.2){hip=rawHip;torsoLen=d.length();hipCenterNorm=(l[23].x+l[24].x)/2}else{torsoLen=sw*1.18;hip=shoulder.clone().add(new THREE.Vector3(0,-torsoLen,0))}}else{torsoLen=sw*1.18;hip=shoulder.clone().add(new THREE.Vector3(0,-torsoLen,0))}const torsoAxis=hip.clone().sub(shoulder).normalize(),torsoCenter=mean(shoulder,hip),profile=lastSilhouetteProfile||{torso:{rows:fallbackRows(shoulderNorm*1.1,shoulderCenterNorm,8)},hair:{rows:fallbackRows(shoulderNorm*.9,l[0]?.x??shoulderCenterNorm,8)},engine:'pose-fallback'};let headCenter=shoulder.clone().add(new THREE.Vector3(0,sw*.82,0));if(reliablePoint(l,7,.28)&&reliablePoint(l,8,.28)){const earMid=mean(v(l,7),v(l,8)),delta=earMid.clone().sub(shoulder);if(delta.y>.1&&delta.length()<sw*1.6)headCenter=earMid}else if(reliablePoint(l,0,.3)){const nose=v(l,0),delta=nose.clone().sub(shoulder);if(delta.y>.1&&delta.length()<sw*1.6)headCenter=nose.clone().add(new THREE.Vector3(0,sw*.12,0))}const headR=Math.max(.24,sw*.31);addMesh(new THREE.SphereGeometry(1,28,20),'head',headCenter,new THREE.Vector3(headR*.80,headR,headR*.70));const hairRows=profile.hair?.rows||fallbackRows(shoulderNorm*.9,l[0]?.x??shoulderCenterNorm,8),hairLen=Math.max(sw*1.05,headR*2.25),hairRef=l[0]?.x??shoulderCenterNorm,hair=addMesh(envelopeGeometry(hairRows,hairLen,sw,shoulderNorm,.72,hairRef,1.02,22),'hair',headCenter.clone().add(new THREE.Vector3(0,headR*.12,-headR*.02)));hair.scale.z=1.02;const torsoRows=profile.torso?.rows||fallbackRows(shoulderNorm*1.1,shoulderCenterNorm,8),body=addMesh(envelopeGeometry(torsoRows,torsoLen,sw,shoulderNorm,.48,(shoulderCenterNorm+hipCenterNorm)/2,.82,22),'body',torsoCenter);body.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0),torsoAxis);const garment=addMesh(envelopeGeometry(torsoRows,torsoLen*1.03,sw,shoulderNorm,.58,(shoulderCenterNorm+hipCenterNorm)/2,1.02,22),'garment',torsoCenter.clone().add(new THREE.Vector3(0,-sw*.02,0)));garment.quaternion.copy(body.quaternion);const armChains=[['left_arm',11,13,15],['right_arm',12,14,16]];for(const [part,a,b,c] of armChains){if(!reliablePoint(l,b,.22))continue;const A=v(l,a),B=v(l,b);cylinderBetween(A,B,Math.max(.055,sw*.09),part);if(reliablePoint(l,c,.2))cylinderBetween(B,v(l,c),Math.max(.05,sw*.08),part)}if(cov!=='upper_body'){const legChains=[['left_leg',23,25,27],['right_leg',24,26,28]];for(const [part,a,b,c] of legChains){if(!reliablePoint(l,a,.35)||!reliablePoint(l,b,.3))continue;const A=v(l,a),B=v(l,b);cylinderBetween(A,B,Math.max(.07,sw*.115),part);if(reliablePoint(l,c,.28))cylinderBetween(B,v(l,c),Math.max(.06,sw*.095),part)}}root.userData.proxyBodyFrame='silhouette-envelope-v0.5';root.userData.silhouetteEngine=profile.engine||'pose-fallback';viewerEmpty.style.display='none';fitCamera();selectPart(selected)}'''
+
+BUILD_IR = r'''function buildIR(l){const shoulder=Math.hypot(l[11].x-l[12].x,l[11].y-l[12].y),hip=Math.hypot(l[23].x-l[24].x,l[23].y-l[24].y),vis=l.reduce((s,p)=>s+(p.visibility??1),0)/l.length,cov=coverage(l),sil=lastSilhouetteProfile;return{schema:SCHEMA,version:VERSION,llm_tokens:0,observed:{image:{width:img.naturalWidth,height:img.naturalHeight},pose:{landmarks:33,mean_visibility:+vis.toFixed(3),coverage:cov},silhouette:sil?{engine:sil.engine,background_rgb:sil.background_rgb,torso_rows:sil.torso.rows.length,torso_confidence:sil.torso.confidence,hair_rows:sil.hair.rows.length,hair_confidence:sil.hair.confidence}:null},inferred:{proportions:{shoulder_width_norm:+shoulder.toFixed(4),hip_width_norm:+hip.toFixed(4),shoulder_hip_ratio:+(shoulder/Math.max(.001,hip)).toFixed(3)},parts:['head','hair','body','garment','left_arm','right_arm'].concat(cov==='upper_body'?[]:['left_leg','right_leg']),envelope:{torso_profile:sil?.torso?.rows||[],hair_profile:sil?.hair?.rows||[]}},assumed:{backside:'unobserved',body_depth:'elliptical depth from silhouette width',hair_depth:'silhouette envelope with assumed rear depth',garment_depth:'silhouette envelope with outer-shell depth'},proxy_3d:{renderer:'threejs-silhouette-envelope/v0.5',interactive:true,source:'pose+image-silhouette+deterministic-geometry'}}}'''
 
 
 def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def validate(text: str) -> None:
-    missing = [m for m in MARKERS if m not in text]
+def validate_source(text: str) -> None:
+    missing = [m for m in SOURCE_MARKERS if m not in text]
     if missing:
         raise SystemExit(f'character blueprint source invalid: missing={missing}')
     if all(x in text for x in FORBIDDEN_FALLBACK):
@@ -67,66 +61,79 @@ def make_browser_safe(text: str) -> str:
     new = f'{IMPORT_MAP}\n<script type="module">\n{THREE_MAPPED}\n{ORBIT_MAPPED}'
     if old not in text:
         raise SystemExit('character blueprint deploy transform failed: expected Three.js direct imports not found')
-    text = text.replace(old, new, 1)
-    required = ['type="importmap"', '"three/addons/"', "from 'three'", "from 'three/addons/controls/OrbitControls.js'"]
-    missing = [m for m in required if m not in text]
-    if missing:
-        raise SystemExit(f'character blueprint browser import transform invalid: missing={missing}')
-    return text
+    return text.replace(old, new, 1)
 
 
-def make_proxy_stable(text: str) -> str:
-    pattern = re.compile(r"function coverage\(l\)\{.*?\}\nfunction buildIR\(l\)", re.S)
-    m = pattern.search(text)
-    if not m:
-        raise SystemExit('character blueprint geometry transform failed: coverage/buildIR boundary missing')
-    prefix = STABLE_PROXY_FUNCTIONS.split('function rebuild3D', 1)[0]
-    text = text[:m.start()] + prefix + 'function buildIR(l)' + text[m.end():]
+def make_envelope_v05(text: str) -> str:
+    pattern = re.compile(r"function coverage\(l\)\{.*?\}\nfunction buildIR\(l\)\{.*?\}\nlet renderer", re.S)
+    if not pattern.search(text):
+        raise SystemExit('character blueprint v0.5 transform failed: coverage/buildIR boundary missing')
+    replacement = ENVELOPE_FUNCTIONS.split('function rebuild3D', 1)[0] + BUILD_IR + '\nlet renderer'
+    text = pattern.sub(replacement, text, count=1)
     rebuild_pattern = re.compile(r"function rebuild3D\(l\)\{.*?viewerEmpty\.style\.display='none';fitCamera\(\);selectPart\(selected\)\}", re.S)
-    rebuild = 'function rebuild3D' + STABLE_PROXY_FUNCTIONS.split('function rebuild3D', 1)[1]
+    rebuild = 'function rebuild3D' + ENVELOPE_FUNCTIONS.split('function rebuild3D', 1)[1]
     text, count = rebuild_pattern.subn(rebuild, text, count=1)
     if count != 1:
-        raise SystemExit(f'character blueprint geometry transform failed: rebuild matches={count}')
-    text = text.replace('POC v0.4 · browser-local', 'POC v0.4.1 · browser-local', 1)
-    text = text.replace('<title>Character Blueprint POC v0.4</title>', '<title>Character Blueprint POC v0.4.1</title>', 1)
-    text = text.replace('meta name="character-blueprint-poc" content="v0.4.0"', 'meta name="character-blueprint-poc" content="v0.4.1"', 1)
-    text = text.replace("const VERSION='0.4.0'", "const VERSION='0.4.1'", 1)
-    if "proxyBodyFrame='visibility-gated-v0.4.1'" not in text:
-        raise SystemExit('character blueprint stable body-frame marker missing')
+        raise SystemExit(f'character blueprint v0.5 transform failed: rebuild matches={count}')
+    old_analyze = "currentLm=res.landmarks[0];currentIR=buildIR(currentLm);selected='body';draw2D();rebuild3D(currentLm);"
+    new_analyze = "currentLm=res.landmarks[0];lastSilhouetteProfile=extractSilhouetteProfile(currentLm);currentIR=buildIR(currentLm);selected='body';draw2D();rebuild3D(currentLm);"
+    if old_analyze not in text:
+        raise SystemExit('character blueprint v0.5 transform failed: analyze pipeline marker missing')
+    text = text.replace(old_analyze, new_analyze, 1)
+    text = text.replace('data-version="0.4.0"', 'data-version="0.5.0"', 1)
+    text = text.replace('meta name="character-blueprint-poc" content="v0.4.0"', 'meta name="character-blueprint-poc" content="v0.5.0"', 1)
+    text = text.replace('<title>Character Blueprint POC v0.4</title>', '<title>Character Blueprint POC v0.5</title>', 1)
+    text = text.replace('POC v0.4 · browser-local', 'POC v0.5 · silhouette envelope', 1)
+    text = text.replace('CHARACTER BLUEPRINT · IMAGE → 3D PROXY', 'CHARACTER BLUEPRINT · IMAGE → 3D ENVELOPE', 1)
+    text = text.replace("const VERSION='0.4.0', SCHEMA='character-blueprint-ir/v0.4';", "const VERSION='0.5.0', SCHEMA='character-blueprint-ir/v0.5';", 1)
+    text = text.replace("a.download='character-blueprint-ir-v0.4.json'", "a.download='character-blueprint-ir-v0.5.json'", 1)
+    text = text.replace('頭、四肢與軀幹來自 Pose / 比例；頭髮與衣服目前是依頭部與軀幹建立的<strong>深度假設</strong>', '軀幹、衣服與頭髮的正面寬度已開始來自<strong>圖片 silhouette</strong>；背面深度仍是明確標示的假設', 1)
+    if "proxyBodyFrame='silhouette-envelope-v0.5'" not in text or 'border-evidence-silhouette/v0.5' not in text:
+        raise SystemExit('character blueprint v0.5 envelope markers missing')
     return text
 
 
 def make_browser_testable(text: str) -> str:
     old = "window.CharacterBlueprintPOC={version:VERSION,schema:SCHEMA,threeDProxy:true,interactivePartLinking:true,llmTokens:0};"
-    new = """window.CharacterBlueprintPOC={version:VERSION,schema:SCHEMA,threeDProxy:true,interactivePartLinking:true,llmTokens:0,browserSelfTest:true,selfTestLandmarks:(l)=>{currentLm=l;currentIR=buildIR(l);selected='body';rebuild3D(l);const parts=[...new Set(meshParts.map(x=>x.userData.part))];selectPart('head');return{coverage:coverage(l),parts,selected,meshCount:meshParts.length,canvasCount:viewer.querySelectorAll('canvas').length,bodyFrame:root?.userData?.proxyBodyFrame||null}}};"""
+    new = """window.CharacterBlueprintPOC={version:VERSION,schema:SCHEMA,threeDProxy:true,interactivePartLinking:true,silhouetteEnvelope:true,llmTokens:0,browserSelfTest:true,selfTestLandmarks:(l)=>{currentLm=l;lastSilhouetteProfile=null;currentIR=buildIR(l);selected='body';rebuild3D(l);const parts=[...new Set(meshParts.map(x=>x.userData.part))];selectPart('head');return{coverage:coverage(l),parts,selected,meshCount:meshParts.length,canvasCount:viewer.querySelectorAll('canvas').length,bodyFrame:root?.userData?.proxyBodyFrame||null,silhouetteEngine:root?.userData?.silhouetteEngine||null}}};"""
     if old not in text:
         raise SystemExit('character blueprint browser self-test transform failed: public API marker missing')
-    text = text.replace(old, new, 1)
-    if 'browserSelfTest:true' not in text or 'selfTestLandmarks' not in text:
-        raise SystemExit('character blueprint browser self-test hook missing')
-    return text
+    return text.replace(old, new, 1)
+
+
+def validate_published(text: str) -> None:
+    required = [
+        'data-version="0.5.0"',
+        'character-blueprint-ir/v0.5',
+        'threejs-silhouette-envelope/v0.5',
+        'border-evidence-silhouette/v0.5',
+        "proxyBodyFrame='silhouette-envelope-v0.5'",
+        'silhouetteEnvelope:true',
+        'browserSelfTest:true',
+        'type="importmap"',
+        "from 'three/addons/controls/OrbitControls.js'",
+        '"llm_tokens":0',
+    ]
+    missing = [m for m in required if m not in text]
+    if missing:
+        raise SystemExit(f'character blueprint published artifact invalid: missing={missing}')
 
 
 def main() -> int:
     if not SOURCE.is_file():
         raise SystemExit(f'missing source: {SOURCE}')
     source_text = SOURCE.read_text(encoding='utf-8')
-    validate(source_text)
+    validate_source(source_text)
     TARGET.parent.mkdir(parents=True, exist_ok=True)
     TARGET.parent.chmod(0o755)
     tmp: Path | None = Path(tempfile.mkdtemp(prefix='.character-blueprint-', dir=str(TARGET.parent)))
     tmp.chmod(0o755)
     try:
         index = tmp / 'index.html'
-        published_text = make_browser_testable(make_proxy_stable(make_browser_safe(source_text)))
+        published_text = make_browser_testable(make_envelope_v05(make_browser_safe(source_text)))
+        validate_published(published_text)
         index.write_text(published_text, encoding='utf-8')
         index.chmod(0o644)
-        deployed_text = index.read_text(encoding='utf-8')
-        validate(deployed_text)
-        required = ['type="importmap"', "from 'three/addons/controls/OrbitControls.js'", 'v0.4.1', "proxyBodyFrame='visibility-gated-v0.4.1'", 'browserSelfTest:true', 'selfTestLandmarks']
-        missing = [m for m in required if m not in deployed_text]
-        if missing:
-            raise SystemExit(f'character blueprint published artifact invalid: missing={missing}')
         backup = TARGET.with_name(TARGET.name + '.previous')
         if backup.exists(): shutil.rmtree(backup)
         if TARGET.exists(): TARGET.rename(backup)
@@ -139,20 +146,18 @@ def main() -> int:
 
     deployed = TARGET / 'index.html'
     final_text = deployed.read_text(encoding='utf-8')
-    validate(final_text)
-    if 'type="importmap"' not in final_text or "proxyBodyFrame='visibility-gated-v0.4.1'" not in final_text or 'browserSelfTest:true' not in final_text:
-        raise SystemExit('character blueprint public artifact missing runtime safety markers')
+    validate_published(final_text)
     print(json.dumps({
         'ok': True,
-        'release': 'character-blueprint-poc-v0.4.1',
+        'release': 'character-blueprint-poc-v0.5.0',
         'target': str(TARGET),
         'public_path': '/poc/character-blueprint/',
-        'marker': 'character-blueprint-poc/v0.4.1',
-        'three_d_proxy': True,
+        'marker': 'character-blueprint-poc/v0.5.0',
+        'three_d_envelope': True,
+        'silhouette_engine': 'border-evidence-silhouette/v0.5',
         'interactive_part_linking': True,
         'browser_import_map': True,
         'browser_self_test': True,
-        'visibility_gated_body_frame': True,
         'llm_tokens': 0,
         'sha256': digest(deployed),
     }, ensure_ascii=False, sort_keys=True))


### PR DESCRIPTION
Advance the Character Blueprint demo from primitive capsule/sphere proxies to silhouette-driven 2.5D envelopes. The authoritative deployer now samples foreground silhouette rows from the uploaded image, builds custom Three.js BufferGeometry for body/garment/hair, keeps hidden rear depth explicit as an assumption, upgrades Character IR to v0.5, and extends geometry + real-image Chromium E2E gates to require the silhouette envelope pipeline.