### PR TITLE
fix(agentos): certify governed GUI control for Issue #105

### DIFF
--- a/.agentos/evidence/node-gui/vopc5750/acceptance.json
+++ b/.agentos/evidence/node-gui/vopc5750/acceptance.json
@@ -1,0 +1,43 @@
+{
+  "acceptance": "PASS",
+  "cleanup": true,
+  "interactive_session": true,
+  "keyboard": {
+    "characters": 34,
+    "marker": "AGENTOS GUI KEYBOARD PASS 20260830",
+    "ok": true
+  },
+  "mouse": {
+    "button": "left",
+    "ok": true,
+    "operation": "click",
+    "x": 300,
+    "y": 260
+  },
+  "node_id": "vopc5750",
+  "schema": "agentos.node-gui-regression/v1",
+  "screenshot": {
+    "after_input": {
+      "artifact_file": ".agentos/evidence/node-gui/vopc5750/after-input.jpg",
+      "bytes": 227107,
+      "height": 1920,
+      "sha256": "73207f7abb55a2823458a6b6ac60a93f3302d1f7d19f60aff2ae507629bedd10",
+      "width": 3000
+    },
+    "before": {
+      "artifact_file": ".agentos/evidence/node-gui/vopc5750/before.jpg",
+      "bytes": 210964,
+      "height": 1920,
+      "sha256": "830073edb1b9305abdfab646bca0cc3c72f2fdb7c735a89405a531b4969a3970",
+      "width": 3000
+    }
+  },
+  "test_window": {
+    "observed": true,
+    "process_name": "powershell.exe"
+  },
+  "window_inspection": {
+    "ok": true,
+    "window_count": 25
+  }
+}

--- a/agent_core/control_inbox_bridge.py
+++ b/agent_core/control_inbox_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -19,6 +20,7 @@ DEFAULT_ISSUE_NUMBER = 50
 DEFAULT_ALLOWED_LOGIN = 'alstonhuang'
 DEFAULT_ONE_URL = 'http://127.0.0.1:8780'
 MAX_COMMAND_LIFETIME_SECONDS = 600
+CONTROLLER_DISPATCH_SUCCESS_CODES = frozenset({200, 202})
 
 
 def _utc_now() -> datetime:
@@ -174,7 +176,7 @@ class OneControllerClient:
             **args,
         }
         status, payload = self._request('POST', '/v1/controller/dispatch', body)
-        if status != 202 or not isinstance(payload, dict) or not payload.get('ok'):
+        if status not in CONTROLLER_DISPATCH_SUCCESS_CODES or not isinstance(payload, dict) or not payload.get('ok'):
             raise RuntimeError(f'ONE dispatch failed: HTTP {status}: {payload}')
         return payload
 
@@ -241,6 +243,56 @@ class ControlInboxBridge:
             'args': args,
         }
 
