### PR TITLE
governance(core): classify Model2IR v0.9.1 as migration carrier

### DIFF
--- a/docs/PRODUCT_MIGRATION_INVENTORY.md
+++ b/docs/PRODUCT_MIGRATION_INVENTORY.md
@@ -13,7 +13,7 @@ This document classifies non-Core work that still appears in `alston-personal/ag
 | LayoutLib | `alston-personal/layoutlib` | Core-side deploy/governance residue tracked by #96 | Keep only generic deployment/promotion adapter. Layout implementation and product tests stay in `layoutlib`; POC consumes exact candidate SHA, production consumes promoted release. |
 | Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | historical `ops/leopardcat-runtime-inspect` and `chore/leopardcat-runtime-inspect` carrier branches plus Tarot-specific deploy/inspect/probe workflows | Product handoff is `alston-personal/leopardcat-tarot#44`. PR #41 is a product-owned read-only parity gate, but retirement also requires a product-owned write/deploy replacement (or thin caller of a generic governed Core deploy capability) and exact runtime/artifact evidence. |
 | Character Blueprint | unresolved; `alston-personal/charactergenerator` explicitly rejected as a provenance match | PR #53 browser/deployer fix | Preserve PR #53 as migration source and do not merge it into Core. Assign/create the actual Character Blueprint canonical repo before migrating v0.4 behavior; do not overwrite the distinct `charactergenerator` product. |
-| Model2IR | unresolved | future risk of implementation landing in Core | Do not add new Model2IR implementation to `agentmanager`; assign/create a canonical library repo first. |
+| Model2IR | canonical repo not yet assigned/created | real standalone package under `libs/model2ir` across historical `feat/model2ir-*` / `fix/model2ir-*` branches; latest observed carrier is v0.9.1 | Freeze the `agentmanager` lineage as migration provenance. Assign/create a standalone canonical repository, then migrate package/tests/fixtures/history with parity; do not continue library implementation in Core. |
 
 ## Leopard Cat Tarot carrier inventory
 
@@ -48,6 +48,32 @@ Observed `charactergenerator` product:
 - no `OrbitControls` or `character-blueprint-ir` marker is present in repository code search.
 
 This is sufficient to reject automatic identity inference. It is not authority to rename or repurpose `charactergenerator`; #118 instead keeps Character Blueprint unresolved until an explicit canonical repository is assigned or created. PR #53 remains frozen migration evidence and must not be merged into AgentOS Core.
+
+## Model2IR carrier inventory
+
+Model2IR already exists as an independently packaged library inside historical `agentmanager` branches. It must therefore be treated as a concrete migration, not a future placement rule.
+
+Latest observed carrier:
+
+- `feat/model2ir-meshy-weak-structure-v091` @ `1314bb01e718e1a930e24441b3544dd8da020065`;
+- package root `libs/model2ir/` with `README.md`, `pyproject.toml`, and `src/`;
+- package metadata declares `name = "model2ir"`, `version = "0.9.1"`, Python `>=3.10`, and a `model2ir` console script;
+- README describes the reusable 3D asset → Canonical Character IR boundary extracted from AgentOS research, including reversible GLB/VRM handling, stabilization, teacher dataset support, and weak-structure profiling.
+
+Observed branch lineage includes:
+
+- `feat/model2ir-v01`;
+- `feat/model2ir-reversible-v02`;
+- `feat/model2ir-external-semantics-v03`;
+- `feat/model2ir-stabilized-import-v04`;
+- `feat/model2ir-real-family-stability-v05`;
+- `feat/model2ir-vrm-topology-v06`;
+- `feat/model2ir-teacher-dataset-v07` plus rebase variants;
+- `feat/model2ir-library-v08` and `fix/model2ir-cli-v081`;
+- `feat/model2ir-reversible-glb-v09`;
+- `feat/model2ir-meshy-weak-structure-v091`.
+
+The branch names are provenance, not canonical source authority. Preserve the latest accepted package state and relevant history until a standalone repository is assigned/created. Migration must reproduce package tests/fixtures and preserve the library contract before the old `agentmanager` carrier can be retired. New Model2IR implementation must not continue in Core merely because the current carrier is there.
 
 ## Legacy Core proposal separation
 

