### PR TITLE
[MIGRATION CARRIER — DO NOT MERGE] fix(vendors): publish patrol receipts as workflow artifacts

### DIFF
--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -14,7 +14,7 @@ on:
       - 'config/vendor_threads_sources.txt'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   register:
@@ -87,15 +87,11 @@ jobs:
           python3 -m json.tool "$OUT" >/dev/null
           cat "$OUT"
           exit "$SSH_RC"
-      - name: Commit sanitized patrol evidence
+      - name: Upload sanitized patrol evidence
         if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -s .agentos/evidence/vendor-threads-patrol.json || exit 0
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add .agentos/evidence/vendor-threads-patrol.json
-          git diff --cached --quiet && exit 0
-          git commit -m 'evidence(vendors): Threads patrol receipt'
-          git push
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor-threads-patrol-receipt
+          path: .agentos/evidence/vendor-threads-patrol.json
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
Follow-up to PR #91 and the first calibrated Oracle patrol run.

The runtime patrol itself completed successfully, but its final evidence step attempted `git push` to the protected target branch and was correctly rejected by repository rules.

This PR removes repository mutation from evidence publication:
- reduce workflow permission from `contents: write` to `contents: read`
- replace `git commit && git push` with `actions/upload-artifact@v4`
- preserve `if: always()` so sanitized success/failure receipts remain available
- use artifact name `vendor-threads-patrol-receipt`, retention 30 days

No AgentOS Core runtime change. No Vendor Service behavior change. This only repairs the carrier/evidence publication path under protected-branch governance.

First patrol evidence from run 33309586115 is already preserved in PR #91 discussion: 54 queries, 18 harvest results, 18 filtered, 0 candidates, 0 errors.