### PR TITLE
docs(agentos): finalize accepted Core worker state

### DIFF
--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T01:21:00Z",
+  "generated_at": "2026-08-31T01:24:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -86,18 +86,18 @@
       "execution_lane": "architecture-migration-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/PROJECT_REPO_MAP.md", "pull/139"],
+      "evidence": ["docs/PROJECT_REPO_MAP.md", "pull/141"],
       "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
     },
     {
       "issue": 137,
       "name": "Parallel worker/dependency control-plane",
       "branch": "core/issue-137-worker-coordination",
-      "status": "acceptance_ready",
+      "status": "accepted",
       "execution_lane": "canonical-coordination-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/138"],
+      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/140"],
       "non_authorities": ["protected-main merge"]
     }
   ],


### PR DESCRIPTION
Finalize #137 after PR #140 integrated the worker/dependency model. Updates machine-readable status to `accepted` and corrects evidence references for #137/#118 to the actual integrated PRs (#140/#141). Targets `core/integration`, not protected `main`.