### PR TITLE
docs(agentos): inventory product-owned migration sources for #118

### DIFF
--- a/docs/PRODUCT_MIGRATION_INVENTORY.md
+++ b/docs/PRODUCT_MIGRATION_INVENTORY.md
@@ -1,0 +1,73 @@
+# Product Migration Inventory
+
+Status: Issue #118 phase 2 inventory, 2026-08-31
+
+Purpose: identify product-owned material still represented in `alston-personal/agentmanager` so Core can stop acting as a catch-all product/deployment repository. This document classifies current open PRs by ownership; it does not delete history or claim migration parity.
+
+## Classification rules
+
+- **CORE**: generic AgentOS runtime, ONE/Realm, Node protocols, governance/authority, canonical state, receipts, generic capability contracts.
+- **PRODUCT**: product-specific implementation, UI, data, product deployers/workflows, release scripts, product benchmarks.
+- **MIXED**: contains both reusable Core capability/runtime work and product-specific adapters/ingestion; must be split before integration.
+- Product-owned work must not be merged into `agentmanager` merely because Oracle currently executes its carrier.
+- Oracle execution/deployment authority is a Core concern; the workload definition/source remains product-owned.
+
+## Open PR inventory
+
+| PR | Observed changed files | Classification | Migration disposition |
+| --- | --- | --- | --- |
+| #127 Vendor monitored source sync | `.github/workflows/oracle-register-vendor-threads-source.yml`, `.github/workflows/oracle-sync-vendor-monitored-sources.yml`, `scripts/run_vendor_monitored_source_sync.sh` | PRODUCT | Freeze as migration source. Vendor workload/schedule belongs to `alston-personal/vendor-reputation-service`; Core should expose only the governed execution/deployment primitive needed to run it. |
+| #99 Vendor Threads calibration | `.github/workflows/oracle-vendor-threads-calibration.yml`, `scripts/run_vendor_threads_calibration.sh` | PRODUCT | Freeze as migration source. Calibration workflow belongs to Vendor repo; Core provides generic Oracle execution boundary only. |
+| #97 Vendor patrol receipt carrier | `.github/workflows/oracle-register-vendor-threads-source.yml` | PRODUCT | Freeze as migration source. Evidence publication policy may inform generic Core receipts, but this workflow is Vendor-specific. |
+| #136 ArcanaForge POC release | `.github/workflows/oracle-release-arcanaforge-poc.yml` | PRODUCT/CARRIER | Freeze as migration source. Arcana release intent/source belongs to Arcana/Studio source repo; generic fenced static-release authority belongs to Core #66. |
+| #53 Character Blueprint browser deployer | `scripts/deploy_character_blueprint_poc.py` | PRODUCT | Freeze as migration source until canonical Character Blueprint repo is verified. Do not integrate into Core. |
+| #125 Social capability + Vendor ingestion | generic social capability/governance files plus `agentos_node/social/vendor_ingest.py` and `tests/test_vendor_threads_ingest.py` | MIXED | Split. Generic social capability can be extracted to focused Core issue branch; Vendor ingestion adapter/tests belong to Vendor repo. Do not merge mixed PR as-is. |
+
+## Current canonical repositories
+
+- Vendor Reputation Service: `alston-personal/vendor-reputation-service`
+- LayoutLib / Layout Lab: `alston-personal/layoutlib`
+- ArcanaForge: `alston-personal/arcanaforge`
+- Leopard Cat Tarot: `alston-personal/leopardcat-tarot`
+- Character Blueprint: unresolved; `alston-personal/charactergenerator` is only a naming candidate and is not accepted as authority without provenance verification.
+- Model2IR: unresolved; no same-name canonical repository established yet.
+
+## Required migration pattern
+
+For a product-specific Oracle workflow currently living in `agentmanager`:
+
+1. preserve the current PR/branch as historical migration source;
+2. move workload definition, product script, schedule intent, tests and product-specific evidence policy to the canonical product repo;
+3. if the product repo cannot directly reach Oracle, depend on a generic Core capability rather than copying product workflow into Core;
+4. Core capability accepts a bounded artifact/request and returns a governed receipt;
+5. verify parity against the historical carrier;
+6. only then close the legacy `agentmanager` PR as superseded;
+7. do not delete historical branch/evidence until provenance is accounted for.
+
+## Mixed PR #125 split boundary
+
+Keep/extract to Core only if independently justified and tested:
+- generic social capability contracts;
+- credential-reference boundary and secret-free receipts;
+- generic Threads/Facebook/Instagram executor implementation;
+- generic capability governance and write-approval gates;
+- generic social capability documentation/tests.
+
+Move out of Core:
+- `agentos_node/social/vendor_ingest.py`;
+- `tests/test_vendor_threads_ingest.py`;
+- any Vendor-specific workflow, query semantics, schema mapping, DB ingestion, calibration or patrol behavior.
+
+The extraction must be based on actual accepted deltas, not a blind merge of #125.
+
+## Non-blocking rule
+
+Migration work does not globally pause the product. Only steps requiring a missing Core capability remain blocked. Product feature development continues in its canonical repository.
+
+## Exit criteria for #118 phase 2
+
+- every open product-owned/mixed `agentmanager` PR is classified;
+- product PRs are explicitly frozen from Core integration pending migration parity;
+- migration issues exist in canonical product repos where the repository is known;
+- mixed PRs have an explicit split boundary;
+- no protected `main` publication is implied by this inventory.

