### PR TITLE
Extract Model2IR teacher pipeline into standalone library boundary

### DIFF
--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -1,0 +1,48 @@
+name: Model2IR Library v0.8
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'tests/test_model2ir_teacher_library.py'
+      - '.github/workflows/model2ir-library-v08.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'scripts/model2ir_teacher_dataset.py'
+      - 'tests/test_model2ir_teacher_library.py'
+      - '.github/workflows/model2ir-library-v08.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  library-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install standalone package
+        run: python -m pip install -e libs/model2ir
+      - name: Compile package
+        run: python -m compileall -q libs/model2ir/src
+      - name: Run library contract tests
+        run: python -m unittest discover -s tests -p 'test_model2ir_teacher_library.py' -q
+      - name: Verify public API and console entrypoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import model2ir
+          assert model2ir.__version__ == '0.8.0'
+          assert callable(model2ir.extract_ir)
+          assert callable(model2ir.build_teacher_dataset)
+          assert callable(model2ir.validate_teacher_dataset_manifest)
+          assert model2ir.TEACHER_DATASET_SCHEMA == 'model2ir-teacher-dataset/v0.7'
+          print('model2ir library boundary=ok')
+          PY
+          model2ir --help >/dev/null

--- a/libs/model2ir/README.md
+++ b/libs/model2ir/README.md
@@ -1,0 +1,80 @@
+# model2ir
+
+`model2ir` is the reusable 3D asset → Canonical Character IR boundary extracted from the AgentOS research codebase.
+
+Its job is not to make every 3D asset look humanoid. Its job is to preserve what the source actually supports, keep inference distinguishable from observation, and make the resulting Character IR stable enough for reversible round-trips, regression, and teacher-data generation.
+
+## Public boundary
+
+```python
+from model2ir import (
+    load_asset,
+    extract_ir,
+    stabilize_external_ir,
+    audit_asset,
+    diff_ir,
+    reconcile_ir,
+    score_roundtrip,
+    compile_reversible_gltf,
+    save_reversible_gltf,
+    ir_digest,
+    build_teacher_dataset,
+    validate_teacher_dataset_manifest,
+)
+```
+
+The package can also be invoked with:
+
+```bash
+model2ir --help
+# or
+python -m model2ir --help
+```
+
+## Truth invariants
+
+1. A first import of an external model is not automatically canonical truth.
+2. Standardized metadata such as VRM humanoid mappings outranks weaker naming/topology inference.
+3. Inferred semantics remain inferred; stabilization never launders them into observed facts.
+4. Unknown and unresolved fields are retained instead of filled merely to make the IR dense.
+5. Reversibility and semantic certainty are separate dimensions. An embedded Canonical Character IR may round-trip exactly even when the original external asset required inference.
+
+## Teacher dataset API
+
+The multi-view teacher contract is now library-owned. Rendering is intentionally an injected adapter so `model2ir` itself does not depend on Playwright, Three.js, a browser, or an AgentOS repository layout.
+
+```python
+from pathlib import Path
+from model2ir import build_teacher_dataset
+
+
+def render_four_views(local_glb: Path, case_dir: Path):
+    # Call any renderer. It must create these files under case_dir.
+    return {
+        "front": "canonical-front.png",
+        "yaw45": "canonical-yaw45.png",
+        "right": "canonical-right.png",
+        "back": "canonical-back.png",
+    }
+
+manifest = build_teacher_dataset(
+    "character.glb",
+    "character-a",
+    "teacher-out",
+    renderer=render_four_views,
+)
+```
+
+`build_teacher_dataset` owns 3D inspection, repeatability audit, stable Character IR projection, admission, hashes, unresolved-label preservation, and manifest construction. The renderer owns only image production.
+
+The retained `model2ir-teacher-dataset/v0.7` schema is intentional: moving the implementation behind a library API does not silently rewrite the already established dataset contract.
+
+## Current format boundary
+
+Core extraction supports the formats handled by the existing loader stack, including the current GLB/glTF/VRM paths. The teacher-data builder currently stages self-contained `.glb` only because copying a standalone `.gltf` file without its referenced buffers/textures would create a misleading dataset artifact. Multi-file glTF staging should be added as an explicit bundle feature rather than guessed.
+
+## Repository adapters
+
+Repository-level scripts may provide renderers, benchmark harnesses, CI, downloads, and product integration. They should call the package API rather than reimplement extraction, truth policy, hashing, admission, or manifest semantics.
+
+This boundary is what allows Image→IR, Character Blueprint, future model-training pipelines, and external repositories to consume the same 3D→IR behavior without depending on AgentOS internals.

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,10 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.6.0"
-description = "Evidence-fused reversible Character IR decompiler for 3D assets"
+version = "0.8.0"
+description = "Standalone evidence-fused reversible Canonical Character IR decompiler for 3D assets"
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = []
+
+[project.scripts]
+model2ir = "model2ir.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -10,6 +10,13 @@ from .v06 import (
 )
 from .reversible import ir_digest
 from .audit import audit_asset as _audit_asset
