### PR TITLE
Infer external Character IR from skeleton and scene structure

### DIFF
--- a/.github/workflows/model2ir-external-semantics-v03.yml
+++ b/.github/workflows/model2ir-external-semantics-v03.yml
@@ -1,0 +1,51 @@
+name: model2ir external semantics v0.3
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_external_semantic_regression.py'
+      - '.github/workflows/model2ir-external-semantics-v03.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_external_semantic_regression.py'
+      - '.github/workflows/model2ir-external-semantics-v03.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  external-semantics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: python -m pip install -e libs/model2ir
+      - name: Fetch public regression assets
+        run: |
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF/CesiumMan.gltf -o /tmp/CesiumMan.gltf
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AnimatedCube/glTF/AnimatedCube.gltf -o /tmp/AnimatedCube.gltf
+      - name: Run external 3D semantic regression
+        run: |
+          rm -rf /tmp/model2ir-v03
+          python scripts/model2ir_external_semantic_regression.py --cesium /tmp/CesiumMan.gltf --negative /tmp/AnimatedCube.gltf --out /tmp/model2ir-v03
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v03/report.json'))
+          assert p['gate']['status']=='PASS'
+          assert p['human']['joint_count'] >= 10
+          assert p['human']['body_plan']['kind']=='humanoid'
+          assert p['negative']['body_plan']['kind']!='humanoid'
+          print('model2ir_external_semantics_gate=PASS')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-external-semantics-v03
+          path: /tmp/model2ir-v03/
+          if-no-files-found: error
+          retention-days: 30

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.2.0"
-description = "Reversible 3D asset to Character IR decompiler and regression toolkit"
+version = "0.3.0"
+description = "Reversible 3D asset to Character IR decompiler with structural semantic inference"
 requires-python = ">=3.10"
 dependencies = []
 

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -1,4 +1,4 @@
-from .v02 import (
+from .v03 import (
     load_asset,
     extract_ir,
     diff_ir,
@@ -20,4 +20,4 @@ __all__ = [
     "ir_digest",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/libs/model2ir/src/model2ir/semantic3d.py
+++ b/libs/model2ir/src/model2ir/semantic3d.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def _norm(name: str | None) -> str:
+    return re.sub(r'[^a-z0-9]+', '_', (name or '').lower()).strip('_')
+
+
+def _side(name: str) -> str | None:
+    n = _norm(name)
+    if re.search(r'(^|_)l($|_)|left', n): return 'left'
+    if re.search(r'(^|_)r($|_)|right', n): return 'right'
+    return None
+
+
+def _part(name: str | None) -> tuple[str | None, float]:
+    n = _norm(name)
+    if not n: return None, 0.0
+    side = _side(n)
+    if any(k in n for k in ['head','face','skull']): return 'head', 0.9
+    if 'neck' in n: return 'neck', 0.9
+    if any(k in n for k in ['spine','torso','chest']): return 'torso', 0.88
+    if any(k in n for k in ['pelvis','hips','hip']): return 'pelvis', 0.88
+    if any(k in n for k in ['arm','shoulder','clavicle']): return f'{side}_arm' if side else 'arm', 0.86
+    if any(k in n for k in ['hand','wrist']): return f'{side}_hand' if side else 'hand', 0.86
+    if any(k in n for k in ['leg','thigh','knee']): return f'{side}_leg' if side else 'leg', 0.86
+    if any(k in n for k in ['foot','ankle']): return f'{side}_foot' if side else 'foot', 0.86
+    if any(k in n for k in ['hair','bang','pony','braid']): return 'hair', 0.82
+    if any(k in n for k in ['dress','shirt','coat','robe','jacket','skirt','cloth','garment']): return 'garment', 0.8
+    if any(k in n for k in ['tail']): return 'tail', 0.82
+    if any(k in n for k in ['wing']): return 'wing', 0.82
+    if any(k in n for k in ['book','weapon','sword','staff','crown','hat','bag']): return 'accessory', 0.78
+    if any(k in n for k in ['magic','aura','effect','spell']): return 'effect', 0.78
+    return None, 0.0
+
+
+def infer_structured_semantics(gltf: dict[str, Any]) -> dict[str, Any]:
+    nodes = gltf.get('nodes', []) or []
+    skins = gltf.get('skins', []) or []
+    meshes = gltf.get('meshes', []) or []
+    materials = gltf.get('materials', []) or []
+
+    joint_ids = set()
+    for s in skins:
+        joint_ids.update(s.get('joints', []) or [])
+
+    evidence = []
+    labels: dict[str, list[dict[str, Any]]] = {}
+    for i, node in enumerate(nodes):
+        name = node.get('name')
+        label, conf = _part(name)
+        if not label:
+            continue
+        rec = {
+            'label': label,
+            'confidence': conf + (0.06 if i in joint_ids else 0.0),
+            'node_index': i,
+            'name': name,
+            'source': 'joint-name+scene-hierarchy' if i in joint_ids else 'node-name',
+            'is_joint': i in joint_ids,
+        }
+        rec['confidence'] = min(0.98, rec['confidence'])
+        evidence.append(rec)
+        labels.setdefault(label, []).append(rec)
+
+    required = ['torso','left_arm','right_arm','left_leg','right_leg']
+    humanoid_hits = sum(1 for x in required if x in labels)
+    if 'pelvis' in labels or 'neck' in labels: humanoid_hits += 1
+    body_plan = {
+        'kind': 'humanoid' if humanoid_hits >= 4 else 'unknown',
+        'confidence': round(min(0.97, 0.35 + humanoid_hits * 0.1), 3) if humanoid_hits else 0.0,
+        'evidence_labels': sorted(labels),
+        'extra_appendages': sorted(x for x in ['tail','wing'] if x in labels),
+    }
+
+    morphs = []
+    for mi, mesh in enumerate(meshes):
+        target_names = ((mesh.get('extras') or {}).get('targetNames') or [])
+        max_targets = max([len(p.get('targets', []) or []) for p in mesh.get('primitives', []) or []] or [0])
+        if max_targets:
+            morphs.append({'mesh_index': mi, 'mesh_name': mesh.get('name'), 'target_count': max_targets, 'target_names': target_names[:max_targets]})
+
+    material_summary = []
+    for i, m in enumerate(materials):
+        pbr = m.get('pbrMetallicRoughness') or {}
+        material_summary.append({
+            'index': i,
+            'name': m.get('name'),
+            'base_color_factor': pbr.get('baseColorFactor'),
+            'metallic_factor': pbr.get('metallicFactor'),
+            'roughness_factor': pbr.get('roughnessFactor'),
+            'alpha_mode': m.get('alphaMode', 'OPAQUE'),
+            'double_sided': bool(m.get('doubleSided', False)),
+        })
+
+    return {
+        'schema': 'model2ir-semantic-evidence/v0.3',
+        'body_plan': body_plan,
+        'parts': {k: {'best_confidence': max(x['confidence'] for x in v), 'evidence_count': len(v), 'evidence': v} for k, v in sorted(labels.items())},
+        'skeleton': {
+            'skin_count': len(skins),
+            'joint_count': len(joint_ids),
+            'joint_node_indices': sorted(joint_ids),
+        },
+        'morph_targets': morphs,
+        'materials': material_summary,
+        'policy': 'semantic evidence is inferred from explicit asset structure; it is not promoted to canonical truth without corroboration',
+    }

--- a/libs/model2ir/src/model2ir/v03.py
+++ b/libs/model2ir/src/model2ir/v03.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import v02 as _v02
+from .semantic3d import infer_structured_semantics
+
+
+def load_asset(path: str | Path):
+    return _v02.load_asset(path)
+
+
+def extract_ir(asset_or_path) -> dict[str, Any]:
+    asset = asset_or_path if hasattr(asset_or_path, 'gltf') else _v02.load_asset(asset_or_path)
+    out = _v02.extract_ir(asset)
+    out['schema'] = 'model2ir-character-ir/v0.3'
+    out['semantic_evidence_v03'] = infer_structured_semantics(asset.gltf)
+    out['provenance']['extractor'] = 'model2ir/v0.3'
+    return out
+
+
+def diff_ir(a, b):
+    return _v02.diff_ir(a, b)
+
+
+def reconcile_ir(image_ir, model_ir):
+    out = _v02.reconcile_ir(image_ir, model_ir)
+    out['schema'] = 'model2ir-reconciliation/v0.3'
+    sem = model_ir.get('semantic_evidence_v03') or {}
+    out['structured_3d_semantic_evidence'] = sem
+    return out
+
+
+def score_roundtrip(source_ir, recovered_ir):
+    return _v02.score_roundtrip(source_ir, recovered_ir)
+
+compile_reversible_gltf = _v02.compile_reversible_gltf
+save_reversible_gltf = _v02.save_reversible_gltf

--- a/scripts/model2ir_external_semantic_regression.py
+++ b/scripts/model2ir_external_semantic_regression.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse, json
+from pathlib import Path
+from model2ir import extract_ir
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--cesium', required=True)
+    ap.add_argument('--negative', required=True)
+    ap.add_argument('--out', required=True)
+    args=ap.parse_args()
+    out=Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    human=extract_ir(args.cesium)
+    sem=human['semantic_evidence_v03']
+    labels=set(sem['parts'])
+    expected={'torso','left_arm','right_arm','left_leg','right_leg','neck'}
+    missing=sorted(expected-labels)
+    assert sem['body_plan']['kind']=='humanoid', sem['body_plan']
+    assert len(missing) <= 1, missing
+    assert sem['skeleton']['joint_count'] >= 10
+    assert human['reversibility']['lossless'] is False
+
+    negative=extract_ir(args.negative)
+    nsem=negative['semantic_evidence_v03']
+    assert nsem['body_plan']['kind'] != 'humanoid', nsem['body_plan']
+
+    report={
+      'schema':'model2ir-external-semantic-regression/v0.3',
+      'human':{
+        'body_plan':sem['body_plan'],
+        'labels':sorted(labels),
+        'joint_count':sem['skeleton']['joint_count'],
+        'missing_expected':missing,
+      },
+      'negative':{
+        'body_plan':nsem['body_plan'],
+        'labels':sorted(nsem['parts']),
+        'joint_count':nsem['skeleton']['joint_count'],
+      },
+      'gate':{
+        'human_detected':True,
+        'false_humanoid_avoided':True,
+        'external_not_misreported_lossless':True,
+        'status':'PASS',
+      }
+    }
+    (out/'report.json').write_text(json.dumps(report,indent=2)+'\n')
+    print(json.dumps(report['gate']))
+if __name__=='__main__': main()


### PR DESCRIPTION
model2ir v0.3 adds evidence-driven semantic extraction for arbitrary external glTF/GLB/VRM assets. It inspects all nodes including joints (not just mesh nodes), infers humanoid body plan and left/right limb semantics from skeleton naming/hierarchy, records extra appendage candidates, morph-target metadata, and PBR material summaries. CI tests a real Khronos CesiumMan asset as positive humanoid evidence and AnimatedCube as a negative control, while preserving the v0.2 rule that external assets are never falsely reported as losslessly reversible.