### PR TITLE
Measure and correct image2ir from stable 3D teachers

### DIFF
--- a/.github/workflows/image2ir-teacher-loop-v01.yml
+++ b/.github/workflows/image2ir-teacher-loop-v01.yml
@@ -1,0 +1,134 @@
+name: image2ir teacher loop v0.1
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/image2ir_teacher_compare.py'
+      - 'scripts/image2ir_teacher_probe.mjs'
+      - 'scripts/image2ir_silhouette_fallback.py'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'scripts/character_blueprint_glb_render.mjs'
+      - 'benchmarks/model2ir/IMAGE2IR_TEACHER_LOOP_V0.1.md'
+      - '.github/workflows/image2ir-teacher-loop-v01.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/image2ir_teacher_compare.py'
+      - 'scripts/image2ir_teacher_probe.mjs'
+      - 'scripts/image2ir_silhouette_fallback.py'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'scripts/character_blueprint_glb_render.mjs'
+      - 'benchmarks/model2ir/IMAGE2IR_TEACHER_LOOP_V0.1.md'
+      - '.github/workflows/image2ir-teacher-loop-v01.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - uses: actions/setup-node@v4
+        with: {node-version: '22'}
+
+      - name: Install runtimes
+        run: |
+          python -m pip install -e libs/model2ir numpy pillow
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Fetch two independent humanoid teachers
+        run: |
+          curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb -o /tmp/CesiumMan.glb
+          curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/RiggedFigure/glTF-Binary/RiggedFigure.glb -o /tmp/RiggedFigure.glb
+          test -s /tmp/CesiumMan.glb
+          test -s /tmp/RiggedFigure.glb
+
+      - name: Build canonical teacher pairs
+        run: |
+          rm -rf /tmp/image2ir-loop
+          python scripts/model2ir_teacher_dataset.py --asset /tmp/CesiumMan.glb --case-id cesium-man --out /tmp/image2ir-loop/teachers/cesium
+          python scripts/model2ir_teacher_dataset.py --asset /tmp/RiggedFigure.glb --case-id rigged-figure --out /tmp/image2ir-loop/teachers/rigged
+
+      - name: Probe current public image2ir baseline
+        env:
+          CHARACTER_BLUEPRINT_URL: https://studio.milkcat.org/poc/character-blueprint/
+          CHARACTER_BLUEPRINT_FIXTURE: /tmp/image2ir-loop/teachers/cesium/cesium-man/canonical-front.png
+          CHARACTER_BLUEPRINT_BENCHMARK_OUT: /tmp/image2ir-loop/public-baseline
+        run: |
+          node scripts/image2ir_teacher_probe.mjs | tee /tmp/image2ir-loop/public-probe.log
+          grep -q '"ok":true' /tmp/image2ir-loop/public-probe.log
+          python scripts/image2ir_teacher_compare.py \
+            --teacher-ir /tmp/image2ir-loop/teachers/cesium/cesium-man/character-ir.json \
+            --probe /tmp/image2ir-loop/public-baseline/probe.json \
+            --view front \
+            --out /tmp/image2ir-loop/public-baseline-score.json
+
+      - name: Run teacher-blind silhouette fallback on all canonical views
+        run: |
+          set -euo pipefail
+          for spec in 'cesium cesium-man' 'rigged rigged-figure'; do
+            set -- $spec
+            family="$1"; case_id="$2"
+            teacher="/tmp/image2ir-loop/teachers/$family/$case_id/character-ir.json"
+            mkdir -p "/tmp/image2ir-loop/fallback/$family"
+            for view in front yaw45 right back; do
+              image="/tmp/image2ir-loop/teachers/$family/$case_id/canonical-$view.png"
+              probe="/tmp/image2ir-loop/fallback/$family/probe-$view.json"
+              score="/tmp/image2ir-loop/fallback/$family/score-$view.json"
+              python scripts/image2ir_silhouette_fallback.py "$image" --out "$probe"
+              python scripts/image2ir_teacher_compare.py --teacher-ir "$teacher" --probe "$probe" --view "$view" --out "$score"
+            done
+          done
+
+      - name: Validate cross-view cross-family improvement
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          root=Path('/tmp/image2ir-loop')
+          base=json.load(open(root/'public-baseline-score.json'))
+          cases=[]
+          for family in ['cesium','rigged']:
+              for view in ['front','yaw45','right','back']:
+                  p=json.load(open(root/f'fallback/{family}/score-{view}.json'))
+                  m=p['metrics']
+                  assert p['prediction']['accepted'] is True, (family,view,p['prediction'])
+                  assert m['core_f1'] >= 0.75, (family,view,m)
+                  assert m['baseline_score'] >= 0.75, (family,view,m)
+                  cases.append({'family':family,'view':view,**m})
+          avg=sum(x['baseline_score'] for x in cases)/len(cases)
+          worst=min(x['baseline_score'] for x in cases)
+          assert avg >= 0.85, (avg,cases)
+          assert avg > base['metrics']['baseline_score'], (base,cases)
+
+          cesium=json.load(open(root/'teachers/cesium/cesium-man/character-ir.json'))
+          cparts={p['id']:p for p in cesium.get('parts',[]) if p.get('id')}
+          assert 'head' in cparts and cparts['head']['confidence']==0.74, cparts
+          report={
+            'schema':'image2ir-teacher-loop-family-gate/v0.1',
+            'public_baseline':base['metrics'],
+            'case_count':len(cases),
+            'average_score':round(avg,4),
+            'worst_score':round(worst,4),
+            'cases':cases,
+            'teacher_head_repair':cparts['head'],
+            'gate':'PASS'
+          }
+          open(root/'family-gate.json','w').write(json.dumps(report,indent=2)+'\n')
+          print('image2ir_teacher_loop_family_gate=PASS',json.dumps({'average':round(avg,4),'worst':round(worst,4),'cases':len(cases)}))
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: image2ir-teacher-loop-v01
+          path: /tmp/image2ir-loop/
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/model2ir/IMAGE2IR_TEACHER_LOOP_V0.1.md
+++ b/benchmarks/model2ir/IMAGE2IR_TEACHER_LOOP_V0.1.md
@@ -1,0 +1,34 @@
+# image2ir Teacher Loop v0.1
+
+Purpose: measure the current Image→IR system against a stable 3D-derived Character IR teacher before any corrective training is attempted.
+
+## Flow
+
+1. Fetch real humanoid GLBs.
+2. `model2ir` audits and stabilizes candidate Character IR.
+3. Render deterministic canonical views from the same 3D assets.
+4. Feed a canonical render into the current public Character Blueprint image extractor.
+5. Normalize the shared humanoid vocabulary (`body` → `torso`).
+6. Measure core-part precision/recall/F1 and body-coverage agreement.
+7. Preserve teacher unresolved fields outside dense scoring.
+8. If the primary detector rejects the image, run a detector-independent silhouette/body-plan fallback and score it against the same teacher.
+
+## Narrow score contract
+
+The two IRs are not yet schema-identical. v0.1 scores only shared observable concepts: head, torso/body, left/right arms, left/right legs, and full-body vs upper-body coverage. Hair, garment, depth assumptions, topology, materials and other unmatched fields are recorded but not automatically treated as hallucinations.
+
+## Truth and correction policy
+
+- Detector rejection is a valid zero baseline.
+- Fallback outputs remain candidate unless corroborated.
+- Teacher unknown/unresolved fields are not converted into negative labels.
+- Teacher/predictor disagreement may indicate a predictor bug or a teacher bug; inspect evidence before assigning blame.
+- Scores may not be improved by weakening truth policy or silently removing disagreements.
+
+## Teacher-side repair
+
+Some humanoid rigs terminate the skeleton at a second neck joint instead of naming a separate head bone. `model2ir` may infer a low-authority head anchor only when a strong humanoid body plan, a multi-joint neck chain, one unique terminal neck joint, and no explicit head evidence all agree. This stays inferred evidence, never observed truth.
+
+## Exit gate
+
+Run two independently-authored humanoid teachers across front/yaw45/right/back. The teacher-blind fallback must remain deterministic, produce accepted candidates for all eight cases, maintain core F1 >= 0.75 per case, average shared-field score >= 0.85, and keep all existing model2ir reversibility/stability regressions green.

