### PR TITLE
governance(core): register cross-repository Oracle execution boundary

### DIFF
--- a/docs/CROSS_REPO_EXECUTION_BOUNDARY.md
+++ b/docs/CROSS_REPO_EXECUTION_BOUNDARY.md
@@ -1,0 +1,171 @@
+# Cross-Repository Governed Execution Boundary
+
+Status: canonical architecture decision for Core #165, 2026-08-31
+
+## Why this boundary exists
+
+Issue #118 requires product implementation, product CI/request definitions, release logic, and product-specific runtime behavior to live in each canonical product repository. That does not imply each product repository must directly own or reach the privileged Oracle execution identity.
+
+A product can own **what should be executed** while AgentOS Core/ONE owns **whether that privileged execution is authorized, how it is isolated, and how evidence is returned**.
+
+The boundary therefore separates:
+
+1. product source/request ownership;
+2. Core authority and capability resolution;
+3. privileged Oracle execution;
+4. sanitized receipt/evidence.
+
+## Fresh evidence and epistemic boundary
+
+AgentOS Core #130 proved that an Oracle-labelled self-hosted runner can claim and complete governed jobs in `alston-personal/agentmanager`.
+
+That proof is repository-local. It does not prove that the same runner can be directly claimed from every product repository.
+
+Leopard Cat Tarot provides the first concrete cross-repository counterexample requiring diagnosis:
+
+- product PR `alston-personal/leopardcat-tarot#41` owns a read-only `Production Parity Gate`;
+- it requests `[self-hosted, Linux, ARM64, oracle]`;
+- original run `33312465860` remained queued without a runner claim;
+- after #130 recovery, the workflow was retriggered without semantic behavior changes at product commit `27610149eafe27872e71e0b4f2fdebded2d164fb`;
+- retriggered run `33352392531`, job `99368137799`, was also observed queued with no execution steps started.
+
+This evidence proves only that **agentmanager runner health is insufficient evidence of direct product-repository reachability**. It does not yet prove whether the cause is repository-scoped registration, organization scope, label/runner-group policy, concurrency, availability, or another GitHub Actions boundary. #165 must preserve this distinction.
+
+## Ownership contract
+
+### Product repository owns
+
+- canonical product source;
+- feature/fix/develop/main promotion state according to product policy;
+- product tests;
+- typed execution/deployment request definition;
+- product artifact definition;
+- product-specific parity criteria;
+- exact candidate/accepted source identity.
+
+### AgentOS Core / ONE owns
+
+- Project Identity resolution;
+- source/release-lane authority checks;
+- capability/action allowlist;
+- privileged Oracle execution boundary;
+- project/capability-scoped secret brokering where required;
+- idempotency/replay policy;
+- sanitized receipt/evidence contract;
+- cross-repository execution protocol.
+
+Core does **not** regain ownership of product implementation merely because Core executes an authorized product request.
+
+## Request contract
+
+The target model is a versioned request equivalent to `agentos.execution-request/v1`.
+
+Minimum semantic fields:
+
+```json
+{
+  "schema": "agentos.execution-request/v1",
+  "request_id": "<stable idempotency key>",
+  "project_id": "<canonical project id>",
+  "repository": "owner/repo",
+  "source_ref": "<branch/tag/release ref>",
+  "source_sha": "<exact 40-char sha>",
+  "capability": "<governed capability id>",
+  "environment": "<poc|staging|production|none>",
+  "parameters": {},
+  "expected_result": "<typed receipt/artifact contract>"
+}
+```
+
+The request is not an authority token. Core resolves the canonical Project Identity and checks the requested ref/SHA/capability/environment against governance before privileged execution.
+
+## Execution constraints
+
+The generic boundary must reject:
+
+- arbitrary shell strings;
+- arbitrary executable paths;
+- unrestricted argv tunneling;
+- branch-only deployment identity without an exact SHA;
+- unregistered project/repository substitutions;
+- requests whose source SHA is not valid for the authorized source/ref relation;
+- replay where the request contract is non-idempotent and replay was not explicitly authorized;
+- Core-wide secret export to product repositories.
+
+Execution should use a capability-scoped adapter, standardized product entrypoint/container, or another bounded runtime contract. A product may execute its own pinned code, but the privileged surface and available secrets/resources remain capability-scoped.
+
+## Secret boundary
+
+Product repositories must not receive generic Oracle/Core secrets simply because they need privileged execution.
+
+If a capability requires a credential, it should be resolved at execution time from a project+capability-scoped secret authority. The receipt may record secret identity/version metadata when safe, but never the secret value.
+
+## Receipt contract
+
+A successful or failed request persists enough identity to reproduce what was attempted:
+
+```json
+{
+  "schema": "agentos.execution-receipt/v1",
+  "request_id": "...",
+  "project_id": "...",
+  "repository": "owner/repo",
+  "environment": "...",
+  "source_ref": "...",
+  "source_sha": "...",
+  "capability": "...",
+  "artifact_digest": "...",
+  "result_status": "...",
+  "executor_identity": "...",
+  "started_at": "...",
+  "completed_at": "..."
+}
+```
+
+Product-specific acceptance data may be attached as typed evidence, but credentials/private payloads are never returned by default.
+
+## Transport is an implementation choice, not architecture authority
+
+#165 must first diagnose why a product-repository Oracle job is not being claimed. After that, choose the narrowest safe transport.
+
+Candidate transports include:
+
+- product-owned request manifest/artifact consumed by Core/ONE;
+- a project-scoped authenticated ONE/Realm request;
+- a bounded GitHub App-mediated request;
+- direct product-repository self-hosted execution only if runner scope/authority is deliberately configured and still satisfies secret/governance isolation.
+
+The architecture does not require all products to use the same GitHub branch topology, and it does not require a product repository to host the privileged runner directly.
+
+## First consumers
+
+### Leopard Cat Tarot
+
+The product repository owns parity/deploy request definitions. Core #165 supplies only the generic Oracle execution boundary. Retirement of historical `agentmanager` Tarot carriers still requires product-owned write/deploy replacement plus exact source/artifact runtime parity; a successful read-only parity gate alone is necessary but not sufficient.
+
+### Vendor Reputation Service
+
+The product repository owns monitored-source scheduling/request definitions and exact Vendor source identity. Core #165 may execute the authorized capability on Oracle and return a sanitized receipt. This is the intended path toward retiring agentmanager Vendor carriers #97/#99/#127 without copying Core secrets into Vendor.
+
+## Relationship to other Core issues
+
+- #130: accepted repository-local Oracle runner recovery evidence; not a cross-repository reachability guarantee.
+- #66: accepted generic static release capability; does not by itself establish product source/artifact provenance or product-repo Oracle reachability.
+- #96: Layout release-lane authority/live POC acceptance; may later consume this generic boundary but remains independently scoped today.
+- #160: privileged Codex executor provider boundary; separate from product cross-repository execution.
+- #118: repository separation authority; #165 blocks only the exact carrier-retirement steps that require Oracle execution.
+
+## Acceptance
+
+#165 is accepted only after all of the following are true:
+
+1. the actual current runner scope/availability boundary is diagnosed and evidenced;
+2. one product-owned deterministic read-only/no-secret request executes through the generic boundary;
+3. exact product repo/ref/SHA is verified before execution;
+4. capability authority is enforced without arbitrary shell/argv;
+5. a sanitized execution receipt is persisted;
+6. no Core-wide secret is copied into the product repository;
+7. the product can keep implementation/request ownership outside `agentmanager`;
+8. at least one #118 carrier-retirement path materially advances using the boundary.
+
+Until then, #165 is a shared infrastructure worker, not a reason to pause unrelated product development.

