### PR TITLE
Add Meshy weak-structure geometry profiling to Model2IR v0.9.1

### DIFF
--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -7,6 +7,8 @@ on:
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
       - 'tests/test_model2ir_cli.py'
+      - 'tests/test_model2ir_geometry_profile.py'
+      - 'tests/fixtures/model2ir/**'
       - 'tests/test_model2ir_glb_reversible_v09.py'
       - '.github/workflows/model2ir-library-v08.yml'
   push:
@@ -16,6 +18,8 @@ on:
       - 'scripts/model2ir_teacher_dataset.py'
       - 'tests/test_model2ir_teacher_library.py'
       - 'tests/test_model2ir_cli.py'
+      - 'tests/test_model2ir_geometry_profile.py'
+      - 'tests/fixtures/model2ir/**'
       - 'tests/test_model2ir_glb_reversible_v09.py'
       - '.github/workflows/model2ir-library-v08.yml'
 
@@ -38,6 +42,7 @@ jobs:
         run: |
           python -m unittest discover -s tests -p 'test_model2ir_teacher_library.py' -q
           python -m unittest discover -s tests -p 'test_model2ir_cli.py' -q
+          python -m unittest discover -s tests -p 'test_model2ir_geometry_profile.py' -q
           python -m unittest discover -s tests -p 'test_model2ir_glb_reversible_v09.py' -q
       - name: Verify public API and console entrypoint
         shell: bash
@@ -45,17 +50,20 @@ jobs:
           set -euo pipefail
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.9.0'
+          assert model2ir.__version__ == '0.9.1'
           assert callable(model2ir.extract_ir)
+          assert callable(model2ir.profile_asset_structure)
           assert callable(model2ir.build_teacher_dataset)
           assert callable(model2ir.validate_teacher_dataset_manifest)
           assert callable(model2ir.compile_reversible_glb)
           assert callable(model2ir.save_reversible_glb)
           assert callable(model2ir.verify_glb_container_preservation)
+          assert model2ir.GEOMETRY_PROFILE_SCHEMA == 'model2ir-geometry-profile/v0.9.1'
           assert model2ir.TEACHER_DATASET_SCHEMA == 'model2ir-teacher-dataset/v0.7'
           print('model2ir library boundary=ok')
           PY
           model2ir --help >/dev/null
+          model2ir profile --help >/dev/null
           model2ir stabilize --help >/dev/null
           model2ir embed-ir --help >/dev/null
       - name: Prove wheel isolation from monorepo
@@ -70,10 +78,12 @@ jobs:
           cd /tmp
           /tmp/model2ir-wheel-venv/bin/python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.9.0'
+          assert model2ir.__version__ == '0.9.1'
+          assert callable(model2ir.profile_asset_structure)
           assert callable(model2ir.compile_reversible_glb)
           assert callable(model2ir.build_teacher_dataset)
           print('model2ir isolated wheel import=PASS')
           PY
           /tmp/model2ir-wheel-venv/bin/model2ir --help >/dev/null
+          /tmp/model2ir-wheel-venv/bin/model2ir profile --help >/dev/null
           /tmp/model2ir-wheel-venv/bin/model2ir embed-ir --help >/dev/null