--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T01:24:00Z",
+  "generated_at": "2026-08-31T01:53:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -75,18 +75,18 @@
       "execution_lane": "independent-worker",
       "dependencies": [130],
       "blocking_scope": ["arcanaforge:poc-static-release"],
-      "evidence": [],
+      "evidence": ["alston-personal/arcanaforge#2"],
       "non_authorities": ["arbitrary shell authority", "protected-main merge"]
     },
     {
       "issue": 118,
       "name": "Repository-boundary cleanup",
-      "branch": "core/issue-118-repo-boundary",
+      "branch": "core/issue-118-product-migration-inventory",
       "status": "running",
       "execution_lane": "architecture-migration-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/PROJECT_REPO_MAP.md", "pull/141"],
+      "evidence": ["docs/PROJECT_REPO_MAP.md", "docs/PRODUCT_MIGRATION_INVENTORY.md", "pull/141", "alston-personal/vendor-reputation-service#26", "alston-personal/arcanaforge#2"],
       "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
     },
     {
@@ -99,6 +99,17 @@
       "blocking_scope": [],
       "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/140"],
       "non_authorities": ["protected-main merge"]
+    },
+    {
+      "issue": 144,
+      "name": "Extract generic social capability from mixed PR #125",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "independent-core-extraction-worker",
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": ["pull/125", "alston-personal/vendor-reputation-service#26"],
+      "non_authorities": ["merge mixed PR #125", "retain Vendor product ingestion in Core", "protected-main merge"]
     }
   ],
   "dependency_edges": [
@@ -106,7 +117,10 @@
     {"from": "agentos-core#117", "to": "agentos-core#130"},
     {"from": "agentos-core#72", "to": "agentos-core#130"},
     {"from": "vendor-reputation:semantic-classification", "to": "agentos-core#72"},
+    {"from": "vendor-reputation:migrate-agentmanager-carriers", "to": "alston-personal/vendor-reputation-service#26"},
     {"from": "layoutlib:poc-deployment", "to": "agentos-core#96"},
-    {"from": "arcanaforge:poc-static-release", "to": "agentos-core#66"}
+    {"from": "arcanaforge:poc-static-release", "to": "agentos-core#66"},
+    {"from": "arcanaforge:migrate-agentmanager-carrier", "to": "alston-personal/arcanaforge#2"},
+    {"from": "agentos-core:social-capability-extraction", "to": "agentos-core#144"}
   ]
 }


### PR DESCRIPTION
Superseded without merge. While this branch was open, another #118 worker integrated the phase-2 baseline into `core/integration` at `459008da15835943cf155079b378264041a6e357`, causing a real conflict on the same inventory/state files. The additive file-level evidence, migration issue links, and #125 split state were rebuilt from current `core/integration` on `core/issue-118-product-migration-inventory-v2`. No content from concurrent workers was overwritten.