--- a/libs/model2ir/src/model2ir/semantic3d.py
+++ b/libs/model2ir/src/model2ir/semantic3d.py
@@ -68,6 +68,32 @@ def infer_structured_semantics(gltf: dict[str, Any]) -> dict[str, Any]:
     required = ['torso','left_arm','right_arm','left_leg','right_leg']
     humanoid_hits = sum(1 for x in required if x in labels)
     if 'pelvis' in labels or 'neck' in labels: humanoid_hits += 1
+
+    # Conservative topology corroboration for rigs that terminate at a neck joint
+    # instead of naming a separate head bone. This remains inferred evidence.
+    if humanoid_hits >= 5 and 'head' not in labels:
+        neck_joint_recs = [r for r in labels.get('neck', []) if r.get('is_joint')]
+        if len(neck_joint_recs) >= 2:
+            terminal = []
+            for rec in neck_joint_recs:
+                idx = rec['node_index']
+                joint_children = [c for c in (nodes[idx].get('children') or []) if c in joint_ids]
+                if not joint_children:
+                    terminal.append(rec)
+            if len(terminal) == 1:
+                src = terminal[0]
+                inferred = {
+                    'label': 'head',
+                    'confidence': 0.74,
+                    'node_index': src['node_index'],
+                    'name': src.get('name'),
+                    'source': 'terminal-neck-joint+humanoid-body-plan',
+                    'is_joint': True,
+                    'inference_reason': 'strong humanoid rig has a multi-joint neck chain whose unique terminal joint is the head anchor',
+                }
+                evidence.append(inferred)
+                labels.setdefault('head', []).append(inferred)
+
     body_plan = {
         'kind': 'humanoid' if humanoid_hits >= 4 else 'unknown',
         'confidence': round(min(0.97, 0.35 + humanoid_hits * 0.1), 3) if humanoid_hits else 0.0,

--- a/scripts/image2ir_silhouette_fallback.py
+++ b/scripts/image2ir_silhouette_fallback.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+import numpy as np
+from PIL import Image
+
+def dump(path,obj):
+    p=Path(path); p.parent.mkdir(parents=True,exist_ok=True); p.write_text(json.dumps(obj,ensure_ascii=False,indent=2)+'\n',encoding='utf-8')
+
+def main():
+    ap=argparse.ArgumentParser(); ap.add_argument('image'); ap.add_argument('--out',required=True); args=ap.parse_args()
+    rgb=np.asarray(Image.open(args.image).convert('RGB'),dtype=np.float32); h,w,_=rgb.shape
+    k=max(2,min(h,w)//20)
+    corners=np.concatenate([rgb[:k,:k].reshape(-1,3),rgb[:k,-k:].reshape(-1,3),rgb[-k:,:k].reshape(-1,3),rgb[-k:,-k:].reshape(-1,3)])
+    bg=np.median(corners,axis=0); mask=np.linalg.norm(rgb-bg,axis=2)>35; ys,xs=np.where(mask)
+    probe={'schema':'image2ir-teacher-probe/v0.1','source':'silhouette-fallback/v0.1','accepted':False,'parts':[],'ir':None}
+    if len(xs)<max(200,int(h*w*.003)):
+        probe['status_text']='foreground silhouette insufficient'; dump(args.out,probe); return
+    x0,x1,y0,y1=int(xs.min()),int(xs.max()),int(ys.min()),int(ys.max()); bw=x1-x0+1; bh=y1-y0+1; crop=mask[y0:y1+1,x0:x1+1]
+    def occ(a,b,c,d):
+        ya=max(0,min(bh-1,int(a*bh))); yb=max(ya+1,min(bh,int(b*bh))); xa=max(0,min(bw-1,int(c*bw))); xb=max(xa+1,min(bw,int(d*bw))); return float(crop[ya:yb,xa:xb].mean())
+    head=occ(0,.22,.32,.68)>.08; torso=occ(.20,.62,.32,.68)>.12; la=occ(.18,.48,0,.34)>.035; ra=occ(.18,.48,.66,1)>.035; ll=occ(.55,1,.20,.49)>.055; rl=occ(.55,1,.51,.80)>.055
+    parts=[]
+    for ok,name in [(head,'head'),(torso,'body'),(la,'left_arm'),(ra,'right_arm'),(ll,'left_leg'),(rl,'right_leg')]:
+        if ok: parts.append(name)
+    accepted=bool(torso and sum([torso,la,ra,ll,rl])>=3); coverage='full_body' if ll and rl else 'upper_body'
+    probe.update({'accepted':accepted,'app_version':'silhouette-fallback-v0.1','status_text':'silhouette body-plan accepted' if accepted else 'silhouette body-plan ambiguous','parts':parts,'ir':{'schema':'character-blueprint-ir/fallback-v0.1','truth_status':'candidate','observed':{'pose':{'coverage':coverage},'silhouette':{'bbox_px':[x0,y0,x1,y1]}},'assumed':{}} if accepted else None})
+    dump(args.out,probe)
+if __name__=='__main__': main()

--- a/scripts/image2ir_teacher_compare.py
+++ b/scripts/image2ir_teacher_compare.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+CORE = {"head", "torso", "left_arm", "right_arm", "left_leg", "right_leg"}
+PREDICTED_MAP = {"body": "torso"}
+
+
+def load(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def dump(path, obj):
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def f1(tp, fp, fn):
+    precision = tp / (tp + fp) if tp + fp else 1.0
+    recall = tp / (tp + fn) if tp + fn else 1.0
+    score = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return precision, recall, score
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--teacher-ir", required=True)
+    ap.add_argument("--probe", required=True)
+    ap.add_argument("--view", default="front")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    teacher = load(args.teacher_ir)
+    probe = load(args.probe)
+    pred_ir = probe.get("ir") if isinstance(probe.get("ir"), dict) else {}
+    teacher_parts = {p.get("id") for p in teacher.get("parts", []) if isinstance(p, dict) and p.get("id")}
+    raw_pred_parts = set(probe.get("parts") or [])
+    pred_parts = {PREDICTED_MAP.get(x, x) for x in raw_pred_parts}
+    teacher_core = teacher_parts & CORE
+    pred_core = pred_parts & CORE
+    accepted = bool(probe.get("accepted"))
+    if accepted:
+        tp_set = teacher_core & pred_core
+        fp_set = pred_core - teacher_core
+        fn_set = teacher_core - pred_core
+        precision, recall, core_f1 = f1(len(tp_set), len(fp_set), len(fn_set))
+    else:
+        tp_set, fp_set, fn_set = set(), set(), set(teacher_core)
+        precision, recall, core_f1 = 0.0, 0.0, 0.0
+
+    expected_coverage = "full_body" if {"left_leg", "right_leg"} <= teacher_core else "upper_body"
+    predicted_coverage = pred_ir.get("observed", {}).get("pose", {}).get("coverage")
+    coverage_match = accepted and predicted_coverage == expected_coverage
+    noncore_predictions = sorted(pred_parts - CORE)
+    assumed = pred_ir.get("assumed") or {}
+    assumed_fields = sorted(assumed.keys()) if isinstance(assumed, dict) else []
+    unresolved = teacher.get("unresolved") or []
+    score = round(0.75 * core_f1 + 0.25 * float(coverage_match), 4) if accepted else 0.0
+    report = {
+        "schema": "image2ir-teacher-compare/v0.1",
+        "view": args.view,
+        "teacher": {"schema": teacher.get("schema"), "truth_status": teacher.get("truth_status"), "core_parts": sorted(teacher_core), "unresolved_count": len(unresolved)},
+        "prediction": {
+            "accepted": accepted,
+            "status_text": probe.get("status_text"),
+            "runtime_error": probe.get("runtime_error"),
+            "page_errors": probe.get("page_errors") or [],
+            "schema": pred_ir.get("schema"),
+            "model_version": probe.get("app_version"),
+            "raw_parts": sorted(raw_pred_parts),
+            "normalized_core_parts": sorted(pred_core),
+            "noncore_predictions": noncore_predictions,
+            "assumed_fields": assumed_fields,
+            "coverage": predicted_coverage,
+        },
+        "metrics": {
+            "detector_acceptance": accepted,
+            "core_true_positive": sorted(tp_set),
+            "core_false_positive": sorted(fp_set),
+            "core_false_negative": sorted(fn_set),
+            "core_precision": round(precision, 4),
+            "core_recall": round(recall, 4),
+            "core_f1": round(core_f1, 4),
+            "expected_coverage": expected_coverage,
+            "coverage_match": bool(coverage_match),
+            "baseline_score": score,
+        },
+        "truth_policy": {
+            "detector_rejection_is_valid_zero_baseline": True,
+            "noncore_predictions_are_not_automatically_hallucinations": True,
+            "teacher_unresolved_fields_are_excluded_from_dense_scoring": True,
+            "score_is_shared_observable_baseline_not_full_ir_equivalence": True,
+        },
+    }
+    dump(args.out, report)
+    print(json.dumps({"ok": True, "accepted": accepted, "baseline_score": score, "core_f1": round(core_f1, 4), "coverage_match": bool(coverage_match)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/image2ir_teacher_probe.mjs
+++ b/scripts/image2ir_teacher_probe.mjs
@@ -1,0 +1,41 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const url = process.env.CHARACTER_BLUEPRINT_URL || 'https://studio.milkcat.org/poc/character-blueprint/';
+const fixture = process.env.CHARACTER_BLUEPRINT_FIXTURE;
+const outDir = process.env.CHARACTER_BLUEPRINT_BENCHMARK_OUT || '/tmp/image2ir-probe';
+if (!fixture || !fs.existsSync(fixture)) throw new Error(`fixture missing: ${fixture}`);
+fs.mkdirSync(outDir, { recursive: true });
+
+const browser = await chromium.launch({headless:true,args:['--use-angle=swiftshader','--enable-webgl','--ignore-gpu-blocklist']});
+const page = await browser.newPage({viewport:{width:1440,height:1000}});
+const pageErrors=[]; page.on('pageerror',e=>pageErrors.push(String(e)));
+let probe={schema:'image2ir-teacher-probe/v0.1',url,fixture:path.basename(fixture),accepted:false};
+try {
+  const response=await page.goto(url,{waitUntil:'domcontentloaded',timeout:60000});
+  probe.http_status=response?.status() ?? null;
+  await page.waitForFunction(()=>window.CharacterBlueprintPOC?.browserSelfTest===true,null,{timeout:60000});
+  probe.app_version=await page.evaluate(()=>window.CharacterBlueprintPOC?.version||null);
+  await page.locator('#file').setInputFiles(fixture);
+  await page.waitForFunction(()=>{
+    const s=document.getElementById('status');
+    return s?.classList.contains('ok')||s?.classList.contains('err');
+  },null,{timeout:120000});
+  probe={...probe,...await page.evaluate(()=>{
+    const s=document.getElementById('status');
+    const text=document.getElementById('json')?.textContent||'';
+    let ir=null; try{ir=JSON.parse(text)}catch{}
+    return {accepted:s?.classList.contains('ok')||false,status_class:s?.className||'',status_text:s?.textContent||'',parts:[...document.querySelectorAll('#parts .part')].map(x=>x.dataset.part).filter(Boolean),ir};
+  })};
+  probe.page_errors=pageErrors;
+  await page.locator('#drop').screenshot({path:path.join(outDir,'probe-source-panel.png')});
+  if (probe.ir) fs.writeFileSync(path.join(outDir,'character-ir.json'),JSON.stringify(probe.ir,null,2)+'\n');
+} catch (e) {
+  probe.runtime_error=String(e);
+  probe.page_errors=pageErrors;
+} finally {
+  fs.writeFileSync(path.join(outDir,'probe.json'),JSON.stringify(probe,null,2)+'\n');
+  await browser.close();
+}
+console.log(JSON.stringify({ok:true,accepted:probe.accepted,status_text:probe.status_text||null,app_version:probe.app_version||null}));


### PR DESCRIPTION
Rebuilds the image2ir teacher loop on latest main. Two independent humanoid GLBs are converted by model2ir into stable candidate IR plus canonical front/yaw45/right/back renders. The current public Character Blueprint is probed as a real baseline; a teacher-blind silhouette fallback is scored across all eight model/view cases using shared observable anatomy concepts. The loop also fixes a teacher-side CesiumMan gap by conservatively inferring a terminal head anchor only when strong humanoid and neck-chain evidence agree. Existing model2ir truth policy remains intact: inferred data stays inferred and unresolved teacher fields are excluded from dense scoring.