### PR TITLE
Harden Model2IR v0.8.1 CLI contract for GLB and VRM

### DIFF
--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -1,4 +1,4 @@
-name: Model2IR Library v0.8
+name: Model2IR Library v0.8.x
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
       - 'libs/model2ir/**'
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
+      - 'tests/test_model2ir_cli.py'
       - '.github/workflows/model2ir-library-v08.yml'
   push:
     branches: [main]
@@ -13,6 +14,7 @@ on:
       - 'libs/model2ir/**'
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
+      - 'tests/test_model2ir_cli.py'
       - '.github/workflows/model2ir-library-v08.yml'
 
 permissions:
@@ -31,14 +33,16 @@ jobs:
       - name: Compile package
         run: python -m compileall -q libs/model2ir/src
       - name: Run library contract tests
-        run: python -m unittest discover -s tests -p 'test_model2ir_teacher_library.py' -q
+        run: |
+          python -m unittest discover -s tests -p 'test_model2ir_teacher_library.py' -q
+          python -m unittest discover -s tests -p 'test_model2ir_cli.py' -q
       - name: Verify public API and console entrypoint
         shell: bash
         run: |
           set -euo pipefail
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.8.0'
+          assert model2ir.__version__ == '0.8.1'
           assert callable(model2ir.extract_ir)
           assert callable(model2ir.build_teacher_dataset)
           assert callable(model2ir.validate_teacher_dataset_manifest)
@@ -46,3 +50,4 @@ jobs:
           print('model2ir library boundary=ok')
           PY
           model2ir --help >/dev/null
+          model2ir stabilize --help >/dev/null

--- a/libs/model2ir/README.md
+++ b/libs/model2ir/README.md
@@ -31,6 +31,22 @@ model2ir --help
 python -m model2ir --help
 ```
 
+### CLI contract
+
+The CLI separates evidence extraction from stabilized Character IR projection:
+
+```bash
+model2ir extract character.glb -o evidence.json
+model2ir stabilize character.glb -o character-ir.json
+model2ir audit character.glb -o audit.json --repeats 3
+model2ir diff a.json b.json -o diff.json
+model2ir reconcile image-ir.json model-ir.json -o reconciliation.json
+```
+
+`extract` returns the full Model2IR evidence envelope. `stabilize` accepts GLB, glTF, and VRM through the normal loader and returns only the stabilized Canonical Character IR candidate/truth; it does not rewrite the source 3D container.
+
+Reversible embedding remains available through the Python API (`compile_reversible_gltf` / `save_reversible_gltf`). A container-writing CLI is deliberately not advertised yet: safely rewriting GLB binary chunks and relocatable multi-file glTF resources needs an explicit preservation contract rather than a JSON-only shortcut.
+
 ## Truth invariants
 
 1. A first import of an external model is not automatically canonical truth.
@@ -41,7 +57,7 @@ python -m model2ir --help
 
 ## Teacher dataset API
 
-The multi-view teacher contract is now library-owned. Rendering is intentionally an injected adapter so `model2ir` itself does not depend on Playwright, Three.js, a browser, or an AgentOS repository layout.
+The multi-view teacher contract is library-owned. Rendering is intentionally an injected adapter so `model2ir` itself does not depend on Playwright, Three.js, a browser, or an AgentOS repository layout.
 
 ```python
 from pathlib import Path
@@ -71,7 +87,7 @@ The retained `model2ir-teacher-dataset/v0.7` schema is intentional: moving the i
 
 ## Current format boundary
 
-Core extraction supports the formats handled by the existing loader stack, including the current GLB/glTF/VRM paths. The teacher-data builder currently stages self-contained `.glb` only because copying a standalone `.gltf` file without its referenced buffers/textures would create a misleading dataset artifact. Multi-file glTF staging should be added as an explicit bundle feature rather than guessed.
+Core extraction and stabilization support the formats handled by the existing loader stack: GLB, glTF, and VRM. The teacher-data builder currently stages self-contained `.glb` only because copying a standalone `.gltf` file without its referenced buffers/textures would create a misleading dataset artifact. Multi-file glTF staging should be added as an explicit bundle feature rather than guessed.
 
 ## Repository adapters
 

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.8.0"
+version = "0.8.1"
 description = "Standalone evidence-fused reversible Canonical Character IR decompiler for 3D assets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -41,4 +41,4 @@ __all__ = [
     "validate_teacher_dataset_manifest",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -1,49 +1,76 @@
 from __future__ import annotations