+from .teacher import (
+    CANONICAL_VIEWS,
+    TEACHER_DATASET_SCHEMA,
+    TeacherDatasetError,
+    build_teacher_dataset,
+    validate_teacher_dataset_manifest,
+)
 
 
 def audit_asset(path, repeats=3):
@@ -27,6 +34,11 @@ __all__ = [
     "save_reversible_gltf",
     "ir_digest",
     "audit_asset",
+    "CANONICAL_VIEWS",
+    "TEACHER_DATASET_SCHEMA",
+    "TeacherDatasetError",
+    "build_teacher_dataset",
+    "validate_teacher_dataset_manifest",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.8.0"

--- a/libs/model2ir/src/model2ir/teacher.py
+++ b/libs/model2ir/src/model2ir/teacher.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Callable, Mapping
+
+from .audit import audit_asset as _audit_asset
+from .reversible import ir_digest
+from .v06 import extract_ir, stabilize_external_ir
+
+TEACHER_DATASET_SCHEMA = "model2ir-teacher-dataset/v0.7"
+CANONICAL_VIEWS = ("front", "yaw45", "right", "back")
+
+Renderer = Callable[[Path, Path], Mapping[str, str | Path]]
+
+
+class TeacherDatasetError(ValueError):
+    """Raised when a source or generated teacher dataset violates the contract."""
+
+
+def _dump(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: str | Path) -> str:
+    p = Path(path)
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def audit_source_asset(path: str | Path, *, repeats: int = 3) -> dict:
+    return _audit_asset(path, extract_ir, stabilize_external_ir, repeats=repeats)
+
+
+def _safe_case_id(case_id: str) -> str:
+    if not case_id or case_id in {".", ".."} or Path(case_id).name != case_id:
+        raise TeacherDatasetError("case_id must be one safe path segment")
+    return case_id
+
+
+def _inside(root: Path, candidate: Path) -> tuple[Path, Path]:
+    root = root.resolve()
+    resolved = candidate.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise TeacherDatasetError(f"dataset path escapes output root: {candidate}") from exc
+    return resolved, relative
+
+
+def _resolve_render(case_dir: Path, value: str | Path, view: str) -> tuple[Path, Path]:
+    raw = Path(value)
+    candidate = raw if raw.is_absolute() else case_dir / raw
+    resolved, relative = _inside(case_dir, candidate)
+    if not resolved.is_file():
+        raise TeacherDatasetError(f"missing canonical render for {view}: {resolved}")
+    return resolved, relative
+
+
+def validate_teacher_dataset_manifest(manifest: Mapping, *, root: str | Path | None = None) -> None:
+    if manifest.get("schema") != TEACHER_DATASET_SCHEMA:
+        raise TeacherDatasetError("unsupported teacher dataset schema")
+
+    policy = manifest.get("policy")
+    if not isinstance(policy, Mapping):
+        raise TeacherDatasetError("teacher dataset policy is required")
+    if policy.get("unknowns_are_labels_not_errors") is not True:
+        raise TeacherDatasetError("unknown/unresolved values must remain labels")
+    if policy.get("external_first_import_claimed_lossless") is not False:
+        raise TeacherDatasetError("external first import must not be claimed lossless")
+    if tuple(policy.get("canonical_views") or ()) != CANONICAL_VIEWS:
+        raise TeacherDatasetError("canonical view contract changed")
+
+    cases = manifest.get("cases")
+    examples = manifest.get("examples")
+    if not isinstance(cases, list) or len(cases) != 1:
+        raise TeacherDatasetError("v0.7 builder requires exactly one source case per manifest")
+    if not isinstance(examples, list) or len(examples) != len(CANONICAL_VIEWS):
+        raise TeacherDatasetError("teacher manifest must contain exactly four canonical examples")
+
+    views = [item.get("view") for item in examples if isinstance(item, Mapping)]
+    if set(views) != set(CANONICAL_VIEWS) or len(views) != len(CANONICAL_VIEWS):
+        raise TeacherDatasetError("teacher examples must cover each canonical view exactly once")
+
+    digests = {item.get("target_ir_digest") for item in examples if isinstance(item, Mapping)}
+    if len(digests) != 1 or None in digests:
+        raise TeacherDatasetError("all canonical views must target the exact same Character IR digest")
+    if cases[0].get("target_ir_digest") not in digests:
+        raise TeacherDatasetError("case and example target IR digests disagree")
+
+    for item in examples:
+        if not isinstance(item, Mapping) or "unresolved" not in item:
+            raise TeacherDatasetError("every teacher example must preserve unresolved labels")
+
+    if root is None:
+        return
+
+    dataset_root = Path(root).resolve()
+    for item in examples:
+        image, _ = _inside(dataset_root, dataset_root / str(item["image"]))
+        target, _ = _inside(dataset_root, dataset_root / str(item["target_ir"]))
+        if not image.is_file() or not target.is_file():
+            raise TeacherDatasetError("teacher manifest references a missing artifact")
+        if sha256_file(image) != item.get("image_sha256"):
+            raise TeacherDatasetError(f"teacher image digest mismatch: {item['image']}")
+        target_ir = json.loads(target.read_text(encoding="utf-8"))
+        if ir_digest(target_ir) != item.get("target_ir_digest"):
+            raise TeacherDatasetError(f"teacher IR digest mismatch: {item['target_ir']}")
+
+
+def build_teacher_dataset(
+    asset: str | Path,
+    case_id: str,
+    out: str | Path,
+    *,
+    renderer: Renderer,
+    repeats: int = 3,
+) -> dict:
+    """Build one evidence-preserving multi-view teacher case from a real GLB.
+
+    3D inspection, stabilization, truth policy, hashing, admission and manifest
+    construction belong to model2ir. Rendering is deliberately injected so the
+    library does not depend on a browser, Three.js, Playwright, or an AgentOS repo
+    layout. The renderer must create the four canonical images under ``case_dir``
+    and return a mapping from canonical view name to file path.
+    """
+
+    source = Path(asset).resolve()
+    if not source.is_file():
+        raise TeacherDatasetError(f"source asset not found: {source}")
+    if source.suffix.lower() != ".glb":
+        raise TeacherDatasetError(
+            "teacher dataset v0.7 stages self-contained GLB only; core 3D→IR extraction may support additional formats"
+        )
+    case_id = _safe_case_id(case_id)
+    dataset_root = Path(out).resolve()
+    case_dir = dataset_root / case_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    audit = audit_source_asset(source, repeats=repeats)
+    stability = audit.get("status", "unstable")
+    if stability == "unstable":
+        raise TeacherDatasetError("asset audit is unstable; refusing teacher dataset admission")
+
+    raw_ir = extract_ir(source)
+    stable_ir = stabilize_external_ir(raw_ir)
+    stable_digest = ir_digest(stable_ir)
+    source_digest = sha256_file(source)
+
+    local_asset = case_dir / "model.glb"
+    shutil.copy2(source, local_asset)
+
+    rendered = renderer(local_asset, case_dir)
+    if not isinstance(rendered, Mapping):
+        raise TeacherDatasetError("renderer must return a view-to-path mapping")
+
+    render_paths: dict[str, tuple[Path, Path]] = {}
+    for view in CANONICAL_VIEWS:
+        if view not in rendered:
+            raise TeacherDatasetError(f"renderer omitted canonical view: {view}")
+        render_paths[view] = _resolve_render(case_dir, rendered[view], view)
+
+    _dump(case_dir / "character-ir.json", stable_ir)
+    _dump(case_dir / "audit.json", audit)
+    unresolved = stable_ir.get("unresolved", [])
+
+    examples = []
+    for view in CANONICAL_VIEWS:
+        image, image_rel = render_paths[view]
+        examples.append(
+            {
+                "example_id": f"{case_id}:{view}",
+                "view": view,
+                "image": str(Path(case_id) / image_rel),
+                "image_sha256": sha256_file(image),
+                "target_ir": str(Path(case_id) / "character-ir.json"),
+                "target_ir_digest": stable_digest,
+                "truth_status": stable_ir.get("truth_status", "candidate"),
+                "semantic_authority": audit.get("semantic_authority"),
+                "unresolved": unresolved,
+            }
+        )
+
+    manifest = {
+        "schema": TEACHER_DATASET_SCHEMA,
+        "policy": {
+            "label_kind": "stabilized-evidence-preserving-character-ir",
+            "unknowns_are_labels_not_errors": True,
+            "external_first_import_claimed_lossless": False,
+            "canonical_views": list(CANONICAL_VIEWS),
+        },
+        "cases": [
+            {
+                "case_id": case_id,
+                "source_asset": str(Path(case_id) / "model.glb"),
+                "source_sha256": source_digest,
+                "audit": str(Path(case_id) / "audit.json"),
+                "target_ir": str(Path(case_id) / "character-ir.json"),
+                "target_ir_digest": stable_digest,
+                "stability": stability,
+                "semantic_authority": audit.get("semantic_authority"),
+                "unresolved_count": len(unresolved),
+            }
+        ],
+        "examples": examples,
+    }
+    _dump(dataset_root / "manifest.json", manifest)
+    validate_teacher_dataset_manifest(manifest, root=dataset_root)
+    return manifest

--- a/scripts/model2ir_teacher_dataset.py
+++ b/scripts/model2ir_teacher_dataset.py
@@ -2,28 +2,51 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
-import shutil
 import subprocess
 from pathlib import Path
 
-from model2ir import audit_asset, extract_ir, stabilize_external_ir, ir_digest
+from model2ir import TeacherDatasetError, build_teacher_dataset
+from model2ir.teacher import sha256_file
 
-VIEWS = ("front", "yaw45", "right", "back")
 
-
-def dump(path: Path, obj):
+def dump(path: Path, obj) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
-def sha256(path: Path) -> str:
-    h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
+def node_renderer(renderer: str):
+    """Adapt the repository's Playwright/Three.js renderer to model2ir's renderer API."""
+
+    def render(local_asset: Path, case_dir: Path):
+        result_stub = case_dir / "render-result.json"
+        dump(
+            result_stub,
+            {
+                "case_id": case_dir.name,
+                "source_sha256": sha256_file(local_asset),
+            },
+        )
+        subprocess.run(
+            [
+                "node",
+                renderer,
+                "--glb",
+                str(local_asset),
+                "--out",
+                str(case_dir),
+                "--result",
+                str(result_stub),
+            ],
+            check=True,
+        )
+        result = json.loads(result_stub.read_text(encoding="utf-8"))
+        renders = result.get("renders")
+        if not isinstance(renders, dict):
+            raise TeacherDatasetError("renderer did not return canonical render paths")
+        return renders
+
+    return render
 
 
 def main():
@@ -34,88 +57,28 @@ def main():
     ap.add_argument("--renderer", default="scripts/character_blueprint_glb_render.mjs")
     args = ap.parse_args()
 
-    asset = Path(args.asset).resolve()
-    out = Path(args.out).resolve()
-    case_dir = out / args.case_id
-    case_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        manifest = build_teacher_dataset(
+            args.asset,
+            args.case_id,
+            args.out,
+            renderer=node_renderer(args.renderer),
+        )
+    except TeacherDatasetError as exc:
+        raise SystemExit(str(exc)) from exc
 
-    audit = audit_asset(asset)
-    raw_ir = extract_ir(asset)
-    stable_ir = stabilize_external_ir(raw_ir)
-    stable_digest = ir_digest(stable_ir)
-
-    stability = audit.get("status", "unstable")
-    if stability == "unstable":
-        raise SystemExit("asset audit is unstable; refusing teacher dataset admission")
-
-    local_asset = case_dir / "model.glb"
-    if asset.suffix.lower() != ".glb":
-        raise SystemExit("teacher renderer v0.7 currently requires GLB input")
-    shutil.copy2(asset, local_asset)
-
-    result_stub = case_dir / "render-result.json"
-    dump(result_stub, {"case_id": args.case_id, "source_sha256": sha256(asset)})
-    subprocess.run([
-        "node", args.renderer,
-        "--glb", str(local_asset),
-        "--out", str(case_dir),
-        "--result", str(result_stub),
-    ], check=True)
-
-    render_result = json.loads(result_stub.read_text(encoding="utf-8"))
-    renders = render_result["renders"]
-    missing = [v for v in VIEWS if v not in renders or not (case_dir / renders[v]).exists()]
-    if missing:
-        raise SystemExit(f"missing canonical renders: {missing}")
-
-    dump(case_dir / "character-ir.json", stable_ir)
-    dump(case_dir / "audit.json", audit)
-    unresolved = stable_ir.get("unresolved", [])
-
-    examples = []
-    for view in VIEWS:
-        image = case_dir / renders[view]
-        examples.append({
-            "example_id": f"{args.case_id}:{view}",
-            "view": view,
-            "image": str(Path(args.case_id) / image.name),
-            "image_sha256": sha256(image),
-            "target_ir": str(Path(args.case_id) / "character-ir.json"),
-            "target_ir_digest": stable_digest,
-            "truth_status": stable_ir.get("truth_status", "candidate"),
-            "semantic_authority": audit.get("semantic_authority"),
-            "unresolved": unresolved,
-        })
-
-    manifest = {
-        "schema": "model2ir-teacher-dataset/v0.7",
-        "policy": {
-            "label_kind": "stabilized-evidence-preserving-character-ir",
-            "unknowns_are_labels_not_errors": True,
-            "external_first_import_claimed_lossless": False,
-            "canonical_views": list(VIEWS),
-        },
-        "cases": [{
-            "case_id": args.case_id,
-            "source_asset": str(Path(args.case_id) / "model.glb"),
-            "source_sha256": sha256(asset),
-            "audit": str(Path(args.case_id) / "audit.json"),
-            "target_ir": str(Path(args.case_id) / "character-ir.json"),
-            "target_ir_digest": stable_digest,
-            "stability": stability,
-            "semantic_authority": audit.get("semantic_authority"),
-            "unresolved_count": len(unresolved),
-        }],
-        "examples": examples,
-    }
-    dump(out / "manifest.json", manifest)
-    print(json.dumps({
-        "ok": True,
-        "case_id": args.case_id,
-        "stability": stability,
-        "examples": len(examples),
-        "target_ir_digest": stable_digest,
-    }))
+    case = manifest["cases"][0]
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "case_id": case["case_id"],
+                "stability": case["stability"],
+                "examples": len(manifest["examples"]),
+                "target_ir_digest": case["target_ir_digest"],
+            }
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_model2ir_teacher_library.py
+++ b/tests/test_model2ir_teacher_library.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from model2ir.teacher import (
+    CANONICAL_VIEWS,
+    TEACHER_DATASET_SCHEMA,
+    TeacherDatasetError,
+    build_teacher_dataset,
+    validate_teacher_dataset_manifest,
+)
+
+
+class TeacherDatasetLibraryTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.asset = self.root / "source.glb"
+        self.asset.write_bytes(b"synthetic-glb-for-library-boundary-test")
+        self.out = self.root / "dataset"
+        self.stable_ir = {
+            "schema": "character-ir-candidate/v0.6",
+            "truth_status": "candidate",
+            "body_plan": {"kind": "humanoid", "confidence": 0.9},
+            "parts": [{"id": "torso", "state": "inferred", "confidence": 0.8}],
+            "unresolved": [{"field": "left_right_assignment", "reason": "test ambiguity"}],
+        }
+        self.audit = {
+            "status": "stable-candidate",
+            "candidate_repeatable": True,
+            "semantic_authority": "inferred",
+        }
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    @staticmethod
+    def renderer(_asset: Path, case_dir: Path):
+        renders = {}
+        for view in CANONICAL_VIEWS:
+            name = f"canonical-{view}.png"
+            (case_dir / name).write_bytes(("image:" + view).encode("utf-8"))
+            renders[view] = name
+        return renders
+
+    def build(self):
+        raw = {"candidate_ir": self.stable_ir}
+        with (
+            mock.patch("model2ir.teacher.audit_source_asset", return_value=self.audit),
+            mock.patch("model2ir.teacher.extract_ir", return_value=raw),
+            mock.patch("model2ir.teacher.stabilize_external_ir", return_value=self.stable_ir),
+        ):
+            return build_teacher_dataset(
+                self.asset,
+                "teacher-a",
+                self.out,
+                renderer=self.renderer,
+            )
+
+    def test_library_builds_v07_manifest_without_repo_renderer_dependency(self):
+        manifest = self.build()
+        self.assertEqual(manifest["schema"], TEACHER_DATASET_SCHEMA)
+        self.assertEqual([x["view"] for x in manifest["examples"]], list(CANONICAL_VIEWS))
+        self.assertEqual(len({x["target_ir_digest"] for x in manifest["examples"]}), 1)
+        self.assertTrue(all("unresolved" in x for x in manifest["examples"]))
+        self.assertFalse(manifest["policy"]["external_first_import_claimed_lossless"])
+        self.assertTrue((self.out / "teacher-a" / "character-ir.json").is_file())
+        self.assertTrue((self.out / "teacher-a" / "audit.json").is_file())
+        validate_teacher_dataset_manifest(manifest, root=self.out)
+
+    def test_validator_detects_render_tampering(self):
+        manifest = self.build()
+        image = self.out / manifest["examples"][0]["image"]
+        image.write_bytes(b"tampered")
+        with self.assertRaisesRegex(TeacherDatasetError, "image digest mismatch"):
+            validate_teacher_dataset_manifest(manifest, root=self.out)
+
+    def test_case_id_cannot_escape_dataset_root(self):
+        with self.assertRaisesRegex(TeacherDatasetError, "safe path segment"):
+            build_teacher_dataset(self.asset, "../escape", self.out, renderer=self.renderer)
+
+    def test_unstable_asset_is_not_admitted(self):
+        with mock.patch("model2ir.teacher.audit_source_asset", return_value={"status": "unstable"}):
+            with self.assertRaisesRegex(TeacherDatasetError, "unstable"):
+                build_teacher_dataset(self.asset, "unstable", self.out, renderer=self.renderer)
+
+    def test_manifest_on_disk_matches_returned_manifest(self):
+        manifest = self.build()
+        disk = json.loads((self.out / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(disk, manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal
Continue the existing Model2IR line without restarting it, and make `libs/model2ir` a real reusable 3D model → Canonical Character IR library boundary.

## What this changes
- keeps the existing v0.6 extraction/reversible/VRM/topology implementation intact
- publishes the package boundary as `model2ir` v0.8.0 with an installed `model2ir` CLI
- moves teacher-dataset truth/admission/hash/manifest logic into `model2ir.teacher`
- keeps the established `model2ir-teacher-dataset/v0.7` schema unchanged
- injects rendering through a callback so the library has no Playwright/Three.js/AgentOS repo dependency
- reduces `scripts/model2ir_teacher_dataset.py` to the repository renderer adapter
- adds contract validation for canonical views, shared target IR digest, unresolved labels, path containment, artifact existence and hash integrity
- documents the standalone public boundary and truth invariants
- adds stdlib unit regression plus a dedicated library CI gate

## Non-goals
- does not duplicate or replace the open Image→IR teacher-loop work in PR #126
- does not promote inferred semantics to observed truth
- does not claim external first-import losslessness
- does not silently broaden teacher staging to multi-file glTF; the teacher builder remains self-contained GLB until bundle staging is explicit

## Compatibility
The dataset schema remains v0.7. The v0.8 version is the library/API milestone, not a teacher-data schema rewrite.

## Validation
- branch is based on current main `9964841a461e376211acca2832dc0dc70d6f0ccb`
- branch diff is 7 commits ahead / 0 behind at PR creation
- new `Model2IR Library v0.8` workflow installs the package independently, compiles it, runs contract tests, verifies the public API, and checks the console entrypoint
- existing teacher-dataset workflow should continue exercising the real renderer/dataset path because the same library and adapter paths changed

## Follow-up after this boundary lands
1. rebase/merge PR #126 onto the library boundary
2. feed stable 3D teacher IR + canonical renders through Image→IR comparison as a consumer of the package
3. expand external real-model families and VRM topology cases before changing inference confidence policy
4. add explicit multi-file glTF bundle staging rather than copying incomplete `.gltf` files
