### PR TITLE
ops(vendors): re-register monitored source manifest

### DIFF
--- a/config/vendor_threads_sources.txt
+++ b/config/vendor_threads_sources.txt
@@ -1,5 +1,6 @@
 # Active Threads sources monitored by Vendor Reputation Service.
 # Keep share/input URLs verbatim; Oracle resolves canonical post URLs at registration/sync time.
 # patrol-trigger: verify stdin-isolated discovery worker
+# registration-retrigger: reconcile manifest sources after stable identity registration
 https://www.threads.com/share/_yh22msHD/
 https://www.threads.com/share/BAUXFamItI/


### PR DESCRIPTION
No domain-logic change. Re-touch the Vendor monitored-source manifest so the current stable registration carrier reprocesses both supplied Threads share URLs and reconciles the DB registry. This is intended to verify/recover the missing `_yh22msHD` source without direct DB mutation.

No AgentOS Core changes.