### PR TITLE
Reconcile Image IR with generated 3D IR

### DIFF
--- a/.github/workflows/character-blueprint-meshy-benchmark.yml
+++ b/.github/workflows/character-blueprint-meshy-benchmark.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/character-blueprint-meshy-benchmark.yml'
       - 'scripts/character_blueprint_meshy_benchmark.py'
       - 'scripts/character_blueprint_glb_render.mjs'
+      - 'scripts/character_blueprint_benchmark_capture.mjs'
+      - 'scripts/character_glb_to_ir.py'
+      - 'scripts/character_ir_reconcile.py'
       - 'benchmarks/character-blueprint/providers-v0.1.json'
 
 permissions:
@@ -26,12 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate Meshy benchmark adapter
+      - name: Validate Meshy benchmark adapter and round-trip tools
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m py_compile scripts/character_blueprint_meshy_benchmark.py
+          python3 -m py_compile \
+            scripts/character_blueprint_meshy_benchmark.py \
+            scripts/character_glb_to_ir.py \
+            scripts/character_ir_reconcile.py
           node --check scripts/character_blueprint_glb_render.mjs
+          node --check scripts/character_blueprint_benchmark_capture.mjs
           python3 - <<'PY'
           import json
           from pathlib import Path
@@ -79,6 +86,19 @@ jobs:
           test "$(wc -c < "$FIXTURE")" -gt 10000
           file "$FIXTURE" | grep -qi 'JPEG image data'
 
+      - name: Capture source Image to Character IR evidence
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        env:
+          CHARACTER_BLUEPRINT_URL: https://studio.milkcat.org/poc/character-blueprint/
+          CHARACTER_BLUEPRINT_FIXTURE: /tmp/character-blueprint-benchmark-person.jpg
+          CHARACTER_BLUEPRINT_CASE_ID: real-person-fullbody
+          CHARACTER_BLUEPRINT_BENCHMARK_OUT: benchmark-artifacts/meshy/real-person-fullbody/source-ir
+        run: |
+          set -euo pipefail
+          node scripts/character_blueprint_benchmark_capture.mjs
+          test -s benchmark-artifacts/meshy/real-person-fullbody/source-ir/character-ir.json
+
       - name: Run Meshy Image-to-3D benchmark
         if: steps.key.outputs.available == 'true'
         shell: bash
@@ -108,11 +128,29 @@ jobs:
           grep -q 'threejs-glb-canonical/v0.1' "$OUT/result.json"
           echo 'meshy_character_benchmark=PASS'
 
+      - name: Meshy GLB to 3D-derived IR and reconcile
+        if: steps.key.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=benchmark-artifacts/meshy/real-person-fullbody/meshy-7
+          python3 scripts/character_glb_to_ir.py \
+            --input-glb "$OUT/model.glb" \
+            --output "$OUT/ir-from-3d.json"
+          python3 scripts/character_ir_reconcile.py \
+            --image-ir benchmark-artifacts/meshy/real-person-fullbody/source-ir/character-ir.json \
+            --three-d-ir "$OUT/ir-from-3d.json" \
+            --output "$OUT/reconciliation.json"
+          test -s "$OUT/ir-from-3d.json"
+          test -s "$OUT/reconciliation.json"
+          grep -q 'character-ir-reconciliation/v0.1' "$OUT/reconciliation.json"
+          echo 'meshy_character_ir_roundtrip=PASS'
+
       - name: Upload Meshy benchmark evidence
         if: steps.key.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: character-blueprint-benchmark-meshy-real-person-fullbody
