### PR TITLE
Add real multi-model stability gate for model2ir

### DIFF
--- a/.github/workflows/model2ir-real-family-stability-v05.yml
+++ b/.github/workflows/model2ir-real-family-stability-v05.yml
@@ -1,0 +1,53 @@
+name: model2ir real family stability v0.5
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_real_family_stability.py'
+      - '.github/workflows/model2ir-real-family-stability-v05.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_real_family_stability.py'
+      - '.github/workflows/model2ir-real-family-stability-v05.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  real-family:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: python -m pip install -e libs/model2ir
+      - name: Fetch public real model family
+        run: |
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF/CesiumMan.gltf -o /tmp/CesiumMan.gltf
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/RiggedFigure/glTF/RiggedFigure.gltf -o /tmp/RiggedFigure.gltf
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AnimatedCube/glTF/AnimatedCube.gltf -o /tmp/AnimatedCube.gltf
+      - name: Run real family stability benchmark
+        run: |
+          rm -rf /tmp/model2ir-v05
+          python scripts/model2ir_real_family_stability.py --cesium /tmp/CesiumMan.gltf --rigged /tmp/RiggedFigure.gltf --negative /tmp/AnimatedCube.gltf --out /tmp/model2ir-v05
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v05/report.json'))
+          assert p['gate']['status']=='PASS'
+          assert p['gate']['two_independent_humanoids_consistent'] is True
+          assert p['gate']['candidate_repeatability']==1.0
+          assert p['gate']['post_stabilization_reversibility']==1.0
+          assert p['gate']['unknown_when_evidence_removed'] is True
+          print('model2ir_real_family_stability=PASS')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-real-family-stability-v05
+          path: /tmp/model2ir-v05/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/model2ir_real_family_stability.py
+++ b/scripts/model2ir_real_family_stability.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse, copy, json
+from pathlib import Path
+from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip, ir_digest
+
+CORE={'torso','left_arm','right_arm','left_leg','right_leg','neck'}
+
+def labels(ir):
+    return set((ir.get('semantic_evidence_v03') or {}).get('parts',{}))
+
+def stabilize(path: Path, out: Path):
+    m=extract_ir(path)
+    c=stabilize_external_ir(m)
+    raw=json.loads(path.read_text())
+    carrier=compile_reversible_gltf(raw,c)
+    p=out/f'{path.stem}-stable.gltf'
+    p.write_text(json.dumps(carrier,ensure_ascii=False,indent=2)+'\n')
+    back=extract_ir(p)
+    s=score_roundtrip(c,back)
+    assert s['lossless_reversible'] is True
+    return m,c,s
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--cesium',required=True)
+    ap.add_argument('--rigged',required=True)
+    ap.add_argument('--negative',required=True)
+    ap.add_argument('--out',required=True)
+    args=ap.parse_args()
+    out=Path(args.out); out.mkdir(parents=True,exist_ok=True)
+
+    results={}
+    human_labels=[]
+    for name,path in [('cesium',Path(args.cesium)),('rigged',Path(args.rigged))]:
+        first=extract_ir(path); second=extract_ir(path)
+        c1=stabilize_external_ir(first); c2=stabilize_external_ir(second)
+        assert ir_digest(c1)==ir_digest(c2)
+        assert (first.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind')=='humanoid'
+        labs=labels(first); human_labels.append(labs)
+        assert len(CORE-labs)<=1, (name,sorted(CORE-labs))
+        m,c,s=stabilize(path,out)
+        results[name]={
+          'labels':sorted(labs),
+          'candidate_digest':ir_digest(c),
+          'joint_count':c['skeleton'].get('joint_count',0),
+          'roundtrip_exact':s['lossless_reversible'],
+        }
+
+    shared=set.intersection(*human_labels)
+    assert len(CORE-shared)<=1, sorted(CORE-shared)
+
+    neg=extract_ir(args.negative)
+    assert (neg.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind')!='humanoid'
+
+    # Remove all node names from a real rig. The extractor must lose semantics rather than hallucinate them.
+    sanitized=json.loads(Path(args.rigged).read_text())
+    for n in sanitized.get('nodes',[]): n.pop('name',None)
+    for m in sanitized.get('meshes',[]): m.pop('name',None)
+    sanp=out/'rigged-no-names.gltf'; sanp.write_text(json.dumps(sanitized,indent=2)+'\n')
+    sani=extract_ir(sanp)
+    assert (sani.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind')!='humanoid'
+    sc=stabilize_external_ir(sani)
+    carrier=compile_reversible_gltf(sanitized,sc)
+    stable=out/'rigged-no-names-stable.gltf'; stable.write_text(json.dumps(carrier,indent=2)+'\n')
+    back=extract_ir(stable)
+    score=score_roundtrip(sc,back)
+    assert score['lossless_reversible'] is True
+
+    report={
+      'schema':'model2ir-real-family-stability/v0.5',
+      'humanoid_models':results,
+      'shared_core_labels':sorted(shared),
+      'negative_control_kind':(neg.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind'),
+      'name_erasure':{
+        'body_plan_after_erasure':(sani.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind'),
+        'hallucination_avoided':True,
+        'stabilized_roundtrip_exact':score['lossless_reversible'],
+      },
+      'gate':{
+        'two_independent_humanoids_consistent':True,
+        'candidate_repeatability':1.0,
+        'post_stabilization_reversibility':1.0,
+        'negative_control_correct':True,
+        'unknown_when_evidence_removed':True,
+        'status':'PASS'
+      }
+    }
+    (out/'report.json').write_text(json.dumps(report,indent=2)+'\n')
+    print(json.dumps(report['gate']))
+if __name__=='__main__': main()


### PR DESCRIPTION
Adds a real model family regression using two independently-authored Khronos humanoid rigs (CesiumMan and RiggedFigure) plus a non-humanoid negative control. The gate checks cross-model agreement on core humanoid semantics, deterministic repeated candidate projection, exact post-stabilization round-trip, and an adversarial name-erasure case where semantics must degrade to unknown rather than hallucinate. This turns 'stable' into measurable behavior across different real 3D assets.