--- a/libs/model2ir/README.md
+++ b/libs/model2ir/README.md
@@ -20,6 +20,7 @@ from model2ir import (
     compile_reversible_glb,
     save_reversible_glb,
     verify_glb_container_preservation,
+    profile_asset_structure,
     ir_digest,
     build_teacher_dataset,
     validate_teacher_dataset_manifest,
@@ -36,10 +37,11 @@ python -m model2ir --help
 
 ## CLI contract
 
-The CLI separates evidence extraction, stabilized Character IR projection, and reversible container writing:
+The CLI separates evidence extraction, geometry/structure profiling, stabilized Character IR projection, and reversible container writing:
 
 ```bash
 model2ir extract character.glb -o evidence.json
+model2ir profile character.glb -o profile.json
 model2ir stabilize character.glb -o character-ir.json
 model2ir audit character.glb -o audit.json --repeats 3
 model2ir diff a.json b.json -o diff.json
@@ -47,9 +49,23 @@ model2ir reconcile image-ir.json model-ir.json -o reconciliation.json
 model2ir embed-ir character.glb canonical-ir.json -o reversible.glb --report preservation.json
 ```
 
-`extract` returns the full Model2IR evidence envelope. `stabilize` accepts GLB, glTF, and VRM through the normal loader and returns only the stabilized Canonical Character IR candidate/truth.
+`extract` returns the full Model2IR evidence envelope. `profile` returns only the conservative geometry/rig structure evidence. `stabilize` accepts GLB, glTF, and VRM through the normal loader and returns only the stabilized Canonical Character IR candidate/truth.
 
 `embed-ir` is intentionally narrower. It writes a **new** `.glb` or `.vrm`, rewrites only the JSON chunk to carry the canonical IR sidecar, and preserves every non-JSON chunk byte-for-byte and in order. It refuses in-place overwrite. By default it also rejects non-data external buffer/image URIs so moving the output cannot silently break relative resources.
+
+## Geometry and weak-structure profiling
+
+Model2IR v0.9.1 adds an evidence-only geometry profile for assets that are technically 3D but carry weak volumetric or rig structure, including relief-like AI-generated assets.
+
+The profile keeps these layers separate:
+
+- **Observed:** local accessor bounding-box extents, mesh/primitive/component counts, skin count, joint count, and animation count.
+- **Inferred:** axis-anisotropy shape hint (`planar-or-relief-like`, `volumetric-like`, `elongated-or-linear-like`, or `anisotropic-3d`) and a conservative structural signal.
+- **Unresolved:** missing or unusable extent evidence.
+
+A `planar-or-relief-like` asset with no skin, no joints, and only one mesh component is classified as `structural_signal: weak`. That is explicitly **not** permission to infer humanoid bones or promote semantic parts. The purpose of the profile is to make weak evidence visible, not to make sparse 3D assets look more complete than they are.
+
+The regression fixture derived from the Meshy relief sample stores only measured metadata and its SHA-256 reference; the uploaded binary/image are not committed. The sample remains `body_plan: unknown`, with no automatic humanoid promotion.
 
 ## Two different lossless claims
 

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.9.0"
+version = "0.9.1"
 description = "Standalone evidence-fused reversible Canonical Character IR decompiler for 3D assets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -14,6 +14,7 @@ from .glb_container import (
     save_reversible_glb,
     verify_glb_container_preservation,
 )
