### PR TITLE
governance(core): accept executor identity boundary and reconcile worker graph

### DIFF
--- a/docs/CORE_WORKER_MODEL.md
+++ b/docs/CORE_WORKER_MODEL.md
@@ -1,6 +1,6 @@
 # AgentOS Core Worker Model
 
-Status: canonical proposal for Issue #137
+Status: accepted canonical control-plane model from Issue #137; machine state is continuously reconciled in `governance/core-workers.json`.
 
 ## Purpose
 
@@ -20,6 +20,8 @@ The canonical Core authority owns:
 
 A Core worker owns only its declared issue execution scope. A worker may branch, implement, test, collect evidence, and report `acceptance_ready`. It does not gain protected-main merge authority, deployment-generation authority, or authority over unrelated issues.
 
+When a worker discovers a privileged boundary, new cross-Core protocol, or architecture/invariant change, it reports that decision point back to canonical Core. Canonical Core may accept a bounded decision, reject it, or split it into a new dependency worker rather than allowing scope creep inside the reporting issue.
+
 ## Worker state contract
 
 Canonical machine-readable worker state is recorded in `governance/core-workers.json` with schema `agentos.core-workers/v0`.
@@ -34,6 +36,8 @@ Allowed worker states:
 
 Each worker records issue id, branch where known, dependencies, evidence refs, blocking scope, and explicit non-authorities.
 
+The prose issue body is historical intent; the machine graph is the current dependency projection. The graph must be reconciled when evidence resolves a dependency. A closed/completed issue is not automatically `accepted` without evidence, but once canonical acceptance evidence exists it must not remain as a stale blocker.
+
 ## Dependency semantics
 
 Dependencies are directed edges, not project-wide pauses.
@@ -45,6 +49,20 @@ Example:
 Only `semantic-classification` waits for #72. Collection, UI, tests, documentation, or unrelated Vendor work continue unless they declare their own dependency.
 
 A dependency is satisfiable only when its Core worker reaches `accepted` with the required evidence. `acceptance_ready`, CI green, PR mergeability, or a generic `continue` is not sufficient.
+
+Resolved infrastructure dependencies and unretired product carriers are separate states. A product carrier may remain open for migration/parity after the shared Core capability it once depended on has been accepted.
+
+## Architecture-return pattern
+
+A worker architecture report does not authorize that worker to widen privileged contracts itself.
+
+Current accepted examples:
+
+- #117 discovered the ubuntu-owned Codex identity/executable boundary. Canonical Core split the privileged provider work into #160 and chose an isolated fixed-provider Codex relay/service/root rather than generic executable selection.
+- #117 also distinguished passive Experience hydration from a fully ONE-aware executor. Canonical Core kept passive hydration inside #117 acceptance and split the higher bidirectional handshake into #161, which does not block #117.
+- #72 received bounded authority for sanitized Claude liveness diagnostics only; this did not grant generic shell/argv, credential access, permission broadening, or timeout-policy changes.
+
+This pattern keeps execution parallel while preserving one architecture authority plane.
 
 ## Branch and environment semantics
 
@@ -63,15 +81,23 @@ Product development should follow the same authority principle without requiring
 
 Every deployment receipt should identify project id, repository, environment, source ref, exact source SHA, artifact digest where applicable, and deployment timestamp/generation.
 
-## Initial worker lanes
+## Current worker-lane interpretation
 
-- #117 ONE Experience regression: separate worker; currently may depend on #72 and #130.
-- #72 Antigravity/Claude executor liveness: shared executor-runtime worker.
-- #130 Oracle self-hosted runner recovery: shared infrastructure worker.
-- #105 governed GUI certification: independent worker.
-- #96 LayoutLib development/deployment authority: independent worker.
-- #66 governed Studio static release: independent worker.
-- #118 repository-boundary cleanup: architecture/migration worker; must not globally block product feature work.
+Do not copy a static dependency list from this document into a worker. Read `governance/core-workers.json`.
+
+As of the 2026-08-31 reconciliation:
+
+- #117 ONE Experience regression is a separate worker and is blocked only on #72 (Claude liveness) and #160 (governed Codex relay). #130 is resolved; #161 is not a #117 blocker.
+- #72 Antigravity/Claude executor liveness is a running shared executor-runtime worker with no Core dependency.
+- #130 Oracle self-hosted runner recovery is accepted and no longer appears in dependency edges.
+- #105 governed GUI certification remains a running independent worker pending its live certification evidence.
+- #96 LayoutLib authority has its generic policy accepted in `core/integration`; only live exact-candidate POC receipt/public acceptance remains.
+- #66 governed Studio static release is accepted; ArcanaForge's remaining source/artifact provenance is a product migration gate, not a #66 Core dependency.
+- #118 repository-boundary cleanup remains a running architecture/migration worker and must not globally block product feature work.
+- #137 worker/dependency control-plane is accepted.
+- #147 legacy proposal delta extraction remains an independent architecture-extraction worker.
+- #160 isolated fixed-provider Codex relay is a separate privileged-executor worker and blocks only #117's real Codex regression step.
+- #161 ONE-aware executor handshake is a separate architecture worker and does not block passive Experience hydration.
 
 ## Invariants
 
