### PR TITLE
Stabilize external 3D imports into reversible Character IR

### DIFF
--- a/.github/workflows/model2ir-stabilized-import-v04.yml
+++ b/.github/workflows/model2ir-stabilized-import-v04.yml
@@ -1,0 +1,48 @@
+name: model2ir stabilized import v0.4
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
+      - '.github/workflows/model2ir-stabilized-import-v04.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
+      - '.github/workflows/model2ir-stabilized-import-v04.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stabilized-import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: python -m pip install -e libs/model2ir
+      - name: Fetch external humanoid asset
+        run: curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF/CesiumMan.gltf -o /tmp/CesiumMan.gltf
+      - name: Stabilize import and prove future reversibility
+        run: |
+          rm -rf /tmp/model2ir-v04
+          python scripts/model2ir_stabilized_import_regression.py --input /tmp/CesiumMan.gltf --out /tmp/model2ir-v04
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v04/report.json'))
+          assert p['gate']['candidate_repeatability']==1.0
+          assert p['gate']['post_stabilization_reversibility']==1.0
+          assert p['roundtrip']['canonical_difference_count']==0
+          print('model2ir_stabilized_import_gate=PASS')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-stabilized-import-v04
+          path: /tmp/model2ir-v04/
+          if-no-files-found: error
+          retention-days: 30

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.3.0"
-description = "Reversible 3D asset to Character IR decompiler with structural semantic inference"
+version = "0.4.0"
+description = "Stable reversible Character IR import/export for 3D assets"
 requires-python = ">=3.10"
 dependencies = []
 

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -1,6 +1,7 @@
-from .v03 import (
+from .v04 import (
     load_asset,
     extract_ir,
+    stabilize_external_ir,
     diff_ir,
     reconcile_ir,
     score_roundtrip,
@@ -12,6 +13,7 @@ from .reversible import ir_digest
 __all__ = [
     "load_asset",
     "extract_ir",
+    "stabilize_external_ir",
     "diff_ir",
     "reconcile_ir",
     "score_roundtrip",
@@ -20,4 +22,4 @@ __all__ = [
     "ir_digest",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/libs/model2ir/src/model2ir/normalize.py
+++ b/libs/model2ir/src/model2ir/normalize.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+def project_candidate_ir(model_ir: dict[str, Any]) -> dict[str, Any]:
+    """Project extracted 3D evidence into a stable, explicit candidate Character IR.
+
+    This is not canonical truth. It is the deterministic import boundary: once
+    created, this candidate IR can be embedded in a carrier and round-tripped
+    losslessly even if the original external asset had no model2ir metadata.
+    """
+    sem = model_ir.get('semantic_evidence_v03') or {}
+    body = sem.get('body_plan') or {}
+    parts_src = sem.get('parts') or {}
+    parts = []
+    for label, rec in sorted(parts_src.items()):
+        parts.append({
+            'id': label,
+            'state': 'inferred_from_3d',
+            'confidence': rec.get('best_confidence', 0.0),
+            'evidence_count': rec.get('evidence_count', 0),
+        })
+    unresolved = []
+    for c in (model_ir.get('semantic_ir') or {}).get('unresolved', []) or []:
+        unresolved.append({
+            'component': c.get('name'),
+            'node_index': c.get('node_index'),
+            'reason': 'semantic-class-unresolved',
+        })
+    return {
+        'schema': 'character-ir-candidate/v0.4',
+        'truth_status': 'candidate',
+        'source': {
+            'kind': model_ir.get('source_kind'),
+            'name': (model_ir.get('source') or {}).get('name'),
+            'extractor': (model_ir.get('provenance') or {}).get('extractor'),
+        },
+        'body_plan': {
+            'kind': body.get('kind', 'unknown'),
+            'confidence': body.get('confidence', 0.0),
+            'extra_appendages': copy.deepcopy(body.get('extra_appendages', [])),
+        },
+        'parts': parts,
+        'skeleton': copy.deepcopy(sem.get('skeleton') or {}),
+        'materials': copy.deepcopy(sem.get('materials') or []),
+        'morph_targets': copy.deepcopy(sem.get('morph_targets') or []),
+        'unresolved': unresolved,
+        'provenance': {
+            'policy': 'candidate only; no inferred field is automatically canonical truth',
+            'semantic_evidence_schema': sem.get('schema'),
+        },
+    }

--- a/libs/model2ir/src/model2ir/v04.py
+++ b/libs/model2ir/src/model2ir/v04.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import v03 as _v03
+from .normalize import project_candidate_ir
+
+
+def load_asset(path: str | Path):
+    return _v03.load_asset(path)
+
+
+def extract_ir(asset_or_path) -> dict[str, Any]:
+    out = _v03.extract_ir(asset_or_path)
+    out['schema'] = 'model2ir-character-ir/v0.4'
+    if out.get('canonical_ir') is None:
+        out['candidate_ir'] = project_candidate_ir(out)
+        out['stabilization'] = {
+            'mode': 'external-import-candidate',
+            'candidate_created': True,
+            'future_roundtrip_can_be_lossless_if_embedded': True,
+        }
+    else:
+        out['candidate_ir'] = None
+        out['stabilization'] = {
+            'mode': 'embedded-canonical',
+            'candidate_created': False,
+            'future_roundtrip_can_be_lossless_if_embedded': True,
+        }
+    out['provenance']['extractor'] = 'model2ir/v0.4'
+    return out
+
+
+def stabilize_external_ir(model_ir: dict[str, Any]) -> dict[str, Any]:
+    if model_ir.get('canonical_ir') is not None:
+        return model_ir['canonical_ir']
+    c = model_ir.get('candidate_ir')
+    return c if isinstance(c, dict) else project_candidate_ir(model_ir)
+
+
+def diff_ir(a, b): return _v03.diff_ir(a, b)
+def reconcile_ir(a, b): return _v03.reconcile_ir(a, b)
+def score_roundtrip(a, b): return _v03.score_roundtrip(a, b)
+compile_reversible_gltf = _v03.compile_reversible_gltf
+save_reversible_gltf = _v03.save_reversible_gltf

--- a/scripts/model2ir_stabilized_import_regression.py
+++ b/scripts/model2ir_stabilized_import_regression.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse, json
+from pathlib import Path
+from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip, ir_digest
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--input', required=True)
+    ap.add_argument('--out', required=True)
+    args=ap.parse_args()
+    out=Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    # Repeated external extraction must be deterministic.
+    a=extract_ir(args.input)
+    b=extract_ir(args.input)
+    ca=stabilize_external_ir(a)
+    cb=stabilize_external_ir(b)
+    assert ca == cb
+    assert ir_digest(ca) == ir_digest(cb)
+    assert a['reversibility']['lossless'] is False
+    assert ca['truth_status']=='candidate'
+
+    # Stabilize the external model by embedding the candidate IR into its glTF carrier.
+    raw=json.loads(Path(args.input).read_text())
+    carrier=compile_reversible_gltf(raw, ca)
+    stable_path=out/'stabilized.gltf'
+    stable_path.write_text(json.dumps(carrier,ensure_ascii=False,indent=2)+'\n')
+    recovered=extract_ir(stable_path)
+    assert recovered['reversibility']['lossless'] is True
+    assert recovered['canonical_ir'] == ca
+    assert recovered['canonical_ir_digest'] == ir_digest(ca)
+    score=score_roundtrip(ca,recovered)
+    assert score['lossless_reversible'] is True
+    assert score['canonical_difference_count']==0
+
+    report={
+      'schema':'model2ir-stabilized-import-regression/v0.4',
+      'source_lossless':False,
+      'candidate_digest':ir_digest(ca),
+      'deterministic_initial_projection':True,
+      'stabilized_lossless':True,
+      'roundtrip':score,
+      'candidate_body_plan':ca['body_plan'],
+      'candidate_parts':[p['id'] for p in ca['parts']],
+      'unresolved_count':len(ca['unresolved']),
+      'gate':{'status':'PASS','candidate_repeatability':1.0,'post_stabilization_reversibility':1.0},
+    }
+    (out/'report.json').write_text(json.dumps(report,indent=2)+'\n')
+    print(json.dumps(report['gate']))
+if __name__=='__main__': main()


### PR DESCRIPTION
model2ir v0.4 adds a deterministic external-import boundary. Arbitrary 3D assets are projected into an explicit candidate Character IR with truth_status=candidate, provenance, confidence, unresolved components, skeleton/material/morph evidence. Repeated extraction must produce the same candidate digest. The candidate can then be embedded back into the 3D carrier so every subsequent IR→3D→IR cycle is losslessly reversible. CI proves this flow on the real Khronos CesiumMan asset.