### PR TITLE
governance(core): reject false Character Blueprint repository candidate

### DIFF
--- a/docs/PRODUCT_MIGRATION_INVENTORY.md
+++ b/docs/PRODUCT_MIGRATION_INVENTORY.md
@@ -12,7 +12,7 @@ This document classifies non-Core work that still appears in `alston-personal/ag
 | ArcanaForge | `alston-personal/arcanaforge` | PR #136 POC release carrier | Keep until #66 provides a governed static-release path and an exact ArcanaForge source/artifact receipt can drive `/poc/arcanaforge/`. |
 | LayoutLib | `alston-personal/layoutlib` | Core-side deploy/governance residue tracked by #96 | Keep only generic deployment/promotion adapter. Layout implementation and product tests stay in `layoutlib`; POC consumes exact candidate SHA, production consumes promoted release. |
 | Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | historical `ops/leopardcat-runtime-inspect` and `chore/leopardcat-runtime-inspect` carrier branches plus Tarot-specific deploy/inspect/probe workflows | Product handoff is `alston-personal/leopardcat-tarot#44`. PR #41 is a product-owned read-only parity gate, but retirement also requires a product-owned write/deploy replacement (or thin caller of a generic governed Core deploy capability) and exact runtime/artifact evidence. |
-| Character Blueprint | unresolved; `alston-personal/charactergenerator` is only a candidate | PR #53 browser/deployer fix | Preserve, do not merge into Core. First establish explicit Project Identity and canonical repo, then migrate with parity evidence. |
+| Character Blueprint | unresolved; `alston-personal/charactergenerator` explicitly rejected as a provenance match | PR #53 browser/deployer fix | Preserve PR #53 as migration source and do not merge it into Core. Assign/create the actual Character Blueprint canonical repo before migrating v0.4 behavior; do not overwrite the distinct `charactergenerator` product. |
 | Model2IR | unresolved | future risk of implementation landing in Core | Do not add new Model2IR implementation to `agentmanager`; assign/create a canonical library repo first. |
 
 ## Leopard Cat Tarot carrier inventory
@@ -30,6 +30,24 @@ The remaining Tarot residue has now been reduced from an unspecified file-level 
 The canonical product repository already owns product-side Oracle/runtime inspection and production AI probing. PR `alston-personal/leopardcat-tarot#41` adds a read-only `Production Parity Gate`. That is necessary evidence, but it is not sufficient to retire a write-capable production deploy carrier. Product issue `alston-personal/leopardcat-tarot#44` therefore owns the remaining deploy/parity handoff.
 
 Core must not delete or merge these historical carriers into `core/integration`. They become retirement candidates only after #44 demonstrates a product-owned deployment path (or a thin product caller of a generic governed Core deploy surface), exact source/artifact identity, public/runtime parity, and persisted receipt/evidence.
+
+## Character Blueprint negative provenance
+
+The previous `alston-personal/charactergenerator` name candidate has been inspected and rejected as a canonical identity match for the known Character Blueprint artifact.
+
+Known Character Blueprint migration source:
+
+- PR #53 is a one-file product deployer fix for `scripts/deploy_character_blueprint_poc.py`;
+- that deployer consumes `web_assets/character-blueprint-poc.html`;
+- the source carries `character-blueprint-poc` / v0.4 markers, `character-blueprint-ir/v0.4`, an image → 3D proxy interaction, Three.js, and `OrbitControls`.
+
+Observed `charactergenerator` product:
+
+- `main` currently contains a single `index.html`;
+- the UI describes image upload → AI-generated character text description and full-body imagery;
+- no `OrbitControls` or `character-blueprint-ir` marker is present in repository code search.
+
+This is sufficient to reject automatic identity inference. It is not authority to rename or repurpose `charactergenerator`; #118 instead keeps Character Blueprint unresolved until an explicit canonical repository is assigned or created. PR #53 remains frozen migration evidence and must not be merged into AgentOS Core.
 
 ## Legacy Core proposal separation
 

--- a/docs/PROJECT_REPO_MAP.md
+++ b/docs/PROJECT_REPO_MAP.md
@@ -23,8 +23,19 @@ This document separates **Project Identity**, **repository ownership**, **develo
 | LayoutLib / Layout Lab | `alston-personal/layoutlib` | `feature/*` / `fix/*` → `develop` | accepted/promoted Layout source | POC may consume exact `develop` candidate SHA; production remains promoted/release state | canonical repo confirmed; #96 governs lane/deploy boundary |
 | ArcanaForge | `alston-personal/arcanaforge` | product feature/fix lane; integration policy to be normalized | accepted ArcanaForge source | `/poc/arcanaforge/` is POC and must deploy a pinned candidate through governed static-release capability | canonical repo confirmed; #66 blocks only POC release step |
 | Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | product feature/fix lane; integration policy to be normalized | accepted Tarot source | production/POC source mapping still requires explicit deployment receipt inventory | canonical repo confirmed; remove any product implementation/carriers from Core after parity evidence |