--- a/docs/PROJECT_REPO_MAP.md
+++ b/docs/PROJECT_REPO_MAP.md
@@ -24,7 +24,7 @@ This document separates **Project Identity**, **repository ownership**, **develo
 | ArcanaForge | `alston-personal/arcanaforge` | product feature/fix lane; integration policy to be normalized | accepted ArcanaForge source | `/poc/arcanaforge/` is POC and must deploy a pinned candidate through governed static-release capability | canonical repo confirmed; #66 blocks only POC release step |
 | Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | product feature/fix lane; integration policy to be normalized | accepted Tarot source | production/POC source mapping still requires explicit deployment receipt inventory | canonical repo confirmed; remove any product implementation/carriers from Core after parity evidence |
 | Character Blueprint | unresolved; `alston-personal/charactergenerator` has been checked and rejected as a canonical identity match | unresolved | unresolved | existing Character Blueprint material in `agentmanager` must not be treated as Core authority or migrated into `charactergenerator` by name similarity | canonical repository NOT yet assigned; explicit create/assignment decision required |
-| Model2IR | unresolved; no `alston-personal` repository named `model2ir` found in current repository search | unresolved | unresolved | new independent-library direction requires explicit canonical repository assignment | repository unresolved; do not place implementation in Core by default |
+| Model2IR | canonical repository unassigned; no `alston-personal/model2ir` repository exists in current inventory | historical `feat/model2ir-*` / `fix/model2ir-*` work in `agentmanager` is a migration carrier, not an approved Core development lane | new repository `main` must become accepted library source after migration | library boundary; no production web environment required by default | actual standalone v0.9.1 library carrier identified in `agentmanager`; repo creation/assignment is now the blocking identity step |
 
 ## Character Blueprint identity evidence
 
@@ -36,6 +36,22 @@ This document separates **Project Identity**, **repository ownership**, **develo
 - repository code search finds neither `OrbitControls` nor `character-blueprint-ir` in `charactergenerator`.
 
 Therefore similar naming is contradicted by product behavior and source markers. Core must not overwrite or repurpose `charactergenerator` as the Character Blueprint canonical repository without a separate explicit product-consolidation decision. For #118, Character Blueprint remains identity-unresolved and requires assignment/creation of its canonical repository before PR #53 behavior is migrated.
+
+## Model2IR carrier evidence
+
+Model2IR is no longer classified as merely a future independent-library direction. A real standalone package already exists on historical non-Core branches inside `agentmanager`.
+
+Latest observed carrier:
+
+- branch: `feat/model2ir-meshy-weak-structure-v091`;
+- tip: `1314bb01e718e1a930e24441b3544dd8da020065`;
+- package root: `libs/model2ir/`;
+- `pyproject.toml`: project `model2ir`, version `0.9.1`, console script `model2ir`;
+- README explicitly defines the reusable **3D asset → Canonical Character IR** boundary as extracted from the AgentOS research codebase.
+
+Observed lineage in `agentmanager` includes `feat/model2ir-v01`, reversible v0.2, external semantics v0.3, stabilized import v0.4, real-family stability v0.5, VRM topology v0.6, teacher-dataset v0.7 variants, library v0.8 / CLI v0.8.1, reversible GLB v0.9, and Meshy weak-structure v0.9.1.
+
+This lineage is migration provenance, not permission to keep developing the library inside Core. #118 must preserve the v0.9.1 carrier until a canonical standalone repository is assigned/created and the package, tests, fixtures, and relevant history are migrated with parity. After that migration, new Model2IR work belongs in the product/library repository.
 
 ## `agentmanager` ownership boundary
 

