### PR TITLE
Build model2ir multi-view teacher dataset

### DIFF
--- a/.github/workflows/model2ir-teacher-dataset-v07.yml
+++ b/.github/workflows/model2ir-teacher-dataset-v07.yml
@@ -1,0 +1,86 @@
+name: model2ir teacher dataset v0.7
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'scripts/character_blueprint_glb_render.mjs'
+      - 'benchmarks/model2ir/TEACHER_DATASET_CONTRACT_V0.7.md'
+      - '.github/workflows/model2ir-teacher-dataset-v07.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'scripts/character_blueprint_glb_render.mjs'
+      - 'benchmarks/model2ir/TEACHER_DATASET_CONTRACT_V0.7.md'
+      - '.github/workflows/model2ir-teacher-dataset-v07.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  teacher-dataset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - uses: actions/setup-node@v4
+        with: {node-version: '22'}
+
+      - name: Install model2ir and renderer runtime
+        run: |
+          python -m pip install -e libs/model2ir
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Fetch real humanoid GLB teacher source
+        run: |
+          curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb -o /tmp/CesiumMan.glb
+          test -s /tmp/CesiumMan.glb
+
+      - name: Build paired multi-view teacher dataset
+        run: |
+          rm -rf /tmp/model2ir-teacher-v07
+          python scripts/model2ir_teacher_dataset.py \
+            --asset /tmp/CesiumMan.glb \
+            --case-id cesium-man \
+            --out /tmp/model2ir-teacher-v07 | tee /tmp/model2ir-teacher-v07.log
+          grep -q '"ok": true' /tmp/model2ir-teacher-v07.log
+
+      - name: Validate teacher dataset contract
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          root=Path('/tmp/model2ir-teacher-v07')
+          m=json.loads((root/'manifest.json').read_text())
+          assert m['schema']=='model2ir-teacher-dataset/v0.7'
+          assert len(m['cases'])==1
+          assert len(m['examples'])==4
+          assert {x['view'] for x in m['examples']}=={'front','yaw45','right','back'}
+          assert len({x['target_ir_digest'] for x in m['examples']})==1
+          assert m['cases'][0]['stability'] in {'lossless','stable-candidate','stable-but-ambiguous','stable-unknown'}
+          assert m['cases'][0]['stability']!='unstable'
+          for x in m['examples']:
+              assert (root/x['image']).stat().st_size > 1000
+              assert (root/x['target_ir']).is_file()
+              assert 'unresolved' in x
+          ir=json.loads((root/'cesium-man/character-ir.json').read_text())
+          assert ir['truth_status']=='candidate'
+          audit=json.loads((root/'cesium-man/audit.json').read_text())
+          assert audit['candidate_repeatable'] is True
+          assert audit['truth_policy']['automatic_promotion_of_inference'] is False
+          print('model2ir_teacher_dataset=PASS')
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-teacher-dataset-v07
+          path: /tmp/model2ir-teacher-v07/
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/model2ir/TEACHER_DATASET_CONTRACT_V0.7.md
+++ b/benchmarks/model2ir/TEACHER_DATASET_CONTRACT_V0.7.md
@@ -1,0 +1,30 @@
+# model2ir Teacher Dataset Contract v0.7
+
+Goal: turn stable 3D assets into evidence-preserving supervision for image→IR without laundering inference into fact.
+
+## Record shape
+
+Each admitted 3D asset produces:
+
+- `character-ir.json`: the stabilized candidate Character IR.
+- `audit.json`: repeatability, semantic authority, coverage, and truth-policy evidence.
+- canonical renders at yaw `0°`, `45°`, `90°`, `180°`.
+- `manifest.json`: one training example per canonical render, all linked to the exact same IR digest.
+
+## Admission rules
+
+1. `model2ir audit` must not return `unstable`.
+2. External first import remains `candidate`; stabilization does not rewrite inferred semantics as observed truth.
+3. Unknown/unresolved values are preserved as labels. They are not filled merely to make the dataset dense.
+4. Every rendered image records its SHA-256 and exact target IR digest.
+5. A case whose repeated candidate extraction changes digest is a release blocker and is not admitted.
+
+## What this dataset can teach
+
+The paired renders can supervise observable and semantically supported Character IR fields, while providing explicit masks for fields that should remain unknown from a particular view.
+
+The initial v0.7 gate intentionally uses a real Khronos humanoid asset and four deterministic views. It proves the data plumbing and truth boundary; it does **not** claim a trained image2ir model yet.
+
+## Next gate
+
+`image2ir-teacher-loop/v0.1` must consume this manifest, predict IR from each view independently, compare it to the teacher IR using observable-field-aware scoring, and show that correction/training reduces held-out IR error without increasing hallucinated fields.

