### PR TITLE
chore(vendors): deploy calibrated context harvester

### DIFF
--- a/.agentos/evidence/issue-92/pr91-required-check-revalidation.md
+++ b/.agentos/evidence/issue-92/pr91-required-check-revalidation.md
@@ -1,0 +1,7 @@
+# Issue #92 — PR #91 required-check revalidation
+
+This marker intentionally changes no Vendor runtime or deployment behavior.
+
+Reason: PR #91's last governance checks were created before PR #78 introduced the canonical `guard` producer on the protected target branch. This commit forces a fresh `pull_request synchronize` event after that producer became available, so the repository ruleset can be validated against the actual current workflow set.
+
+Expected required context: `guard`.

--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: ab4b7a1f584945e2e00bd98a21bee710c6fe8a35
+      SERVICE_SHA: f1b2937b2df908d23b190b256fbe4b8665b46ec1
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent

--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 2308e32a759502b6e12caed457ee38c72c378ac4
+      SERVICE_SHA: 98b503364634fb0a6e3b64318a81a5bd36fba23c
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent
@@ -80,7 +80,7 @@ jobs:
           import json,pathlib,sys
           rc=int(sys.argv[1]); p=pathlib.Path(sys.argv[2])
           text=' '.join((p.read_text(errors='replace') if p.exists() else '').split())[-800:]
