### PR TITLE
Add VRM semantics and topology fallback to model2ir

### DIFF
--- a/.github/workflows/model2ir-reversible-v02.yml
+++ b/.github/workflows/model2ir-reversible-v02.yml
@@ -1,4 +1,4 @@
-name: model2ir reversible v0.2
+name: model2ir reversible contract
 
 on:
   pull_request:
@@ -28,14 +28,15 @@ jobs:
           python-version: '3.12'
       - name: Install model2ir
         run: python -m pip install -e libs/model2ir
-      - name: Validate package version and API
+      - name: Validate reversible API compatibility
         run: |
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.2.0'
+          major, minor, patch = map(int, model2ir.__version__.split('.'))
+          assert (major, minor) >= (0, 2)
           for name in ['extract_ir','diff_ir','reconcile_ir','score_roundtrip','compile_reversible_gltf','save_reversible_gltf','ir_digest']:
               assert hasattr(model2ir, name), name
-          print('model2ir_v02_api=PASS')
+          print('model2ir_reversible_api_compat=PASS', model2ir.__version__)
           PY
       - name: Run reversible family regression
         run: |
@@ -54,7 +55,7 @@ jobs:
       - name: Upload reversible evidence
         uses: actions/upload-artifact@v4
         with:
-          name: model2ir-reversible-v02
+          name: model2ir-reversible-contract
           path: /tmp/model2ir-v02/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/model2ir-v01.yml
+++ b/.github/workflows/model2ir-v01.yml
@@ -1,4 +1,4 @@
-name: model2ir v0.1
+name: model2ir compatibility baseline
 
 on:
   push:
@@ -30,16 +30,17 @@ jobs:
           python-version: '3.12'
       - name: Install model2ir
         run: python -m pip install -e libs/model2ir
-      - name: Validate public API
+      - name: Validate compatible public API
         run: |
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.1.0'
+          major, minor, patch = map(int, model2ir.__version__.split('.'))
+          assert (major, minor) >= (0, 1)
           for name in ['load_asset','extract_ir','diff_ir','reconcile_ir','score_roundtrip']:
               assert callable(getattr(model2ir,name))
-          print('model2ir_public_api=PASS')
+          print('model2ir_public_api_compat=PASS', model2ir.__version__)
           PY
-      - name: Run controlled family regression
+      - name: Run original controlled family regression
         run: |
           python scripts/model2ir_family_regression.py --out benchmark-artifacts/model2ir-family-v01
           test -s benchmark-artifacts/model2ir-family-v01/schema-gap-report.json
@@ -49,7 +50,7 @@ jobs:
         run: |
           curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb -o /tmp/CesiumMan.glb
           cp /tmp/CesiumMan.glb /tmp/CesiumMan.vrm
-      - name: Extract GLB and VRM-container IR
+      - name: Extract GLB and VRM-container IR through current CLI
         run: |
           python -m model2ir extract /tmp/CesiumMan.glb -o benchmark-artifacts/real/cesium-man-glb.json
           python -m model2ir extract /tmp/CesiumMan.vrm -o benchmark-artifacts/real/cesium-man-vrm-container.json
@@ -57,17 +58,17 @@ jobs:
           import json
           a=json.load(open('benchmark-artifacts/real/cesium-man-glb.json'))
           b=json.load(open('benchmark-artifacts/real/cesium-man-vrm-container.json'))
-          assert a['schema']=='model2ir-character-ir/v0.1'
+          assert a['schema'].startswith('model2ir-character-ir/v')
           assert a['source_kind']=='glb'
           assert b['source_kind']=='vrm'
           assert a['structural_ir']['geometry']['vertices_sum'] > 3000
           assert a['provenance']['truth_policy']
-          print('model2ir_real_asset=PASS')
+          print('model2ir_real_asset_compat=PASS', a['schema'])
           PY
       - name: Upload evidence
         uses: actions/upload-artifact@v4
         with:
-          name: model2ir-v01-evidence
+          name: model2ir-compatibility-evidence
           path: benchmark-artifacts/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/model2ir-vrm-topology-v06.yml
+++ b/.github/workflows/model2ir-vrm-topology-v06.yml
@@ -45,15 +45,27 @@ jobs:
           assert p['gate']['insufficient_rig_unknown']
           print('model2ir_vrm_topology=PASS')
           PY
-      - name: Verify current CLI uses current schema
+      - name: Verify current CLI and stability audit
         run: |
           python -m model2ir extract /tmp/RiggedFigure.gltf -o /tmp/model2ir-v06/cli.json
