### PR TITLE
[MIGRATION CARRIER — DO NOT MERGE] experiment(vendors): run aggregate Threads signal calibration on Oracle

### DIFF
--- a/.github/workflows/oracle-vendor-threads-calibration.yml
+++ b/.github/workflows/oracle-vendor-threads-calibration.yml
@@ -1,0 +1,72 @@
+name: Oracle Vendor Threads Calibration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/oracle-vendor-threads-calibration.yml'
+      - 'scripts/run_vendor_threads_calibration.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 10
+    env:
+      DEPLOY_HOST: 127.0.0.1
+      DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
+      DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
+      SERVICE_SHA: 2c991b9e3d75e0128bed119ea4dff0b4a02fd55e
+    steps:
+      - uses: actions/checkout@v4
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AGENTOS_DEPLOY_SSH_KEY || secrets.N8N_DEPLOY_SSH_KEY }}
+      - name: Run aggregate-only Threads vendor-signal calibration on Oracle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .agentos/evidence
+          OUT=.agentos/evidence/vendor-threads-calibration.json
+          SSHERR=.agentos/evidence/vendor-threads-calibration-ssh.err
+          ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            'umask 077; cat > /tmp/run_vendor_threads_calibration.sh' \
+            < scripts/run_vendor_threads_calibration.sh
+          set +e
+          ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            bash /tmp/run_vendor_threads_calibration.sh "$SERVICE_SHA" \
+            > "$OUT" 2> "$SSHERR"
+          SSH_RC=$?
+          set -e
+          if [ ! -s "$OUT" ]; then
+            python3 - "$SSH_RC" "$SSHERR" > "$OUT" <<'PY'
+          import json,pathlib,sys
+          rc=int(sys.argv[1]); p=pathlib.Path(sys.argv[2])
+          text=' '.join((p.read_text(errors='replace') if p.exists() else '').split())[-800:]
+          print(json.dumps({
+            'schema':'milkcat.threads-vendor-signal-calibration/v1',
+            'ok':False,'failed_stage':'ssh','requests':0,'results_seen':0,
+            'qualified_under_current_filter':0,'filtered_out':0,
+            'filtered_hint_counts':{},'by_harvest_term':{},
+            'errors':[{'exception_type':'ssh_failure','detail':text}],
+            'raw_text_emitted':False,'raw_text_persisted':False,
+            'candidate_db_modified':False,'reviews_published':False
+          },ensure_ascii=False))
+          PY
+          fi
+          rm -f "$SSHERR"
+          python3 -m json.tool "$OUT" >/dev/null
+          cat "$OUT"
+          exit "$SSH_RC"
+      - name: Upload calibration receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor-threads-signal-calibration
+          path: .agentos/evidence/vendor-threads-calibration.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/run_vendor_threads_calibration.sh
+++ b/scripts/run_vendor_threads_calibration.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHA="${1:?service sha required}"
+BASE=/home/ubuntu/vendor-reputation-service
+ERR=/tmp/vendor-threads-calibration.err
+: >"$ERR"
+
+emit_failure() {
+  local stage="$1" rc="$2"
+  python3 - "$stage" "$rc" "$ERR" <<'PY'
+import json,pathlib,sys
+stage,rc,path=sys.argv[1],int(sys.argv[2]),sys.argv[3]
+p=pathlib.Path(path)
+text=' '.join((p.read_text(errors='replace') if p.exists() else '').split())[-800:]
+print(json.dumps({
+  'schema':'milkcat.threads-vendor-signal-calibration/v1',
+  'ok':False,
+  'failed_stage':stage,
+  'requests':0,
+  'results_seen':0,
+  'qualified_under_current_filter':0,
+  'filtered_out':0,
+  'filtered_hint_counts':{},
+  'by_harvest_term':{},
+  'errors':[{'exception_type':'carrier_failure','detail':text}],
+  'raw_text_emitted':False,
+  'raw_text_persisted':False,
+  'candidate_db_modified':False,
+  'reviews_published':False
+},ensure_ascii=False))
+PY
+  exit "$rc"
+}
+
+if [ ! -d "$BASE/.git" ]; then echo 'service git repo missing' >"$ERR"; emit_failure repo 2; fi
+git -C "$BASE" fetch --depth=1 origin "$SHA" >"$ERR" 2>&1 || emit_failure fetch $?
+git -C "$BASE" checkout --detach "$SHA" >"$ERR" 2>&1 || emit_failure checkout $?
+
+SOC_THREADS_TOKEN=$(python3 - <<'PY'
+from pathlib import Path
+p=Path('/home/ubuntu/agent-data/secrets/zeus-writer.env')
+value=''
+for line in p.read_text().splitlines():
+    if line.startswith('SOC_THREADS_TOKEN='):
+        value=line.split('=',1)[1].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value=value[1:-1]
+        break
+if not value:
+    raise SystemExit('SOC_THREADS_TOKEN missing')
+print(value)
+PY
+) || emit_failure threads_token $?
+export SOC_THREADS_TOKEN
+
+cd "$BASE" || emit_failure chdir $?
+python3 scripts/calibrate_threads_vendor_signals.py 2>"$ERR" || emit_failure calibration $?


### PR DESCRIPTION
Carrier for the privacy-safe Threads vendor-signal calibration in `alston-personal/vendor-reputation-service#20`.

Dependency:
- Vendor Service PR #20
- calibration commit `2c991b9e3d75e0128bed119ea4dff0b4a02fd55e`

Behavior:
- fetches the exact Vendor Service calibration commit on Oracle
- reads the existing Threads token from the Oracle secret boundary without printing or committing it
- runs `scripts/calibrate_threads_vendor_signals.py`
- emits aggregate-only JSON: result counts, current-filter qualification counts, and filtered hint-term counts
- does not connect to candidate/review DB
- does not emit or persist raw Threads text or identity fields
- uploads the receipt via `actions/upload-artifact@v4`
- repository permission is `contents: read`; there is no repository mutation path

The workflow triggers once when these carrier files land on the protected target branch, and can also be manually dispatched later.

No AgentOS Core runtime modification.