-          path: benchmark-artifacts/meshy/real-person-fullbody/meshy-7/
+          path: benchmark-artifacts/meshy/real-person-fullbody/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/character-ir-reconciliation.yml
+++ b/.github/workflows/character-ir-reconciliation.yml
@@ -1,0 +1,75 @@
+name: Character IR Reconciliation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/character-ir-reconciliation.yml'
+      - 'scripts/character_ir_reconcile.py'
+      - 'scripts/character_glb_to_ir.py'
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build minimal source Character IR fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/reconcile
+          cat > /tmp/reconcile/image-ir.json <<'JSON'
+          {
+            "schema":"character-blueprint-ir/v0.5",
+            "inferred":{"parts":["head","body","left_arm","right_arm","left_leg","right_leg"]},
+            "assumed":{"backside":"unobserved","body_depth":"unknown-from-single-view"}
+          }
+          JSON
+
+      - name: Fetch and extract real human-shaped GLB
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fL --retry 4 --retry-delay 2 \
+            'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb' \
+            -o /tmp/reconcile/CesiumMan.glb
+          python3 scripts/character_glb_to_ir.py \
+            --input-glb /tmp/reconcile/CesiumMan.glb \
+            --output /tmp/reconcile/ir-from-3d.json
+
+      - name: Reconcile evidence without hallucinating semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-artifacts/character-ir-reconciliation
+          python3 scripts/character_ir_reconcile.py \
+            --image-ir /tmp/reconcile/image-ir.json \
+            --three-d-ir /tmp/reconcile/ir-from-3d.json \
+            --output benchmark-artifacts/character-ir-reconciliation/report.json \
+            | tee /tmp/reconcile-output.json
+          grep -q '"ok": true' /tmp/reconcile-output.json
+          python3 - <<'PY'
+          import json
+          r=json.load(open('benchmark-artifacts/character-ir-reconciliation/report.json'))
+          assert r['schema']=='character-ir-reconciliation/v0.1'
+          assert r['canonical_update_policy']['automatic_promotions']==[]
+          assert r['summary']['image_part_count']==6
+          assert r['summary']['unresolved_3d_component_count']>=1
+          assert r['summary']['semantic_recovery_ratio']==0.0
+          assert r['semantic_comparison']['image_parts_not_recovered_from_3d']
+          print('character_ir_reconciliation_contract=PASS')
+          PY
+
+      - name: Upload reconciliation evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: character-ir-reconciliation-v01
+          path: benchmark-artifacts/character-ir-reconciliation/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/character_ir_reconcile.py
+++ b/scripts/character_ir_reconcile.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import argparse, json
+from pathlib import Path
+
+
+def load(p): return json.loads(Path(p).read_text())
+def dump(p, x):
+    Path(p).parent.mkdir(parents=True, exist_ok=True)
+    Path(p).write_text(json.dumps(x, ensure_ascii=False, indent=2) + '\n')
+
+
+def source_parts(ir):
+    out=[]
+    for p in ir.get('inferred',{}).get('parts',[]) or []:
+        if isinstance(p,str): out.append(p)
+        elif isinstance(p,dict): out.append(p.get('id') or p.get('part') or p.get('name'))
+    return sorted({x for x in out if x})
+
+
+def derived_candidates(ir3d):
+    comps=ir3d.get('observed_3d',{}).get('components',[]) or []
+    resolved=[]; unresolved=[]
+    for c in comps:
+        sem=c.get('semantic_candidate') or {}
+        rec={
+            'component': c.get('name'),
+            'label': sem.get('label','unknown'),
+            'confidence': sem.get('confidence',0),
+            'source': sem.get('source'),
+        }
+        (unresolved if rec['label']=='unknown' else resolved).append(rec)
+    return resolved, unresolved
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--image-ir',required=True)
+    ap.add_argument('--three-d-ir',required=True)
+    ap.add_argument('--output',required=True)
+    args=ap.parse_args()
+    image_ir=load(args.image_ir); ir3d=load(args.three_d_ir)
+    src=source_parts(image_ir)
+    resolved, unresolved=derived_candidates(ir3d)
+    labels=sorted({x['label'] for x in resolved})
+    srcset=set(src); labset=set(labels)
+    matched=sorted(srcset & labset)
+    source_not_recovered=sorted(srcset-labset)
+    candidate_only=sorted(labset-srcset)
+    geometry=ir3d.get('observed_3d',{}).get('geometry',{}) or {}
+    assumed=image_ir.get('assumed',{}) or {}
+
+    suggestions=[]
+    for x in source_not_recovered:
+        suggestions.append({
+            'kind':'missing-3d-semantic-evidence',
+            'field':f'part:{x}',
+            'action':'improve 3D semantic extraction or compiler traceability; do not assume the part is absent',
+        })
+    for x in candidate_only:
+        suggestions.append({
+            'kind':'candidate-new-3d-information',
+            'field':f'part:{x}',
+            'action':'keep as hypothesis until image evidence, another view, or user confirmation supports it',
+        })
+    if unresolved:
+        suggestions.append({
+            'kind':'unresolved-3d-components',
+            'count':len(unresolved),
+            'action':'segment/classify geometry before attempting canonical IR promotion',
+        })
+
+    report={
+        'schema':'character-ir-reconciliation/v0.1',
+        'inputs':{
+            'image_ir_schema':image_ir.get('schema'),
+            'three_d_ir_schema':ir3d.get('schema'),
+            'three_d_source_kind':ir3d.get('source_kind'),
+        },
+        'semantic_comparison':{
+            'image_ir_parts':src,
+            'resolved_3d_labels':labels,
+            'matched':matched,
+            'image_parts_not_recovered_from_3d':source_not_recovered,
+            '3d_candidates_not_in_image_ir':candidate_only,
+            'unresolved_3d_components':unresolved,
+        },
+        'geometry_evidence_from_3d':geometry,
+        'image_ir_completion_assumptions':assumed,
+        'canonical_update_policy':{
+            'automatic_promotions':[],
+            'rule':'3D generator output is candidate evidence, never canonical truth by itself',
+        },
+        'refinement_suggestions':suggestions,
+        'summary':{
+            'image_part_count':len(src),
+            'resolved_3d_label_count':len(labels),
+            'matched_part_count':len(matched),
+            'unresolved_3d_component_count':len(unresolved),
+            'semantic_recovery_ratio':round(len(matched)/len(src),4) if src else 1.0,
+        },
+    }
+    dump(args.output,report)
+    print(json.dumps({'ok':True, **report['summary']},ensure_ascii=False))
+
+if __name__=='__main__': main()


### PR DESCRIPTION
Adds the 2D/3D Character IR reconciliation layer. It compares semantic parts from image-derived IR against semantic hypotheses recovered from GLB, surfaces unrecovered source parts, candidate-only 3D information and unresolved components, and forbids automatic promotion of generator output into canonical truth. Also wires the Meshy benchmark so a future real Meshy GLB automatically runs GLB→IR→reconciliation when MESHY_API_KEY is available.