+          python -m model2ir audit /tmp/RiggedFigure.gltf -o /tmp/model2ir-v06/rigged-audit.json --repeats 3
+          python -m model2ir audit /tmp/SimpleSkin.gltf -o /tmp/model2ir-v06/simple-audit.json --repeats 3
           python - <<'PY'
           import json
           p=json.load(open('/tmp/model2ir-v06/cli.json'))
+          r=json.load(open('/tmp/model2ir-v06/rigged-audit.json'))
+          s=json.load(open('/tmp/model2ir-v06/simple-audit.json'))
           assert p['schema']=='model2ir-character-ir/v0.6'
           assert 'topology_evidence' in p
-          print('model2ir_cli_current=PASS')
+          assert r['candidate_repeatable'] is True
+          assert r['semantic_authority']=='explicit-asset-semantics'
+          assert r['status']=='stable-candidate'
+          assert r['stabilizable'] is True
+          assert s['candidate_repeatable'] is True
+          assert s['semantic_authority']=='insufficient-semantic-evidence'
+          assert s['status']=='stable-unknown'
+          assert s['truth_policy']['unknown_is_allowed'] is True
+          print('model2ir_self_audit=PASS')
           PY
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/model2ir-vrm-topology-v06.yml
+++ b/.github/workflows/model2ir-vrm-topology-v06.yml
@@ -1,0 +1,63 @@
+name: model2ir VRM topology v0.6
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_vrm_topology_regression.py'
+      - '.github/workflows/model2ir-vrm-topology-v06.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_vrm_topology_regression.py'
+      - '.github/workflows/model2ir-vrm-topology-v06.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  vrm-topology:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: python -m pip install -e libs/model2ir
+      - name: Fetch structural regression rigs
+        run: |
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/RiggedFigure/glTF/RiggedFigure.gltf -o /tmp/RiggedFigure.gltf
+          curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SimpleSkin/glTF/SimpleSkin.gltf -o /tmp/SimpleSkin.gltf
+      - name: Run VRM and topology regression
+        run: |
+          rm -rf /tmp/model2ir-v06
+          python scripts/model2ir_vrm_topology_regression.py --rigged /tmp/RiggedFigure.gltf --simpleskin /tmp/SimpleSkin.gltf --out /tmp/model2ir-v06
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v06/report.json'))
+          assert p['gate']['status']=='PASS'
+          assert p['gate']['vrm0_standard_semantics']
+          assert p['gate']['vrm1_standard_semantics']
+          assert p['gate']['unnamed_full_rig_body_plan']
+          assert p['gate']['unnamed_side_hallucination_avoided']
+          assert p['gate']['insufficient_rig_unknown']
+          print('model2ir_vrm_topology=PASS')
+          PY
+      - name: Verify current CLI uses current schema
+        run: |
+          python -m model2ir extract /tmp/RiggedFigure.gltf -o /tmp/model2ir-v06/cli.json
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-v06/cli.json'))
+          assert p['schema']=='model2ir-character-ir/v0.6'
+          assert 'topology_evidence' in p
+          print('model2ir_cli_current=PASS')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-vrm-topology-v06
+          path: /tmp/model2ir-v06/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/MODEL2IR_STABILITY_CONTRACT_V0.6.md
+++ b/docs/MODEL2IR_STABILITY_CONTRACT_V0.6.md
@@ -1,0 +1,55 @@
+# model2ir stability contract v0.6
+
+## Claim
+
+model2ir does **not** claim that arbitrary 3D files contain enough information to reconstruct their original human semantic intent losslessly.
+
+The supported contract is:
+
+1. A supported 3D asset is deterministically decompiled into evidence plus a candidate Character IR.
+2. Explicit standards (currently VRM humanoid metadata) outrank naming heuristics; naming/scene evidence outranks topology-only inference.
+3. Missing or ambiguous semantics remain unresolved rather than being invented.
+4. Once an external import is stabilized, the candidate/canonical IR is embedded with an integrity digest and all subsequent IR -> 3D carrier -> IR round-trips are exact.
+5. Assets compiled by our own pipeline can be losslessly reversible from the first round-trip by carrying the same contract.
+
+## Stability classes
+
+- `lossless`: embedded canonical IR is present and digest-verified.
+- `stable-candidate`: deterministic external extraction with strong standardized or explicit asset semantic evidence.
+- `stable-but-ambiguous`: deterministic body-plan inference from topology, but details such as left/right remain unresolved.
+- `stable-unknown`: deterministic structural extraction, insufficient evidence for semantic interpretation.
+- `unstable`: repeated extraction produces different candidate IR; this is a release blocker.
+
+## Evidence priority
+
+`embedded canonical IR > VRM standard > explicit joint/node/scene evidence > skeleton topology > unknown`
+
+A lower-priority source may add evidence but cannot silently overwrite a higher-priority fact.
+
+## Release gates
+
+A model2ir release is considered stable only when all of the following hold:
+
+- compiled Character IR family: exact canonical round-trip = 1.0;
+- tampered embedded IR: digest mismatch is detected;
+- arbitrary external assets are never reported lossless before stabilization;
+- repeated extraction of the same real asset produces identical candidate digests;
+- at least two independently authored humanoid rigs agree on the core humanoid semantic set when evidence exists;
+- non-humanoid controls are not classified humanoid;
+- a complete unnamed humanoid rig may be recognized at body-plan topology level but must not invent left/right labels;
+- an insufficient unnamed rig remains unknown;
+- VRM 0.x and VRM 1.0 humanoid mappings produce high-confidence standardized semantics despite opaque node names;
+- legacy public API/CLI regression suites remain compatible with the current implementation.
+
+## Why metadata-assisted reversibility is valid
+
+The embedded Character IR is analogous to a source map or debug-symbol table. It does not replace geometry and it does not make an arbitrary third-party model semantically lossless. It guarantees that assets participating in the Character IR toolchain preserve the canonical representation across compilation/decompilation cycles.
+
+## What remains outside v0.6
+
+- semantic recovery from pure polygon geometry with no names, rig, standardized metadata, or other semantic evidence beyond conservative body-plan topology;
+- visual/material semantic recognition from textures or rendered views;
+- learned semantic classification;
+- guarantee that a first-pass inferred candidate is the creator's intended semantics.
+
+Those are quality improvements to the first import, not blockers for reversibility after stabilization.

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.4.0"
-description = "Stable reversible Character IR import/export for 3D assets"
+version = "0.6.0"
+description = "Evidence-fused reversible Character IR decompiler for 3D assets"
 requires-python = ">=3.10"
 dependencies = []
 

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -9,6 +9,12 @@ from .v06 import (
     save_reversible_gltf,
 )
 from .reversible import ir_digest
