### PR TITLE
Add byte-preserving reversible GLB/VRM containers to Model2IR v0.9

### DIFF
--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -64,7 +64,7 @@ jobs:
           set -euo pipefail
           rm -rf /tmp/model2ir-wheel /tmp/model2ir-wheel-venv
           mkdir -p /tmp/model2ir-wheel
-          python -m pip wheel --no-deps --no-build-isolation libs/model2ir -w /tmp/model2ir-wheel
+          python -m pip wheel --no-deps libs/model2ir -w /tmp/model2ir-wheel
           python -m venv /tmp/model2ir-wheel-venv
           /tmp/model2ir-wheel-venv/bin/python -m pip install --no-deps /tmp/model2ir-wheel/model2ir-*.whl
           cd /tmp

--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -1,4 +1,4 @@
-name: Model2IR Library v0.8.x
+name: Model2IR Library v0.9.x
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
       - 'tests/test_model2ir_cli.py'
+      - 'tests/test_model2ir_glb_reversible_v09.py'
       - '.github/workflows/model2ir-library-v08.yml'
   push:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
       - 'tests/test_model2ir_cli.py'
+      - 'tests/test_model2ir_glb_reversible_v09.py'
       - '.github/workflows/model2ir-library-v08.yml'
 
 permissions:
@@ -36,18 +38,42 @@ jobs:
         run: |
           python -m unittest discover -s tests -p 'test_model2ir_teacher_library.py' -q
           python -m unittest discover -s tests -p 'test_model2ir_cli.py' -q
+          python -m unittest discover -s tests -p 'test_model2ir_glb_reversible_v09.py' -q
       - name: Verify public API and console entrypoint
         shell: bash
         run: |
           set -euo pipefail
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.8.1'
+          assert model2ir.__version__ == '0.9.0'
           assert callable(model2ir.extract_ir)
           assert callable(model2ir.build_teacher_dataset)
           assert callable(model2ir.validate_teacher_dataset_manifest)
+          assert callable(model2ir.compile_reversible_glb)
+          assert callable(model2ir.save_reversible_glb)
+          assert callable(model2ir.verify_glb_container_preservation)
           assert model2ir.TEACHER_DATASET_SCHEMA == 'model2ir-teacher-dataset/v0.7'
           print('model2ir library boundary=ok')
           PY
           model2ir --help >/dev/null
           model2ir stabilize --help >/dev/null
+          model2ir embed-ir --help >/dev/null
+      - name: Prove wheel isolation from monorepo
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/model2ir-wheel /tmp/model2ir-wheel-venv
+          mkdir -p /tmp/model2ir-wheel
+          python -m pip wheel --no-deps --no-build-isolation libs/model2ir -w /tmp/model2ir-wheel
+          python -m venv /tmp/model2ir-wheel-venv
+          /tmp/model2ir-wheel-venv/bin/python -m pip install --no-deps /tmp/model2ir-wheel/model2ir-*.whl
+          cd /tmp
+          /tmp/model2ir-wheel-venv/bin/python - <<'PY'
+          import model2ir
+          assert model2ir.__version__ == '0.9.0'
+          assert callable(model2ir.compile_reversible_glb)
+          assert callable(model2ir.build_teacher_dataset)
+          print('model2ir isolated wheel import=PASS')
+          PY
+          /tmp/model2ir-wheel-venv/bin/model2ir --help >/dev/null
+          /tmp/model2ir-wheel-venv/bin/model2ir embed-ir --help >/dev/null

--- a/.github/workflows/model2ir-reversible-glb-v09.yml
+++ b/.github/workflows/model2ir-reversible-glb-v09.yml
@@ -1,0 +1,70 @@
+name: model2ir reversible GLB VRM v0.9
+
+on:
+  pull_request:
+    paths:
+      - 'libs/model2ir/**'
+      - 'tests/test_model2ir_glb_reversible_v09.py'
+      - 'scripts/model2ir_glb_reversible_regression.py'
+      - '.github/workflows/model2ir-reversible-glb-v09.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libs/model2ir/**'
+      - 'tests/test_model2ir_glb_reversible_v09.py'
+      - 'scripts/model2ir_glb_reversible_regression.py'
+      - '.github/workflows/model2ir-reversible-glb-v09.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reversible-glb-container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install standalone model2ir
+        run: python -m pip install -e libs/model2ir
+
+      - name: Run synthetic binary-container contract tests
+        run: python -m unittest discover -s tests -p 'test_model2ir_glb_reversible_v09.py' -q
+
+      - name: Fetch real self-contained humanoid GLB
+        run: |
+          curl -fL --retry 4 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF-Binary/CesiumMan.glb -o /tmp/CesiumMan.glb
+          test -s /tmp/CesiumMan.glb
+
+      - name: Prove real GLB binary container preservation
+        run: |
+          rm -rf /tmp/model2ir-glb-v09
+          python scripts/model2ir_glb_reversible_regression.py \
+            --asset /tmp/CesiumMan.glb \
+            --out /tmp/model2ir-glb-v09 | tee /tmp/model2ir-glb-v09.log
+          grep -q '"ok": true' /tmp/model2ir-glb-v09.log
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/model2ir-glb-v09/report.json'))
+          assert p['schema']=='model2ir-glb-reversible-regression/v0.9'
+          assert p['gate']['status']=='PASS'
+          assert p['gate']['source_unchanged'] is True
+          assert p['gate']['canonical_ir_exact'] is True
+          assert p['gate']['non_json_chunks_exact'] is True
+          assert p['gate']['relocatable_source'] is True
+          assert p['preservation']['lossless_reversible'] is True
+          assert p['preservation']['container']['non_json_chunk_count'] >= 1
+          assert p['preservation']['container']['source_chunks'] == p['preservation']['container']['output_chunks']
+          print('model2ir_real_glb_container_preservation=PASS')
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: model2ir-reversible-glb-v09
+          path: /tmp/model2ir-glb-v09/
+          if-no-files-found: error
+          retention-days: 30

