### PR TITLE
chore(vendors): deploy high-precision Threads queries

### DIFF
--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -52,7 +52,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 1ea5b0e38db5d2d5f2228d1597e17acfdc5b8aad
+      SERVICE_SHA: 97cd0bd8671c2afce936d3d9479499db1585544e
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent


### PR DESCRIPTION
Pin Oracle Vendor Threads Patrol to vendor-reputation-service SHA `97cd0bd8671c2afce936d3d9479499db1585544e`, which adds high-precision direct service queries (`抓漏`, `冷氣清洗`, `居家清潔`, `家電維修`, `驗屋`, trade-specific 師傅 queries, etc.).

Existing governance-safe artifact receipt and reputation recompute behavior are unchanged. Hits remain candidate sources only; no automatic vendor/review publication. No private evidence is used for outbound query selection. No AgentOS Core changes.