### PR TITLE
ops(vendors): retrigger source graph probe

### DIFF
--- a/.github/workflows/oracle-probe-vendor-source-link-graph.yml
+++ b/.github/workflows/oracle-probe-vendor-source-link-graph.yml
@@ -1,3 +1,4 @@
+# retrigger: source graph probe after SSH boundary fix
 name: Oracle Probe Vendor Source Link Graph
 
 on:


### PR DESCRIPTION
No functional change. Re-touch the registered Vendor source-link graph workflow so the main push path filter creates a fresh Oracle run after PR #108's execution-boundary fix. Probe logic, permissions, privacy constraints, and AgentOS Core remain unchanged.