--- a/scripts/model2ir_teacher_dataset.py
+++ b/scripts/model2ir_teacher_dataset.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from model2ir import audit_asset, extract_ir, stabilize_external_ir, ir_digest
+
+VIEWS = ("front", "yaw45", "right", "back")
+
+
+def dump(path: Path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--asset", required=True)
+    ap.add_argument("--case-id", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--renderer", default="scripts/character_blueprint_glb_render.mjs")
+    args = ap.parse_args()
+
+    asset = Path(args.asset).resolve()
+    out = Path(args.out).resolve()
+    case_dir = out / args.case_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    audit = audit_asset(asset)
+    raw_ir = extract_ir(asset)
+    stable_ir = stabilize_external_ir(raw_ir)
+    stable_digest = ir_digest(stable_ir)
+
+    stability = audit.get("status", "unstable")
+    if stability == "unstable":
+        raise SystemExit("asset audit is unstable; refusing teacher dataset admission")
+
+    local_asset = case_dir / "model.glb"
+    if asset.suffix.lower() != ".glb":
+        raise SystemExit("teacher renderer v0.7 currently requires GLB input")
+    shutil.copy2(asset, local_asset)
+
+    result_stub = case_dir / "render-result.json"
+    dump(result_stub, {"case_id": args.case_id, "source_sha256": sha256(asset)})
+    subprocess.run([
+        "node", args.renderer,
+        "--glb", str(local_asset),
+        "--out", str(case_dir),
+        "--result", str(result_stub),
+    ], check=True)
+
+    render_result = json.loads(result_stub.read_text(encoding="utf-8"))
+    renders = render_result["renders"]
+    missing = [v for v in VIEWS if v not in renders or not (case_dir / renders[v]).exists()]
+    if missing:
+        raise SystemExit(f"missing canonical renders: {missing}")
+
+    dump(case_dir / "character-ir.json", stable_ir)
+    dump(case_dir / "audit.json", audit)
+    unresolved = stable_ir.get("unresolved", [])
+
+    examples = []
+    for view in VIEWS:
+        image = case_dir / renders[view]
+        examples.append({
+            "example_id": f"{args.case_id}:{view}",
+            "view": view,
+            "image": str(Path(args.case_id) / image.name),
+            "image_sha256": sha256(image),
+            "target_ir": str(Path(args.case_id) / "character-ir.json"),
+            "target_ir_digest": stable_digest,
+            "truth_status": stable_ir.get("truth_status", "candidate"),
+            "semantic_authority": audit.get("semantic_authority"),
+            "unresolved": unresolved,
+        })
+
+    manifest = {
+        "schema": "model2ir-teacher-dataset/v0.7",
+        "policy": {
+            "label_kind": "stabilized-evidence-preserving-character-ir",
+            "unknowns_are_labels_not_errors": True,
+            "external_first_import_claimed_lossless": False,
+            "canonical_views": list(VIEWS),
+        },
+        "cases": [{
+            "case_id": args.case_id,
+            "source_asset": str(Path(args.case_id) / "model.glb"),
+            "source_sha256": sha256(asset),
+            "audit": str(Path(args.case_id) / "audit.json"),
+            "target_ir": str(Path(args.case_id) / "character-ir.json"),
+            "target_ir_digest": stable_digest,
+            "stability": stability,
+            "semantic_authority": audit.get("semantic_authority"),
+            "unresolved_count": len(unresolved),
+        }],
+        "examples": examples,
+    }
+    dump(out / "manifest.json", manifest)
+    print(json.dumps({
+        "ok": True,
+        "case_id": args.case_id,
+        "stability": stability,
+        "examples": len(examples),
+        "target_ir_digest": stable_digest,
+    }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Clean rebase-equivalent branch from the latest main. Adds model2ir teacher dataset v0.7: deterministic 3D→stable Character IR→canonical multi-view render pairing. Each view carries the exact target IR digest, image SHA-256, semantic authority, and unresolved fields; unstable assets are rejected. CI validates the contract on a real Khronos CesiumMan GLB.