-| Character Blueprint | unresolved; `alston-personal/charactergenerator` is a repository-name candidate only | unresolved | unresolved | existing Character Blueprint material in `agentmanager` must not be treated as Core authority | canonical repository NOT yet verified; do not infer from similar name |
+| Character Blueprint | unresolved; `alston-personal/charactergenerator` has been checked and rejected as a canonical identity match | unresolved | unresolved | existing Character Blueprint material in `agentmanager` must not be treated as Core authority or migrated into `charactergenerator` by name similarity | canonical repository NOT yet assigned; explicit create/assignment decision required |
 | Model2IR | unresolved; no `alston-personal` repository named `model2ir` found in current repository search | unresolved | unresolved | new independent-library direction requires explicit canonical repository assignment | repository unresolved; do not place implementation in Core by default |
+
+## Character Blueprint identity evidence
+
+`alston-personal/charactergenerator` is no longer an unresolved name candidate. It has been inspected and does not match the known Character Blueprint product provenance:
+
+- frozen migration source PR #53 changes `scripts/deploy_character_blueprint_poc.py` and deploys `web_assets/character-blueprint-poc.html`;
+- the Character Blueprint source identifies `data-app="character-blueprint-poc"`, version `0.4.0`, schema `character-blueprint-ir/v0.4`, a browser-local image → 3D proxy flow, Three.js, and `OrbitControls`;
+- `alston-personal/charactergenerator` `main` currently contains a single `index.html` whose UI describes image upload → AI text description / full-body image generation;
+- repository code search finds neither `OrbitControls` nor `character-blueprint-ir` in `charactergenerator`.
+
+Therefore similar naming is contradicted by product behavior and source markers. Core must not overwrite or repurpose `charactergenerator` as the Character Blueprint canonical repository without a separate explicit product-consolidation decision. For #118, Character Blueprint remains identity-unresolved and requires assignment/creation of its canonical repository before PR #53 behavior is migrated.
 
 ## `agentmanager` ownership boundary
 

--- a/governance/product-migrations.json
+++ b/governance/product-migrations.json
@@ -1,6 +1,6 @@
 {
   "schema": "agentos.product-migrations/v0",
-  "generated_at": "2026-08-31T02:29:00Z",
+  "generated_at": "2026-08-31T02:35:00Z",
   "core_repository": "alston-personal/agentmanager",
   "invariant": "Product implementation, UI, product CI/deployers and product-specific runtime carriers belong in the canonical product repository. Core retains only generic capability contracts and cross-repository governance/integration machinery.",
   "projects": [
@@ -68,12 +68,17 @@
     {
       "project_id": "character-blueprint",
       "canonical_repository": null,
-      "repository_candidate": "alston-personal/charactergenerator",
+      "rejected_repository_candidates": [
+        {
+          "repository": "alston-personal/charactergenerator",
+          "reason": "content provenance mismatch: Character Blueprint is image-to-3D proxy with character-blueprint-ir/v0.4 and Three.js OrbitControls, while charactergenerator is a distinct image-to-AI-description/full-body-image product and contains neither marker"
+        }
+      ],
       "status": "identity_unresolved",
       "core_prs": [53],
-      "classification": "Character Blueprint product work exists in agentmanager but canonical product repository has not been verified; similar repository name is not sufficient identity evidence",
-      "retire_when": ["explicitly establish canonical project identity/repository", "migrate v0.4 browser/deployer behavior with parity evidence", "verify public surface"],
-      "safe_now": "preserve_pr_53_and_do_not_merge_to_core"
+      "classification": "Character Blueprint product work exists in agentmanager, but the only repository-name candidate was inspected and rejected by source/product provenance; canonical repository still requires explicit assignment or creation",
+      "retire_when": ["explicitly assign/create canonical project repository", "migrate v0.4 browser/deployer behavior with parity evidence", "verify public surface"],
+      "safe_now": "preserve_pr_53_and_do_not_merge_to_core_or_charactergenerator"
     },
     {
       "project_id": "model2ir",


### PR DESCRIPTION
Advances #118 by reducing Character Blueprint identity ambiguity without guessing a new canonical repository.

Evidence checked:

- frozen migration source PR #53 deploys `web_assets/character-blueprint-poc.html`;
- Character Blueprint v0.4 identifies `character-blueprint-ir/v0.4`, image → 3D proxy behavior, Three.js, and OrbitControls;
- `alston-personal/charactergenerator` currently contains a distinct single-page image → AI character description/full-body-image product;
- repository search finds neither `OrbitControls` nor `character-blueprint-ir` in `charactergenerator`.

This PR therefore changes `charactergenerator` from a weak name candidate to an explicitly rejected provenance match. Character Blueprint remains identity-unresolved and still requires explicit canonical repo assignment/creation before PR #53 behavior can migrate.

Updates:
- `docs/PROJECT_REPO_MAP.md`
- `docs/PRODUCT_MIGRATION_INVENTORY.md`
- `governance/product-migrations.json`

No product code moves, PR #53 remains preserved/unmerged, and protected `main` is untouched. Targets `core/integration` only.