### PR TITLE
Build model2ir library v0.1

### DIFF
--- a/.github/workflows/model2ir-v01.yml
+++ b/.github/workflows/model2ir-v01.yml
@@ -1,0 +1,73 @@
+name: model2ir v0.1
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_family_regression.py'
+      - 'benchmarks/model2ir/**'
+      - '.github/workflows/model2ir-v01.yml'
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_family_regression.py'
+      - 'benchmarks/model2ir/**'
+      - '.github/workflows/model2ir-v01.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  library-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install model2ir
+        run: python -m pip install -e libs/model2ir
+      - name: Validate public API
+        run: |
+          python - <<'PY'
+          import model2ir
+          assert model2ir.__version__ == '0.1.0'
+          for name in ['load_asset','extract_ir','diff_ir','reconcile_ir','score_roundtrip']:
+              assert callable(getattr(model2ir,name))
+          print('model2ir_public_api=PASS')
+          PY
+      - name: Run controlled family regression
+        run: |
+          python scripts/model2ir_family_regression.py --out benchmark-artifacts/model2ir-family-v01
+          test -s benchmark-artifacts/model2ir-family-v01/schema-gap-report.json
+          grep -q 'hair.style_or_length' benchmark-artifacts/model2ir-family-v01/schema-gap-report.json
+          grep -q 'bodyplan.extra_appendages' benchmark-artifacts/model2ir-family-v01/schema-gap-report.json
+      - name: Fetch real human GLB fixture
+        run: |
+          curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb -o /tmp/CesiumMan.glb
+          cp /tmp/CesiumMan.glb /tmp/CesiumMan.vrm
+      - name: Extract GLB and VRM-container IR
+        run: |
+          python -m model2ir extract /tmp/CesiumMan.glb -o benchmark-artifacts/real/cesium-man-glb.json
+          python -m model2ir extract /tmp/CesiumMan.vrm -o benchmark-artifacts/real/cesium-man-vrm-container.json
+          python - <<'PY'
+          import json
+          a=json.load(open('benchmark-artifacts/real/cesium-man-glb.json'))
+          b=json.load(open('benchmark-artifacts/real/cesium-man-vrm-container.json'))
+          assert a['schema']=='model2ir-character-ir/v0.1'
+          assert a['source_kind']=='glb'
+          assert b['source_kind']=='vrm'
+          assert a['structural_ir']['geometry']['vertices_sum'] > 3000
+          assert a['provenance']['truth_policy']
+          print('model2ir_real_asset=PASS')
+          PY
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-v01-evidence
+          path: benchmark-artifacts/
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/model2ir/family-v0.1.json
+++ b/benchmarks/model2ir/family-v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema": "model2ir-family-benchmark/v0.1",
+  "goal": "Measure whether structurally similar character assets produce stable IR with localized semantic diffs.",
+  "families": [
+    {
+      "id": "hair-garment-controlled",
+      "intent": "same humanoid core, vary hair and garment labels",
+      "cases": ["long_hair_dress", "short_hair_dress", "long_hair_coat"]
+    },
+    {
+      "id": "accessory-effect-controlled",
+      "intent": "same humanoid core, vary prop/effect labels",
+      "cases": ["body_book", "body_crown", "body_magic_ring"]
+    },
+    {
+      "id": "bodyplan-extension-controlled",
+      "intent": "same humanoid core, add body-plan extensions without relabeling the core",
+      "cases": ["body_only", "body_tail", "body_wing"]
+    }
+  ],
+  "note": "v0.1 uses deterministic synthetic glTF manifests to isolate extractor/schema behavior. Real licensed model families are the next evidence layer, not replaced by these fixtures."
+}

