### PR TITLE
fix(vendors): enforce canonical Threads source identity on Oracle

### DIFF
--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -25,7 +25,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: fbcf3cb1ece1bf7b2d928634cf4afd3901cf894b
+      SERVICE_SHA: 21fb1e9e32211060161c9c84c865e3d1ce428cb2
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent
@@ -36,14 +36,38 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p .agentos/evidence
+          : > .agentos/evidence/vendor-source-registration.jsonl
           while IFS= read -r SOURCE_URL; do
             [ -n "$SOURCE_URL" ] || continue
             case "$SOURCE_URL" in \#*) continue ;; esac
             ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
               bash -s -- "$SERVICE_SHA" "$SOURCE_URL" \
               < scripts/register_vendor_threads_source.sh \
-              >/dev/null
+              >> .agentos/evidence/vendor-source-registration.jsonl
           done < config/vendor_threads_sources.txt
+          python3 - <<'PY'
+          import json
+          path='.agentos/evidence/vendor-source-registration.jsonl'
+          rows=[json.loads(line) for line in open(path) if line.strip()]
+          assert rows, rows
+          assert all(x.get('core_modified') is False for x in rows), rows
+          assert all(x.get('raw_threads_content_emitted') is False for x in rows), rows
+          print(json.dumps({
+            'registrations': len(rows),
+            'active_sources': rows[-1].get('active_sources'),
+            'unique_source_objects': rows[-1].get('unique_source_objects'),
+            'core_modified': False,
+            'raw_threads_content_emitted': False,
+          }, ensure_ascii=False))
+          PY
+      - name: Upload sanitized registration evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor-source-registration-${{ github.run_id }}
+          path: .agentos/evidence/vendor-source-registration.jsonl
+          if-no-files-found: error
+          retention-days: 30
 
   discover:
     runs-on: [self-hosted, Linux, ARM64, oracle]
@@ -52,7 +76,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 97cd0bd8671c2afce936d3d9479499db1585544e
+      SERVICE_SHA: 21fb1e9e32211060161c9c84c865e3d1ce428cb2
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent
@@ -80,7 +104,7 @@ jobs:
           import json,pathlib,sys
           rc=int(sys.argv[1]); p=pathlib.Path(sys.argv[2])
           text=' '.join((p.read_text(errors='replace') if p.exists() else '').split())[-800:]
