### PR TITLE
fix(vendors): run source graph probe through SSH boundary

### DIFF
--- a/.github/workflows/oracle-probe-vendor-source-link-graph.yml
+++ b/.github/workflows/oracle-probe-vendor-source-link-graph.yml
@@ -15,16 +15,30 @@ jobs:
   probe:
     runs-on: [self-hosted, Linux, ARM64, oracle]
     timeout-minutes: 10
+    env:
+      DEPLOY_HOST: 127.0.0.1
+      DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
+      DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
     steps:
       - uses: actions/checkout@v4
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AGENTOS_DEPLOY_SSH_KEY || secrets.N8N_DEPLOY_SSH_KEY }}
       - name: Read active monitored source registry
         shell: bash
         run: |
           set -euo pipefail
+          ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" 'bash -s' \
+            > /tmp/vendor-active-sources.tsv <<'REMOTE'
+          set -euo pipefail
+          set -a
+          . /home/ubuntu/agent-data/secrets/vendor-reputation.env
+          set +a
           cd /home/ubuntu/vendor-reputation-service
           docker compose exec -T db psql -At -F $'\t' -U vendor_service -d vendor_reputation \
-            -c "select input_url, coalesce(canonical_url,'') from monitored_sources where status='active' order by created_at, input_url;" \
-            > /tmp/vendor-active-sources.tsv
+            -c "select input_url, coalesce(canonical_url,'') from monitored_sources where status='active' order by created_at, input_url;"
+          REMOTE
           test -s /tmp/vendor-active-sources.tsv
       - name: Probe public source link graph
         shell: bash


### PR DESCRIPTION
Route the Vendor source-link graph probe through the same localhost SSH -> ubuntu execution boundary already used by the production Vendor patrol. This avoids granting the `agentos-node` runner direct Docker socket access.

The probe still only reads active monitored source URLs, anonymously fetches public Threads pages, extracts connected public post URLs, and uploads a sanitized artifact. No DB writes, candidate promotion, login/anti-bot bypass, or AgentOS Core changes.