### PR TITLE
docs(agentos): register legacy proposal extraction worker

### DIFF
--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T01:24:00Z",
+  "generated_at": "2026-08-31T02:03:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -64,7 +64,7 @@
       "execution_lane": "independent-worker",
       "dependencies": [130],
       "blocking_scope": ["layoutlib:poc-deployment"],
-      "evidence": [],
+      "evidence": ["alston-personal/layoutlib#2"],
       "non_authorities": ["layoutlib production promotion", "protected-main merge"]
     },
     {
@@ -75,18 +75,18 @@
       "execution_lane": "independent-worker",
       "dependencies": [130],
       "blocking_scope": ["arcanaforge:poc-static-release"],
-      "evidence": [],
+      "evidence": ["alston-personal/arcanaforge#3"],
       "non_authorities": ["arbitrary shell authority", "protected-main merge"]
     },
     {
       "issue": 118,
       "name": "Repository-boundary cleanup",
-      "branch": "core/issue-118-repo-boundary",
+      "branch": "core/issue-118-product-handoffs",
       "status": "running",
       "execution_lane": "architecture-migration-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/PROJECT_REPO_MAP.md", "pull/141"],
+      "evidence": ["docs/PROJECT_REPO_MAP.md", "docs/PRODUCT_MIGRATION_INVENTORY.md", "governance/product-migrations.json", "pull/141", "pull/143", "pull/146"],
       "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
     },
     {
@@ -99,6 +99,17 @@
       "blocking_scope": [],
       "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/140"],
       "non_authorities": ["protected-main merge"]
+    },
+    {
+      "issue": 147,
+      "name": "Legacy Core proposal delta extraction",
+      "branch": "core/issue-147-legacy-proposal-inventory",
+      "status": "running",
+      "execution_lane": "architecture-extraction-worker",
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": ["governance/legacy-core-proposals.json"],
+      "non_authorities": ["wholesale legacy PR merge", "blind retarget to core/integration", "protected-main merge"]
     }
   ],
   "dependency_edges": [
@@ -106,6 +117,7 @@
     {"from": "agentos-core#117", "to": "agentos-core#130"},
     {"from": "agentos-core#72", "to": "agentos-core#130"},
     {"from": "vendor-reputation:semantic-classification", "to": "agentos-core#72"},
+    {"from": "vendor-reputation:oracle-carriers", "to": "agentos-core#130"},
     {"from": "layoutlib:poc-deployment", "to": "agentos-core#96"},
     {"from": "arcanaforge:poc-static-release", "to": "agentos-core#66"}
   ]

--- a/governance/legacy-core-proposals.json
+++ b/governance/legacy-core-proposals.json
@@ -1,0 +1,67 @@
+{
+  "schema": "agentos.legacy-core-proposals/v0",
+  "generated_at": "2026-08-31T02:02:00Z",
+  "canonical_base": "core/integration",
+  "policy": {
+    "wholesale_merge": "forbidden",
+    "blind_retarget": "forbidden",
+    "protected_main_mutation": "forbidden_without_explicit_human_authorization",
+    "extraction_flow": "classify unique delta -> focused core/issue-* branch -> current tests/acceptance -> core/integration",
+    "classifications": ["already_integrated", "superseded", "still_needed", "product_owned", "research_only", "mixed_split_required"]
+  },
+  "proposals": [
+    {
+      "pr": 2,
+      "title": "Distributed AgentOS runtime foundation",
+      "status": "audit_required",
+      "classification": "mixed_split_required",
+      "finding": "very large historical foundation containing both Core runtime/research and product-specific tarot/divination/browser deployment carriers",
+      "action": "use only as source/evidence; classify deltas against current Core before focused extraction"
+    },
+    {
+      "pr": 17,
+      "title": "Recover minimal Agent Employee Runtime and closure wave 1",
+      "status": "candidate_delta_present",
+      "classification": "still_needed_review",
+      "key_unique_paths": ["agent_core/employee_runtime.py", "tests/test_employee_runtime.py"],
+      "current_core_check": "agent_core/employee_runtime.py absent from core/integration",
+      "action": "reconcile employee identity/assignment/memory model with current worker, Experience and state architecture"
+    },
+    {
+      "pr": 22,
+      "title": "separate node runtime from desktop executor",
+      "status": "candidate_delta_present",
+      "classification": "still_needed_review",
+      "key_unique_paths": ["agentos_node/executor_registry.py", "agentos_node/executor_bridge.py", "agentos_node/desktop_executor_host.py"],
+      "current_core_check": "agentos_node/executor_registry.py absent from core/integration",
+      "action": "reconcile with accepted Node Golden Path, issue #72 executor liveness and issue #105 GUI control before extraction"
+    },
+    {
+      "pr": 43,
+      "title": "publish execution heads and resolve freshness",
+      "status": "candidate_delta_present",
+      "classification": "still_needed_review",
+      "key_unique_paths": ["scripts/execution_head.py", "scripts/project_overview.py", "tests/test_execution_head.py"],
+      "current_core_check": "scripts/execution_head.py absent from core/integration",
+      "action": "reconcile with current Project Identity, runtime provenance, continuation state and deployment authority"
+    },
+    {
+      "pr": 18,
+      "title": "add governed AgentOS social capability",
+      "status": "candidate_delta_present",
+      "classification": "still_needed_review",
+      "key_unique_paths": ["agentos_node/social_capability.py", "agentos_node/social_cli.py", "tests/test_social_capability.py"],
+      "current_core_check": "agentos_node/social_capability.py absent from core/integration",
+      "action": "extract only generic social capability; reconcile with newer #125 implementation and keep product-specific Vendor ingestion outside Core"
+    },
+    {
+      "pr": 125,
+      "title": "social capability pack and vendor Threads ingestion",
+      "status": "split_required",
+      "classification": "mixed_split_required",
+      "generic_core_paths": ["agentos_node/social/contracts.py", "agentos_node/social/credentials.py", "agentos_node/social/facebook.py", "agentos_node/social/instagram.py", "agentos_node/social/threads.py", "agent_core/capability_governance.py"],
+      "product_owned_paths": ["agentos_node/social/vendor_ingest.py", "tests/test_vendor_threads_ingest.py"],
+      "action": "generic social capability may become focused Core work; Vendor ingestion migrates to alston-personal/vendor-reputation-service"
+    }
+  ]
+}


### PR DESCRIPTION
Implements the first #147 control-plane inventory. Adds `governance/legacy-core-proposals.json` with file-level classification for PRs #2/#17/#22/#43/#18/#125 and registers #147 in `governance/core-workers.json`.

This does not port or merge legacy code. It explicitly forbids wholesale legacy PR merge/blind retarget and establishes focused extraction as the only current Core path.

Also updates #118 evidence/handoffs in worker state. Targets `core/integration`, not protected `main`.