### PR TITLE
chore(vendors): deploy alias-preserving source identity

### DIFF
--- a/.github/workflows/oracle-register-vendor-threads-source.yml
+++ b/.github/workflows/oracle-register-vendor-threads-source.yml
@@ -25,7 +25,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 21fb1e9e32211060161c9c84c865e3d1ce428cb2
+      SERVICE_SHA: 7f17f5a2eebd5452614e3591253f56d8d6b338cf
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent
@@ -76,7 +76,7 @@ jobs:
       DEPLOY_HOST: 127.0.0.1
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
-      SERVICE_SHA: 21fb1e9e32211060161c9c84c865e3d1ce428cb2
+      SERVICE_SHA: 7f17f5a2eebd5452614e3591253f56d8d6b338cf
     steps:
       - uses: actions/checkout@v4
       - name: Start SSH agent


### PR DESCRIPTION
Pin both Vendor source registration and discovery to vendor-reputation-service `7f17f5a2eebd5452614e3591253f56d8d6b338cf`, which preserves historical Threads input/share aliases across repeated source-identity migration passes.

No carrier behavior changes beyond the service SHA pin. No AgentOS Core changes.