### PR TITLE
governance(core): reconcile #118 dependency reality

### DIFF
--- a/docs/PRODUCT_MIGRATION_INVENTORY.md
+++ b/docs/PRODUCT_MIGRATION_INVENTORY.md
@@ -8,12 +8,22 @@ This document classifies non-Core work that still appears in `alston-personal/ag
 
 | Product / scope | Canonical repo | Agentmanager residue | Current decision |
 | --- | --- | --- | --- |
-| Vendor Reputation | `alston-personal/vendor-reputation-service` | PR #97 patrol artifact carrier, #99 calibration carrier, #127 monitored-source scheduler | Keep temporarily. Product implementation is already outside Core, but Oracle execution/scheduling carriers still depend on Core infrastructure. Migrate after a governed product-owned runner/capability path is verified. |
-| ArcanaForge | `alston-personal/arcanaforge` | PR #136 POC release carrier | Keep until #66 provides a governed static-release path and an exact ArcanaForge source/artifact receipt can drive `/poc/arcanaforge/`. |
-| LayoutLib | `alston-personal/layoutlib` | Core-side deploy/governance residue tracked by #96 | Keep only generic deployment/promotion adapter. Layout implementation and product tests stay in `layoutlib`; POC consumes exact candidate SHA, production consumes promoted release. |
+| Vendor Reputation | `alston-personal/vendor-reputation-service` | PR #97 patrol artifact carrier, #99 calibration carrier, #127 monitored-source scheduler | Core runner blocker #130 is resolved. Keep carriers only until Vendor #27 owns an equivalent governed request/execution path with exact Vendor source identity and sanitized receipt/runtime parity. |
+| ArcanaForge | `alston-personal/arcanaforge` | PR #136 POC release carrier | Core static-release blocker #66 is resolved. Remaining gate is product provenance: #136 pins a `studio-web` host-adapter SHA, but retirement requires the receipt to identify the exact `arcanaforge` source/artifact as canonical product provenance. |
+| LayoutLib | `alston-personal/layoutlib` | historical/main Layout-specific POC deploy carrier tracked by #96 | Generic release-lane authority is now canonical in `core/integration` via #158. Keep Layout-specific carrier only until a real exact `develop` candidate is dispatched, public/source receipt parity is proven, and the carrier can be replaced by a generic governed adapter. |
 | Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | historical `ops/leopardcat-runtime-inspect` and `chore/leopardcat-runtime-inspect` carrier branches plus Tarot-specific deploy/inspect/probe workflows | Product handoff is `alston-personal/leopardcat-tarot#44`. PR #41 is a product-owned read-only parity gate, but retirement also requires a product-owned write/deploy replacement (or thin caller of a generic governed Core deploy capability) and exact runtime/artifact evidence. |
 | Character Blueprint | unresolved; `alston-personal/charactergenerator` explicitly rejected as a provenance match | PR #53 browser/deployer fix | Preserve PR #53 as migration source and do not merge it into Core. Assign/create the actual Character Blueprint canonical repo before migrating v0.4 behavior; do not overwrite the distinct `charactergenerator` product. |
 | Model2IR | canonical repo not yet assigned/created | real standalone package under `libs/model2ir` across historical `feat/model2ir-*` / `fix/model2ir-*` branches; latest observed carrier is v0.9.1 | Freeze the `agentmanager` lineage as migration provenance. Assign/create a standalone canonical repository, then migrate package/tests/fixtures/history with parity; do not continue library implementation in Core. |
+
+## Dependency reality — 2026-08-31
+
+The migration registry must distinguish a resolved shared Core dependency from a still-open product migration gate.
+
+- **Vendor #130:** completed. Vendor PR #127 governance audit run `33344571389`, job `99346155434`, completed successfully on the canonical Oracle-labelled runner `instance-20260129-0852`. Vendor #27 can continue; this does not authorize merging #97/#99/#127 into Core.
+- **ArcanaForge #66:** completed. The fenced static-release capability/public POC acceptance exists. ArcanaForge #3 is now blocked only by product source/artifact provenance, not by missing Core release capability.
+- **LayoutLib #96:** partially accepted. PR #158 (`6deea2ec7debb2e912d6e53eb2954fd081c85c1e`) puts generic release-lane authority in `core/integration` with one machine-readable policy source and exact-SHA deployment authorization. #96 remains open only for live exact-candidate POC dispatch/receipt acceptance and carrier retirement.
+
+A resolved dependency must not remain in `core_dependencies` merely because a product carrier still exists. Carrier retirement and infrastructure availability are different states.
 
 ## Leopard Cat Tarot carrier inventory
 