--- a/governance/product-migrations.json
+++ b/governance/product-migrations.json
@@ -1,6 +1,6 @@
 {
   "schema": "agentos.product-migrations/v0",
-  "generated_at": "2026-08-31T02:35:00Z",
+  "generated_at": "2026-08-31T02:38:00Z",
   "core_repository": "alston-personal/agentmanager",
   "invariant": "Product implementation, UI, product CI/deployers and product-specific runtime carriers belong in the canonical product repository. Core retains only generic capability contracts and cross-repository governance/integration machinery.",
   "projects": [
@@ -83,10 +83,29 @@
     {
       "project_id": "model2ir",
       "canonical_repository": null,
-      "status": "repository_unresolved",
-      "classification": "independent library direction exists but no canonical repository was found by current repository inventory",
-      "retire_when": ["assign/create canonical repository outside agentmanager", "move product/library implementation there"],
-      "safe_now": "do_not_add_new_model2ir_implementation_to_core"
+      "status": "carrier_identified_repository_unassigned",
+      "latest_core_carrier": {
+        "ref": "feat/model2ir-meshy-weak-structure-v091",
+        "tip": "1314bb01e718e1a930e24441b3544dd8da020065",
+        "package_root": "libs/model2ir",
+        "package_version": "0.9.1"
+      },
+      "carrier_lineage": [
+        "feat/model2ir-v01",
+        "feat/model2ir-reversible-v02",
+        "feat/model2ir-external-semantics-v03",
+        "feat/model2ir-stabilized-import-v04",
+        "feat/model2ir-real-family-stability-v05",
+        "feat/model2ir-vrm-topology-v06",
+        "feat/model2ir-teacher-dataset-v07",
+        "feat/model2ir-library-v08",
+        "fix/model2ir-cli-v081",
+        "feat/model2ir-reversible-glb-v09",
+        "feat/model2ir-meshy-weak-structure-v091"
+      ],
+      "classification": "a standalone model2ir v0.9.1 library is already implemented under libs/model2ir on historical agentmanager branches; this is concrete migration provenance, not future Core work",
+      "retire_when": ["assign/create canonical standalone repository outside agentmanager", "migrate package, tests, fixtures and relevant history from the v0.9.1 carrier", "reproduce package/CLI behavior and regression evidence in the new repository", "declare the new repository main/release as canonical Model2IR authority"],
+      "safe_now": "freeze_agentmanager_model2ir_carrier_for_migration; do_not_continue_library_implementation_in_core"
     }
   ],
   "legacy_core_proposals": [


### PR DESCRIPTION
Advances #118 by correcting Model2IR from a future-placement risk to a concrete non-Core migration carrier already present in historical `agentmanager` branches.

Evidence recorded:

- latest observed carrier: `feat/model2ir-meshy-weak-structure-v091` @ `1314bb01e718e1a930e24441b3544dd8da020065`;
- package root: `libs/model2ir/`;
- `pyproject.toml` declares standalone package `model2ir` v0.9.1 with its own CLI;
- README explicitly defines the reusable 3D asset → Canonical Character IR boundary as extracted from AgentOS research;
- historical lineage from v0.1 through reversible import, external semantics, stabilization, VRM topology, teacher dataset, library/CLI v0.8.x, reversible GLB v0.9, and Meshy weak-structure v0.9.1 is recorded as migration provenance.

Canonical repository is still unassigned: no `alston-personal/model2ir` repository exists in the current inventory. This PR does **not** guess or create repository identity. It freezes the `agentmanager` Model2IR lineage for migration and makes repository assignment/creation + package/test/fixture parity the explicit retirement gate.

Updates:
- `docs/PROJECT_REPO_MAP.md`
- `docs/PRODUCT_MIGRATION_INVENTORY.md`
- `governance/product-migrations.json`

No Model2IR implementation is merged into Core, no historical carrier is deleted, and protected `main` is untouched. Targets `core/integration` only.