### PR TITLE
Character IR round-trip loop v0.1

### DIFF
--- a/.github/workflows/character-ir-roundtrip.yml
+++ b/.github/workflows/character-ir-roundtrip.yml
@@ -1,0 +1,84 @@
+name: Character IR Round-trip
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/character-ir-roundtrip.yml'
+      - 'scripts/character_ir_roundtrip.py'
+      - 'docs/CHARACTER_IR_ROUNDTRIP_V0.1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: character-ir-roundtrip
+  cancel-in-progress: true
+
+jobs:
+  roundtrip-real-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Playwright Chromium
+        run: |
+          set -euo pipefail
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Fetch frozen real-person fixture
+        run: |
+          set -euo pipefail
+          curl -fL --retry 5 --retry-delay 2 \
+            'https://upload.wikimedia.org/wikipedia/commons/c/c3/Man-standing.jpg' \
+            -o /tmp/character-roundtrip-person.jpg
+          test "$(wc -c < /tmp/character-roundtrip-person.jpg)" -gt 10000
+
+      - name: Image to Character IR through production
+        env:
+          CHARACTER_BLUEPRINT_URL: https://studio.milkcat.org/poc/character-blueprint/
+          CHARACTER_BLUEPRINT_FIXTURE: /tmp/character-roundtrip-person.jpg
+          CHARACTER_BLUEPRINT_CASE_ID: real-person-fullbody
+          CHARACTER_BLUEPRINT_BENCHMARK_OUT: benchmark-artifacts/character-roundtrip/source
+        run: |
+          set -euo pipefail
+          node scripts/character_blueprint_benchmark_capture.mjs
+          test -s benchmark-artifacts/character-roundtrip/source/character-ir.json
+
+      - name: Character IR to 3D representation to recovered IR
+        run: |
+          set -euo pipefail
+          python3 scripts/character_ir_roundtrip.py \
+            --input-ir benchmark-artifacts/character-roundtrip/source/character-ir.json \
+            --out-dir benchmark-artifacts/character-roundtrip/roundtrip \
+            | tee /tmp/roundtrip.json
+          grep -q '"ok": true' /tmp/roundtrip.json
+          test -s benchmark-artifacts/character-roundtrip/roundtrip/compiled-scene.json
+          test -s benchmark-artifacts/character-roundtrip/roundtrip/ir-from-3d.json
+          test -s benchmark-artifacts/character-roundtrip/roundtrip/roundtrip-report.json
+          python3 - <<'PY'
+          import json
+          p='benchmark-artifacts/character-roundtrip/roundtrip/roundtrip-report.json'
+          r=json.load(open(p))
+          s=r['diff']['summary']
+          assert r['schema']=='character-ir-roundtrip/v0.1'
+          assert s['changed_fields']==0
+          assert s['lost_fields']==0
+          assert s['preservation_ratio']==1.0
+          print('character_ir_roundtrip_v01=PASS', s)
+          PY
+
+      - name: Upload round-trip evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: character-ir-roundtrip-v01-real-person
+          path: benchmark-artifacts/character-roundtrip/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/CHARACTER_IR_ROUNDTRIP_V0.1.md
+++ b/docs/CHARACTER_IR_ROUNDTRIP_V0.1.md
@@ -1,0 +1,53 @@
+# Character IR Round-trip v0.1
+
+Goal: test whether Character IR can act as a generative intermediate representation rather than metadata only.
+
+## Loop
+
+`Image -> Character IR -> compiled 3D representation -> 3D-derived IR -> semantic diff -> IR refinement`
+
+v0.1 intentionally uses a **compiled scene manifest** for the 3D representation because Character Blueprint v0.5 does not yet export GLB. This is not called mesh decompilation. The contract is designed so a later GLB/mesh extractor can replace the manifest extractor without changing the loop.
+
+## Evidence classes
+
+Every recovered field must carry provenance:
+
+- `observed_2d`: directly visible in source image.
+- `inferred_2d`: inferred from image evidence.
+- `compiled_3d`: materialized by the IR->3D compiler.
+- `inferred_3d_candidate`: inferred from generated 3D and therefore not ground truth.
+- `confirmed_user`: explicit human confirmation.
+- `assumed_policy`: completion required by a reconstruction policy.
+
+A generated model must never promote unseen geometry to canonical truth merely because it looks plausible.
+
+## v0.1 checks
+
+The first round-trip checks whether the following survive compilation:
+
+- coverage
+- semantic part set
+- shoulder/hip proportions when available
+- backside uncertainty
+- body depth assumption
+- hair depth assumption
+- garment depth assumption
+
+The report separates:
+
+- `preserved`: value survived round-trip.
+- `changed`: value differs after round-trip.
+- `lost`: source IR contained information not represented in compiled 3D.
+- `invented`: 3D-derived IR contains information absent from source IR.
+
+## Success criteria
+
+v0.1 is successful when the loop produces reproducible artifacts and clearly identifies information loss. It is **not** a claim of high-fidelity mesh reconstruction.
+
+Next milestones:
+
+1. expose/export Character Blueprint GLB or a geometry scene snapshot;
+2. implement real `GLB -> 3D IR` extraction;
+3. run Meshy/Rodin/Tripo GLBs through the same extractor;
+4. use disagreements to evolve Character IR schema;
+5. close the loop with IR refinement and recompilation.