-import argparse, json
+
+import argparse
+import json
 from pathlib import Path
-from . import extract_ir, diff_ir, reconcile_ir, stabilize_external_ir, compile_reversible_gltf, audit_asset
+
+from . import audit_asset, diff_ir, extract_ir, reconcile_ir, stabilize_external_ir
 
 
-def load_json(path):
-    return json.loads(Path(path).read_text(encoding='utf-8'))
+def load_json(path: str | Path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
-def write_json(path, data):
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    Path(path).write_text(json.dumps(data, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+def write_json(path: str | Path, data) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
-def main():
-    ap = argparse.ArgumentParser(prog='model2ir')
-    sub = ap.add_subparsers(dest='cmd', required=True)
-    p = sub.add_parser('extract')
-    p.add_argument('asset'); p.add_argument('-o', '--output', required=True)
-    p = sub.add_parser('diff')
-    p.add_argument('a'); p.add_argument('b'); p.add_argument('-o','--output', required=True)
-    p = sub.add_parser('reconcile')
-    p.add_argument('image_ir'); p.add_argument('model_ir'); p.add_argument('-o','--output', required=True)
-    p = sub.add_parser('stabilize')
-    p.add_argument('asset'); p.add_argument('-o','--output', required=True)
-    p = sub.add_parser('audit')
-    p.add_argument('asset'); p.add_argument('-o','--output', required=True); p.add_argument('--repeats',type=int,default=3)
-    args = ap.parse_args()
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="model2ir",
+        description="Extract and stabilize evidence-preserving Canonical Character IR from 3D assets.",
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
 
-    if args.cmd == 'extract':
+    p = sub.add_parser("extract", help="Extract the full Model2IR evidence envelope from GLB/glTF/VRM.")
+    p.add_argument("asset")
+    p.add_argument("-o", "--output", required=True)
+
+    p = sub.add_parser("stabilize", help="Project a 3D asset to stabilized Canonical Character IR candidate/truth.")
+    p.add_argument("asset")
+    p.add_argument("-o", "--output", required=True)
+
+    p = sub.add_parser("audit", help="Repeat extraction/stabilization and report deterministic admission status.")
+    p.add_argument("asset")
+    p.add_argument("-o", "--output", required=True)
+    p.add_argument("--repeats", type=int, default=3)
+
+    p = sub.add_parser("diff", help="Compare two IR JSON documents.")
+    p.add_argument("a")
+    p.add_argument("b")
+    p.add_argument("-o", "--output", required=True)
+
+    p = sub.add_parser("reconcile", help="Reconcile image-derived IR with model-derived IR evidence.")
+    p.add_argument("image_ir")
+    p.add_argument("model_ir")
+    p.add_argument("-o", "--output", required=True)
+
+    return ap
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    if args.cmd == "extract":
         out = extract_ir(args.asset)
-    elif args.cmd == 'diff':
-        out = diff_ir(load_json(args.a), load_json(args.b))
-    elif args.cmd == 'reconcile':
-        out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
-    elif args.cmd == 'audit':
+    elif args.cmd == "stabilize":
+        out = stabilize_external_ir(extract_ir(args.asset))
+    elif args.cmd == "audit":
+        if args.repeats < 1:
+            raise SystemExit("--repeats must be >= 1")
         out = audit_asset(args.asset, repeats=args.repeats)
-    else:
-        model_ir = extract_ir(args.asset)
-        candidate = stabilize_external_ir(model_ir)
-        asset_json = load_json(args.asset)
-        out = compile_reversible_gltf(asset_json, candidate)
+    elif args.cmd == "diff":
+        out = diff_ir(load_json(args.a), load_json(args.b))
+    elif args.cmd == "reconcile":
+        out = reconcile_ir(load_json(args.image_ir), load_json(args.model_ir))
+    else:  # pragma: no cover - argparse owns command admission.
+        raise AssertionError(args.cmd)
 
     write_json(args.output, out)
-    print(json.dumps({'ok': True, 'schema': out.get('schema'), 'output': args.output}))
+    print(json.dumps({"ok": True, "schema": out.get("schema"), "output": args.output}))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/test_model2ir_cli.py
+++ b/tests/test_model2ir_cli.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import struct
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from model2ir.__main__ import main
+
+
+def write_minimal_glb(path: Path) -> None:
+    payload = json.dumps({"asset": {"version": "2.0"}, "nodes": [], "meshes": []}, separators=(",", ":")).encode("utf-8")
+    payload += b" " * ((4 - len(payload) % 4) % 4)
+    chunk = struct.pack("<II", len(payload), 0x4E4F534A) + payload
+    path.write_bytes(struct.pack("<4sII", b"glTF", 2, 12 + len(chunk)) + chunk)
+
+
+class Model2IRCliTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_cli(self, *args: str) -> dict:
+        buf = StringIO()
+        with mock.patch("sys.argv", ["model2ir", *args]), redirect_stdout(buf):
+            main()
+        return json.loads(buf.getvalue().strip())
+
+    def test_stabilize_accepts_glb_and_emits_character_ir(self):
+        asset = self.root / "minimal.glb"
+        output = self.root / "stable.json"
+        write_minimal_glb(asset)
+
+        status = self.run_cli("stabilize", str(asset), "-o", str(output))
+        stable = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertTrue(status["ok"])
+        self.assertEqual(status["schema"], "character-ir-candidate/v0.6")
+        self.assertEqual(stable["schema"], "character-ir-candidate/v0.6")
+        self.assertNotIn("asset", stable)
+
+    def test_stabilize_accepts_vrm_container_suffix(self):
+        asset = self.root / "minimal.vrm"
+        output = self.root / "stable-vrm.json"
+        write_minimal_glb(asset)
+
+        self.run_cli("stabilize", str(asset), "-o", str(output))
+        stable = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(stable["schema"], "character-ir-candidate/v0.6")
+
+    def test_extract_keeps_full_model2ir_envelope(self):
+        asset = self.root / "minimal.glb"
+        output = self.root / "extract.json"
+        write_minimal_glb(asset)
+
+        self.run_cli("extract", str(asset), "-o", str(output))
+        extracted = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(extracted["schema"], "model2ir-character-ir/v0.6")
+        self.assertIn("candidate_ir", extracted)
+        self.assertIn("topology_evidence", extracted)
+
+    def test_audit_rejects_zero_repeats_at_cli_boundary(self):
+        asset = self.root / "minimal.glb"
+        output = self.root / "audit.json"
+        write_minimal_glb(asset)
+        with self.assertRaisesRegex(SystemExit, "repeats must be >= 1"):
+            self.run_cli("audit", str(asset), "-o", str(output), "--repeats", "0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal
Harden the newly standalone Model2IR library boundary after v0.8 by fixing a pre-existing CLI contract bug without changing semantic inference policy.

## Problem
`model2ir stabilize <asset>` first extracted GLB/glTF/VRM correctly, then tried to read the original asset as JSON and compile a reversible glTF document. That made `.glb`/`.vrm` fail and also blurred two separate contracts: stabilized IR projection vs container rewriting.

## Changes
- bump standalone package to `0.8.1`
- make `stabilize` emit the stabilized Canonical Character IR candidate/truth
- keep `extract` as the full Model2IR evidence envelope
- retain `audit`, `diff`, and `reconcile` with explicit CLI help
- reject `audit --repeats < 1` at the CLI boundary
- add minimal real GLB-container tests, including `.vrm` suffix handling
- extend the standalone library CI gate to run the new CLI tests and verify the v0.8.1 entrypoint
- document that reversible embedding remains a Python API until GLB binary-chunk and relocatable multi-file glTF preservation are explicitly specified

## Non-goals
- no changes to VRM/topology/inference confidence
- no changes to reversible IR truth semantics
- no unsafe JSON-only claim that binary GLB can already be rewritten losslessly by the CLI

## Relationship to current Model2IR line
This is a direct follow-up to merged PR #132 (standalone library boundary) and PR #126 (3D teacher → Image2IR regression loop). It is deliberately isolated from their semantic work.