@@ -81,3 +107,5 @@ Every deployment receipt should identify project id, repository, environment, so
 4. `main` is accepted/promotion state; active development does not write directly to it.
 5. Online/staging/production state is identified by environment + exact source/artifact identity, never by branch name alone.
 6. Machine-readable worker/dependency state is canonical enough for discovery, but acceptance still requires preserved evidence.
+7. Architecture findings return to canonical Core; reporting workers do not silently acquire cross-Core or privileged authority.
+8. Resolved dependencies are removed from active edges; historical provenance remains as evidence, not as a permanent blocker.

--- a/docs/EXECUTOR_PROVIDER_BOUNDARY.md
+++ b/docs/EXECUTOR_PROVIDER_BOUNDARY.md
@@ -1,0 +1,83 @@
+# Executor Provider / Identity Boundary
+
+Status: canonical Core architecture decision, 2026-08-31. Origin: #117 architecture return; execution follow-ups #72, #160, #161.
+
+## Problem
+
+Oracle has intentionally different identities for infrastructure execution and interactive/Antigravity executor state:
+
+- the GitHub/AgentOS runner executes as `agentos-node`;
+- Antigravity Claude/Codex binaries and their user-scoped identity/session/config live under `ubuntu`;
+- private Antigravity extension roots are not intended to be traversed by `agentos-node`.
+
+This is a security boundary, not a file-permission bug. A regression worker must not solve executor discovery by widening filesystem access, copying credentials/binaries, or introducing arbitrary privileged shell execution.
+
+## Decision 1 — provider-specific privileged relays
+
+Privileged executors whose usable binary/identity are owned by another OS identity are exposed through a **fixed-provider governed relay/service boundary**.
+
+For Codex, #160 uses a separate ubuntu-owned fixed-provider Codex relay/service/root. It must not turn the existing Claude relay into a capsule-controlled arbitrary executable gateway.
+
+The Codex relay contract is bounded by these invariants:
+
+1. provider is fixed by service configuration, not capsule input;
+2. executable discovery is allowlisted to the expected Antigravity Codex extension path class;
+3. the executor naturally uses ubuntu-owned user identity/config, but the relay never reads/returns/copies credential or session contents as data;
+4. request input is an AgentOS execution contract, not generic shell/argv authority;
+5. receipt output is sanitized and provenance-bearing;
+6. no chmod/sudo/credential relocation/binary copying is used to bypass identity separation;
+7. deployment/publication authority remains separate from executor availability.
+
+A future multi-provider relay is not prohibited, but it requires a separate acceptance proving that provider selection is a closed canonical allowlist with equivalent isolation. It is not the default solution for #117.
+
+## Decision 2 — bounded Claude diagnostics
+
+#72 may run minimal diagnostics inside the existing ubuntu-owned Claude boundary:
+
+- supported auth/status probe;
+- deterministic normal headless print;
+- deterministic restricted headless print where supported.
+
+This authority is diagnostic-only. It does not authorize generic shell/argv, setting mutation, credential/session inspection, permission widening, or timeout increases.
+
+Persisted evidence should contain only safe execution metadata needed to distinguish failure classes: CLI/provider version, command class, timing, return code, timeout status, safe stdout/stderr size/digest/classification, and deterministic expected-token result.
+
+## Decision 3 — managed/passive vs ONE-aware executor
+
+Experience hydration and executor protocol awareness are distinct capabilities.
+
+### Managed/passive executor
+
+A trusted AgentOS adapter may:
+
+1. resolve project/Realm/task identity;
+2. discover canonical Experience;
+3. project bounded hydration;
+4. invoke a target executor;
+5. collect output and governed receipt.
+
+The underlying model does not need to understand AgentOS itself. This is a valid executor mode and is sufficient for #117 baseline-vs-hydrated Master Experience Floor acceptance when evidence isolation and authority constraints pass.
+
+### ONE-aware executor/node
+
+A higher-capability executor participates in a model-neutral AgentOS startup/continuation handshake and can use governed protocol surfaces to discover/query allowed state/capabilities and emit progress/state-delta/evidence/receipt back to ONE.
+
+This capability is tracked by #161. It must reuse existing Realm/ANCP/node/receipt/canonical-state primitives where possible and must not create a new canonical memory store or imply arbitrary mutation authority.
+
+#161 is intentionally **not** a dependency of #117. Otherwise a focused Experience hypothesis test would become blocked on a general bidirectional executor protocol redesign.
+
+## Acceptance and evidence principle
+
+Executor availability, executor awareness, Experience hydration, and mutation/publication authority are four independent dimensions. Passing one does not imply the others.
+
+A receipt/evidence record should therefore make these claims separately where applicable:
+
+- which provider/executor identity actually ran;
+- which governed adapter/relay authorized execution;
+- which hydration artifact/digest was supplied;
+- whether the executor was passive or ONE-aware;
+- what capabilities/authority were exposed;
+- exact result/timing/error evidence;
+- whether any state mutation or deployment authority was exercised.
+
+This separation is required so a successful model response cannot be misreported as proof of privileged authority, ONE awareness, or durable cross-executor continuity.