+from .geometry_profile import GEOMETRY_PROFILE_SCHEMA, profile_asset_structure
 from .audit import audit_asset as _audit_asset
 from .teacher import (
     CANONICAL_VIEWS,
@@ -42,6 +43,8 @@ __all__ = [
     "verify_glb_container_preservation",
     "ir_digest",
     "audit_asset",
+    "GEOMETRY_PROFILE_SCHEMA",
+    "profile_asset_structure",
     "CANONICAL_VIEWS",
     "TEACHER_DATASET_SCHEMA",
     "TeacherDatasetError",
@@ -49,4 +52,4 @@ __all__ = [
     "validate_teacher_dataset_manifest",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/libs/model2ir/src/model2ir/__main__.py
+++ b/libs/model2ir/src/model2ir/__main__.py
@@ -36,6 +36,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("asset")
     p.add_argument("-o", "--output", required=True)
 
+    p = sub.add_parser(
+        "profile",
+        help="Summarize geometry dimensionality and rig/structure signals without promoting semantics.",
+    )
+    p.add_argument("asset")
+    p.add_argument("-o", "--output", required=True)
+
     p = sub.add_parser("stabilize", help="Project a 3D asset to stabilized Canonical Character IR candidate/truth.")
     p.add_argument("asset")
     p.add_argument("-o", "--output", required=True)
@@ -92,6 +99,8 @@ def main() -> None:
 
     if args.cmd == "extract":
         out = extract_ir(args.asset)
+    elif args.cmd == "profile":
+        out = extract_ir(args.asset)["geometry_profile_evidence"]
     elif args.cmd == "stabilize":
         out = stabilize_external_ir(extract_ir(args.asset))
     elif args.cmd == "audit":

--- a/libs/model2ir/src/model2ir/geometry_profile.py
+++ b/libs/model2ir/src/model2ir/geometry_profile.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+GEOMETRY_PROFILE_SCHEMA = "model2ir-geometry-profile/v0.9.1"
+PLANAR_THIN_AXIS_RATIO_MAX = 0.15
+PLANAR_MIDDLE_AXIS_RATIO_MIN = 0.55
+VOLUMETRIC_THIN_AXIS_RATIO_MIN = 0.35
+ELONGATED_MIDDLE_AXIS_RATIO_MAX = 0.35
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bbox_extents(model_ir: dict[str, Any]) -> list[float] | None:
+    bbox = ((model_ir.get("structural_ir") or {}).get("geometry") or {}).get("bbox") or {}
+    raw = bbox.get("extent_local_untransformed")
+    if not isinstance(raw, list) or len(raw) < 3:
+        return None
+    try:
+        extents = [float(raw[i]) for i in range(3)]
+    except (TypeError, ValueError):
+        return None
+    if not all(math.isfinite(x) and x >= 0.0 for x in extents):
+        return None
+    return extents
+
+
+def profile_asset_structure(model_ir: dict[str, Any]) -> dict[str, Any]:
+    """Summarize geometric dimensionality and structural strength without inventing semantics.
+
+    The profile deliberately keeps measured facts separate from heuristic interpretation.
+    In particular, a thin unrigged mesh can be called planar/relief-like evidence, but it
+    is never promoted to humanoid structure merely because its silhouette looks human.
+    """
+
+    geometry = (model_ir.get("structural_ir") or {}).get("geometry") or {}
+    semantic = model_ir.get("semantic_evidence_v03") or {}
+    skeleton = semantic.get("skeleton") or {}
+
+    extents = _bbox_extents(model_ir)
+    thin_axis_ratio = None
+    middle_axis_ratio = None
+    shape_hint = "unknown"
+    unresolved: list[str] = []
+
+    if extents is None:
+        unresolved.append("bbox-extents-unavailable")
+    else:
+        ordered = sorted(extents)
+        longest = ordered[-1]
+        if longest <= 0.0:
+            unresolved.append("bbox-has-zero-longest-axis")
+        else:
+            thin_axis_ratio = ordered[0] / longest
+            middle_axis_ratio = ordered[1] / longest
+            if (
+                thin_axis_ratio <= PLANAR_THIN_AXIS_RATIO_MAX
+                and middle_axis_ratio >= PLANAR_MIDDLE_AXIS_RATIO_MIN
+            ):
+                shape_hint = "planar-or-relief-like"
+            elif thin_axis_ratio >= VOLUMETRIC_THIN_AXIS_RATIO_MIN:
+                shape_hint = "volumetric-like"
+            elif middle_axis_ratio <= ELONGATED_MIDDLE_AXIS_RATIO_MAX:
+                shape_hint = "elongated-or-linear-like"
+            else:
+                shape_hint = "anisotropic-3d"
+
+    skin_count = _safe_int(geometry.get("skin_count"))
+    joint_count = _safe_int(skeleton.get("joint_count"))
+    component_count = _safe_int(geometry.get("component_count"))
+
+    reasons: list[str] = []
+    if shape_hint == "planar-or-relief-like":
+        reasons.append("thin-axis-geometry")
+    if skin_count == 0:
+        reasons.append("no-skin")
+    if joint_count == 0:
+        reasons.append("no-joints")
+    if component_count <= 1:
+        reasons.append("single-or-zero-mesh-component")
+
+    if (
+        shape_hint == "planar-or-relief-like"
+        and skin_count == 0
+        and joint_count == 0
+        and component_count <= 1
+    ):
+        structural_signal = "weak"
+    elif skin_count > 0 or joint_count >= 12:
+        structural_signal = "rigged-or-structured"
+    else:
+        structural_signal = "indeterminate"
+
+    return {
+        "schema": GEOMETRY_PROFILE_SCHEMA,
+        "observed": {
+            "bbox_extent_local_untransformed": extents,
+            "mesh_count": _safe_int(geometry.get("mesh_count")),
+            "primitive_count": _safe_int(geometry.get("primitive_count")),
+            "component_count": component_count,
+            "skin_count": skin_count,
+            "joint_count": joint_count,
+            "animation_count": _safe_int(geometry.get("animation_count")),
+        },
+        "inferred": {
+            "shape_hint": shape_hint,
+            "thin_axis_ratio": round(thin_axis_ratio, 6) if thin_axis_ratio is not None else None,
+            "middle_axis_ratio": round(middle_axis_ratio, 6) if middle_axis_ratio is not None else None,
+            "structural_signal": structural_signal,
+            "reasons": reasons,
+        },
+        "unresolved": unresolved,
+        "policy": (
+            "bbox anisotropy and rig presence are evidence only; planar/relief-like or weak-structure "
+            "classification must not promote humanoid bones, parts, or canonical truth"
+        ),
+    }

--- a/libs/model2ir/src/model2ir/v06.py
+++ b/libs/model2ir/src/model2ir/v06.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from . import v04 as _v04
+from .geometry_profile import profile_asset_structure
 from .standards import extract_vrm_humanoid
 from .topology import infer_humanoid_topology
 
@@ -72,6 +73,7 @@ def extract_ir(asset_or_path) -> dict[str, Any]:
     out['schema'] = 'model2ir-character-ir/v0.6'
     out['vrm_humanoid_evidence'] = vrm
     out['topology_evidence'] = topo
+    out['geometry_profile_evidence'] = profile_asset_structure(out)
     if out.get('canonical_ir') is None:
         out['candidate_ir'] = _fused_candidate(out, vrm, topo)
     out['provenance']['extractor'] = 'model2ir/v0.6'

--- a/tests/fixtures/model2ir/meshy_foxfire_weak_structure_reference.json
+++ b/tests/fixtures/model2ir/meshy_foxfire_weak_structure_reference.json
@@ -1,0 +1,38 @@
+{
+  "schema": "model2ir-regression-reference/v0.1",
+  "case_id": "meshy-foxfire-tempest-2p5d",
+  "source": {
+    "generator": "meshy-scene",
+    "sha256": "8e73140979e4de8faf6d745e07353f594f5f4df01616b5a81e1da7e33c4eab25",
+    "bytes": 10631348,
+    "binary_committed": false,
+    "note": "Measurement-derived reference only; the uploaded source GLB and image are not committed."
+  },
+  "observed": {
+    "mesh_count": 1,
+    "primitive_count": 1,
+    "component_count": 1,
+    "vertices_sum": 53940,
+    "indices_sum": 263676,
+    "triangle_faces_sum": 87892,
+    "material_count": 1,
+    "skin_count": 0,
+    "joint_count": 0,
+    "animation_count": 0,
+    "image_count": 3,
+    "texture_count": 3,
+    "bbox_extent_local_untransformed": [
+      1.686348021030426,
+      1.8182989954948425,
+      0.23552899807691574
+    ]
+  },
+  "expected": {
+    "shape_hint": "planar-or-relief-like",
+    "structural_signal": "weak",
+    "thin_axis_ratio": 0.129533,
+    "middle_axis_ratio": 0.927432,
+    "body_plan": "unknown",
+    "automatic_humanoid_promotion": false
+  }
+}

--- a/tests/test_model2ir_geometry_profile.py
+++ b/tests/test_model2ir_geometry_profile.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import struct
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from model2ir import GEOMETRY_PROFILE_SCHEMA, extract_ir, profile_asset_structure
+from model2ir.__main__ import main
+
+
+REFERENCE = Path(__file__).parent / "fixtures" / "model2ir" / "meshy_foxfire_weak_structure_reference.json"
+
+
+def write_reference_glb(path: Path, reference: dict) -> None:
+    observed = reference["observed"]
+    extent = observed["bbox_extent_local_untransformed"]
+    gltf = {
+        "asset": {"version": "2.0", "generator": reference["source"]["generator"]},
+        "accessors": [
+            {
+                "componentType": 5126,
+                "count": observed["vertices_sum"],
+                "type": "VEC3",
+                "min": [0.0, 0.0, 0.0],
+                "max": extent,
+            },
+            {
+                "componentType": 5125,
+                "count": observed["indices_sum"],
+                "type": "SCALAR",
+            },
+        ],
+        "materials": [{"name": "material"}],
+        "meshes": [
+            {
+                "name": "mesh",
+                "primitives": [
+                    {
+                        "attributes": {"POSITION": 0},
+                        "indices": 1,
+                        "material": 0,
+                        "mode": 4,
+                    }
+                ],
+            }
+        ],
+        "nodes": [{"mesh": 0, "name": "mesh_node"}],
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+    }
+    payload = json.dumps(gltf, separators=(",", ":")).encode("utf-8")
+    payload += b" " * ((4 - len(payload) % 4) % 4)
+    json_chunk = struct.pack("<II", len(payload), 0x4E4F534A) + payload
+    path.write_bytes(struct.pack("<4sII", b"glTF", 2, 12 + len(json_chunk)) + json_chunk)
+
+
+class Model2IRGeometryProfileTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.reference = json.loads(REFERENCE.read_text(encoding="utf-8"))
+
+    def test_measurement_derived_meshy_reference_is_weak_relief_not_humanoid_truth(self):
+        observed = self.reference["observed"]
+        model_ir = {
+            "structural_ir": {
+                "geometry": {
+                    "bbox": {"extent_local_untransformed": observed["bbox_extent_local_untransformed"]},
+                    "mesh_count": observed["mesh_count"],
+                    "primitive_count": observed["primitive_count"],
+                    "component_count": observed["component_count"],
+                    "skin_count": observed["skin_count"],
+                    "animation_count": observed["animation_count"],
+                }
+            },
+            "semantic_evidence_v03": {"skeleton": {"joint_count": observed["joint_count"]}},
+        }
+
+        profile = profile_asset_structure(model_ir)
+        expected = self.reference["expected"]
+
+        self.assertEqual(profile["schema"], GEOMETRY_PROFILE_SCHEMA)
+        self.assertEqual(profile["inferred"]["shape_hint"], expected["shape_hint"])
+        self.assertEqual(profile["inferred"]["structural_signal"], expected["structural_signal"])
+        self.assertEqual(profile["inferred"]["thin_axis_ratio"], expected["thin_axis_ratio"])
+        self.assertEqual(profile["inferred"]["middle_axis_ratio"], expected["middle_axis_ratio"])
+        self.assertIn("thin-axis-geometry", profile["inferred"]["reasons"])
+        self.assertIn("no-skin", profile["inferred"]["reasons"])
+        self.assertIn("no-joints", profile["inferred"]["reasons"])
+
+    def test_integrated_extract_keeps_meshy_like_body_plan_unknown(self):
+        with tempfile.TemporaryDirectory() as td:
+            asset = Path(td) / "meshy-reference.glb"
+            write_reference_glb(asset, self.reference)
+            extracted = extract_ir(asset)
+
+        profile = extracted["geometry_profile_evidence"]
+        candidate = extracted["candidate_ir"]
+        self.assertEqual(profile["inferred"]["shape_hint"], "planar-or-relief-like")
+        self.assertEqual(profile["inferred"]["structural_signal"], "weak")
+        self.assertEqual(candidate["body_plan"]["kind"], "unknown")
+        self.assertEqual(candidate["parts"], [])
+        self.assertEqual(candidate["topology_evidence"]["kind"], "unknown")
+        self.assertEqual(candidate["topology_evidence"]["reason"], "too-few-joints")
+
+    def test_volumetric_unrigged_mesh_is_not_forced_into_weak_relief_class(self):
+        profile = profile_asset_structure(
+            {
+                "structural_ir": {
+                    "geometry": {
+                        "bbox": {"extent_local_untransformed": [1.0, 1.0, 1.0]},
+                        "mesh_count": 1,
+                        "primitive_count": 1,
+                        "component_count": 1,
+                        "skin_count": 0,
+                        "animation_count": 0,
+                    }
+                },
+                "semantic_evidence_v03": {"skeleton": {"joint_count": 0}},
+            }
+        )
+        self.assertEqual(profile["inferred"]["shape_hint"], "volumetric-like")
+        self.assertEqual(profile["inferred"]["structural_signal"], "indeterminate")
+
+    def test_profile_cli_returns_only_profile_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            asset = Path(td) / "meshy-reference.glb"
+            output = Path(td) / "profile.json"
+            write_reference_glb(asset, self.reference)
+            buf = StringIO()
+            with mock.patch("sys.argv", ["model2ir", "profile", str(asset), "-o", str(output)]), redirect_stdout(buf):
+                main()
+            status = json.loads(buf.getvalue().strip())
+            profile = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertTrue(status["ok"])
+        self.assertEqual(status["schema"], GEOMETRY_PROFILE_SCHEMA)
+        self.assertEqual(profile["inferred"]["structural_signal"], "weak")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Turn the uploaded Meshy relief-style GLB into a conservative Model2IR regression contract without committing the user binary/image.

### Added
- evidence-only geometry/rig profile API (`profile_asset_structure`)
- `model2ir profile` CLI
- explicit observed vs inferred vs unresolved structure evidence
- conservative `planar-or-relief-like` and `structural_signal: weak` classification
- measurement-derived Meshy reference fixture (SHA/geometry metadata only)
- regression proving the Meshy-like case remains `body_plan: unknown`, has no semantic parts, and receives no automatic humanoid promotion
- volumetric control case so unrigged geometry is not automatically called weak relief
- standalone wheel/API/CLI CI gates for v0.9.1

## Truth boundary

This PR does **not** infer humanoid bones from silhouette or thin geometry. Geometry anisotropy is evidence only. The existing stabilized Character IR contract remains unchanged; the new profile is attached to the full extraction envelope.

## Source privacy / repository size

The ~10 MB uploaded Meshy GLB and source image are not committed. The reference fixture stores only measured metadata and SHA-256 for regression traceability.