--- a/docs/MODEL2IR_V0.1.md
+++ b/docs/MODEL2IR_V0.1.md
@@ -1,0 +1,54 @@
+# model2ir v0.1
+
+`model2ir` is the reusable 3D asset → Character IR decompiler and regression layer for Character Blueprint research.
+
+## Public API
+
+```python
+from model2ir import load_asset, extract_ir, diff_ir, reconcile_ir, score_roundtrip
+
+ir = extract_ir('character.glb')
+diff = diff_ir(ir_a, ir_b)
+report = reconcile_ir(image_ir, ir)
+score = score_roundtrip(source_ir, recovered_ir)
+```
+
+Supported containers in v0.1:
+
+- `.glb`
+- `.gltf`
+- `.vrm` as a GLB-compatible container; VRM extension semantics are preserved as structural evidence but are not yet fully interpreted.
+
+## Truth policy
+
+The library separates factual asset observations from semantic hypotheses:
+
+- geometry counts, scene graph, node hierarchy, materials, skins and accessor bounds are structural evidence;
+- semantic labels inferred from names are candidates only;
+- unresolved components remain unresolved;
+- no 3D generator result is automatically promoted into canonical Character IR.
+
+## v0.1 IR layers
+
+- `structural_ir`: meshes, primitives, nodes/components, scene edges, skins, transforms, bounds, extensions.
+- `semantic_ir`: conservative name-derived candidates plus unresolved components.
+- `relations`: node-child and skin-binding relations.
+- `provenance`: extractor version and truth policy.
+
+## Family regression
+
+`benchmarks/model2ir/family-v0.1.json` defines three controlled families. v0.1 intentionally uses synthetic glTF manifests for regression isolation, while CI also runs against the real Khronos CesiumMan GLB. The synthetic families do not replace future licensed real-model families.
+
+The first schema-gap report deliberately exposes missing representation/extraction capacity:
+
+- hair style/length detail;
+- garment subtype/layer detail;
+- extra appendages such as tail/wing;
+- semantic attachment relations;
+- material-driven semantic evidence.
+
+Those gaps are expected research output, not hidden failures.
+
+## Next evidence layer
+
+The next step is to collect licensed, structurally similar real character model families and run the same `extract_ir → pairwise diff → gap report` protocol. Learned semantic extraction should be trained only after corrected/gold IR pairs exist; v0.1 is deterministic by design.

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "model2ir"
+version = "0.1.0"
+description = "Deterministic 3D asset to Character IR decompiler and regression toolkit"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -1,0 +1,11 @@
+from .core import extract_ir, diff_ir, reconcile_ir, score_roundtrip, load_asset
+
+__all__ = [
+    "load_asset",
+    "extract_ir",
+    "diff_ir",
+    "reconcile_ir",
+    "score_roundtrip",
+]
+
+__version__ = "0.1.0"

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from .core import extract_ir, diff_ir, reconcile_ir
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def write_json(path, data):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps(data, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+
+
+def main():
+    ap = argparse.ArgumentParser(prog='model2ir')
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    p = sub.add_parser('extract')
+    p.add_argument('asset')
+    p.add_argument('-o', '--output', required=True)
+    p = sub.add_parser('diff')
+    p.add_argument('a'); p.add_argument('b'); p.add_argument('-o','--output', required=True)
+    p = sub.add_parser('reconcile')
+    p.add_argument('image_ir'); p.add_argument('model_ir'); p.add_argument('-o','--output', required=True)
+    args = ap.parse_args()
+    if args.cmd == 'extract': out = extract_ir(args.asset)
+    elif args.cmd == 'diff': out = diff_ir(load_json(args.a), load_json(args.b))
+    else: out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
+    write_json(args.output, out)
+    print(json.dumps({'ok': True, 'schema': out.get('schema'), 'output': args.output}))
+
+if __name__ == '__main__':
+    main()

--- a/libs/model2ir/src/model2ir/core.py
+++ b/libs/model2ir/src/model2ir/core.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import math
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+JSON_CHUNK = 0x4E4F534A
+SUPPORTED = {".glb", ".gltf", ".vrm"}
+
+
+@dataclass(frozen=True)
+class Asset:
+    path: Path
+    kind: str
+    gltf: dict[str, Any]
+    bytes_size: int
+    chunks: list[dict[str, int]]
+
+
+def _read_glb(path: Path) -> tuple[dict[str, Any], list[dict[str, int]]]:
+    data = path.read_bytes()
+    if len(data) < 20:
+        raise ValueError("GLB too small")
+    magic, version, total = struct.unpack_from("<4sII", data, 0)
+    if magic != b"glTF":
+        raise ValueError("not a GLB/VRM container")
+    if version != 2:
+        raise ValueError(f"unsupported GLB version {version}")
+    if total > len(data):
+        raise ValueError("declared GLB length exceeds file size")
+    off = 12
+    gltf = None
+    chunks: list[dict[str, int]] = []
+    while off + 8 <= total:
+        length, ctype = struct.unpack_from("<II", data, off)
+        off += 8
+        payload = data[off:off + length]
+        off += length
+        chunks.append({"type": ctype, "length": length})
+        if ctype == JSON_CHUNK:
+            gltf = json.loads(payload.rstrip(b"\x00 \t\r\n").decode("utf-8"))
+    if gltf is None:
+        raise ValueError("GLB missing JSON chunk")
+    return gltf, chunks
+
+
+def load_asset(path: str | Path) -> Asset:
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix not in SUPPORTED:
+        raise ValueError(f"unsupported asset type {suffix}; supported: {sorted(SUPPORTED)}")
+    if suffix == ".gltf":
+        gltf = json.loads(p.read_text(encoding="utf-8"))
+        return Asset(p, "gltf", gltf, p.stat().st_size, [])
+    gltf, chunks = _read_glb(p)
+    kind = "vrm" if suffix == ".vrm" else "glb"
+    return Asset(p, kind, gltf, p.stat().st_size, chunks)
+
+
+def _accessor(gltf: dict[str, Any], idx: int | None) -> dict[str, Any] | None:
+    if idx is None:
+        return None
+    arr = gltf.get("accessors", [])
+    return arr[idx] if 0 <= idx < len(arr) else None
+
+
+def _semantic_hint(name: str | None) -> dict[str, Any]:
+    s = (name or "").lower().replace("-", "_").replace(" ", "_")
+    rules = [
+        ("hair", ["hair", "bang", "pony", "braid"]),
+        ("head", ["head", "face", "skull"]),
+        ("garment", ["cloth", "shirt", "dress", "coat", "robe", "jacket", "skirt", "garment"]),
+        ("left_arm", ["left_arm", "l_arm", "arm_l"]),
+        ("right_arm", ["right_arm", "r_arm", "arm_r"]),
+        ("left_leg", ["left_leg", "l_leg", "leg_l"]),
+        ("right_leg", ["right_leg", "r_leg", "leg_r"]),
+        ("body", ["body", "torso", "chest", "hips", "pelvis"]),
+        ("accessory", ["crown", "book", "weapon", "accessory", "prop", "hat", "bag"]),
+        ("effect", ["effect", "magic", "aura", "ring", "spell"]),
+    ]
+    for label, keys in rules:
+        if any(k in s for k in keys):
+            return {"label": label, "confidence": 0.72, "source": "node-name-heuristic"}
+    return {"label": "unknown", "confidence": 0.0, "source": "unresolved"}
+
+
+def extract_ir(asset_or_path: Asset | str | Path) -> dict[str, Any]:
+    asset = asset_or_path if isinstance(asset_or_path, Asset) else load_asset(asset_or_path)
+    gltf = asset.gltf
+    meshes = gltf.get("meshes", [])
+    nodes = gltf.get("nodes", [])
+    materials = gltf.get("materials", [])
+    skins = gltf.get("skins", [])
+    animations = gltf.get("animations", [])
+    extensions_used = gltf.get("extensionsUsed", []) or []
+    primitives: list[dict[str, Any]] = []
+    components: list[dict[str, Any]] = []
+    total_vertices = total_indices = total_faces = 0
+    gmin = [math.inf, math.inf, math.inf]
+    gmax = [-math.inf, -math.inf, -math.inf]
+    bbox_samples = 0
+
+    for mi, mesh in enumerate(meshes):
+        mname = mesh.get("name") or f"mesh-{mi}"
+        for pi, prim in enumerate(mesh.get("primitives", [])):
+            pos = _accessor(gltf, (prim.get("attributes") or {}).get("POSITION"))
+            ind = _accessor(gltf, prim.get("indices"))
+            vc = int((pos or {}).get("count", 0))
+            ic = int((ind or {}).get("count", 0))
+            mode = prim.get("mode", 4)
+            faces = ic // 3 if mode == 4 and ic else (vc // 3 if mode == 4 else None)
+            total_vertices += vc
+            total_indices += ic
+            if faces is not None:
+                total_faces += faces
+            pmin, pmax = (pos or {}).get("min"), (pos or {}).get("max")
+            if pmin and pmax and len(pmin) >= 3 and len(pmax) >= 3:
+                for k in range(3):
+                    gmin[k] = min(gmin[k], float(pmin[k]))
+                    gmax[k] = max(gmax[k], float(pmax[k]))
+                bbox_samples += 1
+            primitives.append({
+                "mesh_index": mi,
+                "primitive_index": pi,
+                "name": mname,
+                "vertices": vc,
+                "indices": ic,
+                "faces": faces,
+                "material_index": prim.get("material"),
+                "morph_target_count": len(prim.get("targets", []) or []),
+                "semantic_candidate": _semantic_hint(mname),
+            })
+
+    for ni, node in enumerate(nodes):
+        if "mesh" not in node:
+            continue
+        mi = node["mesh"]
+        name = node.get("name") or (meshes[mi].get("name") if 0 <= mi < len(meshes) else None) or f"node-{ni}"
+        components.append({
+            "node_index": ni,
+            "mesh_index": mi,
+            "name": name,
+            "children": node.get("children", []),
+            "skin": node.get("skin"),
+            "translation": node.get("translation"),
+            "rotation": node.get("rotation"),
+            "scale": node.get("scale"),
+            "semantic_candidate": _semantic_hint(name),
+        })
+
+    bbox = None
+    if bbox_samples:
+        bbox = {
+            "min_local_untransformed": gmin,
+            "max_local_untransformed": gmax,
+            "extent_local_untransformed": [gmax[i] - gmin[i] for i in range(3)],
+            "warning": "accessor min/max aggregated without node transforms in model2ir v0.1",
+        }
+
+    resolved = [c for c in components if c["semantic_candidate"]["label"] != "unknown"]
+    unresolved = [c for c in components if c["semantic_candidate"]["label"] == "unknown"]
+    return {
+        "schema": "model2ir-character-ir/v0.1",
+        "source_kind": asset.kind,
+        "evidence_class": "observed_3d_asset",
+        "source": {"name": asset.path.name, "bytes": asset.bytes_size},
+        "structural_ir": {
+            "geometry": {
+                "mesh_count": len(meshes),
+                "primitive_count": len(primitives),
+                "component_count": len(components),
+                "vertices_sum": total_vertices,
+                "indices_sum": total_indices,
+                "triangle_faces_sum": total_faces,
+                "material_count": len(materials),
+                "skin_count": len(skins),
+                "animation_count": len(animations),
+                "bbox": bbox,
+            },
+            "scene_count": len(gltf.get("scenes", []) or []),
+            "node_count": len(nodes),
+            "extensions_used": extensions_used,
+            "components": components,
+            "primitives": primitives,
+            "skins": skins,
+        },
+        "semantic_ir": {
+            "candidates": [c for c in components if c["semantic_candidate"]["label"] != "unknown"],
+            "unresolved": unresolved,
+            "resolved_component_count": len(resolved),
+            "unresolved_component_count": len(unresolved),
+        },
+        "relations": {
+            "node_child_edges": [
+                {"parent": i, "child": child}
+                for i, node in enumerate(nodes)
+                for child in (node.get("children", []) or [])
+            ],
+            "skin_bindings": [
+                {"node_index": c["node_index"], "skin_index": c["skin"]}
+                for c in components if c.get("skin") is not None
+            ],
+        },
+        "provenance": {
+            "extractor": "model2ir/v0.1",
+            "chunks": asset.chunks,
+            "truth_policy": "geometry/scene structure may be factual; semantic labels are hypotheses until corroborated or confirmed",
+        },
+    }
+
+
+def _semantic_labels(ir: dict[str, Any]) -> set[str]:
+    if ir.get("schema") == "model2ir-character-ir/v0.1":
+        comps = ir.get("semantic_ir", {}).get("candidates", []) or []
+        return {c.get("semantic_candidate", {}).get("label") for c in comps if c.get("semantic_candidate", {}).get("label") not in (None, "unknown")}
+    parts = ir.get("inferred", {}).get("parts", []) or []
+    out: set[str] = set()
+    for p in parts:
+        if isinstance(p, str):
+            out.add(p)
+        elif isinstance(p, dict):
+            x = p.get("id") or p.get("part") or p.get("name")
+            if x:
+                out.add(x)
+    return out
+
+
+def diff_ir(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    la, lb = _semantic_labels(a), _semantic_labels(b)
+    ga = a.get("structural_ir", {}).get("geometry", {})
+    gb = b.get("structural_ir", {}).get("geometry", {})
+    numeric = {}
+    for k in sorted(set(ga) & set(gb)):
+        if isinstance(ga[k], (int, float)) and isinstance(gb[k], (int, float)):
+            numeric[k] = {"a": ga[k], "b": gb[k], "delta": gb[k] - ga[k]}
+    return {
+        "schema": "model2ir-diff/v0.1",
+        "semantic": {
+            "shared": sorted(la & lb),
+            "only_a": sorted(la - lb),
+            "only_b": sorted(lb - la),
+            "jaccard": round(len(la & lb) / len(la | lb), 4) if la | lb else 1.0,
+        },
+        "geometry_numeric": numeric,
+    }
+
+
+def reconcile_ir(image_ir: dict[str, Any], model_ir: dict[str, Any]) -> dict[str, Any]:
+    img = _semantic_labels(image_ir)
+    mdl = _semantic_labels(model_ir)
+    unresolved = model_ir.get("semantic_ir", {}).get("unresolved", []) or []
+    return {
+        "schema": "model2ir-reconciliation/v0.1",
+        "matched": sorted(img & mdl),
+        "image_only": sorted(img - mdl),
+        "model_candidates_only": sorted(mdl - img),
+        "unresolved_model_components": unresolved,
+        "automatic_canonical_promotions": [],
+        "policy": "3D-derived semantics remain candidate evidence until corroborated or user-confirmed",
+        "semantic_recovery_ratio": round(len(img & mdl) / len(img), 4) if img else 1.0,
+    }
+
+
+def score_roundtrip(source_ir: dict[str, Any], recovered_ir: dict[str, Any]) -> dict[str, Any]:
+    d = diff_ir(source_ir, recovered_ir)
+    return {
+        "schema": "model2ir-roundtrip-score/v0.1",
+        "semantic_preservation": d["semantic"]["jaccard"],
+        "diff": d,
+    }

--- a/scripts/model2ir_family_regression.py
+++ b/scripts/model2ir_family_regression.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, tempfile
+from pathlib import Path
+from model2ir import extract_ir, diff_ir
+
+
+def make_gltf(path: Path, names: list[str]):
+    accessors=[]; meshes=[]; nodes=[]
+    for i,name in enumerate(names):
+        pos=len(accessors); idx=pos+1
+        accessors.extend([
+            {"count": 3, "type":"VEC3", "componentType":5126, "min":[0,0,0], "max":[1,1,1]},
+            {"count": 3, "type":"SCALAR", "componentType":5123},
+        ])
+        meshes.append({"name":name,"primitives":[{"attributes":{"POSITION":pos},"indices":idx,"mode":4}]})
+        nodes.append({"name":name,"mesh":i})
+    gltf={"asset":{"version":"2.0"},"scene":0,"scenes":[{"nodes":list(range(len(nodes)))}],"nodes":nodes,"meshes":meshes,"accessors":accessors}
+    path.write_text(json.dumps(gltf),encoding='utf-8')
+
+
+def labels(ir):
+    return sorted({x['semantic_candidate']['label'] for x in ir['semantic_ir']['candidates']})
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--manifest',default='benchmarks/model2ir/family-v0.1.json')
+    ap.add_argument('--out',default='benchmark-artifacts/model2ir-family-v01')
+    args=ap.parse_args()
+    manifest=json.loads(Path(args.manifest).read_text())
+    out=Path(args.out); out.mkdir(parents=True,exist_ok=True)
+    cases={
+        'long_hair_dress':['Body','Head','Long_Hair','Dress'],
+        'short_hair_dress':['Body','Head','Short_Hair','Dress'],
+        'long_hair_coat':['Body','Head','Long_Hair','Coat'],
+        'body_book':['Body','Head','Book'],
+        'body_crown':['Body','Head','Crown'],
+        'body_magic_ring':['Body','Head','Magic_Ring'],
+        'body_only':['Body','Head'],
+        'body_tail':['Body','Head','Tail'],
+        'body_wing':['Body','Head','Wing'],
+    }
+    results={}
+    with tempfile.TemporaryDirectory() as td:
+        td=Path(td)
+        for case,names in cases.items():
+            p=td/f'{case}.gltf'; make_gltf(p,names)
+            ir=extract_ir(p); results[case]=ir
+            (out/f'{case}.json').write_text(json.dumps(ir,indent=2)+'\n')
+
+    pairs=[]
+    for fam in manifest['families']:
+        c=fam['cases']
+        base=c[0]
+        for other in c[1:]:
+            d=diff_ir(results[base],results[other])
+            pairs.append({'family':fam['id'],'a':base,'b':other,'diff':d})
+
+    unresolved={case:[c['name'] for c in ir['semantic_ir']['unresolved']] for case,ir in results.items() if ir['semantic_ir']['unresolved']}
+    gap_report={
+        'schema':'model2ir-schema-gap-report/v0.1',
+        'family_count':len(manifest['families']),
+        'case_count':len(results),
+        'pairwise_diff_count':len(pairs),
+        'semantic_labels_by_case':{k:labels(v) for k,v in results.items()},
+        'unresolved_by_case':unresolved,
+        'observed_gaps':[
+            {'field':'hair.style_or_length','status':'missing','evidence':'long_hair vs short_hair collapse to label hair'},
+            {'field':'garment.subtype','status':'missing','evidence':'dress vs coat collapse to label garment'},
+            {'field':'bodyplan.extra_appendages','status':'missing','evidence':'tail and wing remain unresolved in v0.1'},
+            {'field':'semantic_relations','status':'partial','evidence':'name-only extraction cannot infer held_by/attached_to/surrounds'},
+        ],
+        'next_schema_targets':['hair subtype/shape','garment subtype/layer','extra appendages','attachment relations','material semantic evidence'],
+        'policy':'gaps are evidence for schema/extractor evolution; unresolved is preferred over hallucinated labels',
+    }
+    (out/'pairwise-diffs.json').write_text(json.dumps(pairs,indent=2)+'\n')
+    (out/'schema-gap-report.json').write_text(json.dumps(gap_report,indent=2)+'\n')
+    assert any('Tail' in xs for xs in unresolved.values())
+    assert any('Wing' in xs for xs in unresolved.values())
+    print(json.dumps({'ok':True,'cases':len(results),'pairs':len(pairs),'gaps':len(gap_report['observed_gaps'])}))
+
+if __name__=='__main__': main()


### PR DESCRIPTION
Creates model2ir as a reusable 3D asset→Character IR library instead of project-local scripts. v0.1 supports GLB, glTF, and VRM-as-GLB containers; exposes load_asset/extract_ir/diff_ir/reconcile_ir/score_roundtrip; separates structural facts from semantic hypotheses; adds CLI, controlled family regression, first schema-gap report, and CI against Khronos CesiumMan. Synthetic family fixtures isolate regression behavior; real licensed model families remain the next evidence layer.