### PR TITLE
Character Blueprint benchmark capture runner

### DIFF
--- a/.github/workflows/character-blueprint-benchmark.yml
+++ b/.github/workflows/character-blueprint-benchmark.yml
@@ -1,0 +1,92 @@
+name: Character Blueprint Benchmark Capture
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/character-blueprint-benchmark.yml'
+      - 'scripts/character_blueprint_benchmark_capture.mjs'
+      - 'benchmarks/character-blueprint/benchmark-v0.1.json'
+      - 'benchmarks/character-blueprint/providers-v0.1.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: character-blueprint-benchmark
+  cancel-in-progress: true
+
+jobs:
+  capture-character-blueprint-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate benchmark contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          manifest=json.loads(Path('benchmarks/character-blueprint/benchmark-v0.1.json').read_text())
+          providers=json.loads(Path('benchmarks/character-blueprint/providers-v0.1.json').read_text())
+          assert manifest['schema']=='character-blueprint-benchmark/v0.1'
+          assert providers['schema']=='character-blueprint-benchmark-providers/v0.1'
+          assert {'character-blueprint','meshy','rodin','tripo'} <= set(providers['providers'])
+          assert manifest['evidence_views']==['front','yaw45','right','back']
+          print('character_blueprint_benchmark_contract=PASS')
+          PY
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Fetch frozen baseline fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE=/tmp/character-blueprint-benchmark-person.jpg
+          curl -fL --retry 5 --retry-delay 2 \
+            'https://upload.wikimedia.org/wikipedia/commons/c/c3/Man-standing.jpg' \
+            -o "$FIXTURE"
+          test "$(wc -c < "$FIXTURE")" -gt 10000
+          file "$FIXTURE" | grep -qi 'JPEG image data'
+          sha256sum "$FIXTURE"
+
+      - name: Capture public Character Blueprint baseline
+        shell: bash
+        env:
+          CHARACTER_BLUEPRINT_URL: https://studio.milkcat.org/poc/character-blueprint/
+          CHARACTER_BLUEPRINT_FIXTURE: /tmp/character-blueprint-benchmark-person.jpg
+          CHARACTER_BLUEPRINT_CASE_ID: real-person-fullbody
+          CHARACTER_BLUEPRINT_BENCHMARK_OUT: benchmark-artifacts/character-blueprint/real-person-fullbody/v0.5
+        run: |
+          set -euo pipefail
+          node scripts/character_blueprint_benchmark_capture.mjs | tee /tmp/character-blueprint-benchmark.json
+          grep -q '"ok": true' /tmp/character-blueprint-benchmark.json
+          grep -q 'character-blueprint-benchmark-capture/v0.1' /tmp/character-blueprint-benchmark.json
+          OUT=benchmark-artifacts/character-blueprint/real-person-fullbody/v0.5
+          test -s "$OUT/result.json"
+          test -s "$OUT/character-ir.json"
+          for view in front yaw45 right back; do test -s "$OUT/$view.png"; done
+          grep -q 'character-blueprint-ir/v0.5' "$OUT/character-ir.json"
+          grep -q 'threejs-silhouette-envelope/v0.5' "$OUT/result.json"
+          echo 'character_blueprint_benchmark_baseline=PASS'
+
+      - name: Upload benchmark evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: character-blueprint-benchmark-real-person-fullbody-v05
+          path: benchmark-artifacts/character-blueprint/real-person-fullbody/v0.5/
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/character-blueprint/providers-v0.1.json
+++ b/benchmarks/character-blueprint/providers-v0.1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "character-blueprint-benchmark-providers/v0.1",
+  "providers": {
+    "character-blueprint": {
+      "kind": "public-browser",
+      "url": "https://studio.milkcat.org/poc/character-blueprint/",
+      "credential_env": null,
+      "preferred_output": "benchmark evidence bundle"
+    },
+    "meshy": {
+      "kind": "async-http-api",
+      "base_url": "https://api.meshy.ai",
+      "create_endpoint": "/openapi/v1/image-to-3d",
+      "retrieve_endpoint": "/openapi/v1/image-to-3d/{id}",
+      "credential_env": "MESHY_API_KEY",
+      "input_mode": "image_url-or-data-uri",
+      "preferred_output": "glb",
+      "benchmark_role": "primary-commercial-baseline"
+    },
+    "rodin": {
+      "kind": "async-http-api",
+      "base_url": "https://api.hyper3d.com/api/v2",
+      "create_endpoint": "/rodin",
+      "credential_env": "RODIN_API_KEY",
+      "input_mode": "multipart-images",
+      "max_images": 5,
+      "preferred_output": "glb",
+      "benchmark_role": "quality-ceiling"
+    },
+    "tripo": {
+      "kind": "async-http-api",
+      "base_url": "https://openapi.tripo3d.ai/v3",
+      "create_endpoint": "/generation/image-to-model",
+      "retrieve_endpoint": "/tasks/{task_id}",
+      "credential_env": "TRIPO_API_KEY",
+      "input_mode": "url-file-token-or-task-id",
+      "preferred_output": "glb",
+      "repeatability": "pin model and seed",
+      "benchmark_role": "independent-sanity-baseline"
+    }
+  },
+  "fixture_v0": {
+    "case_id": "real-person-fullbody",
+    "url": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Man-standing.jpg",
+    "license": "Public domain (Wikimedia Commons source; verify provenance metadata when freezing the fixture)",
+    "purpose": "initial pipeline baseline only"
+  }
+}