--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T02:03:00Z",
+  "generated_at": "2026-08-31T02:50:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -18,76 +18,147 @@
       "branch": "core/issue-117-experience-memory",
       "status": "blocked",
       "execution_lane": "separate-worker-thread",
-      "dependencies": [72, 130],
-      "blocking_scope": ["agentos-core:experience-regression"],
-      "evidence": [".agentos/evidence/experience/", "pull/119"],
-      "non_authorities": ["protected-main merge", "deployment-generation advance"]
+      "dependencies": [72, 160],
+      "blocking_scope": [
+        "agentos-core:experience-regression:claude",
+        "agentos-core:experience-regression:codex"
+      ],
+      "evidence": [
+        ".agentos/evidence/experience/",
+        "pull/119",
+        "workflow-run/33347604180",
+        "issue/117#issuecomment-5473078523"
+      ],
+      "non_authorities": [
+        "protected-main merge",
+        "deployment-generation advance",
+        "general executor-protocol redesign"
+      ]
     },
     {
       "issue": 72,
       "name": "Antigravity/Claude executor liveness",
       "branch": null,
-      "status": "queued",
+      "status": "running",
       "execution_lane": "shared-executor-runtime-worker",
-      "dependencies": [130],
-      "blocking_scope": ["agentos-core:experience-regression", "vendor-reputation:semantic-classification"],
-      "evidence": [".agentos/evidence/relay-smoke.json"],
-      "non_authorities": ["protected-main merge"]
+      "dependencies": [],
+      "blocking_scope": [
+        "agentos-core:experience-regression:claude",
+        "vendor-reputation:semantic-classification"
+      ],
+      "evidence": [
+        ".agentos/evidence/relay-smoke.json",
+        "issue/72#issuecomment-5472586373",
+        "issue/72#issuecomment-5473080170"
+      ],
+      "non_authorities": [
+        "generic shell authority",
+        "credential relocation",
+        "timeout increase as liveness fix",
+        "protected-main merge"
+      ]
     },
     {
       "issue": 130,
       "name": "Oracle self-hosted runner recovery",
       "branch": null,
-      "status": "queued",
+      "status": "accepted",
       "execution_lane": "shared-infrastructure-worker",
       "dependencies": [],
-      "blocking_scope": ["oracle:self-hosted-governance-jobs", "agentos-core:experience-regression"],
-      "evidence": [],
-      "non_authorities": ["weaken-governance-gates", "protected-main merge"]
+      "blocking_scope": [],
+      "evidence": [
+        "workflow-run/33344571389",
+        "workflow-job/99346155434",
+        "runner/instance-20260129-0852",
+        "issue/130"
+      ],
+      "non_authorities": [
+        "weaken-governance-gates",
+        "protected-main merge"
+      ]
     },
     {
       "issue": 105,
       "name": "Governed GUI control certification",
       "branch": "core/issue-105-gui-control",
-      "status": "queued",
+      "status": "running",
       "execution_lane": "independent-worker",
       "dependencies": [],
-      "blocking_scope": ["agentos-node:full-chatgpt-one-gui-certification"],
-      "evidence": [".agentos/evidence/node-gui/vopc5750/acceptance.json", "pull/116"],
-      "non_authorities": ["protected-main merge"]
+      "blocking_scope": [
+        "agentos-node:full-chatgpt-one-gui-certification"
+      ],
+      "evidence": [
+        ".agentos/evidence/node-gui/vopc5750/acceptance.json",
+        "pull/116",
+        "issue/105#issuecomment-5469133426"
+      ],
+      "non_authorities": [
+        "protected-main merge"
+      ]
     },
     {
       "issue": 96,
       "name": "LayoutLib development/deployment authority",
-      "branch": "core/layoutlib-poc-candidate-deploy",
-      "status": "queued",
+      "branch": null,
+      "status": "running",
       "execution_lane": "independent-worker",
-      "dependencies": [130],
-      "blocking_scope": ["layoutlib:poc-deployment"],
-      "evidence": ["alston-personal/layoutlib#2"],
-      "non_authorities": ["layoutlib production promotion", "protected-main merge"]
+      "dependencies": [],
+      "blocking_scope": [
+        "layoutlib:poc-deployment:live-acceptance"
+      ],
+      "evidence": [
+        "alston-personal/layoutlib#2",
+        "pull/158",
+        "merge/6deea2ec7debb2e912d6e53eb2954fd081c85c1e"
+      ],
+      "non_authorities": [
+        "layoutlib production promotion",
+        "product-specific deployer ownership",
+        "protected-main merge"
+      ]
     },
     {
       "issue": 66,
       "name": "Governed Studio static release",
       "branch": null,
-      "status": "queued",
+      "status": "accepted",
       "execution_lane": "independent-worker",
-      "dependencies": [130],
-      "blocking_scope": ["arcanaforge:poc-static-release"],
-      "evidence": ["alston-personal/arcanaforge#3"],
-      "non_authorities": ["arbitrary shell authority", "protected-main merge"]
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": [
+        "issue/66",
+        "alston-personal/arcanaforge#3"
+      ],
+      "non_authorities": [
+        "arbitrary shell authority",
+        "protected-main merge"
+      ]
     },
     {
       "issue": 118,
       "name": "Repository-boundary cleanup",
-      "branch": "core/issue-118-product-handoffs",
+      "branch": null,
       "status": "running",
       "execution_lane": "architecture-migration-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/PROJECT_REPO_MAP.md", "docs/PRODUCT_MIGRATION_INVENTORY.md", "governance/product-migrations.json", "pull/141", "pull/143", "pull/146"],