-          print(json.dumps({'schema':'milkcat.vendor-threads-patrol-receipt/v4','ok':False,'failed_stage':'ssh','worker_exit_code':None,'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,'harvest_vendor_matches':0,'harvest_filtered_out':0,'new_candidates':0,'duplicates':0,'errors':1,'candidate_sources_total':None,'candidate_authors_total':None,'sanitized_error_tail':text,'raw_text_emitted':False,'raw_text_persisted':False,'token_exposed':False,'reviews_published':False,'core_modified':False},ensure_ascii=False))
+          print(json.dumps({'schema':'milkcat.vendor-threads-patrol-receipt/v5','ok':False,'failed_stage':'ssh','worker_exit_code':None,'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,'harvest_vendor_matches':0,'harvest_filtered_out':0,'new_candidates':0,'duplicates':0,'actor_observations':0,'same_actor_multiple_sources':0,'same_actor_repeated_text':0,'errors':1,'candidate_sources_total':None,'candidate_authors_total':None,'sanitized_error_tail':text,'raw_text_emitted':False,'raw_text_persisted':False,'token_exposed':False,'reviews_published':False,'core_modified':False},ensure_ascii=False))
           PY
           fi
           rm -f "$SSHERR"

--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: f2e02ac56737d25141103f57471df89d8269d68d
+      SERVICE_SHA: ab4b7a1f584945e2e00bd98a21bee710c6fe8a35
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent

--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: f1b2937b2df908d23b190b256fbe4b8665b46ec1
+      SERVICE_SHA: 2308e32a759502b6e12caed457ee38c72c378ac4
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent

--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 98b503364634fb0a6e3b64318a81a5bd36fba23c
+      SERVICE_SHA: 1ea5b0e38db5d2d5f2228d1597e17acfdc5b8aad
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent

--- a/scripts/run_vendor_threads_patrol.sh
+++ b/scripts/run_vendor_threads_patrol.sh
@@ -5,18 +5,20 @@ SHA="${1:?service sha required}"
 BASE=/home/ubuntu/vendor-reputation-service
 ERR=/tmp/vendor-patrol-stage.err
 OUT=/tmp/vendor-patrol-worker.out
+VENDOR_ENV=/home/ubuntu/agent-data/secrets/vendor-reputation.env
 : >"$ERR"
 : >"$OUT"
 
 emit_failure() {
   local stage="$1" rc="$2" file="${3:-$ERR}"
-  python3 - "$stage" "$rc" "$file" "${SOC_THREADS_TOKEN:-}" <<'PY'
+  python3 - "$stage" "$rc" "$file" "${SOC_THREADS_TOKEN:-}" "${VENDOR_ADMIN_TOKEN:-}" <<'PY'
 import json,pathlib,re,sys
-stage,rc,path,token=sys.argv[1],int(sys.argv[2]),sys.argv[3],sys.argv[4]
+stage,rc,path,threads_token,admin_token=sys.argv[1],int(sys.argv[2]),sys.argv[3],sys.argv[4],sys.argv[5]
 p=pathlib.Path(path)
 text=p.read_text(errors='replace') if p.exists() else ''
-if token:
-    text=text.replace(token,'[REDACTED_TOKEN]')
+for token in (threads_token, admin_token):
+    if token:
+        text=text.replace(token,'[REDACTED_TOKEN]')
 text=re.sub(r'access_token=[^&\s]+','access_token=[REDACTED]',text)
 text=' '.join(text.split())[-800:]
 print(json.dumps({
@@ -39,8 +41,25 @@ if [ ! -d "$BASE/.git" ]; then echo 'service git repo missing' >"$ERR"; emit_fai
 git -C "$BASE" fetch --depth=1 origin "$SHA" >"$ERR" 2>&1 || emit_failure fetch $?
 git -C "$BASE" checkout --detach "$SHA" >"$ERR" 2>&1 || emit_failure checkout $?
 
+if [ ! -f "$VENDOR_ENV" ]; then
+  echo 'vendor env missing' >"$ERR"
+  emit_failure vendor_env 2
+fi
+
+if ! grep -q '^VENDOR_ADMIN_TOKEN=' "$VENDOR_ENV"; then
+  ADMIN_TOKEN=$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+) || emit_failure admin_token_generate $?
+  umask 077
+  printf '\nVENDOR_ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN" >> "$VENDOR_ENV" || emit_failure admin_token_write $?
+  chmod 600 "$VENDOR_ENV" || emit_failure admin_token_permissions $?
+  unset ADMIN_TOKEN
+fi
+
 set -a
-. /home/ubuntu/agent-data/secrets/vendor-reputation.env 2>"$ERR" || emit_failure vendor_env $?
+. "$VENDOR_ENV" 2>"$ERR" || emit_failure vendor_env $?
 set +a
 
 SOC_THREADS_TOKEN=$(python3 - <<'PY'

--- a/scripts/run_vendor_threads_patrol.sh
+++ b/scripts/run_vendor_threads_patrol.sh
@@ -82,9 +82,25 @@ PY
 export SOC_THREADS_TOKEN
 
 cd "$BASE" || emit_failure chdir $?
-docker compose up -d --build >"$ERR" 2>&1 || emit_failure compose $?
+
+# Bring up only PostgreSQL first so schema migrations land before the new API process starts.
+docker compose up -d db >"$ERR" 2>&1 || emit_failure compose_db $?
+READY=0
+for _ in $(seq 1 30); do
+  if docker compose exec -T db pg_isready -U vendor_service -d vendor_reputation >/dev/null 2>"$ERR"; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [ "$READY" -ne 1 ]; then echo 'vendor db did not become ready' >"$ERR"; emit_failure db_ready 2; fi
+
 docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/003_source_discovery.sql >"$ERR" 2>&1 || emit_failure migration_003 $?
 docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/004_actor_independence.sql >"$ERR" 2>&1 || emit_failure migration_004 $?
+docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/005_reputation_snapshot_voice_counts.sql >"$ERR" 2>&1 || emit_failure migration_005 $?
+
+# Only after migrations succeed do we replace/rebuild the API container.
+docker compose up -d --build api >"$ERR" 2>&1 || emit_failure compose_api $?
 
 set +e
 docker compose run --rm -T -e SOC_THREADS_TOKEN="$SOC_THREADS_TOKEN" api \

--- a/scripts/run_vendor_threads_patrol.sh
+++ b/scripts/run_vendor_threads_patrol.sh
@@ -22,12 +22,14 @@ for token in (threads_token, admin_token):
 text=re.sub(r'access_token=[^&\s]+','access_token=[REDACTED]',text)
 text=' '.join(text.split())[-800:]
 print(json.dumps({
-  'schema':'milkcat.vendor-threads-patrol-receipt/v4',
+  'schema':'milkcat.vendor-threads-patrol-receipt/v5',
   'ok':False,'failed_stage':stage,
   'worker_exit_code':rc if stage == 'worker' else None,
   'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,
   'harvest_vendor_matches':0,'harvest_filtered_out':0,
-  'new_candidates':0,'duplicates':0,'errors':1,
+  'new_candidates':0,'duplicates':0,
+  'actor_observations':0,'same_actor_multiple_sources':0,'same_actor_repeated_text':0,
+  'errors':1,
   'by_search_type':{},'harvest_by_search_type':{},'positive_controls':[],'error_signatures':[],
   'candidate_sources_total':None,'candidate_authors_total':None,
   'sanitized_error_tail':text,'raw_text_emitted':False,'raw_text_persisted':False,
@@ -81,7 +83,8 @@ export SOC_THREADS_TOKEN
 
 cd "$BASE" || emit_failure chdir $?
 docker compose up -d --build >"$ERR" 2>&1 || emit_failure compose $?
-docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/003_source_discovery.sql >"$ERR" 2>&1 || emit_failure migration $?
+docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/003_source_discovery.sql >"$ERR" 2>&1 || emit_failure migration_003 $?
+docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/004_actor_independence.sql >"$ERR" 2>&1 || emit_failure migration_004 $?
 
 set +e
 docker compose run --rm -T -e SOC_THREADS_TOKEN="$SOC_THREADS_TOKEN" api \
@@ -98,13 +101,17 @@ python3 - "$OUT" "$CANDIDATES" "$AUTHORS" <<'PY'
 import json,pathlib,sys
 x=json.loads(pathlib.Path(sys.argv[1]).read_text())
 print(json.dumps({
-  'schema':'milkcat.vendor-threads-patrol-receipt/v4',
+  'schema':'milkcat.vendor-threads-patrol-receipt/v5',
   'ok':True,'failed_stage':None,'worker_exit_code':0,
   'queries':x.get('queries',0),'results_seen':x.get('results',0),
   'direct_results':x.get('direct_results',0),'harvest_results':x.get('harvest_results',0),
   'harvest_vendor_matches':x.get('harvest_vendor_matches',0),
   'harvest_filtered_out':x.get('harvest_filtered_out',0),
-  'new_candidates':x.get('new_candidates',0),'duplicates':x.get('duplicates',0),'errors':x.get('errors',0),
+  'new_candidates':x.get('new_candidates',0),'duplicates':x.get('duplicates',0),
+  'actor_observations':x.get('actor_observations',0),
+  'same_actor_multiple_sources':x.get('same_actor_multiple_sources',0),
+  'same_actor_repeated_text':x.get('same_actor_repeated_text',0),
+  'errors':x.get('errors',0),
   'by_search_type':x.get('by_search_type',{}),'harvest_by_search_type':x.get('harvest_by_search_type',{}),
   'positive_controls':x.get('positive_controls',[]),'error_signatures':x.get('error_signatures',[]),
   'candidate_sources_total':int(sys.argv[2]),'candidate_authors_total':int(sys.argv[3]),


### PR DESCRIPTION
Deploy the current Vendor Threads Patrol carrier against vendor-reputation-service SHA `1ea5b0e38db5d2d5f2228d1597e17acfdc5b8aad`.

Included Vendor project behavior:
- calibrated two-stage Threads harvest terms: `台灣`, `台南`, `新家`, `居家`, `安裝`
- local vendor-signal filtering before candidate persistence
- actor-independence observation: same Threads actor across sources and repeated text fingerprints are tracked without deleting evidence or inferring cross-account identity
- runtime admin write guard in Vendor Service
- Oracle-local `VENDOR_ADMIN_TOKEN` provisioning into `/home/ubuntu/agent-data/secrets/vendor-reputation.env` when absent; token is never printed or committed
- error redaction covers both Threads and Vendor admin tokens
- protected admin candidate/review queue read models
- actor-aware temporal Bayesian reputation recompute for explicit structured ratings only; one public actor contributes at most one independent vote per canonical vendor
- public reputation read model exposes `reviewCount` and `independentVoiceCount`
- deployment starts DB first, applies migrations 003/004/005, then replaces/rebuilds API to avoid schema/API mismatch

Carrier/project change only. No AgentOS Core modifications.

Currently blocked by Core governance issue #92 because `main` requires a nonexistent `guard` status context even though the emitted `documentation-reality`, `governance`, and `audit` checks all succeed.