### PR TITLE
feat(agentos): formalize parallel Core workers and dependency state

### DIFF
--- a/docs/CORE_WORKER_MODEL.md
+++ b/docs/CORE_WORKER_MODEL.md
@@ -1,0 +1,83 @@
+# AgentOS Core Worker Model
+
+Status: canonical proposal for Issue #137
+
+## Purpose
+
+The canonical AgentOS Core thread is the architecture and authority control plane. It is not a global single-threaded executor for every Core issue or every product dependency.
+
+Core-owned work may execute in independent worker threads, agents, or nodes. A product project blocks only the exact step whose declared dependency is unsatisfied. Unrelated project work remains runnable.
+
+## Authority split
+
+The canonical Core authority owns:
+- architecture and invariants;
+- project/repository identity rules;
+- issue triage and dependency graph;
+- acceptance criteria and evidence requirements;
+- integration decisions;
+- deployment/publication authority.
+
+A Core worker owns only its declared issue execution scope. A worker may branch, implement, test, collect evidence, and report `acceptance_ready`. It does not gain protected-main merge authority, deployment-generation authority, or authority over unrelated issues.
+
+## Worker state contract
+
+Canonical machine-readable worker state is recorded in `governance/core-workers.json` with schema `agentos.core-workers/v0`.
+
+Allowed worker states:
+- `queued`
+- `running`
+- `blocked`
+- `acceptance_ready`
+- `accepted`
+- `failed`
+
+Each worker records issue id, branch where known, dependencies, evidence refs, blocking scope, and explicit non-authorities.
+
+## Dependency semantics
+
+Dependencies are directed edges, not project-wide pauses.
+
+Example:
+
+`vendor-reputation:semantic-classification -> agentos-core#72`
+
+Only `semantic-classification` waits for #72. Collection, UI, tests, documentation, or unrelated Vendor work continue unless they declare their own dependency.
+
+A dependency is satisfiable only when its Core worker reaches `accepted` with the required evidence. `acceptance_ready`, CI green, PR mergeability, or a generic `continue` is not sufficient.
+
+## Branch and environment semantics
+
+Core development:
+
+`core/issue-* -> core/integration -> explicit promotion PR -> protected main`
+
+Product development should follow the same authority principle without requiring every repository to have an identical branch topology:
+
+- feature/fix branches are mutable development candidates;
+- an optional `develop`/integration branch may back POC or staging;
+- `main` is accepted/promotion state, not an agent workspace;
+- production deploys must resolve to an exact accepted SHA/tag/artifact;
+- POC/staging may resolve to an exact candidate SHA from a feature/develop lane;
+- no environment is authoritative merely because it tracks a branch name.
+
+Every deployment receipt should identify project id, repository, environment, source ref, exact source SHA, artifact digest where applicable, and deployment timestamp/generation.
+
+## Initial worker lanes
+
+- #117 ONE Experience regression: separate worker; currently may depend on #72 and #130.
+- #72 Antigravity/Claude executor liveness: shared executor-runtime worker.
+- #130 Oracle self-hosted runner recovery: shared infrastructure worker.
+- #105 governed GUI certification: independent worker.
+- #96 LayoutLib development/deployment authority: independent worker.
+- #66 governed Studio static release: independent worker.
+- #118 repository-boundary cleanup: architecture/migration worker; must not globally block product feature work.
+
+## Invariants
+
+1. Core ownership does not imply execution serialization.
+2. Worker completion does not imply publication authority.
+3. Product projects block only dependency-scoped steps.
+4. `main` is accepted/promotion state; active development does not write directly to it.
+5. Online/staging/production state is identified by environment + exact source/artifact identity, never by branch name alone.
+6. Machine-readable worker/dependency state is canonical enough for discovery, but acceptance still requires preserved evidence.

--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T01:13:00Z",
+  "generated_at": "2026-08-31T01:21:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -20,7 +20,7 @@
       "execution_lane": "separate-worker-thread",
       "dependencies": [72, 130],
       "blocking_scope": ["agentos-core:experience-regression"],
-      "evidence": [".agentos/evidence/experience/"],
+      "evidence": [".agentos/evidence/experience/", "pull/119"],
       "non_authorities": ["protected-main merge", "deployment-generation advance"]
     },
     {
@@ -53,7 +53,7 @@
       "execution_lane": "independent-worker",
       "dependencies": [],
       "blocking_scope": ["agentos-node:full-chatgpt-one-gui-certification"],
-      "evidence": [".agentos/evidence/node-gui/vopc5750/acceptance.json"],
+      "evidence": [".agentos/evidence/node-gui/vopc5750/acceptance.json", "pull/116"],
       "non_authorities": ["protected-main merge"]
     },
     {
@@ -81,23 +81,23 @@
     {
       "issue": 118,
       "name": "Repository-boundary cleanup",
-      "branch": null,
+      "branch": "core/issue-118-repo-boundary",
       "status": "running",
       "execution_lane": "architecture-migration-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": [],
+      "evidence": ["docs/PROJECT_REPO_MAP.md", "pull/139"],
       "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
     },
     {
       "issue": 137,
       "name": "Parallel worker/dependency control-plane",
       "branch": "core/issue-137-worker-coordination",
-      "status": "running",
+      "status": "acceptance_ready",
       "execution_lane": "canonical-coordination-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json"],
+      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/138"],
       "non_authorities": ["protected-main merge"]
     }
   ],

