### PR TITLE
governance(core): extract canonical project release-lane authority

### DIFF
--- a/.github/workflows/project-release-lane-guard.yml
+++ b/.github/workflows/project-release-lane-guard.yml
@@ -1,0 +1,87 @@
+name: Project Release Lane Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+      - core/integration
+    paths:
+      - 'governance/project-release-lanes.json'
+      - 'scripts/check_project_release_lane.py'
+      - 'tests/test_project_release_lane.py'
+      - '.github/workflows/project-release-lane-guard.yml'
+  push:
+    branches:
+      - main
+      - core/integration
+    paths:
+      - 'governance/project-release-lanes.json'
+      - 'scripts/check_project_release_lane.py'
+      - 'tests/test_project_release_lane.py'
+      - '.github/workflows/project-release-lane-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  release-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run release-lane regression
+        run: python -m unittest -q tests.test_project_release_lane
+      - name: Acceptance probes
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+          python scripts/check_project_release_lane.py \
+            --project layoutlib --action development_write --target-branch develop
+
+          if python scripts/check_project_release_lane.py \
+            --project layoutlib --action development_write --target-branch main; then
+            echo 'expected development->main denial' >&2
+            exit 1
+          fi
+
+          if python scripts/check_project_release_lane.py \
+            --project layoutlib --action promotion --target-branch main; then
+            echo 'expected promotion without human approval denial' >&2
+            exit 1
+          fi
+
+          python scripts/check_project_release_lane.py \
+            --project layoutlib --action promotion --target-branch main \
+            --explicit-human-approval
+
+          if python scripts/check_project_release_lane.py \
+            --project layoutlib --action poc_deploy --target-branch develop; then
+            echo 'expected POC without exact SHA denial' >&2
+            exit 1
+          fi
+
+          if python scripts/check_project_release_lane.py \
+            --project layoutlib --action poc_deploy --target-branch main \
+            --candidate-sha "$SHA"; then
+            echo 'expected POC main-source denial' >&2
+            exit 1
+          fi
+
+          python scripts/check_project_release_lane.py \
+            --project layoutlib --action poc_deploy --target-branch develop \
+            --candidate-sha "$SHA"
+
+          if python scripts/check_project_release_lane.py \
+            --project layoutlib --action production_deploy --target-branch develop \
+            --candidate-sha "$SHA"; then
+            echo 'expected production develop-source denial' >&2
+            exit 1
+          fi
+
+          python scripts/check_project_release_lane.py \
+            --project layoutlib --action production_deploy --target-branch main \
+            --candidate-sha "$SHA"

--- a/docs/PROJECT_RELEASE_LANE_AUTHORITY.md
+++ b/docs/PROJECT_RELEASE_LANE_AUTHORITY.md
@@ -1,0 +1,48 @@
+# Project Release-Lane Authority
+
+Status: Core #96 accepted-delta extraction for `core/integration`, 2026-08-31
+
+Project identity does not imply branch-mutation, promotion, or deployment authority. AgentOS Core treats development, promotion, POC deployment, and production deployment as distinct governed actions.
+
+## Canonical policy source
+
+`governance/project-release-lanes.json` is the single machine-readable authority source for release lanes. Evaluators and CI read this file; they must not maintain a second hard-coded copy of project policy.
+
+The registry records, per project:
+
+- canonical repository;
+- allowed development branch patterns;
+- promotion branch and required approval boundary;
+- POC and production source branches;
+- exact-source-SHA requirements;
+- environment surfaces and immutable release boundaries;
+- authority owners and invariants.
+
+## Enforcement
+
+`scripts/check_project_release_lane.py` denies unknown projects/actions and enforces the registry.
+
+For the current LayoutLib entry:
+
+- development writes are allowed on `develop`, `feature/*`, `fix/*`, and `governance/*`;
+- development writes to `main` are denied;
+- promotion to `main` requires an explicit human approval event;
+- POC deployment requires source branch `develop` **and** an exact 40-character source SHA;
+- production deployment requires source branch `main` **and** an exact 40-character source SHA;
+- immutable `release/v0.7.9` remains provenance and is not rewritten by the v0.8 POC lane.
+
+`.github/workflows/project-release-lane-guard.yml` runs regression and CLI acceptance probes for changes targeting either `core/integration` or `main`.
+
+## Separation from product deployment carriers
+
+This contract intentionally does **not** copy `.github/workflows/oracle-release-layoutlab-v08-dev.yml` from the historical/main #131 carrier into `core/integration`.
+
+The generic Core authority says whether a project/environment/source identity is permitted. Product-specific build/copy/HTML acceptance logic remains a migration carrier until a product-owned release request can invoke a generic governed deployment surface and produce a receipt containing at least:
+
+`project + environment + repo + source_ref + exact SHA + artifact`.
+
+Therefore accepting this Core authority contract does not by itself retire Layout-specific deployment residue. #96 remains open until an exact LayoutLib `develop` candidate is actually deployed through the governed path and public/receipt parity is demonstrated.
+
+## Provenance
+
+The accepted behavior was first proven on historical PR #129 and extended by #131. This integration extraction deliberately removes the earlier dual-authority design in which policy existed both in YAML and a hard-coded Python `POLICIES` table. Historical branches/PRs remain evidence; `core/integration` is the canonical integration target for the cleaned Core contract.