-      "non_authorities": ["global product feature pause", "destructive historical branch deletion", "protected-main merge"]
+      "evidence": [
+        "docs/PROJECT_REPO_MAP.md",
+        "docs/PRODUCT_MIGRATION_INVENTORY.md",
+        "governance/product-migrations.json",
+        "pull/141",
+        "pull/143",
+        "pull/146",
+        "pull/155",
+        "pull/156",
+        "pull/157",
+        "pull/159"
+      ],
+      "non_authorities": [
+        "global product feature pause",
+        "destructive historical branch deletion",
+        "protected-main merge"
+      ]
     },
     {
       "issue": 137,
@@ -97,8 +168,15 @@
       "execution_lane": "canonical-coordination-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["docs/CORE_WORKER_MODEL.md", "governance/core-workers.json", "pull/140"],
-      "non_authorities": ["protected-main merge"]
+      "evidence": [
+        "docs/CORE_WORKER_MODEL.md",
+        "governance/core-workers.json",
+        "pull/140",
+        "pull/142"
+      ],
+      "non_authorities": [
+        "protected-main merge"
+      ]
     },
     {
       "issue": 147,
@@ -108,17 +186,74 @@
       "execution_lane": "architecture-extraction-worker",
       "dependencies": [],
       "blocking_scope": [],
-      "evidence": ["governance/legacy-core-proposals.json"],
-      "non_authorities": ["wholesale legacy PR merge", "blind retarget to core/integration", "protected-main merge"]
+      "evidence": [
+        "governance/legacy-core-proposals.json"
+      ],
+      "non_authorities": [
+        "wholesale legacy PR merge",
+        "blind retarget to core/integration",
+        "protected-main merge"
+      ]
+    },
+    {
+      "issue": 160,
+      "name": "Isolated fixed-provider Codex relay",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "privileged-executor-boundary-worker",
+      "dependencies": [],
+      "blocking_scope": [
+        "agentos-core:experience-regression:codex"
+      ],
+      "evidence": [
+        "issue/160",
+        "issue/137#issuecomment-5472574149"
+      ],
+      "non_authorities": [
+        "generic shell authority",
+        "arbitrary executable selection",
+        "credential relocation",
+        "permission broadening",
+        "protected-main merge",
+        "deployment-generation advance"
+      ]
+    },
+    {
+      "issue": 161,
+      "name": "ONE-aware executor startup/continuation handshake",
+      "branch": null,
+      "status": "queued",
+      "execution_lane": "executor-protocol-architecture-worker",
+      "dependencies": [],
+      "blocking_scope": [],
+      "evidence": [
+        "issue/161",
+        "issue/137#issuecomment-5472788499"
+      ],
+      "non_authorities": [
+        "block passive Experience hydration acceptance",
+        "portable hidden-state claims",
+        "implicit ONE mutation authority",
+        "protected-main merge"
+      ]
     }
   ],
   "dependency_edges": [
-    {"from": "agentos-core#117", "to": "agentos-core#72"},
-    {"from": "agentos-core#117", "to": "agentos-core#130"},
-    {"from": "agentos-core#72", "to": "agentos-core#130"},
-    {"from": "vendor-reputation:semantic-classification", "to": "agentos-core#72"},
-    {"from": "vendor-reputation:oracle-carriers", "to": "agentos-core#130"},
-    {"from": "layoutlib:poc-deployment", "to": "agentos-core#96"},
-    {"from": "arcanaforge:poc-static-release", "to": "agentos-core#66"}
+    {
+      "from": "agentos-core#117",
+      "to": "agentos-core#72"
+    },
+    {
+      "from": "agentos-core#117",
+      "to": "agentos-core#160"
+    },
+    {
+      "from": "vendor-reputation:semantic-classification",
+      "to": "agentos-core#72"
+    },
+    {
+      "from": "layoutlib:poc-deployment:live-acceptance",
+      "to": "agentos-core#96"
+    }
   ]
 }