+    def _compact_receipt(self, receipt: dict[str, Any]) -> dict[str, Any]:
+        action = str(receipt.get('action') or '')
+        base = {key: receipt[key] for key in (
+            'schema', 'realm_id', 'node_id', 'task_id', 'action',
+            'started_at', 'completed_at', 'ok', 'error',
+        ) if key in receipt}
+        if action == 'desktop.screenshot' and receipt.get('ok'):
+            encoded = receipt.get('image_base64')
+            if not isinstance(encoded, str) or not encoded:
+                raise ValueError('desktop.screenshot receipt missing image_base64')
+            raw = base64.b64decode(encoded, validate=True)
+            digest = hashlib.sha256(raw).hexdigest()
+            expected = str(receipt.get('sha256') or '')
+            if expected and digest != expected:
+                raise ValueError('desktop.screenshot sha256 mismatch')
+            reported_bytes = int(receipt.get('bytes') or len(raw))
+            if reported_bytes != len(raw):
+                raise ValueError('desktop.screenshot byte count mismatch')
+            if len(raw) > 1_500_000:
+                raise ValueError('desktop.screenshot exceeds artifact limit')
+            artifact_root = self.config.state_path.parent / 'artifacts'
+            artifact_root.mkdir(parents=True, exist_ok=True)
+            target = artifact_root / f'{digest}.jpg'
+            tmp = target.with_suffix('.tmp')
+            tmp.write_bytes(raw)
+            os.chmod(tmp, 0o600)
+            tmp.replace(target)
+            base.update({
+                'artifact_ref': f'agentos://control-inbox/artifacts/{digest}.jpg',
+                'sha256': digest,
+                'bytes': len(raw),
+                'width': receipt.get('width'),
+                'height': receipt.get('height'),
+                'mime_type': str(receipt.get('mime_type') or 'image/jpeg'),
+            })
+            return base
+        if action == 'desktop.windows.inspect':
+            windows = receipt.get('windows') or []
+            process_names = sorted({str(item.get('process_name')) for item in windows if isinstance(item, dict) and item.get('process_name')})
+            base.update({
+                'window_count': int(receipt.get('window_count') or len(windows)),
+                'process_names': process_names[:50],
+                'window_titles_redacted': True,
+            })
+            return base
+        for key in ('operation', 'button', 'x', 'y', 'characters', 'launched', 'url', 'surface_inventory'):
+            if key in receipt:
+                base[key] = receipt[key]
+        return base
+
     def _result(self, command: dict[str, Any], *, status: str, task_id: str | None = None, receipt: dict[str, Any] | None = None, error: str | None = None) -> dict[str, Any]:
         result: dict[str, Any] = {
             'schema': RESULT_SCHEMA,
@@ -253,7 +305,7 @@ class ControlInboxBridge:
         if task_id:
             result['task_id'] = task_id
         if receipt is not None:
-            result['receipt'] = receipt
+            result['receipt'] = self._compact_receipt(receipt)
         if error:
             result['error'] = error
         return result

--- a/agent_core/controller_api.py
+++ b/agent_core/controller_api.py
@@ -17,6 +17,8 @@ CONTROLLER_ACTION_CAPABILITY = {
     'desktop.windows.inspect': 'desktop.windows.inspect',
     'desktop.screenshot': 'desktop.screenshot',
     'desktop.open_url': 'desktop.open_url',
+    'desktop.mouse': 'desktop.mouse',
+    'desktop.keyboard': 'desktop.keyboard',
     'node.runtime.converge': 'shell.exec',
 }
 
@@ -277,6 +279,48 @@ Write-Output 'agentos_source_commit=SOURCE_COMMIT'
             'nodes': observations,
         }
 
+    @staticmethod
+    def _desktop_input_task(action: str, task_id: str, request: dict[str, Any]) -> dict[str, Any]:
+        task: dict[str, Any] = {
+            'schema': 'agentos.node-task/v0.1',
+            'task_id': task_id,
+            'action': action,
+            'cognition_ids_used': list(request.get('cognition_ids_used') or []),
+        }
+        operation = str(request.get('operation') or '').strip()
+        if action == 'desktop.mouse':
+            if operation not in {'move', 'click'}:
+                raise ValueError('desktop.mouse operation must be move or click')
+            task['operation'] = operation
+            has_x, has_y = 'x' in request, 'y' in request
+            if has_x != has_y:
+                raise ValueError('desktop.mouse x and y must be provided together')
+            if has_x:
+                x, y = request['x'], request['y']
+                if isinstance(x, bool) or isinstance(y, bool) or not isinstance(x, int) or not isinstance(y, int):
+                    raise ValueError('desktop.mouse x and y must be integers')
+                if not (-32768 <= x <= 32767 and -32768 <= y <= 32767):
+                    raise ValueError('desktop.mouse coordinates outside bounded range')
+                task['x'], task['y'] = x, y
+            if operation == 'click':
+                button = str(request.get('button') or 'left').strip()
+                if button not in {'left', 'right'}:
+                    raise ValueError('desktop.mouse button must be left or right')
+                task['button'] = button
+            elif 'button' in request:
+                raise ValueError('desktop.mouse move does not accept button')
+            return task
+        if action == 'desktop.keyboard':
+            if operation != 'type':
+                raise ValueError('desktop.keyboard only supports operation=type')
+            text = request.get('text')
+            if not isinstance(text, str) or not (1 <= len(text) <= 1000):
+                raise ValueError('desktop.keyboard text must contain 1..1000 characters')
+            task['operation'] = 'type'
+            task['text'] = text
+            return task
+        raise ValueError(f'unsupported desktop input action: {action}')
+
     def dispatch(self, node_id: str, request: dict[str, Any]) -> dict[str, Any]:
         action = str(request.get('action') or '').strip()
         if action == 'realm.runtime.rollout':
