### PR TITLE
Make model2ir losslessly reversible for compiled assets

### DIFF
--- a/.github/workflows/model2ir-reversible-v02.yml
+++ b/.github/workflows/model2ir-reversible-v02.yml
@@ -1,0 +1,60 @@
+name: model2ir reversible v0.2
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_reversible_regression.py'
+      - '.github/workflows/model2ir-reversible-v02.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_reversible_regression.py'
+      - '.github/workflows/model2ir-reversible-v02.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reversible-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install model2ir
+        run: python -m pip install -e libs/model2ir
+      - name: Validate package version and API
+        run: |
+          python - <<'PY'
+          import model2ir
+          assert model2ir.__version__ == '0.2.0'
+          for name in ['extract_ir','diff_ir','reconcile_ir','score_roundtrip','compile_reversible_gltf','save_reversible_gltf','ir_digest']:
+              assert hasattr(model2ir, name), name
+          print('model2ir_v02_api=PASS')
+          PY
+      - name: Run reversible family regression
+        run: |
+          rm -rf /tmp/model2ir-v02
+          python scripts/model2ir_reversible_regression.py --out /tmp/model2ir-v02
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v02/report.json'))
+          assert p['case_count'] >= 5
+          assert p['all_lossless'] is True
+          assert p['external_asset_correctly_nonlossless'] is True
+          assert p['tamper_detection'] is True
+          assert p['gate']['observed'] == 1.0
+          print('model2ir_lossless_gate=PASS')
+          PY
+      - name: Upload reversible evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-reversible-v02
+          path: /tmp/model2ir-v02/
+          if-no-files-found: error
+          retention-days: 30

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.1.0"
-description = "Deterministic 3D asset to Character IR decompiler and regression toolkit"
+version = "0.2.0"
+description = "Reversible 3D asset to Character IR decompiler and regression toolkit"
 requires-python = ">=3.10"
 dependencies = []
 

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -1,4 +1,13 @@
-from .core import extract_ir, diff_ir, reconcile_ir, score_roundtrip, load_asset
+from .v02 import (
+    load_asset,
+    extract_ir,
+    diff_ir,
+    reconcile_ir,
+    score_roundtrip,
+    compile_reversible_gltf,
+    save_reversible_gltf,
+)
+from .reversible import ir_digest
 
 __all__ = [
     "load_asset",
@@ -6,6 +15,9 @@ __all__ = [
     "diff_ir",
     "reconcile_ir",
     "score_roundtrip",
+    "compile_reversible_gltf",
+    "save_reversible_gltf",
+    "ir_digest",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/libs/model2ir/src/model2ir/reversible.py
+++ b/libs/model2ir/src/model2ir/reversible.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+EXTENSION_KEY = "OPENAI_model2ir_character_ir"
+EXTENSION_VERSION = "0.2.0"
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def ir_digest(ir: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(ir).encode("utf-8")).hexdigest()
+
+
+def embed_ir_in_gltf(gltf: dict[str, Any], ir: dict[str, Any]) -> dict[str, Any]:
+    """Return a glTF document carrying a lossless Character IR sidecar.
+
+    The carrier lives in root extras rather than a registered glTF extension so the
+    resulting asset remains standards-compatible without claiming Khronos registry
+    status. Geometry is untouched.
+    """
+    out = copy.deepcopy(gltf)
+    extras = out.setdefault("extras", {})
+    extras[EXTENSION_KEY] = {
+        "version": EXTENSION_VERSION,
+        "encoding": "json",
+        "digest": ir_digest(ir),
+        "character_ir": copy.deepcopy(ir),
+        "truth_class": "embedded_canonical_ir",
+    }
+    return out
+
+
+def recover_embedded_ir(gltf: dict[str, Any]) -> dict[str, Any] | None:
+    payload = (gltf.get("extras") or {}).get(EXTENSION_KEY)
+    if not isinstance(payload, dict):
+        return None
+    ir = payload.get("character_ir")
+    if not isinstance(ir, dict):
+        return None
+    expected = payload.get("digest")
+    actual = ir_digest(ir)
+    if expected and expected != actual:
+        raise ValueError("embedded Character IR digest mismatch")
+    return copy.deepcopy(ir)
+
+
+def reversible_status(gltf: dict[str, Any]) -> dict[str, Any]:
+    payload = (gltf.get("extras") or {}).get(EXTENSION_KEY)
+    if not isinstance(payload, dict):
+        return {
+            "mode": "inferred",
+            "lossless": False,
+            "reason": "asset has no model2ir embedded canonical IR",
+        }
+    ir = recover_embedded_ir(gltf)
+    return {
+        "mode": "embedded-canonical",
+        "lossless": True,
+        "digest": payload.get("digest") or ir_digest(ir or {}),
+        "version": payload.get("version"),
+    }

--- a/libs/model2ir/src/model2ir/v02.py
+++ b/libs/model2ir/src/model2ir/v02.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from . import core as _v01
+from .reversible import embed_ir_in_gltf, recover_embedded_ir, reversible_status, ir_digest
+
+
+def load_asset(path: str | Path):
+    return _v01.load_asset(path)
+
+
+def extract_ir(asset_or_path) -> dict[str, Any]:
+    asset = asset_or_path if isinstance(asset_or_path, _v01.Asset) else _v01.load_asset(asset_or_path)
+    out = _v01.extract_ir(asset)
+    out["schema"] = "model2ir-character-ir/v0.2"
+    status = reversible_status(asset.gltf)
+    out["reversibility"] = status
+    embedded = recover_embedded_ir(asset.gltf)
+    if embedded is not None:
+        out["canonical_ir"] = embedded
+        out["canonical_ir_digest"] = ir_digest(embedded)
+        out["canonical_recovery"] = {
+            "mode": "lossless-embedded",
+            "verified": True,
+            "semantic_inference_required": False,
+        }
+    else:
+        out["canonical_ir"] = None
+        out["canonical_recovery"] = {
+            "mode": "inferred-only",
+            "verified": False,
+            "semantic_inference_required": True,
+        }
+    out["provenance"]["extractor"] = "model2ir/v0.2"
+    return out
+
+
+def _canonical_payload(ir: dict[str, Any]) -> dict[str, Any] | None:
+    c = ir.get("canonical_ir")
+    if isinstance(c, dict):
+        return c
+    if ir.get("schema", "").startswith("character-") or "inferred" in ir or "observed" in ir:
+        return ir
+    return None
+
+
+def deep_diff(a: Any, b: Any, path: str = "$") -> list[dict[str, Any]]:
+    diffs: list[dict[str, Any]] = []
+    if type(a) is not type(b):
+        return [{"path": path, "kind": "type", "a": a, "b": b}]
+    if isinstance(a, dict):
+        for key in sorted(set(a) | set(b)):
+            p = f"{path}.{key}"
+            if key not in a:
+                diffs.append({"path": p, "kind": "added", "b": b[key]})
+            elif key not in b:
+                diffs.append({"path": p, "kind": "lost", "a": a[key]})
+            else:
+                diffs.extend(deep_diff(a[key], b[key], p))
+        return diffs
+    if isinstance(a, list):
+        if len(a) != len(b):
+            diffs.append({"path": path, "kind": "length", "a": len(a), "b": len(b)})
+        for i, (x, y) in enumerate(zip(a, b)):
+            diffs.extend(deep_diff(x, y, f"{path}[{i}]"))
+        return diffs
+    if a != b:
+        diffs.append({"path": path, "kind": "changed", "a": a, "b": b})
+    return diffs
+
+
+def diff_ir(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    base = _v01.diff_ir(a, b)
+    ca, cb = _canonical_payload(a), _canonical_payload(b)
+    canonical = None
+    if ca is not None and cb is not None:
+        differences = deep_diff(ca, cb)
+        canonical = {
+            "available": True,
+            "exact": not differences,
+            "difference_count": len(differences),
+            "differences": differences,
+            "a_digest": ir_digest(ca),
+            "b_digest": ir_digest(cb),
+        }
+    else:
+        canonical = {"available": False, "exact": False, "difference_count": None, "differences": []}
+    return {
+        "schema": "model2ir-diff/v0.2",
+        "semantic": base["semantic"],
+        "geometry_numeric": base["geometry_numeric"],
+        "canonical": canonical,
+    }
+
+
+def score_roundtrip(source_ir: dict[str, Any], recovered_ir: dict[str, Any]) -> dict[str, Any]:
+    d = diff_ir(source_ir, recovered_ir)
+    canonical = d["canonical"]
+    exact = bool(canonical.get("available") and canonical.get("exact"))
+    return {
+        "schema": "model2ir-roundtrip-score/v0.2",
+        "lossless_reversible": exact,
+        "canonical_exact": exact,
+        "canonical_difference_count": canonical.get("difference_count"),
+        "semantic_preservation": d["semantic"]["jaccard"],
+        "diff": d,
+    }
+
+
+def reconcile_ir(image_ir: dict[str, Any], model_ir: dict[str, Any]) -> dict[str, Any]:
+    out = _v01.reconcile_ir(image_ir, model_ir)
+    out["schema"] = "model2ir-reconciliation/v0.2"
+    out["model_reversibility"] = model_ir.get("reversibility", {"mode": "unknown", "lossless": False})
+    if model_ir.get("canonical_ir") is not None:
+        out["embedded_canonical_ir_digest"] = model_ir.get("canonical_ir_digest")
+        out["policy"] = "embedded canonical IR may be recovered exactly; inferred 3D semantics remain candidate evidence"
+    return out
+
+
+def compile_reversible_gltf(base_gltf: dict[str, Any], canonical_ir: dict[str, Any]) -> dict[str, Any]:
+    return embed_ir_in_gltf(base_gltf, canonical_ir)
+
+
+def save_reversible_gltf(base_gltf: dict[str, Any], canonical_ir: dict[str, Any], output: str | Path) -> Path:
+    p = Path(output)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(compile_reversible_gltf(base_gltf, canonical_ir), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return p

--- a/scripts/model2ir_reversible_regression.py
+++ b/scripts/model2ir_reversible_regression.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from model2ir import compile_reversible_gltf, extract_ir, ir_digest, score_roundtrip
+
+
+def base_gltf(name: str = "CharacterBody") -> dict:
+    return {
+        "asset": {"version": "2.0", "generator": "model2ir-regression"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"name": name, "mesh": 0}],
+        "meshes": [{"name": name, "primitives": []}],
+    }
+
+
+def family() -> list[dict]:
+    common = {
+        "schema": "character-ir/v0.6",
+        "identity": {"archetype": "humanoid", "locked": True},
+        "body": {"plan": "humanoid", "proportions": {"heads_tall": 7.2}},
+    }
+    return [
+        {**common, "id": "long-hair-dress", "hair": {"length": "waist", "style": "straight"}, "garment": {"upper": "dress", "outer": None}, "accessories": []},
+        {**common, "id": "short-hair-dress", "hair": {"length": "chin", "style": "bob"}, "garment": {"upper": "dress", "outer": None}, "accessories": []},
+        {**common, "id": "long-hair-coat", "hair": {"length": "waist", "style": "straight"}, "garment": {"upper": "shirt", "outer": "coat"}, "accessories": []},
+        {**common, "id": "mage-book", "hair": {"length": "shoulder", "style": "wavy"}, "garment": {"upper": "robe", "outer": None}, "accessories": [{"kind": "book", "relation": "held_by:right_hand"}]},
+        {**common, "id": "mage-ring", "hair": {"length": "shoulder", "style": "wavy"}, "garment": {"upper": "robe", "outer": None}, "accessories": [{"kind": "magic_ring", "relation": "surrounds:torso", "class": "effect"}]},
+    ]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    cases = []
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for i, source_ir in enumerate(family()):
+            carrier = compile_reversible_gltf(base_gltf(), source_ir)
+            p = root / f"case-{i}.gltf"
+            p.write_text(json.dumps(carrier, ensure_ascii=False, indent=2), encoding="utf-8")
+            recovered = extract_ir(p)
+            score = score_roundtrip(source_ir, recovered)
+            assert recovered["reversibility"]["lossless"] is True
+            assert recovered["canonical_ir"] == source_ir
+            assert recovered["canonical_ir_digest"] == ir_digest(source_ir)
+            assert score["lossless_reversible"] is True
+            assert score["canonical_difference_count"] == 0
+            cases.append({
+                "id": source_ir["id"],
+                "digest": ir_digest(source_ir),
+                "score": score,
+            })
+
+        # Arbitrary external 3D must never be reported as lossless just because it parses.
+        raw = root / "external.gltf"
+        raw.write_text(json.dumps(base_gltf("UnknownCharacter")), encoding="utf-8")
+        external = extract_ir(raw)
+        assert external["reversibility"]["lossless"] is False
+        assert external["canonical_ir"] is None
+
+        # Tampering with embedded IR while retaining old digest must be detected.
+        bad = compile_reversible_gltf(base_gltf(), family()[0])
+        bad["extras"]["OPENAI_model2ir_character_ir"]["character_ir"]["hair"]["length"] = "tampered"
+        badp = root / "tampered.gltf"
+        badp.write_text(json.dumps(bad), encoding="utf-8")
+        tamper_detected = False
+        try:
+            extract_ir(badp)
+        except ValueError as exc:
+            tamper_detected = "digest mismatch" in str(exc)
+        assert tamper_detected
+
+    report = {
+        "schema": "model2ir-reversible-regression/v0.2",
+        "case_count": len(cases),
+        "all_lossless": all(c["score"]["lossless_reversible"] for c in cases),
+        "external_asset_correctly_nonlossless": True,
+        "tamper_detection": True,
+        "cases": cases,
+        "gate": {
+            "canonical_exact_required": 1.0,
+            "observed": 1.0,
+            "status": "PASS",
+        },
+    }
+    (out / "report.json").write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "cases": len(cases), "lossless": True, "tamper_detection": True}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces model2ir v0.2 reversible mode. It distinguishes inferred reversibility for arbitrary external 3D assets from provable lossless reversibility for assets compiled by our pipeline. Canonical Character IR is embedded in glTF root extras with a SHA-256 digest, recovered and integrity-checked by model2ir, exposed through the public API, and gated by multi-case round-trip regression. Arbitrary assets remain non-lossless unless they carry the contract; tampering is detected.