--- a/governance/project-release-lanes.json
+++ b/governance/project-release-lanes.json
@@ -1,0 +1,46 @@
+{
+  "schema": "agentos.project-release-lanes/v1",
+  "generated_at": "2026-08-31T02:45:00Z",
+  "projects": {
+    "layoutlib": {
+      "canonical_repository": "alston-personal/layoutlib",
+      "development_branch_patterns": [
+        "develop",
+        "feature/*",
+        "fix/*",
+        "governance/*"
+      ],
+      "promotion_branch": "main",
+      "promotion_requires": {
+        "pull_request": true,
+        "explicit_human_approval": true,
+        "core_governance": true
+      },
+      "deployment": {
+        "poc": {
+          "surface": "https://studio.milkcat.org/poc/layout-lab/",
+          "source_branch": "develop",
+          "require_exact_source_sha": true
+        },
+        "production": {
+          "surface": "https://studio.milkcat.org/layout-lab/",
+          "source_branch": "main",
+          "require_exact_source_sha": true,
+          "immutable_release": "release/v0.7.9"
+        }
+      },
+      "authority": {
+        "development_owner": "layoutlib-project",
+        "promotion_owner": "agentos-core",
+        "deployment_owner": "agentos-core"
+      },
+      "invariants": [
+        "project development MUST NOT target main directly",
+        "project threads MUST NOT mutate agentmanager deployment workflows",
+        "POC consumes only an exact validated develop candidate SHA",
+        "production consumes only exact promoted main/release state",
+        "release/v0.7.9 is immutable provenance"
+      ]
+    }
+  }
+}