--- a/governance/core-workers.json
+++ b/governance/core-workers.json
@@ -1,7 +1,7 @@
 {
   "schema": "agentos.core-workers/v0",
   "project_id": "agentos-core",
-  "generated_at": "2026-08-31T02:50:00Z",
+  "generated_at": "2026-08-31T03:04:00Z",
   "authority": {
     "canonical_integration_branch": "core/integration",
     "publication_branch": "main",
@@ -73,6 +73,7 @@
         "issue/130"
       ],
       "non_authorities": [
+        "cross-repository runner reachability claim",
         "weaken-governance-gates",
         "protected-main merge"
       ]
@@ -152,7 +153,10 @@
         "pull/155",
         "pull/156",
         "pull/157",
-        "pull/159"
+        "pull/159",
+        "issue/163",
+        "issue/164",
+        "issue/165"
       ],
       "non_authorities": [
         "global product feature pause",
@@ -236,6 +240,34 @@
         "implicit ONE mutation authority",
         "protected-main merge"
       ]
+    },
+    {
+      "issue": 165,
+      "name": "Governed cross-repository Oracle execution requests",
+      "branch": "core/issue-165-cross-repo-execution",
+      "status": "queued",
+      "execution_lane": "shared-cross-repository-execution-worker",
+      "dependencies": [],
+      "blocking_scope": [
+        "vendor-reputation:oracle-carrier-retirement",
+        "leopardcat-tarot:oracle-carrier-retirement"
+      ],
+      "evidence": [
+        "issue/165",
+        "alston-personal/leopardcat-tarot#41",
+        "workflow-run/33312465860",
+        "workflow-run/33352392531",
+        "workflow-job/99368137799"
+      ],
+      "non_authorities": [
+        "assume runner registration scope without evidence",
+        "generic shell authority",
+        "arbitrary executable or argv tunneling",
+        "copy Core-wide Oracle secrets into product repositories",
+        "product production promotion",
+        "carrier deletion before parity",
+        "protected-main merge"
+      ]
     }
   ],
   "dependency_edges": [
@@ -250,6 +282,14 @@
     {
       "from": "vendor-reputation:semantic-classification",
       "to": "agentos-core#72"
+    },
+    {
+      "from": "vendor-reputation:oracle-carrier-retirement",
+      "to": "agentos-core#165"
+    },
+    {
+      "from": "leopardcat-tarot:oracle-carrier-retirement",
+      "to": "agentos-core#165"
     },
     {
       "from": "layoutlib:poc-deployment:live-acceptance",

--- a/governance/product-migrations.json
+++ b/governance/product-migrations.json
@@ -1,16 +1,16 @@
 {
   "schema": "agentos.product-migrations/v0",
-  "generated_at": "2026-08-31T02:49:00Z",
+  "generated_at": "2026-08-31T03:05:00Z",
   "core_repository": "alston-personal/agentmanager",
   "invariant": "Product implementation, UI, product CI/deployers and product-specific runtime carriers belong in the canonical product repository. Core retains only generic capability contracts and cross-repository governance/integration machinery.",
   "projects": [
     {
       "project_id": "vendor-reputation",
       "canonical_repository": "alston-personal/vendor-reputation-service",
-      "status": "product_handoff_core_runner_blocker_cleared",
+      "status": "product_handoff_cross_repo_execution_pending",
       "product_issue": "alston-personal/vendor-reputation-service#27",
       "core_prs": [97, 99, 127],
-      "core_dependencies": [],
+      "core_dependencies": [165],
       "resolved_core_dependencies": [
         {
           "issue": 130,
@@ -19,9 +19,9 @@
         }
       ],
       "product_evidence": ["alston-personal/vendor-reputation-service#20"],
-      "classification": "product implementation exists in the product repo and the shared Oracle runner blocker is resolved; temporary Vendor scheduling/execution carriers still live in agentmanager and require product-owned governed replacement",
-      "retire_when": ["equivalent Vendor-owned governed execution/request path exists", "exact Vendor source SHA/artifact identity is preserved", "sanitized receipt and runtime parity are verified"],
-      "safe_now": "product_work_and_carrier_migration_continue; carrier_retirement_waits_on_product_issue_27"
+      "classification": "product implementation exists in the product repo and agentmanager-local Oracle runner recovery is accepted; temporary Vendor scheduling/execution carriers still require a product-owned request definition plus a generic governed cross-repository Oracle execution boundary",
+      "retire_when": ["equivalent Vendor-owned governed execution/request path exists", "Core #165 or equivalent accepted generic boundary executes the pinned Vendor source without copying Core-wide secrets", "exact Vendor source SHA/artifact identity is preserved", "sanitized receipt and runtime parity are verified"],
+      "safe_now": "product_work_continues; only Oracle execution/carrier-retirement step waits on product issue 27 and Core 165"
     },
     {
       "project_id": "arcanaforge",
@@ -59,16 +59,22 @@
           "role": "canonical generic project release-lane authority in core/integration"
         }
       ],
-      "classification": "canonical product repo/develop lane exist and generic Core release-lane authority is accepted in core/integration; only the live exact-candidate POC dispatch/receipt acceptance and later carrier retirement remain",
+      "classification": "canonical product repo/develop lane exist and generic Core release-lane authority is accepted in core/integration; no Layout v0.8 workflow_dispatch run was found, so the live exact-candidate POC dispatch/receipt acceptance is genuinely still pending",
       "retire_when": ["POC deploy consumes an exact validated layoutlib develop candidate", "public/receipt evidence records exact LayoutLib source identity", "production remains pinned to promoted release", "agentmanager contains no Layout product implementation/deployer beyond a generic adapter"],
       "safe_now": "layout feature work continues; only live governed POC dispatch/receipt acceptance waits"
     },
     {
       "project_id": "leopardcat-tarot",
       "canonical_repository": "alston-personal/leopardcat-tarot",
-      "status": "handoff_created",
+      "status": "product_parity_retriggered_cross_repo_execution_pending",
       "product_issue": "alston-personal/leopardcat-tarot#44",
-      "product_evidence": ["alston-personal/leopardcat-tarot#41"],
+      "core_dependencies": [165],
+      "product_evidence": [
+        "alston-personal/leopardcat-tarot#41",
+        "leopardcat-tarot@27610149eafe27872e71e0b4f2fdebded2d164fb",
+        "workflow-run/33352392531",
+        "workflow-job/99368137799"
+      ],
       "core_branches": [
         {
           "ref": "ops/leopardcat-runtime-inspect",
@@ -87,29 +93,31 @@
         ".github/workflows/ops-leopardcat-runtime-inspect.yml",
         ".github/workflows/leopardcat-production-deploy.yml"
       ],
-      "classification": "Tarot-specific production verification and write/deploy carriers are explicitly inventoried in historical agentmanager branches; product repo owns parity direction but still needs a product-owned deploy replacement before Core retirement",
-      "retire_when": ["product-owned parity gate succeeds and is accepted", "product-owned deployment path or thin caller of a generic governed Core deployment surface replaces the write carrier", "exact deployed source SHA/artifact and public/runtime parity evidence are persisted", "historical agentmanager Tarot carriers are no longer the only working deployment path"],
-      "safe_now": "product_work_continues_in_product_repo; carrier_retirement_waits_on_product_issue_44"
+      "classification": "Tarot product repo owns a read-only production parity gate, but both its original and post-#130 retriggered Oracle-labelled parity runs have remained queued without a runner claim at observation time; this proves cross-repo execution reachability is still unresolved but does not yet prove the exact runner registration cause",
+      "retire_when": ["product-owned parity gate succeeds and is accepted", "product-owned deployment request/path or thin caller of Core #165 replaces the write carrier", "exact deployed source SHA/artifact and public/runtime parity evidence are persisted", "historical agentmanager Tarot carriers are no longer the only working deployment path"],
+      "safe_now": "product work continues; only Oracle parity/deploy carrier-retirement step waits on product issue 44 and Core 165"
     },
     {
       "project_id": "character-blueprint",
       "canonical_repository": null,
+      "migration_issue": "alston-personal/agentmanager#164",
       "rejected_repository_candidates": [
         {
           "repository": "alston-personal/charactergenerator",
           "reason": "content provenance mismatch: Character Blueprint is image-to-3D proxy with character-blueprint-ir/v0.4 and Three.js OrbitControls, while charactergenerator is a distinct image-to-AI-description/full-body-image product and contains neither marker"
         }
       ],
-      "status": "identity_unresolved",
+      "status": "identity_unresolved_migration_worker_created",
       "core_prs": [53],
-      "classification": "Character Blueprint product work exists in agentmanager, but the only repository-name candidate was inspected and rejected by source/product provenance; canonical repository still requires explicit assignment or creation",
-      "retire_when": ["explicitly assign/create canonical project repository", "migrate v0.4 browser/deployer behavior with parity evidence", "verify public surface"],
-      "safe_now": "preserve_pr_53_and_do_not_merge_to_core_or_charactergenerator"
+      "classification": "Character Blueprint product work exists in agentmanager; charactergenerator is explicitly rejected as an automatic identity match; #164 now owns explicit canonical repository creation/assignment and v0.4 migration",
+      "retire_when": ["#164 explicitly assigns/creates the canonical project repository", "migrate v0.4 browser/deployer behavior with parity evidence", "verify public surface"],
+      "safe_now": "preserve_pr_53_and_do_not_merge_to_core_or_charactergenerator; migration waits only on its own repository identity step"
     },
     {
       "project_id": "model2ir",
       "canonical_repository": null,
-      "status": "carrier_identified_repository_unassigned",
+      "migration_issue": "alston-personal/agentmanager#163",
+      "status": "carrier_identified_repository_creation_worker_created",
       "latest_core_carrier": {
         "ref": "feat/model2ir-meshy-weak-structure-v091",
         "tip": "1314bb01e718e1a930e24441b3544dd8da020065",
@@ -129,8 +137,8 @@
         "feat/model2ir-reversible-glb-v09",
         "feat/model2ir-meshy-weak-structure-v091"
       ],
-      "classification": "a standalone model2ir v0.9.1 library is already implemented under libs/model2ir on historical agentmanager branches; this is concrete migration provenance, not future Core work",
-      "retire_when": ["assign/create canonical standalone repository outside agentmanager", "migrate package, tests, fixtures and relevant history from the v0.9.1 carrier", "reproduce package/CLI behavior and regression evidence in the new repository", "declare the new repository main/release as canonical Model2IR authority"],
+      "classification": "a standalone model2ir v0.9.1 library is already implemented under libs/model2ir on historical agentmanager branches; #163 owns repository creation/assignment and migration, not new Core feature implementation",
+      "retire_when": ["#163 assigns/creates canonical standalone repository outside agentmanager", "migrate package, tests, fixtures and relevant history from the v0.9.1 carrier", "reproduce package/CLI behavior and regression evidence in the new repository", "declare the new repository main/release as canonical Model2IR authority"],
       "safe_now": "freeze_agentmanager_model2ir_carrier_for_migration; do_not_continue_library_implementation_in_core"
     }
   ],
@@ -147,6 +155,7 @@
     "development": "feature/fix branch, optionally through develop/integration",
     "poc_staging": "exact candidate SHA/artifact allowed",
     "production": "exact accepted main SHA/tag/release artifact",
-    "carrier_retirement": "never remove until canonical product-owned replacement and runtime parity evidence exist"
+    "carrier_retirement": "never remove until canonical product-owned replacement and runtime parity evidence exist",
+    "cross_repository_execution": "product owns source/request; Core may own only a generic governed privileged execution boundary and sanitized receipt"
   }
 }