--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,0 +1,112 @@
+{
+  "schema": "agentos.core-workers/v0",
+  "project_id": "agentos-core",
+  "generated_at": "2026-08-31T01:13:00Z",
+  "authority": {
+    "canonical_integration_branch": "core/integration",
+    "publication_branch": "main",
+    "publication_requires_explicit_human_authorization": true,
+    "live_runtime_authority": {
+      "generation": 6,
+      "source_sha": "f842bee2cf7c24fc3bf7424bd121994562e829cd"
+    }
+  },
+  "workers": [
+    {
+      "issue": 117,
+      "name": "ONE Experience discovery/hydration/regression",
+      "branch": "core/issue-117-experience-memory",
+      "status": "blocked",
+      "execution_lane": "separate-worker-thread",
+      "dependencies": [72, 130],
+      "blocking_scope": ["agentos-core:experience-regression"],
+      "evidence": [".agentos/evidence/experience/"],
+      "non_authorities": ["protected-main merge", "deployment-generation advance"]
+    },
+    {
+      "issue": 72,
+      "name": "Antigravity/Claude executor liveness",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "shared-executor-runtime-worker",
+      "dependencies": [130],
+      "blocking_scope": ["agentos-core:experience-regression", "vendor-reputation:semantic-classification"],
+      "evidence": [".agentos/evidence/relay-smoke.json"],
+      "non_authorities": ["protected-main merge"]
+    },
+    {
+      "issue": 130,
+      "name": "Oracle self-hosted runner recovery",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "shared-infrastructure-worker",
+      "dependencies": [],
+      "blocking_scope": ["oracle:self-hosted-governance-jobs", "agentos-core:experience-regression"],
+      "evidence": [],
+      "non_authorities": ["weaken-governance-gates", "protected-main merge"]
+    },
+    {
+      "issue": 105,
+      "name": "Governed GUI control certification",
+      "branch": "core/issue-105-gui-control",
+      "status": "queued",
+      "execution_lane": "independent-worker",
+      "dependencies": [],
+      "blocking_scope": ["agentos-node:full-chatgpt-one-gui-certification"],
+      "evidence": [".agentos/evidence/node-gui/vopc5750/acceptance.json"],
+      "non_authorities": ["protected-main merge"]
+    },
+    {
+      "issue": 96,
+      "name": "LayoutLib development/deployment authority",
+      "branch": "core/layoutlib-poc-candidate-deploy",
+      "status": "queued",
+      "execution_lane": "independent-worker",
+      "dependencies": [130],
+      "blocking_scope": ["layoutlib:poc-deployment"],
+      "evidence": [],
+      "non_authorities": ["layoutlib production promotion", "protected-main merge"]
+    },
+    {
+      "issue": 66,
+      "name": "Governed Studio static release",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "independent-worker",
+      "dependencies": [130],
+      "blocking_scope": ["arcanaforge:poc-static-release"],
+      "evidence": [],
+      "non_authorities": ["arbitrary shell authority", "protected-main merge"]
+    },
+    {
+      "issue": 118,
+      "name": "Repository-boundary cleanup",
+      "branch": null,
+      "status": "running",
+      "execution_lane": "architecture-migration-worker",
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": [],
+      "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
+    },
+    {
+      "issue": 137,
+      "name": "Parallel worker/dependency control-plane",
+      "branch": "core/issue-137-worker-coordination",
+      "status": "running",
+      "execution_lane": "canonical-coordination-worker",
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json"],
+      "non_authorities": ["protected-main merge"]
+    }
+  ],
+  "dependency_edges": [
+    {"from": "agentos-core#117", "to": "agentos-core#72"},
+    {"from": "agentos-core#117", "to": "agentos-core#130"},
+    {"from": "agentos-core#72", "to": "agentos-core#130"},
+    {"from": "vendor-reputation:semantic-classification", "to": "agentos-core#72"},
+    {"from": "layoutlib:poc-deployment", "to": "agentos-core#96"},
+    {"from": "arcanaforge:poc-static-release", "to": "agentos-core#66"}
+  ]
+}


### PR DESCRIPTION
Replacement for draft PR #138 because the connected GitHub draft→ready mutation is currently broken. Same branch/content, same base, no authority widening.

Adds `docs/CORE_WORKER_MODEL.md` and machine-readable `governance/core-workers.json`, establishing dependency-scoped blocking, independent Core worker lanes, and branch/environment semantics.

Targets `core/integration`, not protected `main`.