--- a/docs/PROJECT_REPO_MAP.md
+++ b/docs/PROJECT_REPO_MAP.md
@@ -19,12 +19,23 @@ This document separates **Project Identity**, **repository ownership**, **develo
 | Project | Canonical repository | Development lane | Main meaning | Online/deploy state | Repo-boundary status |
 | --- | --- | --- | --- | --- | --- |
 | AgentOS Core | `alston-personal/agentmanager` | `core/issue-*` → `core/integration` | protected publication history | live Core uses deployment generation + exact accepted SHA, not branch head | canonical Core owner |
-| Vendor Reputation Service | `alston-personal/vendor-reputation-service` | product feature/fix lane; integration policy to be normalized | accepted Vendor source | Oracle/project carriers must consume pinned Vendor SHA; Vendor implementation should not live in `agentmanager` | canonical repo confirmed; migration cleanup pending |
-| LayoutLib / Layout Lab | `alston-personal/layoutlib` | `feature/*` / `fix/*` → `develop` | accepted/promoted Layout source | POC may consume exact `develop` candidate SHA; production remains promoted/release state | canonical repo confirmed; #96 governs lane/deploy boundary |
-| ArcanaForge | `alston-personal/arcanaforge` | product feature/fix lane; integration policy to be normalized | accepted ArcanaForge source | `/poc/arcanaforge/` is POC and must deploy a pinned candidate through governed static-release capability | canonical repo confirmed; #66 blocks only POC release step |
-| Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | product feature/fix lane; integration policy to be normalized | accepted Tarot source | production/POC source mapping still requires explicit deployment receipt inventory | canonical repo confirmed; remove any product implementation/carriers from Core after parity evidence |
+| Vendor Reputation Service | `alston-personal/vendor-reputation-service` | product feature/fix lane; integration policy to be normalized | accepted Vendor source | shared Oracle runner blocker #130 is resolved; remaining migration is Vendor-owned governed scheduling/execution with exact Vendor source identity and receipt/runtime parity | canonical repo confirmed; carrier retirement tracked by Vendor #27 |
+| LayoutLib / Layout Lab | `alston-personal/layoutlib` | `feature/*` / `fix/*` → `develop` | accepted/promoted Layout source | generic release-lane authority is canonical in `core/integration` via #158; POC still needs one live exact-`develop`-candidate dispatch/receipt acceptance under #96 | canonical repo confirmed; product work unblocked, live POC acceptance pending |
+| ArcanaForge | `alston-personal/arcanaforge` | product feature/fix lane; integration policy to be normalized | accepted ArcanaForge source | Core static-release blocker #66 is resolved; remaining gate is to make `/poc/arcanaforge/` receipt identify the exact canonical `arcanaforge` source/artifact rather than only the `studio-web` host-adapter SHA | canonical repo confirmed; product provenance retirement gate tracked by ArcanaForge #3 |
+| Leopard Cat Tarot | `alston-personal/leopardcat-tarot` | product feature/fix lane; integration policy to be normalized | accepted Tarot source | production/POC source mapping still requires product-owned write/deploy replacement plus exact deployment receipt evidence | canonical repo confirmed; carrier retirement tracked by Tarot #44 |
 | Character Blueprint | unresolved; `alston-personal/charactergenerator` has been checked and rejected as a canonical identity match | unresolved | unresolved | existing Character Blueprint material in `agentmanager` must not be treated as Core authority or migrated into `charactergenerator` by name similarity | canonical repository NOT yet assigned; explicit create/assignment decision required |
 | Model2IR | canonical repository unassigned; no `alston-personal/model2ir` repository exists in current inventory | historical `feat/model2ir-*` / `fix/model2ir-*` work in `agentmanager` is a migration carrier, not an approved Core development lane | new repository `main` must become accepted library source after migration | library boundary; no production web environment required by default | actual standalone v0.9.1 library carrier identified in `agentmanager`; repo creation/assignment is now the blocking identity step |
