### PR TITLE
Add Meshy benchmark adapter

### DIFF
--- a/.github/workflows/character-blueprint-meshy-benchmark.yml
+++ b/.github/workflows/character-blueprint-meshy-benchmark.yml
@@ -1,0 +1,118 @@
+name: Character Blueprint Meshy Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/character-blueprint-meshy-benchmark.yml'
+      - 'scripts/character_blueprint_meshy_benchmark.py'
+      - 'scripts/character_blueprint_glb_render.mjs'
+      - 'benchmarks/character-blueprint/providers-v0.1.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: character-blueprint-meshy-benchmark
+  cancel-in-progress: true
+
+jobs:
+  meshy-real-person-fullbody:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      MESHY_API_KEY: ${{ secrets.MESHY_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Meshy benchmark adapter
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m py_compile scripts/character_blueprint_meshy_benchmark.py
+          node --check scripts/character_blueprint_glb_render.mjs
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          p=json.loads(Path('benchmarks/character-blueprint/providers-v0.1.json').read_text())
+          m=p['providers']['meshy']
+          assert m['base_url']=='https://api.meshy.ai'
+          assert m['credential_env']=='MESHY_API_KEY'
+          print('meshy_benchmark_adapter_contract=PASS')
+          PY
+
+      - name: Detect Meshy credential
+        id: key
+        shell: bash
+        run: |
+          if [ -n "${MESHY_API_KEY:-}" ]; then
+            echo 'available=true' >> "$GITHUB_OUTPUT"
+            echo 'meshy_api_key=AVAILABLE'
+          else
+            echo 'available=false' >> "$GITHUB_OUTPUT"
+            echo 'meshy_api_key=MISSING; external benchmark not executed'
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.key.outputs.available == 'true'
+        with:
+          node-version: '22'
+
+      - name: Install Playwright Chromium
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Fetch frozen baseline fixture
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE=/tmp/character-blueprint-benchmark-person.jpg
+          curl -fL --retry 5 --retry-delay 2 \
+            'https://upload.wikimedia.org/wikipedia/commons/c/c3/Man-standing.jpg' \
+            -o "$FIXTURE"
+          test "$(wc -c < "$FIXTURE")" -gt 10000
+          file "$FIXTURE" | grep -qi 'JPEG image data'
+
+      - name: Run Meshy Image-to-3D benchmark
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=benchmark-artifacts/meshy/real-person-fullbody/meshy-7
+          python3 scripts/character_blueprint_meshy_benchmark.py \
+            --image /tmp/character-blueprint-benchmark-person.jpg \
+            --case-id real-person-fullbody \
+            --ai-model meshy-7 \
+            --out "$OUT"
+          test -s "$OUT/model.glb"
+          test -s "$OUT/result.json"
+
+      - name: Render canonical GLB benchmark views
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=benchmark-artifacts/meshy/real-person-fullbody/meshy-7
+          node scripts/character_blueprint_glb_render.mjs \
+            --glb "$OUT/model.glb" \
+            --out "$OUT" \
+            --result "$OUT/result.json"
+          for view in front yaw45 right back; do test -s "$OUT/canonical-$view.png"; done
+          test -s "$OUT/geometry.json"
+          grep -q 'threejs-glb-canonical/v0.1' "$OUT/result.json"
+          echo 'meshy_character_benchmark=PASS'
+
+      - name: Upload Meshy benchmark evidence
+        if: steps.key.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: character-blueprint-benchmark-meshy-real-person-fullbody
+          path: benchmark-artifacts/meshy/real-person-fullbody/meshy-7/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/character_blueprint_glb_render.mjs
+++ b/scripts/character_blueprint_glb_render.mjs
@@ -1,0 +1,78 @@
+import { chromium } from 'playwright';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+
+const args = Object.fromEntries(process.argv.slice(2).map((x, i, a) => x.startsWith('--') ? [x.slice(2), a[i + 1]] : null).filter(Boolean));
+const glbPath = path.resolve(args.glb || 'model.glb');
+const outDir = path.resolve(args.out || path.dirname(glbPath));
+const resultPath = path.resolve(args.result || path.join(outDir, 'result.json'));
+assert(fs.existsSync(glbPath), `GLB not found: ${glbPath}`);
+fs.mkdirSync(outDir, { recursive: true });
+
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#07131d}canvas{display:block;width:100%;height:100%}
+</style><script type="importmap">{"imports":{"three":"https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js","three/addons/":"https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/"}}</script></head><body><script type="module">
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+const scene=new THREE.Scene(); scene.background=new THREE.Color(0x07131d);
+const camera=new THREE.PerspectiveCamera(36,1,0.01,100); camera.position.set(0,0,4.2); camera.lookAt(0,0,0);
+const renderer=new THREE.WebGLRenderer({antialias:true,preserveDrawingBuffer:true}); renderer.setPixelRatio(1); renderer.setSize(768,768); renderer.outputColorSpace=THREE.SRGBColorSpace; document.body.appendChild(renderer.domElement);
+scene.add(new THREE.HemisphereLight(0xddeeff,0x223344,2.2));
+const key=new THREE.DirectionalLight(0xffffff,2.8); key.position.set(3,4,5); scene.add(key);
+const fill=new THREE.DirectionalLight(0x9dc7ff,1.2); fill.position.set(-4,2,2); scene.add(fill);
+const rim=new THREE.DirectionalLight(0xffffff,1.0); rim.position.set(0,3,-5); scene.add(rim);
+const root=new THREE.Group(); scene.add(root);
+let stats={vertices:0,faces:0,components:0};
+function render(){renderer.render(scene,camera)}
+window.setYaw=(deg)=>{root.rotation.y=-THREE.MathUtils.degToRad(deg);render();return deg};
+new GLTFLoader().load('/model.glb',g=>{
+ const model=g.scene; root.add(model);
+ let box=new THREE.Box3().setFromObject(model); const center=box.getCenter(new THREE.Vector3()); model.position.sub(center);
+ box=new THREE.Box3().setFromObject(model); const size=box.getSize(new THREE.Vector3()); const max=Math.max(size.x,size.y,size.z)||1; const scale=2.45/max; model.scale.setScalar(scale);
+ box=new THREE.Box3().setFromObject(model); const sphere=box.getBoundingSphere(new THREE.Sphere());
+ camera.position.set(0,0,Math.max(3.0,sphere.radius*3.15)); camera.lookAt(0,0,0);
+ model.traverse(o=>{if(o.isMesh&&o.geometry){stats.components++;const p=o.geometry.getAttribute('position');if(p)stats.vertices+=p.count;const idx=o.geometry.index;stats.faces+=idx?Math.floor(idx.count/3):p?Math.floor(p.count/3):0;}});
+ window.modelStats=stats; window.ready=true; render();
+},undefined,e=>{window.loadError=String(e);window.ready=false});
+</script></body></html>`;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/model.glb') {
+    res.writeHead(200, {'Content-Type':'model/gltf-binary','Access-Control-Allow-Origin':'*'});
+    fs.createReadStream(glbPath).pipe(res);
+    return;
+  }
+  res.writeHead(200, {'Content-Type':'text/html; charset=utf-8'}); res.end(html);
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const port = server.address().port;
+const browser = await chromium.launch({headless:true,args:['--use-angle=swiftshader','--enable-webgl','--ignore-gpu-blocklist']});
+try {
+  const page=await browser.newPage({viewport:{width:768,height:768}});
+  const errors=[]; page.on('pageerror', e=>errors.push(String(e)));
+  await page.goto(`http://127.0.0.1:${port}/`,{waitUntil:'domcontentloaded',timeout:60000});
+  await page.waitForFunction(()=>window.ready===true||window.loadError,{timeout:60000});
+  const loadError=await page.evaluate(()=>window.loadError||null); assert(!loadError,`GLB load error: ${loadError}`);
+  const views={front:0,yaw45:45,right:90,back:180};
+  const renders={};
+  for (const [name,yaw] of Object.entries(views)) {
+    await page.evaluate(y=>window.setYaw(y),yaw); await page.waitForTimeout(120);
+    const file=`canonical-${name}.png`; await page.locator('canvas').screenshot({path:path.join(outDir,file)}); renders[name]=file;
+  }
+  const stats=await page.evaluate(()=>window.modelStats);
+  fs.writeFileSync(path.join(outDir,'geometry.json'),JSON.stringify(stats,null,2)+'\n');
+  if (fs.existsSync(resultPath)) {
+    const result=JSON.parse(fs.readFileSync(resultPath,'utf8'));
+    result.renders=renders;
+    result.geometry=stats;
+    result.settings={...(result.settings||{}),canonical_render:'threejs-glb-canonical/v0.1'};
+    result.notes=[...(result.notes||[]),'Canonical benchmark renders generated from downloaded GLB at yaw 0°, 45°, 90°, and 180°.'];
+    fs.writeFileSync(resultPath,JSON.stringify(result,null,2)+'\n');
+  }
+  assert(errors.length===0,`browser errors: ${errors.join(' | ')}`);
+  console.log(JSON.stringify({ok:true,suite:'character-blueprint-glb-render/v0.1',renders,geometry:stats},null,2));
+} finally {
+  await browser.close(); await new Promise(resolve=>server.close(resolve));
+}

--- a/scripts/character_blueprint_meshy_benchmark.py
+++ b/scripts/character_blueprint_meshy_benchmark.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Run one fixed Character Blueprint benchmark case through Meshy Image-to-3D.
+
+The script deliberately stores raw provider evidence and emits the same result schema
+used by the local Character Blueprint baseline. It never prints the API key.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import mimetypes
+import os
+from pathlib import Path
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+BASE_URL = "https://api.meshy.ai"
+CREATE_PATH = "/openapi/v1/image-to-3d"
+TERMINAL = {"SUCCEEDED", "FAILED", "CANCELED"}
+
+
+def request_json(method: str, url: str, key: str, payload: dict | None = None, timeout: int = 90) -> dict:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/json"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = Request(url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Meshy HTTP {exc.code}: {body[:1200]}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Meshy network error: {exc}") from exc
+
+
+def download(url: str, path: Path, timeout: int = 180) -> None:
+    req = Request(url, headers={"User-Agent": "CharacterBlueprintBenchmark/0.1"})
+    with urlopen(req, timeout=timeout) as resp:
+        path.write_bytes(resp.read())
+    if path.stat().st_size <= 0:
+        raise RuntimeError(f"empty download: {path}")
+
+
+def image_data_uri(path: Path) -> str:
+    mime = mimetypes.guess_type(path.name)[0] or "image/jpeg"
+    if mime not in {"image/jpeg", "image/png"}:
+        raise SystemExit(f"Meshy fixture must be jpg/jpeg/png, got {mime}")
+    return f"data:{mime};base64," + base64.b64encode(path.read_bytes()).decode("ascii")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--image", required=True)
+    ap.add_argument("--case-id", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--ai-model", default="meshy-7")
+    ap.add_argument("--poll-seconds", type=float, default=5.0)
+    ap.add_argument("--timeout-seconds", type=int, default=1800)
+    args = ap.parse_args()
+
+    key = os.environ.get("MESHY_API_KEY", "").strip()
+    if not key:
+        raise SystemExit("MESHY_API_KEY is required")
+
+    image = Path(args.image)
+    if not image.is_file():
+        raise SystemExit(f"fixture not found: {image}")
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    source = image.read_bytes()
+    source_sha = hashlib.sha256(source).hexdigest()
+    (out / f"source{image.suffix.lower() or '.jpg'}").write_bytes(source)
+
+    settings = {
+        "model_type": "standard",
+        "ai_model": args.ai_model,
+        "image_enhancement": False,
+        "should_texture": False,
+        "enable_pbr": False,
+        "should_remesh": False,
+        "target_formats": ["glb"],
+        "auto_size": True,
+        "origin_at": "bottom",
+        "multi_view_thumbnails": True,
+        "pose_mode": "",
+    }
+    payload = {"image_url": image_data_uri(image), **settings}
+
+    started_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    t0 = time.monotonic()
+    created = request_json("POST", BASE_URL + CREATE_PATH, key, payload)
+    task_id = created.get("result")
+    if not task_id:
+        raise RuntimeError(f"Meshy create response missing task id: {created}")
+
+    deadline = time.monotonic() + args.timeout_seconds
+    task = None
+    while time.monotonic() < deadline:
+        task = request_json("GET", f"{BASE_URL}{CREATE_PATH}/{task_id}", key)
+        status = str(task.get("status") or "")
+        progress = task.get("progress")
+        print(f"meshy_task={task_id} status={status} progress={progress}", flush=True)
+        if status in TERMINAL:
+            break
+        time.sleep(args.poll_seconds)
+    else:
+        raise RuntimeError(f"Meshy task timed out after {args.timeout_seconds}s: {task_id}")
+
+    assert task is not None
+    (out / "provider-response.json").write_text(json.dumps(task, indent=2) + "\n", encoding="utf-8")
+    if task.get("status") != "SUCCEEDED":
+        raise RuntimeError(f"Meshy task {task.get('status')}: {(task.get('task_error') or {}).get('message', 'unknown error')}")
+
+    glb_url = (task.get("model_urls") or {}).get("glb")
+    if not glb_url:
+        raise RuntimeError("Meshy succeeded without model_urls.glb")
+    download(glb_url, out / "model.glb")
+
+    thumbnails = task.get("thumbnail_urls") or {}
+    saved_views: dict[str, str | None] = {"front": None, "yaw45": None, "right": None, "back": None}
+    for view in ("front", "right", "back", "left"):
+        url = thumbnails.get(view)
+        if url:
+            name = f"provider-{view}.png"
+            download(url, out / name)
+            if view in saved_views:
+                saved_views[view] = name
+
+    duration = time.monotonic() - t0
+    result = {
+        "schema": "character-blueprint-benchmark-result/v0.1",
+        "case_id": args.case_id,
+        "system_id": "meshy",
+        "model_version": args.ai_model,
+        "settings": settings,
+        "source_sha256": source_sha,
+        "started_at": started_iso,
+        "duration_seconds": round(duration, 3),
+        "credits": task.get("consumed_credits"),
+        "estimated_cost_usd": None,
+        "model_path": "model.glb",
+        "renders": saved_views,
+        "geometry": {"vertices": None, "faces": None, "components": None},
+        "scores": {},
+        "evidence": {
+            "provider_response": "provider-response.json",
+            "provider_task_id": task_id,
+            "provider_progress": task.get("progress"),
+            "provider_thumbnail_left": "provider-left.png" if (out / "provider-left.png").exists() else None,
+        },
+        "notes": [
+            "Meshy geometry baseline: texture disabled and image enhancement disabled.",
+            "Provider cardinal thumbnails are retained as evidence; yaw45 is filled by the canonical GLB renderer in a later step.",
+            "Signed provider URLs in provider-response.json may expire; downloaded evidence is authoritative.",
+        ],
+    }
+    (out / "result.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "provider": "meshy", "task_id": task_id, "out": str(out), "credits": task.get("consumed_credits")}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"character_blueprint_meshy_benchmark=FAIL {type(exc).__name__}: {exc}", file=sys.stderr)
+        raise


### PR DESCRIPTION
Adds a pinned Meshy 7 Image-to-3D benchmark adapter, a provider-neutral canonical GLB renderer (0/45/90/180 degree views plus geometry counts), and an optional GitHub Actions benchmark that executes only when MESHY_API_KEY is configured. The adapter preserves source fidelity settings (image enhancement off, texture off) and stores raw provider evidence, GLB, credits, duration, and canonical renders.