### PR DESCRIPTION
Canonical Core response to architecture findings returned by #117, plus reconciliation of the machine worker graph after #130/#66/#96 changed state.

## Architecture decisions

- **Codex:** create #160 and use a separate ubuntu-owned fixed-provider Codex relay/service/root. Do not make arbitrary executable/provider selection capsule-controlled, chmod private Antigravity roots, copy credentials/binaries to `agentos-node`, or add generic shell authority.
- **Claude #72 diagnostics:** authorize only bounded sanitized probes inside the existing ubuntu-owned Claude boundary (supported auth/status, deterministic normal headless print, restricted headless print where supported). No setting mutation, credential/session inspection, permission broadening, generic argv/shell, or timeout increase.
- **Executor awareness:** accept `managed/passive executor` and `ONE-aware executor/node` as distinct capability levels. Passive governed hydration remains sufficient for #117 Experience A/B acceptance; the higher bidirectional handshake is split to #161 and does **not** block #117.

## Worker graph reconciliation

- #117: `blocked`, dependencies now `[72, 160]`; stale #130 edge removed.
- #72: `running`, no Core dependency; blocks only Claude-dependent scopes.
- #130: `accepted`; removed from active dependency edges.
- #96: `running`, no #130 dependency; only live exact-candidate POC acceptance remains.
- #66: `accepted`; Arcana product provenance is no longer represented as a #66 Core blocker.
- #105/#118/#147 remain running.
- #137 remains accepted.
- #160 added as queued privileged-executor worker; blocks only #117 Codex regression.
- #161 added as queued executor-protocol architecture worker with no blocking scope for #117.

## Files

- `governance/core-workers.json`
- `docs/CORE_WORKER_MODEL.md`
- `docs/EXECUTOR_PROVIDER_BOUNDARY.md`

This is authority/control-plane work only. It does not implement the Codex relay, run privileged diagnostics, merge #117, advance deployment generation, or touch protected `main`. Targets `core/integration` only.