--- a/scripts/character_ir_roundtrip.py
+++ b/scripts/character_ir_roundtrip.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+import argparse, json, math, os
+from pathlib import Path
+
+SCHEMA = 'character-ir-roundtrip/v0.1'
+
+
+def load(path):
+    return json.loads(Path(path).read_text())
+
+
+def dump(path, obj):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps(obj, indent=2, ensure_ascii=False) + '\n')
+
+
+def part_set(ir):
+    parts = ir.get('inferred', {}).get('parts', []) or []
+    out = []
+    for p in parts:
+        if isinstance(p, str): out.append(p)
+        elif isinstance(p, dict): out.append(p.get('id') or p.get('part') or p.get('name'))
+    return sorted({x for x in out if x})
+
+
+def source_projection(ir):
+    observed = ir.get('observed', {})
+    inferred = ir.get('inferred', {})
+    assumed = ir.get('assumed', {})
+    props = inferred.get('proportions', {}) or {}
+    return {
+        'coverage': observed.get('pose', {}).get('coverage'),
+        'parts': part_set(ir),
+        'shoulder_width_norm': props.get('shoulder_width_norm'),
+        'hip_width_norm': props.get('hip_width_norm'),
+        'shoulder_hip_ratio': props.get('shoulder_hip_ratio'),
+        'backside': assumed.get('backside') or assumed.get('unseen_backside'),
+        'body_depth': assumed.get('body_depth'),
+        'hair_depth': assumed.get('hair_depth'),
+        'garment_depth': assumed.get('garment_depth'),
+    }
+
+
+def compile_scene(ir):
+    src = source_projection(ir)
+    parts = []
+    coverage = src['coverage'] or 'unknown'
+    for pid in src['parts']:
+        role = 'semantic-part'
+        if pid in ('hair', 'garment'): role = 'semantic-shell'
+        parts.append({
+            'id': pid,
+            'role': role,
+            'source': 'compiled_3d',
+            'confidence': 1.0,
+        })
+    scene = {
+        'schema': 'character-compiled-scene/v0.1',
+        'compiler': ir.get('proxy_3d', {}).get('renderer') or 'character-ir-manifest-compiler/v0.1',
+        'coverage': coverage,
+        'parts': parts,
+        'proportions': {
+            'shoulder_width_norm': src['shoulder_width_norm'],
+            'hip_width_norm': src['hip_width_norm'],
+            'shoulder_hip_ratio': src['shoulder_hip_ratio'],
+        },
+        'completion_policy': {
+            'backside': src['backside'],
+            'body_depth': src['body_depth'],
+            'hair_depth': src['hair_depth'],
+            'garment_depth': src['garment_depth'],
+        },
+        'provenance': {
+            'source_character_ir_schema': ir.get('schema'),
+            'note': 'v0.1 scene manifest; not a mesh decompiler input',
+        },
+    }
+    return scene
+
+
+def extract_3d_ir(scene):
+    props = scene.get('proportions', {})
+    policy = scene.get('completion_policy', {})
+    return {
+        'schema': 'character-3d-derived-ir/v0.1',
+        'source_kind': 'compiled-scene-manifest',
+        'evidence_class': 'compiled_3d',
+        'observed_3d': {
+            'coverage': scene.get('coverage'),
+            'parts': sorted(p.get('id') for p in scene.get('parts', []) if p.get('id')),
+            'proportions': props,
+        },
+        'hypothesis': {
+            'backside': {'value': policy.get('backside'), 'source': 'assumed_policy'},
+            'body_depth': {'value': policy.get('body_depth'), 'source': 'assumed_policy'},
+            'hair_depth': {'value': policy.get('hair_depth'), 'source': 'assumed_policy'},
+            'garment_depth': {'value': policy.get('garment_depth'), 'source': 'assumed_policy'},
+        },
+        'provenance': scene.get('provenance', {}),
+    }
+
+
+def recovered_projection(ir3d):
+    obs = ir3d.get('observed_3d', {})
+    props = obs.get('proportions', {})
+    hyp = ir3d.get('hypothesis', {})
+    def hv(k):
+        v = hyp.get(k)
+        return v.get('value') if isinstance(v, dict) else v
+    return {
+        'coverage': obs.get('coverage'),
+        'parts': sorted(obs.get('parts') or []),
+        'shoulder_width_norm': props.get('shoulder_width_norm'),
+        'hip_width_norm': props.get('hip_width_norm'),
+        'shoulder_hip_ratio': props.get('shoulder_hip_ratio'),
+        'backside': hv('backside'),
+        'body_depth': hv('body_depth'),
+        'hair_depth': hv('hair_depth'),
+        'garment_depth': hv('garment_depth'),
+    }
+
+
+def same(a, b):
+    if isinstance(a, float) or isinstance(b, float):
+        try: return math.isclose(float(a), float(b), rel_tol=1e-6, abs_tol=1e-6)
+        except Exception: pass
+    return a == b
+
+
+def diff(src, rec):
+    preserved, changed, lost, invented = {}, {}, {}, {}
+    for k in sorted(set(src) | set(rec)):
+        a, b = src.get(k), rec.get(k)
+        if a is None and b is not None: invented[k] = b
+        elif a is not None and b is None: lost[k] = a
+        elif same(a, b): preserved[k] = a
+        else: changed[k] = {'source': a, 'recovered': b}
+    total = len([k for k,v in src.items() if v is not None])
+    kept = len(preserved)
+    return {
+        'preserved': preserved,
+        'changed': changed,
+        'lost': lost,
+        'invented': invented,
+        'summary': {
+            'source_fields': total,
+            'preserved_fields': kept,
+            'preservation_ratio': round(kept / total, 4) if total else 1.0,
+            'changed_fields': len(changed),
+            'lost_fields': len(lost),
+            'invented_fields': len(invented),
+        },
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--input-ir', required=True)
+    ap.add_argument('--out-dir', required=True)
+    args = ap.parse_args()
+    ir = load(args.input_ir)
+    out = Path(args.out_dir); out.mkdir(parents=True, exist_ok=True)
+    src = source_projection(ir)
+    scene = compile_scene(ir)
+    ir3d = extract_3d_ir(scene)
+    rec = recovered_projection(ir3d)
+    report = {
+        'schema': SCHEMA,
+        'source_ir_schema': ir.get('schema'),
+        'compiled_scene_schema': scene['schema'],
+        'derived_ir_schema': ir3d['schema'],
+        'mode': 'manifest-roundtrip',
+        'limitations': ['v0.1 does not decompile triangle mesh; it validates the round-trip contract and information accounting'],
+        'diff': diff(src, rec),
+    }
+    dump(out/'source-projection.json', src)
+    dump(out/'compiled-scene.json', scene)
+    dump(out/'ir-from-3d.json', ir3d)
+    dump(out/'roundtrip-report.json', report)
+    s = report['diff']['summary']
+    print(json.dumps({'ok': True, 'schema': SCHEMA, **s}, ensure_ascii=False))
+    if s['changed_fields'] or s['lost_fields']:
+        raise SystemExit(2)
+
+if __name__ == '__main__': main()


### PR DESCRIPTION
Implements the first executable Character IR round-trip loop: production Image→Character IR capture, an explicit compiled-3D scene representation, 3D-derived IR extraction, semantic information-loss diffing, evidence/provenance rules, and a CI artifact. v0.1 deliberately does not claim triangle-mesh decompilation; it establishes the contract that later GLB/Meshy/Rodin extractors will plug into.