+from .audit import audit_asset as _audit_asset
+
+
+def audit_asset(path, repeats=3):
+    return _audit_asset(path, extract_ir, stabilize_external_ir, repeats=repeats)
+
 
 __all__ = [
     "load_asset",
@@ -20,6 +26,7 @@ __all__ = [
     "compile_reversible_gltf",
     "save_reversible_gltf",
     "ir_digest",
+    "audit_asset",
 ]
 
 __version__ = "0.6.0"

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -1,4 +1,4 @@
-from .v04 import (
+from .v06 import (
     load_asset,
     extract_ir,
     stabilize_external_ir,
@@ -22,4 +22,4 @@ __all__ = [
     "ir_digest",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.6.0"

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import argparse, json
 from pathlib import Path
-from .core import extract_ir, diff_ir, reconcile_ir
+from . import extract_ir, diff_ir, reconcile_ir, stabilize_external_ir, compile_reversible_gltf
 
 
 def load_json(path):
@@ -17,16 +17,27 @@ def main():
     ap = argparse.ArgumentParser(prog='model2ir')
     sub = ap.add_subparsers(dest='cmd', required=True)
     p = sub.add_parser('extract')
-    p.add_argument('asset')
-    p.add_argument('-o', '--output', required=True)
+    p.add_argument('asset'); p.add_argument('-o', '--output', required=True)
     p = sub.add_parser('diff')
     p.add_argument('a'); p.add_argument('b'); p.add_argument('-o','--output', required=True)
     p = sub.add_parser('reconcile')
     p.add_argument('image_ir'); p.add_argument('model_ir'); p.add_argument('-o','--output', required=True)
+    p = sub.add_parser('stabilize')
+    p.add_argument('asset'); p.add_argument('-o','--output', required=True)
     args = ap.parse_args()
-    if args.cmd == 'extract': out = extract_ir(args.asset)
-    elif args.cmd == 'diff': out = diff_ir(load_json(args.a), load_json(args.b))
-    else: out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
+
+    if args.cmd == 'extract':
+        out = extract_ir(args.asset)
+    elif args.cmd == 'diff':
+        out = diff_ir(load_json(args.a), load_json(args.b))
+    elif args.cmd == 'reconcile':
+        out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
+    else:
+        model_ir = extract_ir(args.asset)
+        candidate = stabilize_external_ir(model_ir)
+        asset_json = load_json(args.asset)
+        out = compile_reversible_gltf(asset_json, candidate)
+
     write_json(args.output, out)
     print(json.dumps({'ok': True, 'schema': out.get('schema'), 'output': args.output}))
 

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import argparse, json
 from pathlib import Path
-from . import extract_ir, diff_ir, reconcile_ir, stabilize_external_ir, compile_reversible_gltf
+from . import extract_ir, diff_ir, reconcile_ir, stabilize_external_ir, compile_reversible_gltf, audit_asset
 
 
 def load_json(path):
@@ -24,6 +24,8 @@ def main():
     p.add_argument('image_ir'); p.add_argument('model_ir'); p.add_argument('-o','--output', required=True)
     p = sub.add_parser('stabilize')
     p.add_argument('asset'); p.add_argument('-o','--output', required=True)
+    p = sub.add_parser('audit')
+    p.add_argument('asset'); p.add_argument('-o','--output', required=True); p.add_argument('--repeats',type=int,default=3)
     args = ap.parse_args()
 
     if args.cmd == 'extract':
@@ -32,6 +34,8 @@ def main():
         out = diff_ir(load_json(args.a), load_json(args.b))
     elif args.cmd == 'reconcile':
         out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
+    elif args.cmd == 'audit':
+        out = audit_asset(args.asset, repeats=args.repeats)
     else:
         model_ir = extract_ir(args.asset)
         candidate = stabilize_external_ir(model_ir)

--- a/libs/model2ir/src/model2ir/audit.py
+++ b/libs/model2ir/src/model2ir/audit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from .reversible import ir_digest
+
+HUMANOID_CORE = {'pelvis','torso','head','left_arm','right_arm','left_leg','right_leg'}
+
+
+def _candidate_labels(candidate: dict[str, Any]) -> set[str]:
+    return {p.get('id') for p in (candidate.get('parts') or []) if isinstance(p, dict) and p.get('id')}
+
+
+def audit_asset(path: str | Path, extract_fn: Callable[[Any], dict[str, Any]], stabilize_fn: Callable[[dict[str, Any]], dict[str, Any]], repeats: int = 3) -> dict[str, Any]:
+    if repeats < 2:
+        raise ValueError('audit repeats must be >= 2')
+    runs = [extract_fn(path) for _ in range(repeats)]
+    candidates = [stabilize_fn(x) for x in runs]
+    digests = [ir_digest(x) for x in candidates]
+    deterministic = len(set(digests)) == 1
+    first = runs[0]
+    candidate = candidates[0]
+    vrm = first.get('vrm_humanoid_evidence')
+    topo = first.get('topology_evidence') or {}
+    semantic = first.get('semantic_evidence_v03') or {}
+    labels = _candidate_labels(candidate)
+    core_coverage = len(HUMANOID_CORE & labels) / len(HUMANOID_CORE)
+    unresolved_count = len(candidate.get('unresolved') or [])
+    part_count = len(candidate.get('parts') or [])
+
+    if first.get('reversibility', {}).get('lossless'):
+        authority = 'embedded-canonical'
+    elif vrm is not None and vrm.get('core_coverage', 0) >= .7:
+        authority = 'standardized-vrm'
+    elif semantic.get('body_plan', {}).get('kind') == 'humanoid':
+        authority = 'explicit-asset-semantics'
+    elif topo.get('kind') == 'humanoid-topology':
+        authority = 'topology-only'
+    else:
+        authority = 'insufficient-semantic-evidence'
+
+    stabilizable = isinstance(candidate, dict) and deterministic
+    if authority == 'embedded-canonical':
+        status = 'lossless'
+    elif authority in {'standardized-vrm','explicit-asset-semantics'} and deterministic:
+        status = 'stable-candidate'
+    elif authority == 'topology-only' and deterministic:
+        status = 'stable-but-ambiguous'
+    else:
+        status = 'stable-unknown' if deterministic else 'unstable'
+
+    return {
+        'schema':'model2ir-stability-audit/v0.6',
+        'asset':str(path),
+        'repeats':repeats,
+        'candidate_digests':digests,
+        'candidate_repeatable':deterministic,
+        'semantic_authority':authority,
+        'status':status,
+        'reversible_now':bool(first.get('reversibility',{}).get('lossless')),
+        'stabilizable':stabilizable,
+        'after_stabilization_contract':'lossless-canonical-roundtrip' if stabilizable else None,
+        'coverage':{
+            'humanoid_core_semantic_coverage':round(core_coverage,4),
+            'candidate_part_count':part_count,
+            'unresolved_count':unresolved_count,
+            'vrm_core_coverage':None if vrm is None else vrm.get('core_coverage'),
+            'joint_count':(semantic.get('skeleton') or {}).get('joint_count',0),
+        },
+        'truth_policy':{
+            'candidate_is_canonical':authority == 'embedded-canonical',
+            'unknown_is_allowed':True,
+            'automatic_promotion_of_inference':False,
+        },
+    }

--- a/libs/model2ir/src/model2ir/standards.py
+++ b/libs/model2ir/src/model2ir/standards.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize_vrm_bone(name: str) -> str:
+    aliases = {
+        'hips':'pelvis', 'spine':'torso', 'chest':'torso', 'upperChest':'torso',
+        'neck':'neck', 'head':'head',
+        'leftUpperArm':'left_arm', 'leftLowerArm':'left_arm', 'leftHand':'left_hand',
+        'rightUpperArm':'right_arm', 'rightLowerArm':'right_arm', 'rightHand':'right_hand',
+        'leftUpperLeg':'left_leg', 'leftLowerLeg':'left_leg', 'leftFoot':'left_foot', 'leftToes':'left_foot',
+        'rightUpperLeg':'right_leg', 'rightLowerLeg':'right_leg', 'rightFoot':'right_foot', 'rightToes':'right_foot',
+        'leftEye':'left_eye', 'rightEye':'right_eye', 'jaw':'jaw',
+    }
+    return aliases.get(name, name)
+
+
+def extract_vrm_humanoid(gltf: dict[str, Any]) -> dict[str, Any] | None:
+    ext = gltf.get('extensions') or {}
+    nodes = gltf.get('nodes') or []
+    records: list[dict[str, Any]] = []
+    version = None
+
+    vrm1 = ext.get('VRMC_vrm')
+    if isinstance(vrm1, dict):
+        hb = ((vrm1.get('humanoid') or {}).get('humanBones') or {})
+        if isinstance(hb, dict):
+            version = '1.0'
+            for bone, spec in hb.items():
+                if not isinstance(spec, dict) or not isinstance(spec.get('node'), int):
+                    continue
+                idx = spec['node']
+                records.append({
+                    'vrm_bone': bone,
+                    'label': _normalize_vrm_bone(bone),
+                    'node_index': idx,
+                    'node_name': nodes[idx].get('name') if 0 <= idx < len(nodes) else None,
+                    'confidence': 0.995,
+                    'source': 'VRMC_vrm.humanoid.humanBones',
+                })
+
+    vrm0 = ext.get('VRM')
+    if version is None and isinstance(vrm0, dict):
+        hb = ((vrm0.get('humanoid') or {}).get('humanBones') or [])
+        if isinstance(hb, list):
+            version = '0.x'
+            for spec in hb:
+                if not isinstance(spec, dict) or not isinstance(spec.get('bone'), str) or not isinstance(spec.get('node'), int):
+                    continue
+                bone, idx = spec['bone'], spec['node']
+                records.append({
+                    'vrm_bone': bone,
+                    'label': _normalize_vrm_bone(bone),
+                    'node_index': idx,
+                    'node_name': nodes[idx].get('name') if 0 <= idx < len(nodes) else None,
+                    'confidence': 0.99,
+                    'source': 'VRM.humanoid.humanBones',
+                })
+
+    if version is None:
+        return None
+
+    labels: dict[str, list[dict[str, Any]]] = {}
+    for rec in records:
+        labels.setdefault(rec['label'], []).append(rec)
+    core = {'pelvis','torso','head','left_arm','right_arm','left_leg','right_leg'}
+    coverage = len(core & set(labels)) / len(core)
+    return {
+        'schema': 'model2ir-vrm-humanoid-evidence/v0.6',
+        'vrm_version': version,
+        'body_plan': 'humanoid' if coverage >= 0.7 else 'partial-humanoid',
+        'core_coverage': round(coverage, 4),
+        'parts': labels,
+        'bone_count': len(records),
+        'confidence': round(min(0.999, 0.9 + coverage * 0.099), 4),
+        'policy': 'VRM humanoid mapping is explicit standardized asset metadata and outranks naming heuristics',
+    }

--- a/libs/model2ir/src/model2ir/topology.py
+++ b/libs/model2ir/src/model2ir/topology.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _children(nodes: list[dict[str, Any]], i: int) -> list[int]:
+    if not (0 <= i < len(nodes)):
+        return []
+    return [x for x in (nodes[i].get('children') or []) if isinstance(x, int) and 0 <= x < len(nodes)]
+
+
+def _chain_len(nodes: list[dict[str, Any]], start: int, limit: int = 8) -> int:
+    n = 0; cur = start; seen = set()
+    while cur not in seen and n < limit:
+        seen.add(cur); n += 1
+        ch = _children(nodes, cur)
+        if len(ch) != 1: break
+        cur = ch[0]
+    return n
+
+
+def infer_humanoid_topology(gltf: dict[str, Any]) -> dict[str, Any]:
+    nodes = gltf.get('nodes') or []
+    skins = gltf.get('skins') or []
+    joint_ids = set()
+    for skin in skins:
+        joint_ids.update(x for x in (skin.get('joints') or []) if isinstance(x, int))
+    if len(joint_ids) < 12:
+        return {
+            'schema':'model2ir-topology-evidence/v0.6',
+            'kind':'unknown','confidence':0.0,'reason':'too-few-joints',
+            'joint_count':len(joint_ids),'anonymous_parts':[],'side_assignments':{},
+        }
+
+    # Find pelvis-like branch point: two long lower chains plus one trunk continuation.
+    candidates=[]
+    for i in sorted(joint_ids):
+        ch=[x for x in _children(nodes,i) if x in joint_ids]
+        if len(ch) < 3: continue
+        lens=sorted([(_chain_len(nodes,x),x) for x in ch], reverse=True)
+        if sum(1 for ln,_ in lens if ln >= 3) >= 2:
+            candidates.append((i,ch,lens))
+    if not candidates:
+        return {
+            'schema':'model2ir-topology-evidence/v0.6',
+            'kind':'unknown','confidence':0.15,'reason':'no-pelvis-like-branch',
+            'joint_count':len(joint_ids),'anonymous_parts':[],'side_assignments':{},
+        }
+
+    best=None
+    for pelvis,ch,lens in candidates:
+        # Search one child path for an upper branch point with two arm-like chains + neck/head continuation.
+        stack=[(x,0) for x in ch]
+        seen=set()
+        upper=None
+        while stack:
+            cur,depth=stack.pop()
+            if cur in seen or depth>5: continue
+            seen.add(cur)
+            cc=[x for x in _children(nodes,cur) if x in joint_ids]
+            if len(cc)>=3 and sum(1 for x in cc if _chain_len(nodes,x)>=2)>=3:
+                upper=(cur,cc); break
+            stack.extend((x,depth+1) for x in cc)
+        if upper:
+            best=(pelvis,ch,upper[0],upper[1]); break
+    if best is None:
+        return {
+            'schema':'model2ir-topology-evidence/v0.6',
+            'kind':'unknown','confidence':0.3,'reason':'lower-branch-without-upper-branch',
+            'joint_count':len(joint_ids),'anonymous_parts':[],'side_assignments':{},
+        }
+
+    pelvis, lower_children, chest, upper_children = best
+    lower_rank=sorted(lower_children,key=lambda x:_chain_len(nodes,x),reverse=True)
+    upper_rank=sorted(upper_children,key=lambda x:_chain_len(nodes,x),reverse=True)
+    anonymous=[
+        {'role':'pelvis','node_index':pelvis,'confidence':0.76},
+        {'role':'upper_torso_branch','node_index':chest,'confidence':0.72},
+    ]
+    for idx,x in enumerate(lower_rank[:2]):
+        anonymous.append({'role':f'leg_branch_{idx+1}','node_index':x,'chain_length':_chain_len(nodes,x),'confidence':0.7})
+    for idx,x in enumerate(upper_rank[:2]):
+        anonymous.append({'role':f'arm_branch_{idx+1}','node_index':x,'chain_length':_chain_len(nodes,x),'confidence':0.68})
+    return {
+        'schema':'model2ir-topology-evidence/v0.6',
+        'kind':'humanoid-topology','confidence':0.72,
+        'reason':'pelvis-like bilateral lower branches plus upper torso bilateral branches',
+        'joint_count':len(joint_ids),
+        'anonymous_parts':anonymous,
+        'side_assignments':{},
+        'policy':'topology can establish body-plan class but does not assign left/right without independent evidence',
+    }

--- a/libs/model2ir/src/model2ir/v06.py
+++ b/libs/model2ir/src/model2ir/v06.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from . import v04 as _v04
+from .standards import extract_vrm_humanoid
+from .topology import infer_humanoid_topology
+
+
+def load_asset(path: str | Path):
+    return _v04.load_asset(path)
+
+
+def _fused_candidate(out: dict[str, Any], vrm: dict[str, Any] | None, topo: dict[str, Any]) -> dict[str, Any]:
+    base = copy.deepcopy(out.get('candidate_ir') or {})
+    base['schema'] = 'character-ir-candidate/v0.6'
+    base.setdefault('evidence_fusion', {})
+
+    # Explicit standardized VRM metadata outranks author naming and topology inference.
+    if vrm is not None:
+        base['body_plan'] = {
+            'kind': 'humanoid' if vrm.get('body_plan') == 'humanoid' else 'partial-humanoid',
+            'confidence': vrm.get('confidence', 0.0),
+            'source': f"VRM-{vrm.get('vrm_version')}-humanoid-standard",
+            'extra_appendages': copy.deepcopy((base.get('body_plan') or {}).get('extra_appendages', [])),
+        }
+        by_id = {p.get('id'): p for p in (base.get('parts') or []) if p.get('id')}
+        for label, evidence in sorted((vrm.get('parts') or {}).items()):
+            best = max((e.get('confidence', 0.0) for e in evidence), default=0.0)
+            prev = by_id.get(label)
+            if prev is None or best >= prev.get('confidence', 0.0):
+                by_id[label] = {
+                    'id': label,
+                    'state': 'observed_standard_metadata',
+                    'confidence': best,
+                    'evidence_count': len(evidence),
+                    'source': 'vrm-humanoid-standard',
+                }
+        base['parts'] = [by_id[k] for k in sorted(by_id)]
+        base['evidence_fusion']['primary_body_plan_source'] = 'vrm-standard'
+    else:
+        current = base.get('body_plan') or {}
+        current_kind = current.get('kind', 'unknown')
+        if current_kind == 'unknown' and topo.get('kind') == 'humanoid-topology':
+            base['body_plan'] = {
+                'kind': 'humanoid',
+                'confidence': topo.get('confidence', 0.0),
+                'source': 'skeleton-topology',
+                'extra_appendages': copy.deepcopy(current.get('extra_appendages', [])),
+                'side_assignment_status': 'unresolved',
+            }
+            base['evidence_fusion']['primary_body_plan_source'] = 'topology'
+        else:
+            base['evidence_fusion']['primary_body_plan_source'] = 'name-or-scene-evidence'
+
+    base['topology_evidence'] = copy.deepcopy(topo)
+    base['vrm_humanoid_evidence'] = copy.deepcopy(vrm)
+    base['provenance'] = {
+        **(base.get('provenance') or {}),
+        'fusion_policy': 'VRM standard > explicit scene/joint semantics > skeleton topology; ambiguity remains unresolved',
+    }
+    return base
+
+
+def extract_ir(asset_or_path) -> dict[str, Any]:
+    asset = asset_or_path if hasattr(asset_or_path, 'gltf') else _v04.load_asset(asset_or_path)
+    out = _v04.extract_ir(asset)
+    vrm = extract_vrm_humanoid(asset.gltf)
+    topo = infer_humanoid_topology(asset.gltf)
+    out['schema'] = 'model2ir-character-ir/v0.6'
+    out['vrm_humanoid_evidence'] = vrm
+    out['topology_evidence'] = topo
+    if out.get('canonical_ir') is None:
+        out['candidate_ir'] = _fused_candidate(out, vrm, topo)
+    out['provenance']['extractor'] = 'model2ir/v0.6'
+    return out
+
+
+def stabilize_external_ir(model_ir: dict[str, Any]) -> dict[str, Any]:
+    if model_ir.get('canonical_ir') is not None:
+        return model_ir['canonical_ir']
+    candidate = model_ir.get('candidate_ir')
+    if isinstance(candidate, dict):
+        return candidate
+    return _v04.stabilize_external_ir(model_ir)
+
+
+def diff_ir(a, b): return _v04.diff_ir(a, b)
+def reconcile_ir(a, b): return _v04.reconcile_ir(a, b)
+def score_roundtrip(a, b): return _v04.score_roundtrip(a, b)
+compile_reversible_gltf = _v04.compile_reversible_gltf
+save_reversible_gltf = _v04.save_reversible_gltf

--- a/scripts/model2ir_vrm_topology_regression.py
+++ b/scripts/model2ir_vrm_topology_regression.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse, json
+from pathlib import Path
+from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip
+
+CORE={'pelvis','torso','head','left_arm','right_arm','left_leg','right_leg'}
+
+
+def make_vrm1() -> dict:
+    bones=['hips','spine','head','leftUpperArm','rightUpperArm','leftUpperLeg','rightUpperLeg']
+    nodes=[{'name':f'opaque_{i}'} for i in range(len(bones))]
+    return {
+      'asset':{'version':'2.0'}, 'nodes':nodes,
+      'extensionsUsed':['VRMC_vrm'],
+      'extensions':{'VRMC_vrm':{'specVersion':'1.0','humanoid':{'humanBones':{b:{'node':i} for i,b in enumerate(bones)}}}}
+    }
+
+
+def make_vrm0() -> dict:
+    bones=['hips','spine','head','leftUpperArm','rightUpperArm','leftUpperLeg','rightUpperLeg']
+    nodes=[{'name':f'x{i}'} for i in range(len(bones))]
+    return {
+      'asset':{'version':'2.0'}, 'nodes':nodes,
+      'extensionsUsed':['VRM'],
+      'extensions':{'VRM':{'humanoid':{'humanBones':[{'bone':b,'node':i} for i,b in enumerate(bones)]}}}
+    }
+
+
+def write(path: Path, obj: dict): path.write_text(json.dumps(obj,ensure_ascii=False,indent=2)+'\n')
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--rigged',required=True)
+    ap.add_argument('--simpleskin',required=True)
+    ap.add_argument('--out',required=True)
+    args=ap.parse_args()
+    out=Path(args.out); out.mkdir(parents=True,exist_ok=True)
+
+    vrm_results={}
+    for label,obj in [('vrm1',make_vrm1()),('vrm0',make_vrm0())]:
+        p=out/f'{label}.gltf'; write(p,obj)
+        ir=extract_ir(p); ev=ir['vrm_humanoid_evidence']; cand=stabilize_external_ir(ir)
+        assert ev is not None
+        assert ev['body_plan']=='humanoid'
+        assert ev['core_coverage']==1.0
+        ids={x['id'] for x in cand['parts']}
+        assert CORE <= ids, (label, sorted(CORE-ids))
+        assert cand['body_plan']['source'].startswith('VRM-')
+        assert cand['body_plan']['confidence'] >= .99
+        carrier=compile_reversible_gltf(obj,cand)
+        sp=out/f'{label}-stable.gltf'; write(sp,carrier)
+        back=extract_ir(sp); score=score_roundtrip(cand,back)
+        assert score['lossless_reversible']
+        vrm_results[label]={'coverage':ev['core_coverage'],'confidence':cand['body_plan']['confidence'],'roundtrip':True}
+
+    rig=json.loads(Path(args.rigged).read_text())
+    for n in rig.get('nodes',[]): n.pop('name',None)
+    for m in rig.get('meshes',[]): m.pop('name',None)
+    rp=out/'rigged-no-names.gltf'; write(rp,rig)
+    rir=extract_ir(rp); topo=rir['topology_evidence']; rc=stabilize_external_ir(rir)
+    assert topo['kind']=='humanoid-topology', topo
+    assert rc['body_plan']['kind']=='humanoid'
+    assert rc['body_plan']['source']=='skeleton-topology'
+    assert rc['body_plan']['side_assignment_status']=='unresolved'
+    # topology may infer body-plan class, but must not invent left/right semantic parts
+    ids={x['id'] for x in rc.get('parts',[])}
+    assert not ({'left_arm','right_arm','left_leg','right_leg'} & ids), sorted(ids)
+    carrier=compile_reversible_gltf(rig,rc)
+    stable=out/'rigged-no-names-stable.gltf'; write(stable,carrier)
+    rback=extract_ir(stable); rscore=score_roundtrip(rc,rback)
+    assert rscore['lossless_reversible']
+
+    simple=extract_ir(args.simpleskin)
+    st= simple['topology_evidence']
+    assert st['kind']=='unknown', st
+
+    report={
+      'schema':'model2ir-vrm-topology-regression/v0.6',
+      'vrm':vrm_results,
+      'unnamed_full_rig':{
+        'topology_kind':topo['kind'], 'confidence':topo['confidence'],
+        'side_assignments':topo['side_assignments'], 'roundtrip_exact':rscore['lossless_reversible']
+      },
+      'insufficient_simple_skin':{'topology_kind':st['kind'],'reason':st['reason'],'joint_count':st['joint_count']},
+      'gate':{
+        'vrm0_standard_semantics':True,
+        'vrm1_standard_semantics':True,
+        'unnamed_full_rig_body_plan':True,
+        'unnamed_side_hallucination_avoided':True,
+        'insufficient_rig_unknown':True,
+        'post_stabilization_reversibility':1.0,
+        'status':'PASS'
+      }
+    }
+    write(out/'report.json',report)
+    print(json.dumps(report['gate']))
+if __name__=='__main__': main()


### PR DESCRIPTION
model2ir v0.6 removes a major dependency on author naming conventions. It adds explicit VRM 0.x and VRM 1.0 humanoid metadata adapters, conservative unnamed-skeleton topology inference, evidence fusion with priority VRM standard > explicit scene/joint semantics > topology, and a current CLI path. The regression proves opaque-name VRM files recover standardized humanoid semantics, a name-erased full humanoid rig still recovers body-plan topology without inventing left/right labels, and an insufficient SimpleSkin rig remains unknown. Legacy v0.1 CI is made forward-compatible so it no longer pins stale schema/version behavior.