### PR DESCRIPTION
Canonical Core coordination slice for #165 / #118.

Fresh evidence shows `agentmanager#130` runner recovery is repository-local proof only: Leopard Cat Tarot's product-owned read-only parity workflow, using the same `[self-hosted, Linux, ARM64, oracle]` labels, remained unclaimed in original run `33312465860` and again after a zero-semantic-change retrigger at product commit `27610149eafe27872e71e0b4f2fdebded2d164fb` (run `33352392531`, job `99368137799`).

This PR deliberately does **not** assert the exact cause is runner registration scope. #165 must diagnose repository/organization scope, labels, runner groups, concurrency/availability, or another boundary before selecting transport.

Changes:
- register Core #165 in `governance/core-workers.json` as a shared cross-repository execution worker;
- scope only Vendor/Tarot Oracle carrier-retirement steps to #165;
- add an explicit non-authority to accepted #130: agentmanager runner success is not cross-repo reachability proof;
- update `governance/product-migrations.json` with #163/#164 migration owners and #165 Vendor/Tarot execution dependencies;
- add `docs/CROSS_REPO_EXECUTION_BOUNDARY.md` defining product source/request ownership vs Core privileged execution/receipt authority, request/receipt semantics, secret boundary, and acceptance gates.

Architecture invariant: product repos own source/request/parity criteria; Core may own only generic governed privileged execution and sanitized receipts. No generic shell/argv, no Core-wide secret copy, no product implementation moved back into agentmanager.

No carrier deletion, product promotion, deployment-generation advance, workflow dispatch, or protected-main mutation. Targets `core/integration` only.