--- a/scripts/character_blueprint_benchmark_capture.mjs
+++ b/scripts/character_blueprint_benchmark_capture.mjs
@@ -1,0 +1,144 @@
+import { chromium } from 'playwright';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const url = process.env.CHARACTER_BLUEPRINT_URL || 'https://studio.milkcat.org/poc/character-blueprint/';
+const fixture = process.env.CHARACTER_BLUEPRINT_FIXTURE;
+const caseId = process.env.CHARACTER_BLUEPRINT_CASE_ID || 'real-person-fullbody';
+const outDir = process.env.CHARACTER_BLUEPRINT_BENCHMARK_OUT || 'benchmark-artifacts/character-blueprint';
+
+assert(fixture, 'CHARACTER_BLUEPRINT_FIXTURE is required');
+assert(fs.existsSync(fixture), `fixture not found: ${fixture}`);
+fs.mkdirSync(outDir, { recursive: true });
+
+const sourceBytes = fs.readFileSync(fixture);
+const sourceSha256 = crypto.createHash('sha256').update(sourceBytes).digest('hex');
+const sourceExt = path.extname(fixture) || '.jpg';
+const sourceCopy = path.join(outDir, `source${sourceExt}`);
+fs.copyFileSync(fixture, sourceCopy);
+
+const startedAt = new Date().toISOString();
+const t0 = Date.now();
+const browser = await chromium.launch({
+  headless: true,
+  args: ['--use-angle=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+});
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
+const pageErrors = [];
+page.on('pageerror', e => pageErrors.push(String(e)));
+
+async function captureViewer(name) {
+  const viewer = page.locator('#viewer');
+  await viewer.screenshot({ path: path.join(outDir, `${name}.png`) });
+}
+
+async function dragYaw(deltaPixels) {
+  const box = await page.locator('#viewer').boundingBox();
+  assert(box, 'viewer bounding box missing');
+  const x = box.x + box.width * 0.5;
+  const y = box.y + box.height * 0.5;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x - deltaPixels, y, { steps: 14 });
+  await page.mouse.up();
+  await page.waitForTimeout(350);
+}
+
+try {
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  assert(response && response.ok(), `public page HTTP failed: ${response?.status()}`);
+  await page.waitForFunction(() => window.CharacterBlueprintPOC?.browserSelfTest === true, null, { timeout: 60_000 });
+  await page.locator('#file').setInputFiles(fixture);
+  await page.waitForFunction(() => {
+    const s = document.getElementById('status');
+    return s?.classList.contains('ok') || s?.classList.contains('err');
+  }, null, { timeout: 120_000 });
+
+  const state = await page.evaluate(() => {
+    const status = document.getElementById('status');
+    const irText = document.getElementById('json')?.textContent || '';
+    let ir = null;
+    try { ir = JSON.parse(irText); } catch {}
+    return {
+      statusClass: status?.className || '',
+      statusText: status?.textContent || '',
+      parts: [...document.querySelectorAll('#parts .part')].map(x => x.dataset.part),
+      canvasCount: document.querySelectorAll('#viewer canvas').length,
+      version: window.CharacterBlueprintPOC?.version || null,
+      silhouetteEnvelope: window.CharacterBlueprintPOC?.silhouetteEnvelope === true,
+      ir,
+    };
+  });
+
+  assert(state.statusClass.includes('ok'), `analysis failed: ${JSON.stringify(state)}`);
+  assert(state.ir, 'Character IR missing');
+  assert.equal(state.ir.schema, 'character-blueprint-ir/v0.5');
+  assert.equal(state.ir.proxy_3d?.renderer, 'threejs-silhouette-envelope/v0.5');
+  assert(state.canvasCount >= 1, 'Three.js canvas missing');
+  assert(pageErrors.length === 0, `page errors: ${pageErrors.join(' | ')}`);
+
+  fs.writeFileSync(path.join(outDir, 'character-ir.json'), JSON.stringify(state.ir, null, 2) + '\n');
+
+  // OrbitControls maps horizontal drag approximately to 2π * dx / element height.
+  // Use cumulative calibrated drags: 0° -> 45° -> 90° -> 180°.
+  const viewerBox = await page.locator('#viewer').boundingBox();
+  assert(viewerBox, 'viewer bounding box missing');
+  const h = viewerBox.height;
+  await captureViewer('front');
+  await dragYaw(h / 8);
+  await captureViewer('yaw45');
+  await dragYaw(h / 8);
+  await captureViewer('right');
+  await dragYaw(h / 4);
+  await captureViewer('back');
+
+  const result = {
+    schema: 'character-blueprint-benchmark-result/v0.1',
+    case_id: caseId,
+    system_id: 'character-blueprint',
+    model_version: state.version,
+    settings: {
+      public_url: url,
+      renderer: state.ir.proxy_3d?.renderer || null,
+      silhouette_engine: state.ir.observed?.silhouette?.engine || null,
+      view_capture: 'orbitcontrols-drag-calibration/v0.1',
+    },
+    source_sha256: sourceSha256,
+    started_at: startedAt,
+    duration_seconds: Number(((Date.now() - t0) / 1000).toFixed(3)),
+    credits: 0,
+    estimated_cost_usd: 0,
+    model_path: null,
+    renders: {
+      front: 'front.png',
+      yaw45: 'yaw45.png',
+      right: 'right.png',
+      back: 'back.png',
+    },
+    geometry: {
+      vertices: null,
+      faces: null,
+      components: state.parts.length,
+    },
+    scores: {},
+    evidence: {
+      character_ir: 'character-ir.json',
+      source: path.basename(sourceCopy),
+      coverage: state.ir.observed?.pose?.coverage || null,
+      parts: state.parts,
+      llm_tokens: state.ir.llm_tokens,
+      assumed: state.ir.assumed || {},
+    },
+    notes: [
+      'Character Blueprint v0.5 baseline capture.',
+      'View angles are produced by deterministic OrbitControls drag calibration and are approximate until an explicit benchmark camera API is exposed.',
+      'No external paid image-to-3D provider was invoked in this capture.',
+    ],
+  };
+  fs.writeFileSync(path.join(outDir, 'result.json'), JSON.stringify(result, null, 2) + '\n');
+  console.log(JSON.stringify({ ok: true, suite: 'character-blueprint-benchmark-capture/v0.1', outDir, result }, null, 2));
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
Adds an executable Character Blueprint benchmark baseline: a real-image browser capture that stores Character IR plus front/45/right/back viewer evidence, a provider contract for Meshy/Rodin/Tripo, and a CI workflow that uploads the evidence bundle. This does not invoke paid external providers yet; it establishes the same-input evidence package first.