-          print(json.dumps({'schema':'milkcat.vendor-threads-patrol-receipt/v6','ok':False,'failed_stage':'ssh','worker_exit_code':None,'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,'harvest_vendor_matches':0,'harvest_filtered_out':0,'new_candidates':0,'duplicates':0,'actor_observations':0,'same_actor_multiple_sources':0,'same_actor_repeated_text':0,'reputation_vendors_computed':0,'reputation_reviews_seen':0,'reputation_independent_voices':0,'reputation_duplicate_actor_reviews_collapsed':0,'errors':1,'candidate_sources_total':None,'candidate_authors_total':None,'sanitized_error_tail':text,'raw_text_emitted':False,'raw_text_persisted':False,'token_exposed':False,'reviews_published':False,'core_modified':False},ensure_ascii=False))
+          print(json.dumps({'schema':'milkcat.vendor-threads-patrol-receipt/v7','ok':False,'failed_stage':'ssh','worker_exit_code':None,'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,'harvest_vendor_matches':0,'harvest_filtered_out':0,'new_candidates':0,'duplicates':0,'actor_observations':0,'same_actor_multiple_sources':0,'same_actor_repeated_text':0,'reputation_vendors_computed':0,'reputation_reviews_seen':0,'reputation_independent_voices':0,'reputation_duplicate_actor_reviews_collapsed':0,'active_monitored_sources':None,'unique_source_objects':None,'errors':1,'candidate_sources_total':None,'candidate_authors_total':None,'sanitized_error_tail':text,'raw_text_emitted':False,'raw_text_persisted':False,'token_exposed':False,'reviews_published':False,'core_modified':False},ensure_ascii=False))
           PY
           fi
           rm -f "$SSHERR"
@@ -99,6 +123,8 @@ jobs:
           x=json.load(open(sys.argv[1]))
           print('## Vendor Threads Patrol')
           print(f"- ok: `{x.get('ok')}`")
+          print(f"- active monitored sources: `{x.get('active_monitored_sources')}`")
+          print(f"- unique source objects: `{x.get('unique_source_objects')}`")
           print(f"- results seen: `{x.get('results_seen',0)}`")
           print(f"- vendor matches: `{x.get('harvest_vendor_matches',0)}`")
           print(f"- new candidates: `{x.get('new_candidates',0)}`")

--- a/scripts/register_vendor_threads_source.sh
+++ b/scripts/register_vendor_threads_source.sh
@@ -9,32 +9,163 @@ cd "$DIR"
 git fetch --depth=1 origin "$SHA" >/dev/null 2>&1
 git checkout --detach "$SHA" >/dev/null 2>&1
 
+# Ensure both the source registry and the canonical post-identity invariant are
+# present before resolving/upserting the incoming source.
 docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/002_source_registry.sql >/dev/null
+docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/006_threads_source_identity.sql >/dev/null
 
 FINAL=$(curl -LsS --max-time 30 -o /dev/null -w '%{url_effective}' "$INPUT" || true)
-if printf '%s' "$FINAL" | grep -Eq '^https://(www\.)?threads\.(com|net)/@[^/]+/post/[^/?#]+'; then
-  CANONICAL="$FINAL"
+mapfile -t IDENTITY < <(python3 - "$FINAL" <<'PY'
+import re,sys,urllib.parse
+value=sys.argv[1].strip()
+canonical=''
+object_id=''
+try:
+    p=urllib.parse.urlsplit(value)
+    host=(p.hostname or '').lower()
+    path=p.path.rstrip('/')
+    m=re.fullmatch(r'/@[^/]+/post/([^/?#]+)', path)
+    if host in {'threads.com','www.threads.com','threads.net','www.threads.net'} and m:
+        canonical='https://www.threads.com'+path
+        object_id=m.group(1)
+except Exception:
+    pass
+print(canonical)
+print(object_id)
+PY
+)
+CANONICAL="${IDENTITY[0]:-}"
+OBJECT_ID="${IDENTITY[1]:-}"
+if [ -n "$CANONICAL" ] && [ -n "$OBJECT_ID" ]; then
   CANONICAL_STATE=resolved
 else
   CANONICAL=''
+  OBJECT_ID=''
   CANONICAL_STATE=pending
 fi
 
 esc() { printf "%s" "$1" | sed "s/'/''/g"; }
 INPUT_SQL=$(esc "$INPUT")
 CANON_SQL=$(esc "$CANONICAL")
+OBJECT_SQL=$(esc "$OBJECT_ID")
 
+# Keep the first canonical row for a Threads post object. A later share URL or
+# tracking variant is retained as an input alias rather than becoming another
+# monitored source. If an older pending input row exists, preserve its
+# ingestion history before merging it into the canonical keeper.
 docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation >/dev/null <<SQL
 INSERT INTO monitored_sources(id, source_type, input_url, canonical_url, source_object_id, status, sync_policy, last_seen_item_count, metadata)
 VALUES (gen_random_uuid(), 'threads_public_post', 'https://www.threads.com/@nico1e.16/post/DcWVvpwGTSh', 'https://www.threads.com/@nico1e.16/post/DcWVvpwGTSh', 'DcWVvpwGTSh', 'active', 'active-6h', 33, '{"backfilled":true}'::jsonb)
-ON CONFLICT (source_type, input_url) DO UPDATE SET status='active', sync_policy='active-6h', last_seen_item_count=GREATEST(monitored_sources.last_seen_item_count,33), updated_at=now();
+ON CONFLICT (source_type, source_object_id) WHERE source_object_id IS NOT NULL DO UPDATE
+SET status='active',
+    sync_policy='active-6h',
+    last_seen_item_count=GREATEST(monitored_sources.last_seen_item_count,33),
+    updated_at=now();
 
-INSERT INTO monitored_sources(id, source_type, input_url, canonical_url, status, sync_policy, metadata)
-VALUES (gen_random_uuid(), 'threads_public_post', '$INPUT_SQL', NULLIF('$CANON_SQL',''), 'active', 'active-6h', jsonb_build_object('canonical_state','$CANONICAL_STATE'))
-ON CONFLICT (source_type, input_url) DO UPDATE SET canonical_url=COALESCE(EXCLUDED.canonical_url, monitored_sources.canonical_url), status='active', sync_policy='active-6h', metadata=monitored_sources.metadata || EXCLUDED.metadata, updated_at=now();
+DO \$\$
+DECLARE
+  v_input text := '$INPUT_SQL';
+  v_canonical text := NULLIF('$CANON_SQL','');
+  v_object text := NULLIF('$OBJECT_SQL','');
+  v_state text := '$CANONICAL_STATE';
+  keeper uuid;
+  input_row uuid;
+  input_seen integer := 0;
+  input_sync timestamptz;
+  input_meta jsonb := '{}'::jsonb;
+  aliases jsonb;
+BEGIN
+  IF v_object IS NOT NULL THEN
+    SELECT id INTO keeper
+      FROM monitored_sources
+     WHERE source_type='threads_public_post' AND source_object_id=v_object
+     ORDER BY created_at,id LIMIT 1;
+
+    SELECT id, last_seen_item_count, last_synced_at, metadata
+      INTO input_row, input_seen, input_sync, input_meta
+      FROM monitored_sources
+     WHERE source_type='threads_public_post' AND input_url=v_input
+     ORDER BY created_at,id LIMIT 1;
+
+    IF keeper IS NULL THEN
+      IF input_row IS NULL THEN
+        INSERT INTO monitored_sources(
+          id, source_type, input_url, canonical_url, source_object_id,
+          status, sync_policy, metadata
+        ) VALUES (
+          gen_random_uuid(), 'threads_public_post', v_input, v_canonical, v_object,
+          'active', 'active-6h', jsonb_build_object(
+            'canonical_state',v_state,'input_aliases',jsonb_build_array(v_input)
+          )
+        ) RETURNING id INTO keeper;
+      ELSE
+        keeper := input_row;
+        UPDATE monitored_sources
+           SET canonical_url=v_canonical,
+               source_object_id=v_object,
+               status='active', sync_policy='active-6h',
+               metadata=metadata || jsonb_build_object('canonical_state',v_state),
+               updated_at=now()
+         WHERE id=keeper;
+      END IF;
+    ELSIF input_row IS NOT NULL AND input_row <> keeper THEN
+      UPDATE ingestion_runs SET source_id=keeper WHERE source_id=input_row;
+      UPDATE monitored_sources k
+         SET last_seen_item_count=GREATEST(k.last_seen_item_count,input_seen),
+             last_synced_at=CASE
+               WHEN k.last_synced_at IS NULL THEN input_sync
+               WHEN input_sync IS NULL THEN k.last_synced_at
+               ELSE GREATEST(k.last_synced_at,input_sync)
+             END,
+             metadata=k.metadata || input_meta,
+             updated_at=now()
+       WHERE k.id=keeper;
+      DELETE FROM monitored_sources WHERE id=input_row;
+    END IF;
+
+    SELECT COALESCE(jsonb_agg(alias ORDER BY alias),'[]'::jsonb)
+      INTO aliases
+      FROM (
+        SELECT DISTINCT value AS alias
+          FROM jsonb_array_elements_text(
+            COALESCE((SELECT metadata->'input_aliases' FROM monitored_sources WHERE id=keeper),'[]'::jsonb)
+            || jsonb_build_array(v_input)
+          )
+      ) q;
+
+    UPDATE monitored_sources
+       SET canonical_url=v_canonical,
+           source_object_id=v_object,
+           status='active', sync_policy='active-6h',
+           metadata=metadata || jsonb_build_object(
+             'canonical_state',v_state,
+             'input_aliases',aliases
+           ),
+           updated_at=now()
+     WHERE id=keeper;
+  ELSE
+    INSERT INTO monitored_sources(
+      id, source_type, input_url, canonical_url, source_object_id,
+      status, sync_policy, metadata
+    ) VALUES (
+      gen_random_uuid(), 'threads_public_post', v_input, NULL, NULL,
+      'active', 'active-6h', jsonb_build_object('canonical_state',v_state)
+    )
+    ON CONFLICT (source_type,input_url) DO UPDATE
+      SET status='active', sync_policy='active-6h',
+          metadata=monitored_sources.metadata || EXCLUDED.metadata,
+          updated_at=now();
+  END IF;
+END \$\$;
 SQL
 
-TOTAL=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from monitored_sources where status='active';" | tr -d '\r')
-NEW_COUNT=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from monitored_sources where source_type='threads_public_post' and input_url='$(esc "$INPUT")' and status='active';" | tr -d '\r')
+# Re-run the invariant migration idempotently so every registration ends in a
+# normalized, semantically deduplicated registry even after legacy pending rows.
+docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/006_threads_source_identity.sql >/dev/null
 
-printf '{"schema":"milkcat.vendor-source-register/v1","service_sha":"%s","active_sources":%s,"new_source_registered":%s,"canonical_state":"%s","core_modified":false,"raw_threads_content_emitted":false}\n' "$SHA" "$TOTAL" "$NEW_COUNT" "$CANONICAL_STATE"
+TOTAL=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from monitored_sources where status='active';" | tr -d '\r')
+INPUT_ESC=$(esc "$INPUT")
+REGISTERED=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from monitored_sources where source_type='threads_public_post' and status='active' and (input_url='$INPUT_ESC' or coalesce(metadata->'input_aliases','[]'::jsonb) ? '$INPUT_ESC');" | tr -d '\r')
+UNIQUE_OBJECTS=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(distinct source_object_id) from monitored_sources where source_type='threads_public_post' and status='active' and source_object_id is not null;" | tr -d '\r')
+
+printf '{"schema":"milkcat.vendor-source-register/v2","service_sha":"%s","active_sources":%s,"registered_input_alias":%s,"unique_source_objects":%s,"canonical_state":"%s","core_modified":false,"raw_threads_content_emitted":false}\n' "$SHA" "$TOTAL" "$REGISTERED" "$UNIQUE_OBJECTS" "$CANONICAL_STATE"

--- a/scripts/run_vendor_threads_patrol.sh
+++ b/scripts/run_vendor_threads_patrol.sh
@@ -24,7 +24,7 @@ for token in (threads_token, admin_token):
 text=re.sub(r'access_token=[^&\s]+','access_token=[REDACTED]',text)
 text=' '.join(text.split())[-800:]
 print(json.dumps({
-  'schema':'milkcat.vendor-threads-patrol-receipt/v6',
+  'schema':'milkcat.vendor-threads-patrol-receipt/v7',
   'ok':False,'failed_stage':stage,
   'worker_exit_code':rc if stage == 'worker' else None,
   'queries':0,'results_seen':0,'direct_results':0,'harvest_results':0,
@@ -33,6 +33,7 @@ print(json.dumps({
   'actor_observations':0,'same_actor_multiple_sources':0,'same_actor_repeated_text':0,
   'reputation_vendors_computed':0,'reputation_reviews_seen':0,
   'reputation_independent_voices':0,'reputation_duplicate_actor_reviews_collapsed':0,
+  'active_monitored_sources':None,'unique_source_objects':None,
   'errors':1,
   'by_search_type':{},'harvest_by_search_type':{},'positive_controls':[],'error_signatures':[],
   'candidate_sources_total':None,'candidate_authors_total':None,
@@ -90,17 +91,21 @@ cd "$BASE" || emit_failure chdir $?
 docker compose up -d db >"$ERR" 2>&1 || emit_failure compose_db $?
 READY=0
 for _ in $(seq 1 30); do
-  if docker compose exec -T db pg_isready -U vendor_service -d vendor_reputation >/dev/null 2>"$ERR"; then
+  if docker compose exec -T db psql -U vendor_service -d vendor_reputation -Atqc 'select 1' >/dev/null 2>"$ERR"; then
     READY=1
     break
   fi
   sleep 1
 done
-if [ "$READY" -ne 1 ]; then echo 'vendor db did not become ready' >"$ERR"; emit_failure db_ready 2; fi
+if [ "$READY" -ne 1 ]; then echo 'vendor db did not become queryable' >"$ERR"; emit_failure db_ready 2; fi
 
-docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/003_source_discovery.sql >"$ERR" 2>&1 || emit_failure migration_003 $?
-docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/004_actor_independence.sql >"$ERR" 2>&1 || emit_failure migration_004 $?
-docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < sql/005_reputation_snapshot_voice_counts.sql >"$ERR" 2>&1 || emit_failure migration_005 $?
+for migration in \
+  sql/003_source_discovery.sql \
+  sql/004_actor_independence.sql \
+  sql/005_reputation_snapshot_voice_counts.sql \
+  sql/006_threads_source_identity.sql; do
+  docker compose exec -T db psql -v ON_ERROR_STOP=1 -U vendor_service -d vendor_reputation < "$migration" >"$ERR" 2>&1 || emit_failure "migration_$(basename "$migration" .sql)" $?
+done
 
 docker compose up -d --build api >"$ERR" 2>&1 || emit_failure compose_api $?
 
@@ -122,13 +127,15 @@ if [ "$REPUTATION_RC" -ne 0 ]; then emit_failure reputation_recompute "$REPUTATI
 
 CANDIDATES=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from candidate_sources where status='candidate';" 2>"$ERR" | tr -d '\r') || emit_failure db_count $?
 AUTHORS=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(distinct source_author) from candidate_sources where status='candidate' and source_author is not null;" 2>"$ERR" | tr -d '\r') || emit_failure db_count $?
+ACTIVE_SOURCES=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(*) from monitored_sources where status='active';" 2>"$ERR" | tr -d '\r') || emit_failure db_count $?
+UNIQUE_OBJECTS=$(docker compose exec -T db psql -At -U vendor_service -d vendor_reputation -c "select count(distinct source_object_id) from monitored_sources where status='active' and source_type='threads_public_post' and source_object_id is not null;" 2>"$ERR" | tr -d '\r') || emit_failure db_count $?
 
-python3 - "$OUT" "$REPUTATION_OUT" "$CANDIDATES" "$AUTHORS" <<'PY'
+python3 - "$OUT" "$REPUTATION_OUT" "$CANDIDATES" "$AUTHORS" "$ACTIVE_SOURCES" "$UNIQUE_OBJECTS" <<'PY'
 import json,pathlib,sys
 x=json.loads(pathlib.Path(sys.argv[1]).read_text())
 r=json.loads(pathlib.Path(sys.argv[2]).read_text())
 print(json.dumps({
-  'schema':'milkcat.vendor-threads-patrol-receipt/v6',
+  'schema':'milkcat.vendor-threads-patrol-receipt/v7',
   'ok':True,'failed_stage':None,'worker_exit_code':0,
   'queries':x.get('queries',0),'results_seen':x.get('results',0),
   'direct_results':x.get('direct_results',0),'harvest_results':x.get('harvest_results',0),
@@ -142,6 +149,8 @@ print(json.dumps({
   'reputation_reviews_seen':r.get('reviews_seen',0),
   'reputation_independent_voices':r.get('independent_voices',0),
   'reputation_duplicate_actor_reviews_collapsed':r.get('duplicate_actor_reviews_collapsed',0),
+  'active_monitored_sources':int(sys.argv[5]),
+  'unique_source_objects':int(sys.argv[6]),
   'errors':x.get('errors',0),
   'by_search_type':x.get('by_search_type',{}),'harvest_by_search_type':x.get('harvest_by_search_type',{}),
   'positive_controls':x.get('positive_controls',[]),'error_signatures':x.get('error_signatures',[]),


### PR DESCRIPTION
Deploy Vendor Service source-identity invariant `21fb1e9e32211060161c9c84c865e3d1ce428cb2` through both registration and scheduled patrol paths.

Changes:
- resolve share URLs to canonical Threads post URL without query/fragment
- derive post code/source_object_id
- treat alternate share/tracking URLs as input aliases for the same post instead of separate monitored sources
- preserve/move ingestion history when a legacy pending duplicate is merged
- apply migration 006 in both registration and scheduled patrol
- pin both register/discover jobs to the same Vendor Service SHA
- emit sanitized registration artifacts plus patrol v7 source-count fields

Expected Oracle repair: current 3 active rows representing 2 Threads posts collapse to 2 active canonical source objects without losing provenance.

Vendor project/data-integrity change only. No AgentOS Core changes and no privilege broadening.