--- a/libs/model2ir/README.md
+++ b/libs/model2ir/README.md
@@ -17,6 +17,9 @@ from model2ir import (
     score_roundtrip,
     compile_reversible_gltf,
     save_reversible_gltf,
+    compile_reversible_glb,
+    save_reversible_glb,
+    verify_glb_container_preservation,
     ir_digest,
     build_teacher_dataset,
     validate_teacher_dataset_manifest,
@@ -31,9 +34,9 @@ model2ir --help
 python -m model2ir --help
 ```
 
-### CLI contract
+## CLI contract
 
-The CLI separates evidence extraction from stabilized Character IR projection:
+The CLI separates evidence extraction, stabilized Character IR projection, and reversible container writing:
 
 ```bash
 model2ir extract character.glb -o evidence.json
@@ -41,11 +44,23 @@ model2ir stabilize character.glb -o character-ir.json
 model2ir audit character.glb -o audit.json --repeats 3
 model2ir diff a.json b.json -o diff.json
 model2ir reconcile image-ir.json model-ir.json -o reconciliation.json
+model2ir embed-ir character.glb canonical-ir.json -o reversible.glb --report preservation.json
 ```
 
-`extract` returns the full Model2IR evidence envelope. `stabilize` accepts GLB, glTF, and VRM through the normal loader and returns only the stabilized Canonical Character IR candidate/truth; it does not rewrite the source 3D container.
+`extract` returns the full Model2IR evidence envelope. `stabilize` accepts GLB, glTF, and VRM through the normal loader and returns only the stabilized Canonical Character IR candidate/truth.
 
-Reversible embedding remains available through the Python API (`compile_reversible_gltf` / `save_reversible_gltf`). A container-writing CLI is deliberately not advertised yet: safely rewriting GLB binary chunks and relocatable multi-file glTF resources needs an explicit preservation contract rather than a JSON-only shortcut.
+`embed-ir` is intentionally narrower. It writes a **new** `.glb` or `.vrm`, rewrites only the JSON chunk to carry the canonical IR sidecar, and preserves every non-JSON chunk byte-for-byte and in order. It refuses in-place overwrite. By default it also rejects non-data external buffer/image URIs so moving the output cannot silently break relative resources.
+
+## Two different lossless claims
+
+Model2IR treats these as separate invariants:
+
+1. **Canonical-IR lossless** — embedded Canonical Character IR is recovered exactly with a verified digest.
+2. **GLB container preservation** — every non-JSON chunk, including BIN and unknown chunks, is byte-identical after embedding.
+
+A successful `verify_glb_container_preservation(...)` requires both, plus an exact expected JSON transformation. This prevents the older mistake of treating “IR sidecar round-trips” as proof that the whole binary 3D container was preserved.
+
+The original JSON `.gltf` reversible API remains available for compatibility. Multi-file `.gltf` bundles with relative buffers/textures are **not** yet covered by the v0.9 container-level lossless guarantee.
 
 ## Truth invariants
 
@@ -87,10 +102,12 @@ The retained `model2ir-teacher-dataset/v0.7` schema is intentional: moving the i
 
 ## Current format boundary
 
-Core extraction and stabilization support the formats handled by the existing loader stack: GLB, glTF, and VRM. The teacher-data builder currently stages self-contained `.glb` only because copying a standalone `.gltf` file without its referenced buffers/textures would create a misleading dataset artifact. Multi-file glTF staging should be added as an explicit bundle feature rather than guessed.
+Core extraction and stabilization support GLB, glTF, and VRM. Reversible **binary-container** output in v0.9 is limited to GLB/VRM. The teacher-data builder also stages self-contained `.glb` only.
+
+Multi-file glTF requires a separate bundle contract covering URI resolution, path containment, resource copying/rewriting, and resource hashes. That work should be explicit rather than inferred from a standalone `.gltf` JSON file.
 
 ## Repository adapters
 
-Repository-level scripts may provide renderers, benchmark harnesses, CI, downloads, and product integration. They should call the package API rather than reimplement extraction, truth policy, hashing, admission, or manifest semantics.
+Repository-level scripts may provide renderers, benchmark harnesses, CI, downloads, and product integration. They should call the package API rather than reimplement extraction, truth policy, hashing, admission, manifest semantics, or container preservation.
 
-This boundary is what allows Image→IR, Character Blueprint, future model-training pipelines, and external repositories to consume the same 3D→IR behavior without depending on AgentOS internals.
+This boundary lets Image→IR, Character Blueprint, future training pipelines, and external repositories consume the same 3D→IR behavior without depending on AgentOS internals.

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.8.1"
+version = "0.9.0"
 description = "Standalone evidence-fused reversible Canonical Character IR decompiler for 3D assets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -9,6 +9,11 @@ from .v06 import (
     save_reversible_gltf,
 )
 from .reversible import ir_digest
+from .glb_container import (
+    compile_reversible_glb,
+    save_reversible_glb,
+    verify_glb_container_preservation,
+)
 from .audit import audit_asset as _audit_asset
 from .teacher import (
     CANONICAL_VIEWS,
@@ -32,6 +37,9 @@ __all__ = [
     "score_roundtrip",
     "compile_reversible_gltf",
     "save_reversible_gltf",
+    "compile_reversible_glb",
+    "save_reversible_glb",
+    "verify_glb_container_preservation",
     "ir_digest",
     "audit_asset",
     "CANONICAL_VIEWS",
@@ -41,4 +49,4 @@ __all__ = [
     "validate_teacher_dataset_manifest",
 ]
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -4,7 +4,15 @@ import argparse
 import json
 from pathlib import Path
 
-from . import audit_asset, diff_ir, extract_ir, reconcile_ir, stabilize_external_ir
+from . import (
+    audit_asset,
+    diff_ir,
+    extract_ir,
+    reconcile_ir,
+    save_reversible_glb,
+    stabilize_external_ir,
+    verify_glb_container_preservation,
+)
 
 
 def load_json(path: str | Path):
@@ -20,7 +28,7 @@ def write_json(path: str | Path, data) -> None:
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="model2ir",
-        description="Extract and stabilize evidence-preserving Canonical Character IR from 3D assets.",
+        description="Extract, stabilize, and reversibly carry Canonical Character IR in 3D assets.",
     )
     sub = ap.add_subparsers(dest="cmd", required=True)
 
@@ -47,11 +55,40 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("model_ir")
     p.add_argument("-o", "--output", required=True)
 
+    p = sub.add_parser(
+        "embed-ir",
+        help="Embed Canonical Character IR into a self-contained GLB/VRM while preserving non-JSON chunks byte-for-byte.",
+    )
+    p.add_argument("asset", help="Source .glb or .vrm. The source is never modified in place.")
+    p.add_argument("canonical_ir", help="Canonical Character IR JSON to embed.")
+    p.add_argument("-o", "--output", required=True, help="New .glb or .vrm output path.")
+    p.add_argument("--report", help="Optional JSON preservation report path.")
+
     return ap
 
 
 def main() -> None:
     args = build_parser().parse_args()
+
+    if args.cmd == "embed-ir":
+        canonical_ir = load_json(args.canonical_ir)
+        save_reversible_glb(args.asset, canonical_ir, args.output)
+        report = verify_glb_container_preservation(args.asset, args.output, canonical_ir)
+        if args.report:
+            write_json(args.report, report)
+        print(
+            json.dumps(
+                {
+                    "ok": report["lossless_reversible"],
+                    "schema": report["schema"],
+                    "output": args.output,
+                    "report": args.report,
+                    "canonical_ir_lossless": report["canonical_ir"]["lossless"],
+                    "non_json_chunks_exact": report["container"]["non_json_chunks_exact"],
+                }
+            )
+        )
+        return
 
     if args.cmd == "extract":
         out = extract_ir(args.asset)

--- a/libs/model2ir/src/model2ir/glb_container.py
+++ b/libs/model2ir/src/model2ir/glb_container.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .reversible import embed_ir_in_gltf, ir_digest, recover_embedded_ir
+
+GLB_MAGIC = b"glTF"
+GLB_VERSION = 2
+JSON_CHUNK = 0x4E4F534A
+BIN_CHUNK = 0x004E4942
+SUPPORTED_CONTAINER_SUFFIXES = {".glb", ".vrm"}
+
+
+@dataclass(frozen=True)
+class GlbChunk:
+    type: int
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class GlbContainer:
+    gltf: dict[str, Any]
+    chunks: tuple[GlbChunk, ...]
+
+
+def _bytes(value: str | Path | bytes | bytearray) -> bytes:
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return Path(value).read_bytes()
+
+
+def parse_glb_container(value: str | Path | bytes | bytearray) -> GlbContainer:
+    """Parse a GLB 2.0 container without discarding non-JSON chunk bytes."""
+
+    data = _bytes(value)
+    if len(data) < 20:
+        raise ValueError("GLB too small")
+    magic, version, declared_total = struct.unpack_from("<4sII", data, 0)
+    if magic != GLB_MAGIC:
+        raise ValueError("not a GLB/VRM container")
+    if version != GLB_VERSION:
+        raise ValueError(f"unsupported GLB version {version}")
+    if declared_total != len(data):
+        raise ValueError(
+            f"GLB declared length mismatch: header={declared_total} actual={len(data)}"
+        )
+
+    off = 12
+    chunks: list[GlbChunk] = []
+    while off < len(data):
+        if off + 8 > len(data):
+            raise ValueError("truncated GLB chunk header")
+        length, chunk_type = struct.unpack_from("<II", data, off)
+        off += 8
+        if length % 4 != 0:
+            raise ValueError("GLB chunk length must be 4-byte aligned")
+        end = off + length
+        if end > len(data):
+            raise ValueError("GLB chunk exceeds declared container length")
+        chunks.append(GlbChunk(chunk_type, data[off:end]))
+        off = end
+
+    if not chunks:
+        raise ValueError("GLB has no chunks")
+    if chunks[0].type != JSON_CHUNK:
+        raise ValueError("GLB first chunk must be JSON")
+    if sum(1 for chunk in chunks if chunk.type == JSON_CHUNK) != 1:
+        raise ValueError("GLB must contain exactly one JSON chunk")
+
+    raw_json = chunks[0].payload.rstrip(b"\x00 \t\r\n")
+    try:
+        gltf = json.loads(raw_json.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid GLB JSON chunk") from exc
+    if not isinstance(gltf, dict):
+        raise ValueError("GLB JSON chunk must contain an object")
+    return GlbContainer(gltf=gltf, chunks=tuple(chunks))
+
+
+def _resource_uris(gltf: dict[str, Any]) -> list[str]:
+    uris: list[str] = []
+    for item in gltf.get("buffers", []) or []:
+        if isinstance(item, dict) and isinstance(item.get("uri"), str):
+            uris.append(item["uri"])
+    for item in gltf.get("images", []) or []:
+        if isinstance(item, dict) and isinstance(item.get("uri"), str):
+            uris.append(item["uri"])
+    return uris
+
+
+def external_resource_uris(gltf: dict[str, Any]) -> list[str]:
+    """Return glTF resource URIs that are not embedded data URIs."""
+
+    return [uri for uri in _resource_uris(gltf) if not uri.startswith("data:")]
+
+
+def _encode_json_chunk(gltf: dict[str, Any]) -> bytes:
+    payload = json.dumps(
+        gltf,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    payload += b" " * ((4 - len(payload) % 4) % 4)
+    return payload
+
+
+def _serialize(chunks: list[GlbChunk]) -> bytes:
+    body = bytearray()
+    for chunk in chunks:
+        body.extend(struct.pack("<II", len(chunk.payload), chunk.type))
+        body.extend(chunk.payload)
+    total = 12 + len(body)
+    return struct.pack("<4sII", GLB_MAGIC, GLB_VERSION, total) + bytes(body)
+
+
+def _non_json_chunks(container: GlbContainer) -> tuple[GlbChunk, ...]:
+    return tuple(chunk for chunk in container.chunks if chunk.type != JSON_CHUNK)
+
+
+def _chunk_digest(chunk: GlbChunk) -> str:
+    return "sha256:" + hashlib.sha256(chunk.payload).hexdigest()
+
+
+def compile_reversible_glb(
+    source: str | Path | bytes | bytearray,
+    canonical_ir: dict[str, Any],
+    *,
+    require_relocatable: bool = True,
+) -> bytes:
+    """Embed Canonical Character IR into GLB/VRM while preserving non-JSON chunks.
+
+    Only the JSON chunk is rewritten. Every non-JSON chunk is copied byte-for-byte,
+    in the original order. By default assets with non-data external resource URIs
+    are rejected because moving the output could otherwise silently break them.
+    """
+
+    container = parse_glb_container(source)
+    external = external_resource_uris(container.gltf)
+    if require_relocatable and external:
+        raise ValueError(
+            "GLB/VRM references external resources; refusing relocatable reversible output: "
+            + ", ".join(external)
+        )
+
+    embedded = embed_ir_in_gltf(container.gltf, canonical_ir)
+    new_chunks = [GlbChunk(JSON_CHUNK, _encode_json_chunk(embedded))]
+    new_chunks.extend(copy.deepcopy(_non_json_chunks(container)))
+    return _serialize(new_chunks)
+
+
+def verify_glb_container_preservation(
+    source: str | Path | bytes | bytearray,
+    compiled: str | Path | bytes | bytearray,
+    canonical_ir: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify both canonical-IR recovery and non-JSON GLB chunk byte fidelity."""
+
+    src = parse_glb_container(source)
+    dst = parse_glb_container(compiled)
+    src_non_json = _non_json_chunks(src)
+    dst_non_json = _non_json_chunks(dst)
+
+    chunks_exact = len(src_non_json) == len(dst_non_json) and all(
+        a.type == b.type and a.payload == b.payload
+        for a, b in zip(src_non_json, dst_non_json)
+    )
+    expected_gltf = embed_ir_in_gltf(src.gltf, canonical_ir)
+    json_expected = dst.gltf == expected_gltf
+    recovered = recover_embedded_ir(dst.gltf)
+    canonical_exact = recovered == canonical_ir
+    digest_exact = recovered is not None and ir_digest(recovered) == ir_digest(canonical_ir)
+
+    source_chunks = [
+        {"index": i, "type": chunk.type, "bytes": len(chunk.payload), "digest": _chunk_digest(chunk)}
+        for i, chunk in enumerate(src_non_json)
+    ]
+    output_chunks = [
+        {"index": i, "type": chunk.type, "bytes": len(chunk.payload), "digest": _chunk_digest(chunk)}
+        for i, chunk in enumerate(dst_non_json)
+    ]
+    external = external_resource_uris(src.gltf)
+
+    return {
+        "schema": "model2ir-glb-preservation/v0.9",
+        "canonical_ir": {
+            "lossless": canonical_exact and digest_exact,
+            "expected_digest": ir_digest(canonical_ir),
+            "recovered_digest": ir_digest(recovered) if recovered is not None else None,
+        },
+        "container": {
+            "json_expected": json_expected,
+            "non_json_chunks_exact": chunks_exact,
+            "non_json_chunk_count": len(src_non_json),
+            "source_chunks": source_chunks,
+            "output_chunks": output_chunks,
+            "external_resource_uris": external,
+            "relocatable": not external,
+        },
+        "lossless_reversible": canonical_exact and digest_exact and json_expected and chunks_exact,
+    }
+
+
+def save_reversible_glb(
+    source: str | Path,
+    canonical_ir: dict[str, Any],
+    output: str | Path,
+    *,
+    require_relocatable: bool = True,
+) -> Path:
+    src = Path(source)
+    dst = Path(output)
+    if src.suffix.lower() not in SUPPORTED_CONTAINER_SUFFIXES:
+        raise ValueError("reversible container writer supports .glb and .vrm only")
+    if dst.suffix.lower() not in SUPPORTED_CONTAINER_SUFFIXES:
+        raise ValueError("reversible container output must use .glb or .vrm")
+    if src.resolve() == dst.resolve():
+        raise ValueError("refusing to overwrite source asset in place")
+
+    payload = compile_reversible_glb(
+        src,
+        canonical_ir,
+        require_relocatable=require_relocatable,
+    )
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_bytes(payload)
+    report = verify_glb_container_preservation(src, dst, canonical_ir)
+    if not report["lossless_reversible"]:
+        dst.unlink(missing_ok=True)
+        raise ValueError("reversible GLB verification failed; output removed")
+    return dst

--- a/libs/model2ir/src/model2ir/glb_container.py
+++ b/libs/model2ir/src/model2ir/glb_container.py
@@ -15,6 +15,14 @@ GLB_VERSION = 2
 JSON_CHUNK = 0x4E4F534A
 BIN_CHUNK = 0x004E4942
 SUPPORTED_CONTAINER_SUFFIXES = {".glb", ".vrm"}
+NON_CANONICAL_TRUTH_STATUSES = {
+    "candidate",
+    "inferred",
+    "unknown",
+    "stable-candidate",
+    "stable-unknown",
+    "stable-but-ambiguous",
+}
 
 
 @dataclass(frozen=True)
@@ -100,6 +108,16 @@ def external_resource_uris(gltf: dict[str, Any]) -> list[str]:
     return [uri for uri in _resource_uris(gltf) if not uri.startswith("data:")]
 
 
+def _assert_canonical_input(canonical_ir: dict[str, Any]) -> None:
+    if not isinstance(canonical_ir, dict):
+        raise ValueError("canonical IR must be a JSON object")
+    status = canonical_ir.get("truth_status")
+    if isinstance(status, str) and status.lower().replace("_", "-") in NON_CANONICAL_TRUTH_STATUSES:
+        raise ValueError(
+            f"refusing to embed truth_status={status!r} as canonical IR; confirm/promote it explicitly first"
+        )
+
+
 def _encode_json_chunk(gltf: dict[str, Any]) -> bytes:
     payload = json.dumps(
         gltf,
@@ -133,13 +151,16 @@ def compile_reversible_glb(
     *,
     require_relocatable: bool = True,
 ) -> bytes:
-    """Embed Canonical Character IR into GLB/VRM while preserving non-JSON chunks.
+    """Embed confirmed/legacy Canonical Character IR while preserving binary chunks.
 
     Only the JSON chunk is rewritten. Every non-JSON chunk is copied byte-for-byte,
-    in the original order. By default assets with non-data external resource URIs
-    are rejected because moving the output could otherwise silently break them.
+    in the original order. Explicit candidate/inferred truth statuses are rejected
+    so a 3D-derived candidate cannot be laundered into embedded canonical truth.
+    By default assets with non-data external resource URIs are rejected because
+    moving the output could otherwise silently break them.
     """
 
+    _assert_canonical_input(canonical_ir)
     container = parse_glb_container(source)
     external = external_resource_uris(container.gltf)
     if require_relocatable and external:

--- a/scripts/model2ir_glb_reversible_regression.py
+++ b/scripts/model2ir_glb_reversible_regression.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from model2ir import extract_ir, ir_digest, save_reversible_glb, verify_glb_container_preservation
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--asset", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    source = Path(args.asset).resolve()
+    out = Path(args.out).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    output = out / ("reversible" + source.suffix.lower())
+
+    source_hash_before = sha256_file(source)
+    canonical_ir = {
+        "schema": "character-ir/v0.9-regression-fixture",
+        "truth_status": "confirmed",
+        "identity": {"archetype": "humanoid", "locked": True},
+        "provenance": {
+            "purpose": "model2ir binary-container preservation regression",
+            "source_asset_sha256": source_hash_before,
+            "note": "This fixture tests reversible carriage only; it is not inferred from the source model.",
+        },
+        "unresolved": [],
+    }
+
+    save_reversible_glb(source, canonical_ir, output)
+    source_hash_after = sha256_file(source)
+    preservation = verify_glb_container_preservation(source, output, canonical_ir)
+    recovered = extract_ir(output)
+
+    assert source_hash_after == source_hash_before
+    assert preservation["lossless_reversible"] is True
+    assert preservation["container"]["non_json_chunks_exact"] is True
+    assert preservation["container"]["json_expected"] is True
+    assert preservation["container"]["relocatable"] is True
+    assert recovered["reversibility"]["lossless"] is True
+    assert recovered["canonical_ir"] == canonical_ir
+    assert recovered["canonical_ir_digest"] == ir_digest(canonical_ir)
+
+    report = {
+        "schema": "model2ir-glb-reversible-regression/v0.9",
+        "source": {
+            "path": source.name,
+            "sha256_before": source_hash_before,
+            "sha256_after": source_hash_after,
+            "bytes": source.stat().st_size,
+        },
+        "output": {
+            "path": output.name,
+            "sha256": sha256_file(output),
+            "bytes": output.stat().st_size,
+        },
+        "canonical_ir_digest": ir_digest(canonical_ir),
+        "preservation": preservation,
+        "gate": {
+            "source_unchanged": source_hash_before == source_hash_after,
+            "canonical_ir_exact": recovered["canonical_ir"] == canonical_ir,
+            "non_json_chunks_exact": preservation["container"]["non_json_chunks_exact"],
+            "relocatable_source": preservation["container"]["relocatable"],
+            "status": "PASS",
+        },
+    }
+    (out / "canonical-ir.json").write_text(
+        json.dumps(canonical_ir, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    (out / "report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "source": source.name,
+                "non_json_chunks": preservation["container"]["non_json_chunk_count"],
+                "canonical_ir_digest": ir_digest(canonical_ir),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_model2ir_cli.py
+++ b/tests/test_model2ir_cli.py
@@ -9,6 +9,7 @@ from io import StringIO
 from pathlib import Path
 from unittest import mock
 
+from model2ir import extract_ir
 from model2ir.__main__ import main
 
 
@@ -65,6 +66,37 @@ class Model2IRCliTest(unittest.TestCase):
         self.assertEqual(extracted["schema"], "model2ir-character-ir/v0.6")
         self.assertIn("candidate_ir", extracted)
         self.assertIn("topology_evidence", extracted)
+
+    def test_embed_ir_writes_new_verified_container_and_report(self):
+        asset = self.root / "minimal.glb"
+        ir_path = self.root / "canonical-ir.json"
+        output = self.root / "reversible.glb"
+        report_path = self.root / "preservation.json"
+        write_minimal_glb(asset)
+        canonical_ir = {
+            "schema": "character-ir/v0.6",
+            "identity": {"archetype": "humanoid", "locked": True},
+            "unresolved": [],
+        }
+        ir_path.write_text(json.dumps(canonical_ir), encoding="utf-8")
+
+        status = self.run_cli(
+            "embed-ir",
+            str(asset),
+            str(ir_path),
+            "-o",
+            str(output),
+            "--report",
+            str(report_path),
+        )
+
+        self.assertTrue(status["ok"])
+        self.assertTrue(status["canonical_ir_lossless"])
+        self.assertTrue(status["non_json_chunks_exact"])
+        self.assertTrue(output.is_file())
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertTrue(report["lossless_reversible"])
+        self.assertEqual(extract_ir(output)["canonical_ir"], canonical_ir)
 
     def test_audit_rejects_zero_repeats_at_cli_boundary(self):
         asset = self.root / "minimal.glb"

--- a/tests/test_model2ir_glb_reversible_v09.py
+++ b/tests/test_model2ir_glb_reversible_v09.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from model2ir import extract_ir
+from model2ir.glb_container import (
+    BIN_CHUNK,
+    JSON_CHUNK,
+    compile_reversible_glb,
+    parse_glb_container,
+    save_reversible_glb,
+    verify_glb_container_preservation,
+)
+
+CUSTOM_CHUNK = 0x1234ABCD
+
+
+def _pad(payload: bytes, byte: bytes) -> bytes:
+    return payload + byte * ((4 - len(payload) % 4) % 4)
+
+
+def make_glb(gltf: dict, bin_payload: bytes, *, custom_payload: bytes | None = None) -> bytes:
+    json_payload = _pad(json.dumps(gltf, separators=(",", ":")).encode("utf-8"), b" ")
+    bin_payload = _pad(bin_payload, b"\x00")
+    chunks = [(JSON_CHUNK, json_payload), (BIN_CHUNK, bin_payload)]
+    if custom_payload is not None:
+        chunks.append((CUSTOM_CHUNK, _pad(custom_payload, b"\x00")))
+    body = b"".join(struct.pack("<II", len(payload), kind) + payload for kind, payload in chunks)
+    return struct.pack("<4sII", b"glTF", 2, 12 + len(body)) + body
+
+
+class ReversibleGlbV09Test(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.ir = {
+            "schema": "character-ir/v0.6",
+            "identity": {"archetype": "humanoid", "locked": True},
+            "body": {"plan": "humanoid"},
+            "unresolved": [{"field": "hair", "reason": "not asserted"}],
+        }
+        self.gltf = {
+            "asset": {"version": "2.0", "generator": "model2ir-v09-test"},
+            "scene": 0,
+            "scenes": [{"nodes": [0]}],
+            "nodes": [{"name": "Body", "mesh": 0}],
+            "meshes": [{"name": "Body", "primitives": []}],
+            "buffers": [{"byteLength": 12}],
+        }
+        self.bin_payload = b"\x01\x02geometry\x00\xff"
+        self.custom_payload = b"opaque-custom-chunk"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_compile_preserves_every_non_json_chunk_byte_for_byte(self):
+        source = make_glb(self.gltf, self.bin_payload, custom_payload=self.custom_payload)
+        compiled = compile_reversible_glb(source, self.ir)
+        src = parse_glb_container(source)
+        dst = parse_glb_container(compiled)
+
+        src_non_json = [(c.type, c.payload) for c in src.chunks if c.type != JSON_CHUNK]
+        dst_non_json = [(c.type, c.payload) for c in dst.chunks if c.type != JSON_CHUNK]
+        self.assertEqual(src_non_json, dst_non_json)
+
+        report = verify_glb_container_preservation(source, compiled, self.ir)
+        self.assertTrue(report["canonical_ir"]["lossless"])
+        self.assertTrue(report["container"]["json_expected"])
+        self.assertTrue(report["container"]["non_json_chunks_exact"])
+        self.assertTrue(report["lossless_reversible"])
+        self.assertEqual(report["container"]["non_json_chunk_count"], 2)
+
+    def test_saved_glb_reimports_exact_canonical_ir_and_source_is_unchanged(self):
+        source_path = self.root / "source.glb"
+        output_path = self.root / "reversible.glb"
+        source_path.write_bytes(make_glb(self.gltf, self.bin_payload))
+        source_before = hashlib.sha256(source_path.read_bytes()).hexdigest()
+
+        save_reversible_glb(source_path, self.ir, output_path)
+
+        self.assertEqual(hashlib.sha256(source_path.read_bytes()).hexdigest(), source_before)
+        recovered = extract_ir(output_path)
+        self.assertTrue(recovered["reversibility"]["lossless"])
+        self.assertEqual(recovered["canonical_ir"], self.ir)
+        self.assertTrue(
+            verify_glb_container_preservation(source_path, output_path, self.ir)["lossless_reversible"]
+        )
+
+    def test_vrm_suffix_uses_same_binary_container_contract(self):
+        source_path = self.root / "source.vrm"
+        output_path = self.root / "reversible.vrm"
+        source_path.write_bytes(make_glb(self.gltf, self.bin_payload))
+
+        save_reversible_glb(source_path, self.ir, output_path)
+        recovered = extract_ir(output_path)
+        self.assertEqual(recovered["source_kind"], "vrm")
+        self.assertEqual(recovered["canonical_ir"], self.ir)
+
+    def test_relative_external_resources_are_rejected_by_default(self):
+        external = dict(self.gltf)
+        external["images"] = [{"uri": "textures/body.png"}]
+        source = make_glb(external, self.bin_payload)
+        with self.assertRaisesRegex(ValueError, "external resources"):
+            compile_reversible_glb(source, self.ir)
+
+    def test_writer_refuses_in_place_overwrite(self):
+        source_path = self.root / "source.glb"
+        source_path.write_bytes(make_glb(self.gltf, self.bin_payload))
+        with self.assertRaisesRegex(ValueError, "overwrite source"):
+            save_reversible_glb(source_path, self.ir, source_path)
+
+    def test_declared_length_mismatch_is_rejected(self):
+        source = bytearray(make_glb(self.gltf, self.bin_payload))
+        struct.pack_into("<I", source, 8, len(source) - 4)
+        with self.assertRaisesRegex(ValueError, "declared length mismatch"):
+            parse_glb_container(source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model2ir_glb_reversible_v09.py
+++ b/tests/test_model2ir_glb_reversible_v09.py
@@ -101,6 +101,16 @@ class ReversibleGlbV09Test(unittest.TestCase):
         self.assertEqual(recovered["source_kind"], "vrm")
         self.assertEqual(recovered["canonical_ir"], self.ir)
 
+    def test_candidate_truth_cannot_be_laundered_into_canonical_sidecar(self):
+        source = make_glb(self.gltf, self.bin_payload)
+        candidate = {
+            "schema": "character-ir-candidate/v0.6",
+            "truth_status": "candidate",
+            "body_plan": {"kind": "humanoid", "confidence": 0.8},
+        }
+        with self.assertRaisesRegex(ValueError, "refusing to embed truth_status"):
+            compile_reversible_glb(source, candidate)
+
     def test_relative_external_resources_are_rejected_by_default(self):
         external = dict(self.gltf)
         external["images"] = [{"uri": "textures/body.png"}]


### PR DESCRIPTION
## Goal
Continue the existing Model2IR line into real container-level reversibility without changing 3D semantic inference policy.

## Why v0.9
The existing reversible v0.2 contract proves exact Canonical Character IR sidecar recovery in JSON `.gltf` carriers. That is important, but it does not prove that a real GLB/VRM binary container survives embedding without geometry/binary changes.

v0.9 separates those claims explicitly:
1. Canonical-IR lossless recovery
2. non-JSON GLB chunk byte preservation

## Changes
- add strict GLB 2.0 container parser/writer that retains non-JSON chunk bytes and order
- add `compile_reversible_glb`, `save_reversible_glb`, and `verify_glb_container_preservation`
- preserve BIN and unknown non-JSON chunks byte-for-byte while rewriting only the JSON chunk
- reject malformed container lengths/chunk boundaries
- refuse in-place source overwrite
- reject relative/non-data external resources by default so relocatable output is not falsely claimed
- reject explicit candidate/inferred/unknown `truth_status` values from being embedded as canonical truth
- expose `model2ir embed-ir source.glb canonical-ir.json -o output.glb --report ...`
- bump package to `0.9.0`
- add GLB/VRM unit contract tests including custom chunk preservation, exact canonical re-import, source immutability, external resource rejection, candidate-truth rejection, and malformed-container rejection
- add a real CesiumMan GLB regression gate with preservation evidence artifact
- strengthen library CI with wheel build + fresh venv installation to prove the package does not depend on the monorepo editable environment

## Truth policy
This PR intentionally does **not** embed a stabilized 3D-derived candidate as canonical truth. The real-container regression uses an explicit confirmed regression fixture for the carriage test. Existing teacher/3D→IR workflows remain responsible for semantic extraction and candidate-quality evidence.

## Non-goals
- no new topology/semantic heuristics
- no confidence changes
- no claim that multi-file `.gltf` bundles are relocatable/lossless yet
- no PyPI publication or physical repo split yet

## Validation plan
All existing Model2IR gates should rerun because `libs/model2ir/**` changes, including reversible v0.2, stabilized import, VRM topology, real-family semantics, teacher dataset, 3D→Image→IR teacher loop, and governance. New v0.9 gates additionally verify binary container fidelity and isolated wheel installation.