@@ -304,7 +348,9 @@ Write-Output 'agentos_source_commit=SOURCE_COMMIT'
                 'state': existing.get('state'), 'reused': True,
             }
 
-        if action == 'node.runtime.converge':
+        if action in {'desktop.mouse', 'desktop.keyboard'}:
+            task = self._desktop_input_task(action, task_id, request)
+        elif action == 'node.runtime.converge':
             task = self._runtime_convergence_task(
                 task_id,
                 str(request.get('source_commit') or '').strip(),

--- a/docs/CORE_BRANCH_MODEL.md
+++ b/docs/CORE_BRANCH_MODEL.md
@@ -1,0 +1,22 @@
+# AgentOS Core Branch Model
+
+Canonical branch roles:
+
+- `main`: protected publication history only. It is not runtime/deployment authority.
+- `core/integration`: the single long-lived Core development integration branch.
+- `core/issue-<N>-<slug>`: short-lived Core issue branches, created from the accepted Core integration commit and merged back only after acceptance.
+- Runtime/deployment authority is always an exact accepted commit SHA plus deployment generation; never a branch name.
+
+Rules:
+
+1. Do not use multiple long-lived Core feature branches.
+2. Do not merge generic `continue` work to `main`.
+3. Issue branches must not contain temporary patch/carrier workflows in their final accepted diff.
+4. Completed issue branches are deleted after their evidence is canonicalized and their change is integrated.
+5. Publication to `main` is a separate release PR from `core/integration` and requires explicit human merge authorization.
+
+Transition cleanup:
+
+- `feature/realm-node-fabric-readiness` is legacy integration history. Do not add new Core work to it; migrate accepted deltas/evidence into `core/integration`, then retire it.
+- For #105, consolidate the accepted Node GUI evidence and Core GUI-control delta into one `core/issue-105-gui-control` line before live certification.
+- Branches created accidentally or superseded during #105 (`fix/issue-105-core-gui`, `fix/issue-105-governed-gui-control`) are transitional only and must be retired after consolidation.

--- a/tests/test_issue105_gui_control_contract.py
+++ b/tests/test_issue105_gui_control_contract.py
@@ -1,0 +1,103 @@
+import base64
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.control_inbox_bridge import BridgeConfig, ControlInboxBridge
+from agent_core.controller_api import ControllerService, CONTROLLER_ACTION_CAPABILITY
+
+
+class Issue105GuiContractTests(unittest.TestCase):
+    def test_input_capabilities_are_explicit(self):
+        self.assertEqual(CONTROLLER_ACTION_CAPABILITY['desktop.mouse'], 'desktop.mouse')
+        self.assertEqual(CONTROLLER_ACTION_CAPABILITY['desktop.keyboard'], 'desktop.keyboard')
+
+    def test_mouse_validation(self):
+        task = ControllerService._desktop_input_task(
+            'desktop.mouse', 't1',
+            {'operation': 'click', 'x': 12, 'y': -4, 'button': 'left'},
+        )
+        self.assertEqual(task['action'], 'desktop.mouse')
+        self.assertEqual(task['button'], 'left')
+        with self.assertRaises(ValueError):
+            ControllerService._desktop_input_task(
+                'desktop.mouse', 't2',
+                {'operation': 'click', 'x': '12', 'y': 4},
+            )
+        with self.assertRaises(ValueError):
+            ControllerService._desktop_input_task(
+                'desktop.mouse', 't3', {'operation': 'drag'},
+            )
+
+    def test_keyboard_validation(self):
+        task = ControllerService._desktop_input_task(
+            'desktop.keyboard', 't1',
+            {'operation': 'type', 'text': 'PASS'},
+        )
+        self.assertEqual(task['text'], 'PASS')
+        with self.assertRaises(ValueError):
+            ControllerService._desktop_input_task(
+                'desktop.keyboard', 't2',
+                {'operation': 'type', 'text': ''},
+            )
+        with self.assertRaises(ValueError):
+            ControllerService._desktop_input_task(
+                'desktop.keyboard', 't3',
+                {'operation': 'press', 'text': 'x'},
+            )
+
+    def _bridge(self, root):
+        cfg = BridgeConfig(
+            'o/r', 50, 'u', 'g', 'c', 'http://one',
+            Path(root) / 'state.json', 1, 1,
+        )
+        return ControlInboxBridge(cfg, github=object(), one=object())
+
+    def test_screenshot_is_compacted_to_artifact_ref(self):
+        with tempfile.TemporaryDirectory() as td:
+            raw = b'fake-jpeg-bytes'
+            sha = hashlib.sha256(raw).hexdigest()
+            compact = self._bridge(td)._compact_receipt({
+                'schema': 'agentos.node-receipt/v0.1',
+                'node_id': 'n',
+                'task_id': 't',
+                'action': 'desktop.screenshot',
+                'ok': True,
+                'image_base64': base64.b64encode(raw).decode(),
+                'sha256': sha,
+                'bytes': len(raw),
+                'width': 10,
+                'height': 20,
+                'mime_type': 'image/jpeg',
+                'path': 'C:/private/path.jpg',
+                'session': {'username': 'private'},
+            })
+            self.assertNotIn('image_base64', compact)
+            self.assertNotIn('path', compact)
+            self.assertNotIn('session', compact)
+            self.assertEqual(
+                compact['artifact_ref'],
+                f'agentos://control-inbox/artifacts/{sha}.jpg',
+            )
+            self.assertTrue((Path(td) / 'artifacts' / f'{sha}.jpg').is_file())
+
+    def test_window_titles_are_redacted(self):
+        with tempfile.TemporaryDirectory() as td:
+            compact = self._bridge(td)._compact_receipt({
+                'action': 'desktop.windows.inspect',
+                'ok': True,
+                'windows': [
+                    {'title': 'PRIVATE TITLE', 'process_name': 'notepad.exe'},
+                    {'title': 'ANOTHER PRIVATE TITLE', 'process_name': 'notepad.exe'},
+                ],
+                'window_count': 2,
+            })
+            self.assertEqual(compact['process_names'], ['notepad.exe'])
+            self.assertTrue(compact['window_titles_redacted'])
+            self.assertNotIn('windows', compact)
+            self.assertNotIn('PRIVATE TITLE', repr(compact))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Canonical #105 integration PR after Core branch cleanup.

Base authority:
- live accepted Core generation 6 commit `f842bee2cf7c24fc3bf7424bd121994562e829cd`
- canonical long-lived Core line: `core/integration`

This PR contains only:
- explicit governed `desktop.mouse` / `desktop.keyboard` controller actions with bounded validation
- Control Inbox screenshot compaction to `artifact_ref` with SHA/byte verification
- window-title/privacy redaction in Control Inbox results
- focused #105 regression tests
- persisted vopc5750 Node GUI acceptance evidence
- Core branch model documentation

It intentionally excludes temporary patch workflows/helpers and unrelated #77/resolve/history commits.

Still required before integration:
1. CI/contract checks on this canonical branch.
2. Governed live Core rollout without weakening deployment authority.
3. Fresh Issue #50 -> ONE -> vopc5750 screenshot -> mouse -> keyboard -> screenshot acceptance.
4. Persist #105 Core completion evidence.

This PR is intentionally draft until live certification is complete. It does not authorize publication to protected `main`.