+
+## Dependency-state rule
+
+A shared Core dependency and a product-carrier retirement gate are different state dimensions.
+
+- A resolved infrastructure/capability issue must not remain an active project blocker merely because the product still has a historical carrier to migrate.
+- Vendor Core #130 is completed: the Oracle-labelled self-hosted runner successfully claimed and completed the formerly queued Vendor governance audit. Vendor #27 now owns the remaining product execution/scheduling migration.
+- ArcanaForge Core #66 is completed: governed fenced static release exists. ArcanaForge #3 now owns the remaining product source/artifact provenance gate for #136 retirement.
+- LayoutLib #96 is split: generic release-lane authority is accepted in `core/integration` through PR #158; only live exact-candidate POC dispatch, receipt/public parity, and subsequent carrier retirement remain.
+
+This distinction is machine-readable in `governance/product-migrations.json`. Workers block only on the precise unresolved step, not on the historical issue number as a blanket project lock.
 
 ## Character Blueprint identity evidence
 

--- a/governance/product-migrations.json
+++ b/governance/product-migrations.json
@@ -1,41 +1,67 @@
 {
   "schema": "agentos.product-migrations/v0",
-  "generated_at": "2026-08-31T02:38:00Z",
+  "generated_at": "2026-08-31T02:49:00Z",
   "core_repository": "alston-personal/agentmanager",
   "invariant": "Product implementation, UI, product CI/deployers and product-specific runtime carriers belong in the canonical product repository. Core retains only generic capability contracts and cross-repository governance/integration machinery.",
   "projects": [
     {
       "project_id": "vendor-reputation",
       "canonical_repository": "alston-personal/vendor-reputation-service",
-      "status": "handoff_created",
+      "status": "product_handoff_core_runner_blocker_cleared",
       "product_issue": "alston-personal/vendor-reputation-service#27",
       "core_prs": [97, 99, 127],
-      "core_dependencies": [130],
+      "core_dependencies": [],
+      "resolved_core_dependencies": [
+        {
+          "issue": 130,
+          "state": "completed",
+          "evidence": "Vendor PR #127 governance audit run 33344571389 / job 99346155434 completed success on Oracle runner instance-20260129-0852"
+        }
+      ],
       "product_evidence": ["alston-personal/vendor-reputation-service#20"],
-      "classification": "product implementation exists in product repo, but Oracle execution/scheduling carriers still live in agentmanager",
-      "retire_when": ["equivalent product-owned governed execution path exists", "Oracle access/runner boundary is solved without copying Core secrets", "receipt/evidence parity is verified"],
-      "safe_now": "product_work_continues; only carrier-dependent execution waits"
+      "classification": "product implementation exists in the product repo and the shared Oracle runner blocker is resolved; temporary Vendor scheduling/execution carriers still live in agentmanager and require product-owned governed replacement",
+      "retire_when": ["equivalent Vendor-owned governed execution/request path exists", "exact Vendor source SHA/artifact identity is preserved", "sanitized receipt and runtime parity are verified"],
+      "safe_now": "product_work_and_carrier_migration_continue; carrier_retirement_waits_on_product_issue_27"
     },
     {
       "project_id": "arcanaforge",
       "canonical_repository": "alston-personal/arcanaforge",
-      "status": "handoff_created",
+      "status": "product_provenance_gate_core_release_blocker_cleared",
       "product_issue": "alston-personal/arcanaforge#3",
       "core_prs": [136],
-      "core_dependencies": [66],
-      "classification": "product has canonical repo, but public POC release is still carried by agentmanager governance/deploy path",
-      "retire_when": ["product-owned artifact/deploy source is canonical", "governed static release capability or approved runner surface exists", "POC deployment receipt identifies exact ArcanaForge source/artifact"],
-      "safe_now": "product_work_continues; only POC publication waits"
+      "core_dependencies": [],
+      "resolved_core_dependencies": [
+        {
+          "issue": 66,
+          "state": "completed",
+          "evidence": "fenced static-release capability and public POC acceptance completed on 2026-08-31"
+        }
+      ],
+      "current_carrier": {
+        "core_pr": 136,
+        "host_repository": "alston-personal/studio-web",
+        "host_source_sha": "ddd136feb827bb86d91a796414e5a96e4e83d960"
+      },
+      "classification": "generic Core static-release capability is no longer the blocker; #136 still proves only the Studio Web host adapter SHA, while canonical product identity is alston-personal/arcanaforge and its v0.2 Workbench source is distinct",
+      "retire_when": ["ArcanaForge-owned product source/artifact definition is canonical", "host adapter consumes or attests the exact ArcanaForge source/artifact identity", "POC deployment receipt identifies ArcanaForge repo/ref/exact SHA/artifact in addition to host-adapter provenance", "public POC parity is verified"],
+      "safe_now": "product_work_and_provenance_fix_continue; carrier_retirement_waits_on_product_issue_3"
     },
     {
       "project_id": "layoutlib",
       "canonical_repository": "alston-personal/layoutlib",
-      "status": "handoff_created",
+      "status": "core_authority_accepted_live_poc_acceptance_pending",
       "product_issue": "alston-personal/layoutlib#2",
       "core_dependencies": [96],
-      "classification": "canonical product repo and develop lane exist; Core should own only generic promotion/deployment policy, not Layout implementation",
-      "retire_when": ["POC deploy consumes pinned layoutlib candidate", "production remains pinned to promoted release", "agentmanager contains no Layout product implementation/deployer beyond generic adapter"],
-      "safe_now": "layout feature work continues; only governed POC/deploy step waits"
+      "core_evidence": [
+        {
+          "pr": 158,
+          "merge_sha": "6deea2ec7debb2e912d6e53eb2954fd081c85c1e",
+          "role": "canonical generic project release-lane authority in core/integration"
+        }
+      ],
+      "classification": "canonical product repo/develop lane exist and generic Core release-lane authority is accepted in core/integration; only the live exact-candidate POC dispatch/receipt acceptance and later carrier retirement remain",
+      "retire_when": ["POC deploy consumes an exact validated layoutlib develop candidate", "public/receipt evidence records exact LayoutLib source identity", "production remains pinned to promoted release", "agentmanager contains no Layout product implementation/deployer beyond a generic adapter"],
+      "safe_now": "layout feature work continues; only live governed POC dispatch/receipt acceptance waits"
     },
     {
       "project_id": "leopardcat-tarot",


### PR DESCRIPTION
Reconciles #118 canonical migration state after shared Core dependencies changed during parallel worker execution.

Key corrections:

- Vendor: #130 is completed. The Oracle-labelled runner successfully claimed/completed the formerly queued Vendor PR #127 governance audit. Vendor carrier retirement now waits only on product-owned governed execution/request + exact Vendor source identity + sanitized receipt/runtime parity in `vendor-reputation-service#27`.
- ArcanaForge: #66 is completed. Generic fenced static release is no longer the blocker. PR #136 retirement now waits on canonical `arcanaforge` product source/artifact provenance being carried into the POC receipt, rather than only pinning a `studio-web` host-adapter SHA. Product gate is `arcanaforge#3`.
- LayoutLib: generic release-lane authority is accepted in `core/integration` via #158 (`6deea2ec7debb2e912d6e53eb2954fd081c85c1e`). #96 remains only for live exact-`develop`-candidate POC dispatch, receipt/public parity, and carrier retirement.

This PR explicitly separates **resolved infrastructure/capability dependencies** from **still-open product carrier retirement gates**. A product is not globally blocked merely because a historical carrier remains.

Updates:
- `governance/product-migrations.json`
- `docs/PRODUCT_MIGRATION_INVENTORY.md`
- `docs/PROJECT_REPO_MAP.md`

No product code moves, no carrier deletion occurs, no historical mainline is wholesale synced into integration, and protected `main` is untouched. Targets `core/integration` only.