--- a/scripts/check_project_release_lane.py
+++ b/scripts/check_project_release_lane.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POLICY_FILE = Path(__file__).resolve().parents[1] / "governance" / "project-release-lanes.json"
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def load_policy(path: Path | str = DEFAULT_POLICY_FILE) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if data.get("schema") != "agentos.project-release-lanes/v1":
+        raise ValueError("unsupported_project_release_lane_schema")
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        raise ValueError("project_release_lane_projects_missing")
+    return data
+
+
+def _exact_sha_required(config: dict[str, Any], candidate_sha: str | None) -> tuple[bool, str]:
+    if not config.get("require_exact_source_sha", False):
+        return True, "exact_source_sha_not_required"
+    if not candidate_sha:
+        return False, "exact_source_sha_required"
+    if not SHA40.fullmatch(candidate_sha):
+        return False, "exact_source_sha_invalid"
+    return True, "exact_source_sha_valid"
+
+
+def decide(
+    policy: dict[str, Any],
+    project: str,
+    action: str,
+    target_branch: str,
+    *,
+    explicit_human_approval: bool = False,
+    candidate_sha: str | None = None,
+) -> tuple[bool, str]:
+    project_policy = policy["projects"].get(project)
+    if not isinstance(project_policy, dict):
+        return False, "unknown_project"
+
+    promotion_branch = project_policy.get("promotion_branch")
+    development_patterns = project_policy.get("development_branch_patterns", [])
+
+    if action == "development_write":
+        if target_branch == promotion_branch:
+            return False, "development_write_to_promotion_branch_denied"
+        if any(fnmatch(target_branch, pattern) for pattern in development_patterns):
+            return True, "development_lane_allowed"
+        return False, "branch_not_in_development_lane"
+
+    if action == "promotion":
+        if target_branch != promotion_branch:
+            return False, "promotion_target_must_be_promotion_branch"
+        requires = project_policy.get("promotion_requires", {})
+        if requires.get("explicit_human_approval", False) and not explicit_human_approval:
+            return False, "explicit_human_approval_required"
+        return True, "promotion_allowed"
+
+    if action in {"poc_deploy", "production_deploy"}:
+        environment = "poc" if action == "poc_deploy" else "production"
+        config = project_policy.get("deployment", {}).get(environment)
+        if not isinstance(config, dict):
+            return False, f"{environment}_deployment_not_configured"
+        if target_branch != config.get("source_branch"):
+            return False, f"{environment}_requires_configured_source_branch"
+        sha_ok, sha_reason = _exact_sha_required(config, candidate_sha)
+        if not sha_ok:
+            return False, sha_reason
+        return True, f"{environment}_candidate_allowed"
+
+    return False, "unknown_action"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy-file", default=str(DEFAULT_POLICY_FILE))
+    parser.add_argument("--project", required=True)
+    parser.add_argument(
+        "--action",
+        required=True,
+        choices=["development_write", "promotion", "poc_deploy", "production_deploy"],
+    )
+    parser.add_argument("--target-branch", required=True)
+    parser.add_argument("--candidate-sha")
+    parser.add_argument("--explicit-human-approval", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        policy = load_policy(args.policy_file)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"PROJECT_RELEASE_LANE=DENY reason=policy_load_failed detail={exc}")
+        return 2
+
+    allowed, reason = decide(
+        policy,
+        args.project,
+        args.action,
+        args.target_branch,
+        explicit_human_approval=args.explicit_human_approval,
+        candidate_sha=args.candidate_sha,
+    )
+    print(f"PROJECT_RELEASE_LANE={'ALLOW' if allowed else 'DENY'} reason={reason}")
+    return 0 if allowed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_project_release_lane.py
+++ b/tests/test_project_release_lane.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_project_release_lane import decide, load_policy
+
+
+VALID_SHA = "a" * 40
+
+
+class ProjectReleaseLaneTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = load_policy()
+
+    def test_layoutlib_development_lane(self) -> None:
+        self.assertEqual(
+            decide(self.policy, "layoutlib", "development_write", "develop"),
+            (True, "development_lane_allowed"),
+        )
+        self.assertEqual(
+            decide(self.policy, "layoutlib", "development_write", "feature/door-carver"),
+            (True, "development_lane_allowed"),
+        )
+        self.assertEqual(
+            decide(self.policy, "layoutlib", "development_write", "main"),
+            (False, "development_write_to_promotion_branch_denied"),
+        )
+
+    def test_promotion_requires_explicit_human_approval(self) -> None:
+        self.assertEqual(
+            decide(self.policy, "layoutlib", "promotion", "main"),
+            (False, "explicit_human_approval_required"),
+        )
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "promotion",
+                "main",
+                explicit_human_approval=True,
+            ),
+            (True, "promotion_allowed"),
+        )
+
+    def test_poc_requires_develop_and_exact_sha(self) -> None:
+        self.assertEqual(
+            decide(self.policy, "layoutlib", "poc_deploy", "develop"),
+            (False, "exact_source_sha_required"),
+        )
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "poc_deploy",
+                "develop",
+                candidate_sha="abc",
+            ),
+            (False, "exact_source_sha_invalid"),
+        )
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "poc_deploy",
+                "main",
+                candidate_sha=VALID_SHA,
+            ),
+            (False, "poc_requires_configured_source_branch"),
+        )
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "poc_deploy",
+                "develop",
+                candidate_sha=VALID_SHA,
+            ),
+            (True, "poc_candidate_allowed"),
+        )
+
+    def test_production_requires_main_and_exact_sha(self) -> None:
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "production_deploy",
+                "develop",
+                candidate_sha=VALID_SHA,
+            ),
+            (False, "production_requires_configured_source_branch"),
+        )
+        self.assertEqual(
+            decide(
+                self.policy,
+                "layoutlib",
+                "production_deploy",
+                "main",
+                candidate_sha=VALID_SHA,
+            ),
+            (True, "production_candidate_allowed"),
+        )
+
+    def test_unknown_project_is_denied(self) -> None:
+        self.assertEqual(
+            decide(self.policy, "unknown", "development_write", "develop"),
+            (False, "unknown_project"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Accepted-delta extraction for #96 into the canonical `core/integration` lane.

This intentionally does **not** merge historical PR #129/#131 wholesale from `main`, because `main` and `core/integration` have materially diverged and the old implementation mixed a machine-readable YAML declaration with a second hard-coded Python policy table.

This slice keeps only generic Core authority:

- adds `governance/project-release-lanes.json` as the single release-lane authority source;
- adds `scripts/check_project_release_lane.py`, which reads that registry rather than duplicating policy in code;
- denies unknown projects/actions;
- enforces development vs promotion authority;
- requires explicit human approval for promotion;
- requires configured environment source branch **and exact 40-char source SHA** for POC/production deployment authorization;
- adds regression tests and a CI guard that runs for `core/integration` and `main`;
- documents why the Layout-specific #131 deploy workflow remains a migration carrier rather than being copied into Core integration.

Current LayoutLib policy preserves:
- feature/fix/governance/develop development lanes;
- `main` as promoted state;
- POC from exact `develop` candidate;
- production from exact `main` candidate;
- immutable `release/v0.7.9` provenance.

Non-goal: this PR does not claim #96 fully complete. Actual POC dispatch/public receipt parity remains a separate acceptance step, and no product-specific deployer is added here.

No protected `main` mutation. Targets `core/integration` only.