### PR TITLE
Core #152: ONE Canonical IR continuity across Gemini/Codex extensions

### DIFF
--- a/.agentos/evidence/issue-152-antigravity-codex-e3-workspace-authority-failures-2026-09-01.md
+++ b/.agentos/evidence/issue-152-antigravity-codex-e3-workspace-authority-failures-2026-09-01.md
@@ -1,0 +1,56 @@
+# Issue #152 — Antigravity Codex E3 workspace-authority failure evidence
+
+Date: 2026-09-01
+
+Status: E3 NOT VERIFIED. These are sanitized live behavioral failures from completely fresh built-in Antigravity Codex conversations given only `繼續` after the E3 Canonical IR child had already been published.
+
+Expected canonical generation:
+
+- project: `agentos-core`
+- index: `idx-core-152-e3-1`
+- IR: `ir-core-152-e3-1`
+- expected provenance: `source=ONE_PREINVOCATION_IR`
+
+## Attempt 1 — nested if-tv-station workspace
+
+Observed first response continued local `if-tv-station` work instead of the E3 Canonical IR. It reported changes around centralized jobs/memory/render/SFX/YouTube paths, worker `.env` cleanup, `VIDEO_GENERATION_MODE`, build/lint, and local data-layer notes.
+
+Diagnosis at that point: the PreInvocation hook required a workspace path whose basename was exactly `agentmanager`; Antigravity supplied a descendant path under `agentmanager/workspace/if-tv-station`, so the hook returned without hydration.
+
+A descendant-aware gate was implemented, but this was later shown to be insufficient.
+
+## Attempt 2 — unrelated ACAS workspace
+
+Observed first response continued local ACAS work instead of the E3 Canonical IR. It reported:
+
+- new `/home/ubuntu/acas/pytest.ini`;
+- pytest import-path repair;
+- 15/15 pytest pass;
+- 20-turn benchmark pass;
+- update to `/home/ubuntu/agent-data/projects/acas/STATUS.md`;
+- `agentmanager` working changes left untouched.
+
+No `ONE_PREINVOCATION_IR`, `ONE_ACTIVE_CONTINUATION`, `agentos-core`, `idx-core-152-e3-1`, or `ir-core-152-e3-1` provenance was reported.
+
+Diagnosis: even after descendant support, the hook still used `workspacePaths` as a boolean gate. Because `/home/ubuntu/acas` is outside the `agentmanager` tree, the hook again returned without hydration. The model then reconstructed continuation from local workspace state.
+
+## Architecture conclusion
+
+The failure is not a malformed E3 IR and not a failed E2→E3 handoff. The published E3 child had already passed parent fencing and child-generation verification.
+
+The invalid assumption is broader:
+
+> IDE workspace membership must not decide whether a fresh executor receives Canonical IR.
+
+Supporting more workspace shapes only moves the boundary. A fresh executor can be opened in any workspace while the user's active AgentOS task remains elsewhere.
+
+Correction:
+
+- introduce `agentos.active-continuation/v1` as a ONE/runtime pointer containing only `project_id + index_id + ir_id`;
+- keep the referenced `agentos.ir/v1` as the sole durable working-state representation;
+- PreInvocation reads the ONE selector first and revalidates the referenced canonical generation;
+- `workspacePaths` have zero continuation-selection authority;
+- stale/missing selector or generation mismatch fails closed;
+- installer regression probe deliberately uses `/home/ubuntu/acas` and must still hydrate the selected Core IR.
+
+This evidence does not mark E3 PASS. A new fresh built-in Codex regression is required after the active-selector runtime is installed/reloaded.

--- a/.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md
+++ b/.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md
@@ -1,0 +1,50 @@
+# Issue #152 — Antigravity Gemini E2 live verification
+
+Date: 2026-09-01
+Branch: `core/issue-152-executor-awareness`
+Scope: Oracle-hosted Antigravity built-in Gemini fresh-session continuity through AgentOS ONE Canonical IR.
+
+## Verified topology
+
+- Realm: `realm-alston`
+- Node: `oracle-core-node`
+- Surface: `antigravity`
+- Executor class: `antigravity-gemini`
+- Projection: trusted Oracle-local read-only
+- Credential exposed to model/config: `false`
+
+## Canonical continuation
+
+Two completely fresh Antigravity built-in Gemini conversations were opened after reload. No vendor conversation history, copied IR, project name, ONE hint, or #152 hint was supplied. The only user instruction was `繼續`.
+
+Both sessions independently reported the same pre-invocation provenance and canonical identity:
+
+- `source=ONE_PREINVOCATION_IR`
+- `project=agentos-core`
+- `index_id=idx-core-152`
+- `ir_id=ir-core-152`
+- active goal: complete #152 Antigravity IR hydration
+
+The second fresh session also reported successful current-conversation ONE adapter checks (`one_status`, `one_resolve`) against `realm-alston` / `oracle-core-node` and the trusted-local-readonly Antigravity Gemini projection.
+
+## Regression execution reported by live executor
+
+The second fresh session reported `26 / 26 passed` from the selected AgentOS regression set under `/home/ubuntu/agentmanager`, including:
+
+- `test_control_plane.py`
+- `test_crash_resilient_runtime.py`
+- `test_ecosystem_manifests.py`
+- `test_memory_router.py`
+- `test_node_runtime.py`
+- `test_platform_runtime.py`
+- `test_session_close.py`
+
+This test result is recorded as live executor evidence supplied through the Antigravity session; it is separate from GitHub-hosted CI status.
+
+## Verdict
+
+`E2_ANTIGRAVITY_GEMINI_FRESH_IR_CONTINUITY=VERIFIED`
+
+This verifies one concrete continuity slice: a fresh Oracle Antigravity built-in Gemini executor can receive and continue from an authoritative `agentos.ir/v1` head through the PreInvocation hook, without reconstructing state from workspace enumeration, Pulse, PM2, local memory, or copied vendor history.
+
+It does **not** by itself prove general zero-cost switching across arbitrary models/executors/machines. The next experiment is E3: Gemini -> ONE -> fresh Antigravity Codex continuity.

--- a/.agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md
+++ b/.agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md
@@ -1,0 +1,94 @@
+# Issue #152 — Gemini → ONE → OpenAI Codex extension E3 verification
+
+Date: 2026-09-02
+
+Verdict: `E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY=VERIFIED`
+
+## Scope
+
+This verifies one concrete cross-extension continuity slice:
+
+`Antigravity Gemini extension -> AgentOS ONE -> fresh OpenAI Codex IDE extension thread`
+
+The durable authority remained the ONE-selected Canonical IR. Codex bootstrap/configuration contained discovery/runtime instructions only and did not contain a copied Canonical IR body.
+
+Corrected E3 generation:
+
+- project: `agentos-core`
+- index: `idx-core-152-e3-codex-ext-1`
+- IR: `ir-core-152-e3-codex-ext-1`
+- parent IR: `ir-core-152-e3-1`
+- selection source: `ONE_ACTIVE_CONTINUATION`
+- Codex surface: `codex-local`
+- executor class: `openai-codex-local`
+- credential exposed: `false`
+
+## Independent fresh-thread pass 1
+
+A completely fresh OpenAI Codex IDE extension thread received only `繼續` and resolved the active ONE continuation through `agentos-one.one_resolve_active` before workspace-local reconstruction.
+
+Sanitized issue evidence: #152 comment `5503435564`.
+
+Independent terminal receipt after pass 1:
+
+- `verdict=CODEX_ONE_ACTIVE_RESOLVE_OBSERVED`
+- `source=ONE_ACTIVE_CONTINUATION`
+- `project_id=agentos-core`
+- `index_id=idx-core-152-e3-codex-ext-1`
+- `ir_id=ir-core-152-e3-codex-ext-1`
+- `surface=codex-local`
+- `executor_class=openai-codex-local`
+- `credential_exposed=false`
+- `recorded_at=2026-09-02T02:28:29Z`
+
+## Independent fresh-thread pass 2
+
+A second completely fresh OpenAI Codex IDE extension thread again received only `繼續` and independently resolved the same ONE-selected Canonical IR generation.
+
+Sanitized issue evidence: #152 comment `5503469931`.
+
+Independent terminal receipt after pass 2:
+
+- `verdict=CODEX_ONE_ACTIVE_RESOLVE_OBSERVED`
+- `source=ONE_ACTIVE_CONTINUATION`
+- `project_id=agentos-core`
+- `index_id=idx-core-152-e3-codex-ext-1`
+- `ir_id=ir-core-152-e3-codex-ext-1`
+- `surface=codex-local`
+- `executor_class=openai-codex-local`
+- `credential_exposed=false`
+- `recorded_at=2026-09-02T02:32:25Z`
+
+The later receipt timestamp proves this was not merely a reread of the first Codex resolve receipt. The user explicitly opened a second fresh Codex extension thread for this regression.
+
+## Contract / boundary evidence
+
+The second live report also recorded:
+
+- ONE connectivity and executor identity boundary: PASS;
+- E3 contract suite: 28/28 PASS;
+- `credential_exposed=false`;
+- Codex `AGENTS.md` and MCP config contained bootstrap/discovery wiring only, not a duplicated Canonical IR body.
+
+The local executor could not write this evidence file because `.agentos/evidence` on the Oracle working tree was owned by `agentos-node:agentos`. Permissions were deliberately not changed. The evidence was therefore persisted through the governed GitHub worker branch instead.
+
+## Architectural conclusion
+
+The earlier expectation that Codex should trigger Gemini's `~/.gemini/config/hooks.json` PreInvocation lifecycle was incorrect. Gemini and OpenAI Codex are separate extensions with separate native bootstrap surfaces.
+
+Verified flow:
+
+```text
+Antigravity Gemini extension
+        ↓ Gemini PreInvocation
+ONE active selector → Canonical IR
+        ↑ one_resolve_active
+OpenAI Codex IDE extension
+        ↑ Codex AGENTS.md + MCP bootstrap
+```
+
+Workspace location is not continuation authority. Client-specific bootstrap files do not own or duplicate the Canonical IR.
+
+## Acceptance boundary
+
+This verifies/stabilizes the E3 cross-extension continuity slice for the tested Oracle Gemini/Codex surfaces. It does **not** prove arbitrary model/executor/extension/machine portability, and it does **not** close #152. Broader Node/executor lifecycle extraction, capability truthfulness/freshness, bridge reconciliation, and later real client acceptance remain open.

--- a/.agentos/evidence/issue-152-e2-to-e3-advance-2026-09-01.md
+++ b/.agentos/evidence/issue-152-e2-to-e3-advance-2026-09-01.md
@@ -1,0 +1,84 @@
+# AgentOS Core #152 — E2 → E3 Guarded Canonical IR Advancement
+
+Date: 2026-09-01
+Source branch: `core/issue-152-executor-awareness`
+Runtime source commit used by Oracle: `9de0b6377c7b2f8e1dec85e59435bc8ccad1bd08`
+
+## Verdict
+
+`E2_TO_E3_GUARDED_CANONICAL_IR_ADVANCEMENT=PASS`
+
+This evidence records the live Oracle advancement from the verified E2 Gemini continuation generation to the E3 child generation for the next cross-executor continuity experiment.
+
+## Pre-mutation verification
+
+- `agentos_e3_contract_tests=PASS`
+- 21 tests passed (`Ran 21 tests in 0.052s, OK`)
+- `agentos_e3_antigravity_runtime_install=PASS`
+- `preinvocation_hook_probe.ok=true`
+- `preinvocation_hook_probe.source=ONE_PREINVOCATION_IR`
+- `preinvocation_hook_probe.project_id=agentos-core`
+- `preinvocation_hook_probe.index_id=idx-core-152`
+- `preinvocation_hook_probe.ir_id=ir-core-152`
+- `credential_exposed=false`
+
+## Guarded handoff
+
+Parent generation:
+
+- `index_id=idx-core-152`
+- `ir_id=ir-core-152`
+
+Child generation:
+
+- `index_id=idx-core-152-e3-1`
+- `ir_id=ir-core-152-e3-1`
+- `parent_ir_id=ir-core-152`
+
+Handoff receipt:
+
+- schema: `agentos.canonical-ir-handoff/v1`
+- `ok=true`
+- `advanced=true`
+- `evidence_appended=2`
+- publish schema: `agentos.project-continuation-publish/v1`
+- `guarded_advance=true`
+- `mutation_allowed=true`
+- `credential_exposed=false`
+- published at `2026-09-01T02:00:10Z`
+
+Published canonical paths:
+
+- `/home/ubuntu/agent-data/projects/agentos-core/continuity/latest.json`
+  - sha256: `sha256:60075776f517bcdac98d428c3299d0b43be3379d6d4dac4d78aac2d0c2f1687d`
+- `/home/ubuntu/agent-data/projects/agentos-core/execution-head.json`
+  - sha256: `sha256:055f86a10e2892a4c6d7c0dd5cab2ff19f1aa926ca0e1e0ce518de29392d30fb`
+
+## Child probe
+
+Schema: `agentos.issue-152-e3-child-probe/v1`
+
+- `ok=true`
+- `source=ONE_CANONICAL_IR`
+- `project_id=agentos-core`
+- `index_id=idx-core-152-e3-1`
+- `ir_id=ir-core-152-e3-1`
+- `parent_ir_id=ir-core-152`
+- `credential_exposed=false`
+
+Canonical E3 goal:
+
+> Prove E3 continuity: Gemini -> AgentOS ONE -> a completely fresh Antigravity Codex executor continues from the authoritative Canonical IR without copied vendor history.
+
+Canonical next action:
+
+> Reload Antigravity only if required by runtime changes, then open a completely fresh built-in Antigravity Codex conversation and send only `繼續`; verify it reports `source=ONE_PREINVOCATION_IR`, `project=agentos-core`, `index_id=idx-core-152-e3-1`, `ir_id=ir-core-152-e3-1`, and continues the E3 goal.
+
+Final live markers:
+
+- `agentos_issue_152_e2_to_e3=PASS`
+- `antigravity_reload_required=YES`
+
+## Acceptance boundary
+
+This proves guarded canonical advancement and runtime readiness for E3. It does **not** yet prove cross-executor continuity. E3 remains pending until a completely fresh built-in Antigravity Codex conversation receives only `繼續` and recovers the child generation without copied vendor history.

--- a/.agentos/evidence/issue-152-e3-regression-1-fail-2026-09-01.md
+++ b/.agentos/evidence/issue-152-e3-regression-1-fail-2026-09-01.md
@@ -1,0 +1,49 @@
+# Issue #152 — E3 regression #1 failure evidence
+
+Date: 2026-09-01
+
+## Test
+
+A completely fresh built-in Antigravity Codex conversation was opened after the guarded E2 -> E3 Canonical IR advancement. The only user message was `繼續`.
+
+Expected Canonical IR provenance:
+
+- `source=ONE_PREINVOCATION_IR`
+- `project=agentos-core`
+- `index_id=idx-core-152-e3-1`
+- `ir_id=ir-core-152-e3-1`
+- executor identity bound as Antigravity Codex when the hook model name proves it
+
+## Observed first response
+
+The Codex executor instead continued local `if-tv-station` work, reporting architecture/path cleanup, environment fallback fixes, build/lint results, and files under:
+
+`/home/ubuntu/agentmanager/workspace/if-tv-station/...`
+
+It did not report ONE Canonical IR provenance or the E3 `agentos-core` goal.
+
+## Verdict
+
+`E3_REGRESSION_1=FAIL`
+
+This response is not evidence of ONE continuity. It is local workspace continuation.
+
+## Root cause
+
+The Antigravity PreInvocation hook used an exact basename gate:
+
+`Path(workspace).name == "agentmanager"`
+
+When Antigravity supplied the nested active workspace:
+
+`/home/ubuntu/agentmanager/workspace/if-tv-station`
+
+the basename was `if-tv-station`, so the hook returned silently before resolving/injecting Canonical IR.
+
+The bug was in the workspace gate, not the E3 IR child generation. The E3 head remained `idx-core-152-e3-1 / ir-core-152-e3-1`.
+
+## Correction
+
+The gate now accepts the canonical `/home/ubuntu/agentmanager` root or any real path descendant, while still resolving exactly `agentos-core`. Descendant names remain context only and never select continuation state. Prefix lookalikes such as `/home/ubuntu/agentmanager-old` remain rejected.
+
+Regression coverage was added for both nested descendants and prefix lookalikes.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,21 @@
+# AgentOS ONE bootstrap for Antigravity
+
+If this workspace is opened by the actual Gemini agent/session inside Google Antigravity, treat ONE participation as a startup responsibility, not optional project lore.
+
+Before continuing AgentOS work, read and follow:
+
+`.agents/skills/agentos-one-onboarding/SKILL.md`
+
+Identity fence:
+- Antigravity built-in Gemini is the target executor.
+- `agy` is a separate executor/provider and does not prove this Gemini session is connected.
+- standalone `gemini`, Claude, and Codex are separate executor identities unless explicitly bridged and verified.
+
+Startup expectation:
+1. determine whether the local ONE provider/MCP adapter is already available;
+2. if available, use it to resolve canonical project/goal/authority state before re-researching;
+3. if unavailable, execute the onboarding skill to establish the governed adapter without exposing Realm/node credentials;
+4. never treat vendor conversation history as canonical state;
+5. after connection, persist only governed/sanitized receipt or handoff evidence.
+
+A fresh conversation must be able to rediscover ONE from this workspace bootstrap. Do not claim ONE awareness until that regression passes.

--- a/.agents/skills/agentos-one-onboarding/SKILL.md
+++ b/.agents/skills/agentos-one-onboarding/SKILL.md
@@ -1,0 +1,162 @@
+# AgentOS ONE Onboarding for the real Antigravity Gemini
+
+Use this skill only when the current executor is the Gemini agent/session inside the Antigravity IDE/2.0 surface for this workspace.
+
+## Identity invariant
+
+- `antigravity` = IDE/agent surface.
+- Antigravity's built-in Gemini session = the executor this task is targeting.
+- `agy` is a separate executor/provider even if it uses a Gemini-family model. **Do not use `agy` as proof that the Antigravity Gemini is connected to ONE.**
+- `gemini` CLI is also a separate surface unless evidence proves the active IDE session is backed by that exact provider/session.
+
+## Goal
+
+Make the actual fresh Antigravity Gemini session a governed ONE-aware executor without copying vendor chat history and without giving the model Realm/node credentials.
+
+The result must let a fresh Antigravity Gemini session:
+
+1. discover that this workspace participates in AgentOS/ONE;
+2. resolve the current project/active goal/continuation from canonical ONE state;
+3. receive relevant ONE Experience hydration/provenance when available;
+4. know the explicit authority/mutation boundary;
+5. invoke at least one benign ONE query through a mediated adapter;
+6. return a governed receipt or handoff that can be consumed by AgentOS;
+7. repeat the same behavior from a new Antigravity Gemini conversation without relying on the previous vendor session.
+
+## Existing Core contracts — reuse, do not replace
+
+Current AgentOS already has:
+
+- Realm `/v1/bootstrap` for node/realm/capability context;
+- Realm `/v1/resolve` for project identity, active goal, continuation, node context, and mutation boundary;
+- `agentos.session-bridge/v0.1` for provider/session `discover`, `snapshot`, `harvest`, `attach`, `inject`, `handoff`;
+- node task/receipt transport;
+- Experience hydration from #117;
+- the #152 invariant that the Node is the durable Realm participant and executor hosts do not own Realm transport credentials.
+
+Do not create a competing generic protocol unless current contracts are demonstrably insufficient.
+
+## Preferred Antigravity integration point
+
+Antigravity officially supports custom MCP servers and workspace-local configuration under `.agents/mcp_config.json`. Prefer this as the first provider-side integration mechanism because it reaches the actual Antigravity Agent/Gemini session rather than a sibling CLI process.
+
+The preferred shape is:
+
+```text
+Antigravity Gemini
+        |
+        | logical ONE tools/resources only
+        v
+workspace ONE MCP/provider adapter
+        |
+        | trusted Node-side mediation
+        v
+AgentOS ONE / canonical state
+```
+
+The Gemini model/session must never receive a raw Realm bearer credential in prompt text, MCP resource content, config committed to Git, or model-visible environment output.
+
+## Work order
+
+### 1. Prove the actual local identity/surface
+
+From inside the current Antigravity Gemini session, record sanitized evidence of:
+
+- active workspace root;
+- that this is the Antigravity IDE/2.0 Agent surface;
+- available MCP configuration path(s);
+- current workspace `.agents` discovery behavior;
+- current repo branch and commit.
+
+Do not dump auth/token/session files. Do not copy private Antigravity session state into the repository.
+
+### 2. Inspect existing AgentOS primitives
+
+Read, at minimum:
+
+- `AGENTS.md`
+- `docs/CURRENT_STATE.md`
+- `agent_core/realm_server.py`
+- `agent_core/resolve_facade.py`
+- `agentos_node/session_bridge.py`
+- `agentos_node/agent_surfaces.py`
+- Issue #152 context if GitHub access is available.
+
+Confirm what is already implemented before adding code.
+
+### 3. Build the narrow provider adapter
+
+Prefer a small workspace/local MCP server or equivalent Antigravity-supported provider adapter that exposes only bounded logical operations such as:
+
+- `one_status`
+- `one_resolve(project)`
+- `one_experience(project_or_goal)` when Experience integration is available
+- `one_capabilities`
+- `one_handoff(...)` / `one_receipt(...)` through a governed Node-side path
+
+Names are not canonical yet; preserve existing Core schemas internally.
+
+The adapter may execute on the trusted Node/ubuntu side and may use local canonical data or existing authenticated Core calls. The model-facing MCP contract must contain no Realm/node bearer credential.
+
+### 4. Add workspace MCP configuration
+
+When the adapter is ready, add a **secret-free** `.agents/mcp_config.json` entry pointing to the local adapter. Prefer a local stdio/server command or localhost endpoint whose authentication remains outside model-visible configuration.
+
+Do not commit personal OAuth tokens, bearer tokens, API keys, or absolute credential paths.
+
+### 5. Live E2 acceptance with the actual Antigravity Gemini
+
+Start a fresh Antigravity Gemini conversation and verify it can answer from the ONE bridge, not from vendor history:
+
+- What Realm/Node/surface am I participating through?
+- What project is this workspace associated with?
+- What is the current active goal / next action?
+- Is mutation currently allowed? Why?
+- What ONE capabilities can I call?
+
+Then perform one benign mediated ONE query and emit one governed receipt/handoff.
+
+Evidence must identify `surface=antigravity` and the actual IDE Gemini executor/session class. Evidence from `agy`, standalone `gemini`, Claude, or Codex does not satisfy this acceptance.
+
+### 6. Fresh-session regression
+
+Open a second fresh Antigravity Gemini conversation with no copied conversation history. It must rediscover ONE through workspace bootstrap/MCP and recover the same canonical project/goal/authority state within the expected freshness window.
+
+### 7. Generalize only after first success
+
+After the first machine passes E2, extract the minimum portable onboarding bundle for other machines:
+
+```text
+repo checkout
+  -> workspace bootstrap/rule/skill
+  -> secret-free MCP config
+  -> Node enrollment / trusted adapter credential setup outside model context
+  -> Antigravity refresh/reopen
+  -> ONE discovery probe
+  -> fresh-session acceptance
+```
+
+Then validate the same pattern with Antigravity Codex as a distinct executor/session. Do not assume Gemini and Codex share session identity merely because they share the Antigravity surface.
+
+## Safety / authority fences
+
+- Work on `core/issue-152-executor-awareness` unless canonical Core explicitly assigns another worker branch.
+- Do not merge or directly push protected `main`.
+- Do not chmod private vendor credential/session directories to broaden access.
+- Do not copy Antigravity/Gemini/Codex credentials or vendor session files into AgentOS shared storage.
+- Do not make the executor host a Realm Node just to get credentials.
+- Do not use `agy` as a substitute for the Antigravity Gemini acceptance target.
+- Persist only sanitized implementation/evidence artifacts.
+
+## Completion report
+
+Report back to #152 with:
+
+- exact adapter/MCP files added;
+- local Antigravity surface identity evidence;
+- fresh Gemini E2 transcript/evidence summary (sanitized);
+- whether a second fresh Gemini session rediscovered ONE;
+- credentials/authority boundary used;
+- what is machine-specific vs portable;
+- proposed minimal onboarding recipe for a second machine;
+- blockers for repeating the proof with Antigravity Codex.

--- a/.agents/skills/agentos-one-onboarding/SKILL.md
+++ b/.agents/skills/agentos-one-onboarding/SKILL.md
@@ -1,86 +1,109 @@
-# AgentOS ONE Onboarding for the real Antigravity Gemini
+# AgentOS ONE Onboarding for Antigravity executors
 
-Use this skill only for the Gemini agent/session actually running inside the Antigravity IDE for this workspace.
+Use this skill for the actual executor/session running inside the Antigravity IDE surface. Built-in Gemini and built-in Codex are distinct executor identities even when they share the same IDE and ONE adapter.
 
 ## Identity fence
 
 - `antigravity` is the IDE surface.
-- Antigravity built-in Gemini is the target executor.
-- `agy`, standalone `gemini`, Claude and Codex are separate executor/session identities. Never use them as proof that this Gemini is connected to ONE.
+- Built-in Antigravity Gemini and built-in Antigravity Codex are distinct target executors.
+- `agy`, standalone `gemini`, Claude, Codex CLI, and other provider processes are separate identities. Never use one as proof for another.
+- The PreInvocation hook may bind executor identity only from its current `modelName`.
+- The generic MCP process has no trustworthy caller-model identity and therefore remains executor-identity unbound.
 
-## Goal
+## Continuation authority
 
-A fresh Antigravity Gemini conversation must rediscover AgentOS ONE from workspace bootstrap, query canonical Realm/project/goal/authority state, and do so without receiving the raw Realm/node bearer token in model-visible MCP results or config.
+Fresh-session continuation selection is owned by ONE, not by the IDE workspace.
+
+The runtime selector is `agentos.active-continuation/v1` and contains only:
+
+- `project_id`
+- `index_id`
+- `ir_id`
+
+It is a pointer, not a second state store. The authoritative working state is still the referenced `agentos.ir/v1` Canonical IR and matching `agentos.execution-head/v1` generation.
+
+On the first model invocation, the global Antigravity `PreInvocation` hook:
+
+1. reads the ONE active selector;
+2. resolves that project through the trusted Oracle-local ONE projection;
+3. verifies selector `index_id` / `ir_id` exactly match the current canonical generation;
+4. injects a bounded `source=ONE_PREINVOCATION_IR` envelope with `selection_source=ONE_ACTIVE_CONTINUATION`;
+5. binds built-in Gemini/Codex identity only when `modelName` proves it.
+
+`workspacePaths` are not continuation authority. A conversation opened in `/home/ubuntu/acas`, `agentmanager/workspace/...`, or another workspace must still receive the ONE-selected IR. Local workspace state may be used only after newer explicit user intent changes the task or AgentOS deliberately activates another canonical continuation.
 
 ## Existing implementation on this branch
 
 Reuse these files; do not build another protocol:
 
-- `.agents/AGENTS.md` — Antigravity startup/bootstrap instruction.
-- `agentos_node/one_mcp.py` — credential-isolated read-only ONE MCP adapter.
-- `scripts/install_antigravity_one_mcp.py` — installs MCP SDK in AgentOS client state, probes ONE, and registers the `agentos-one` stdio server in Antigravity's MCP config.
+- `agent_core/active_continuation.py` — active Canonical IR pointer and validation.
+- `agent_core/project_continuation_index.py` — canonical generation publisher/fence.
+- `agent_core/canonical_ir_handoff.py` — guarded child-generation handoff.
+- `agentos_node/antigravity_one_hook.py` — PreInvocation hydration and executor identity binding.
+- `agentos_node/one_mcp.py` / `one_mcp_stdio.py` — credential-isolated read-only ONE MCP adapter.
+- `scripts/bootstrap_antigravity_one_oracle.sh` — immutable Oracle bootstrap, selector seed/validation, installer and hook probe.
 - existing ONE `/v1/health`, `/v1/bootstrap`, `/v1/resolve` contracts.
 
-The adapter discovers the existing AgentOS client config. On Windows it supports `%LOCALAPPDATA%\AgentOS\state\client.json` in addition to `AGENTOS_CLIENT_HOME` / `AGENTOS_CLIENT_CONFIG` and legacy `~/.agentos/client.json`.
+For enrolled Windows/external clients, the client adapter discovers `%LOCALAPPDATA%\AgentOS\state\client.json` in addition to `AGENTOS_CLIENT_HOME`, `AGENTOS_CLIENT_CONFIG`, and legacy `~/.agentos/client.json`. Never print or copy its credentials into model-visible context.
 
-## First-run procedure
+## Oracle first-run / repair procedure
 
-From the repository root on `core/issue-152-executor-awareness`:
+Run the immutable bootstrap without switching the working checkout branch:
 
 ```bash
-python scripts/install_antigravity_one_mcp.py --repo .
+git -C /home/ubuntu/agentmanager fetch --no-tags origin core/issue-152-executor-awareness
+git -C /home/ubuntu/agentmanager show FETCH_HEAD:scripts/bootstrap_antigravity_one_oracle.sh | bash
 ```
 
-Do not print or copy `client.json` contents. The installer may read it locally; the token must stay inside the MCP process boundary.
+Bootstrap behavior:
 
-A successful installer result must show:
+- seeds the first `agentos-core` IR only if both canonical head files are absent;
+- seeds the active selector only if no selector exists;
+- refuses partial canonical heads;
+- refuses an existing stale/invalid selector rather than silently moving it;
+- installs the immutable Hook/MCP runtime;
+- probes the hook using `/home/ubuntu/acas` as the deliberate workspace regression case;
+- requires credential isolation.
 
-- `ok: true`
-- `server: agentos-one`
-- `credential_in_mcp_config: false`
-- `probe.probe: PASS`
-- `refresh_required: true`
+After a successful install, reload the Antigravity window.
 
-If the ONE probe fails, stop and diagnose the existing AgentOS client/ONE route. Do not silently rewrite `one_url`, credentials, vendor session files, firewall, or protected branches.
+## MCP query surface
 
-## Antigravity activation
-
-After installation, refresh MCP servers in Antigravity (Agent panel `...` -> MCP Servers / Manage MCP Servers -> refresh), or reload the Antigravity window.
-
-The registered `agentos-one` MCP server exposes only these read-only tools in this first slice:
+The registered `agentos-one` MCP server exposes read-only tools:
 
 - `one_status`
 - `one_bootstrap`
 - `one_capabilities`
 - `one_resolve(project)`
 
-Do not claim receipt/handoff write support yet; that belongs to the next governed #152 slice.
+MCP is an explicit live-query surface. It is not the fresh-session state selector and must not be used to fabricate Gemini/Codex caller identity.
 
-## E2 live acceptance
+## Fresh-session acceptance
 
-In a fresh Antigravity Gemini conversation with no copied vendor history:
+In a brand-new built-in Antigravity executor conversation with no copied vendor history, send only `繼續`.
 
-1. call `one_status` and confirm `connected=true`, `surface=antigravity`, correct Realm/Node, and `credential_exposed=false`;
-2. call `one_capabilities`;
-3. resolve the current AgentOS project with `one_resolve(...)` using the canonical project name/alias available from the workspace/ONE state;
-4. report the returned `active_goal`, `next_action`, and `mutation_allowed` exactly from ONE, not from memory;
-5. identify yourself as the Antigravity Gemini executor, not `agy`.
+A successful first response must be consistent with the injected Canonical IR and should expose provenance sufficient to verify:
 
-The first test proves read-only ONE awareness. It does not yet prove Experience uplift, receipt/handoff writes, or cross-executor continuity.
+- `source=ONE_PREINVOCATION_IR`
+- `selection_source=ONE_ACTIVE_CONTINUATION`
+- selected `project_id`
+- selected `index_id`
+- selected `ir_id`
+- executor class bound from PreInvocation when `modelName` proves it
 
-## Fresh-session regression
+The executor must not choose ACAS, if-tv-station, Zeus Writer, Pulse/PM2, or any other local state merely because that workspace is active.
 
-Open a second brand-new Antigravity Gemini conversation. Without copying the first chat, it must rediscover `.agents/AGENTS.md`, the `agentos-one` MCP server, and the same canonical Realm/project/goal/authority state.
+For explicit validation, `one_status` / `one_resolve` may then confirm Realm/Node connectivity and current project state, but connectivity evidence is separate from executor identity evidence.
 
 ## Safety / authority
 
-- Work only on `core/issue-152-executor-awareness` unless canonical Core changes ownership.
-- Do not merge or push protected `main`.
+- Work only on the declared #152 worker/integration lane unless canonical Core changes ownership.
+- Do not merge or push protected `main`/`master`/`release/*` without explicit human authorization.
 - Do not expose or commit bearer tokens, OAuth credentials, vendor session files, or auth/config contents.
 - Do not broaden permissions on Antigravity/Gemini/Codex private directories.
-- Do not substitute `agy` for the IDE Gemini acceptance target.
+- Do not reconstruct continuation from local workspace state when the active selector/IR is unavailable; fail closed instead.
 - Persist only sanitized evidence.
 
 ## Completion report
 
-Report to #152: installer result (sanitized), MCP config location, `one_status` result, project resolve result, fresh-session result, and any blocker. Then Core can extract the portable onboarding recipe for another machine and repeat with Antigravity Codex as a distinct executor.
+Report sanitized bootstrap/hook evidence, selector generation, fresh-session first response, executor identity provenance, and any blocker to #152. Cross-executor E3 is verified only after independent fresh executor sessions reproduce the same ONE-selected generation without copied vendor history.

--- a/.agents/skills/agentos-one-onboarding/SKILL.md
+++ b/.agents/skills/agentos-one-onboarding/SKILL.md
@@ -38,7 +38,9 @@ Do not create a competing generic protocol unless current contracts are demonstr
 
 ## Preferred Antigravity integration point
 
-Antigravity officially supports custom MCP servers and workspace-local configuration under `.agents/mcp_config.json`. Prefer this as the first provider-side integration mechanism because it reaches the actual Antigravity Agent/Gemini session rather than a sibling CLI process.
+Antigravity officially supports MCP servers. For Antigravity 2.0 / IDE / CLI, the user-level MCP client configuration is `~/.gemini/antigravity/mcp_config.json`.
+
+Prefer MCP as the first provider-side integration mechanism because it reaches the actual Antigravity Agent/Gemini session rather than a sibling CLI process.
 
 The preferred shape is:
 
@@ -47,14 +49,14 @@ Antigravity Gemini
         |
         | logical ONE tools/resources only
         v
-workspace ONE MCP/provider adapter
+ONE MCP/provider adapter
         |
         | trusted Node-side mediation
         v
 AgentOS ONE / canonical state
 ```
 
-The Gemini model/session must never receive a raw Realm bearer credential in prompt text, MCP resource content, config committed to Git, or model-visible environment output.
+The Gemini model/session must never receive a raw Realm bearer credential in prompt text, MCP resource content, committed config, or model-visible environment output.
 
 ## Work order
 
@@ -74,6 +76,7 @@ Do not dump auth/token/session files. Do not copy private Antigravity session st
 
 Read, at minimum:
 
+- `.agents/AGENTS.md`
 - `AGENTS.md`
 - `docs/CURRENT_STATE.md`
 - `agent_core/realm_server.py`
@@ -86,7 +89,7 @@ Confirm what is already implemented before adding code.
 
 ### 3. Build the narrow provider adapter
 
-Prefer a small workspace/local MCP server or equivalent Antigravity-supported provider adapter that exposes only bounded logical operations such as:
+Prefer a small local MCP server or equivalent Antigravity-supported provider adapter that exposes only bounded logical operations such as:
 
 - `one_status`
 - `one_resolve(project)`
@@ -98,11 +101,11 @@ Names are not canonical yet; preserve existing Core schemas internally.
 
 The adapter may execute on the trusted Node/ubuntu side and may use local canonical data or existing authenticated Core calls. The model-facing MCP contract must contain no Realm/node bearer credential.
 
-### 4. Add workspace MCP configuration
+### 4. Configure Antigravity MCP
 
-When the adapter is ready, add a **secret-free** `.agents/mcp_config.json` entry pointing to the local adapter. Prefer a local stdio/server command or localhost endpoint whose authentication remains outside model-visible configuration.
+When the adapter is ready, add a **secret-free** MCP server entry to `~/.gemini/antigravity/mcp_config.json` pointing to the local adapter. Prefer a local stdio/server command or localhost endpoint whose sensitive authentication remains outside model-visible content.
 
-Do not commit personal OAuth tokens, bearer tokens, API keys, or absolute credential paths.
+Do not commit personal OAuth tokens, bearer tokens, API keys, or private credential material to the repository.
 
 ### 5. Live E2 acceptance with the actual Antigravity Gemini
 
@@ -128,9 +131,10 @@ After the first machine passes E2, extract the minimum portable onboarding bundl
 
 ```text
 repo checkout
-  -> workspace bootstrap/rule/skill
-  -> secret-free MCP config
-  -> Node enrollment / trusted adapter credential setup outside model context
+  -> `.agents/AGENTS.md` + onboarding skill
+  -> trusted local ONE adapter install
+  -> secret-free Antigravity MCP registration
+  -> Node enrollment / adapter credential setup outside model context
   -> Antigravity refresh/reopen
   -> ONE discovery probe
   -> fresh-session acceptance

--- a/.agents/skills/agentos-one-onboarding/SKILL.md
+++ b/.agents/skills/agentos-one-onboarding/SKILL.md
@@ -1,166 +1,86 @@
 # AgentOS ONE Onboarding for the real Antigravity Gemini
 
-Use this skill only when the current executor is the Gemini agent/session inside the Antigravity IDE/2.0 surface for this workspace.
+Use this skill only for the Gemini agent/session actually running inside the Antigravity IDE for this workspace.
 
-## Identity invariant
+## Identity fence
 
-- `antigravity` = IDE/agent surface.
-- Antigravity's built-in Gemini session = the executor this task is targeting.
-- `agy` is a separate executor/provider even if it uses a Gemini-family model. **Do not use `agy` as proof that the Antigravity Gemini is connected to ONE.**
-- `gemini` CLI is also a separate surface unless evidence proves the active IDE session is backed by that exact provider/session.
+- `antigravity` is the IDE surface.
+- Antigravity built-in Gemini is the target executor.
+- `agy`, standalone `gemini`, Claude and Codex are separate executor/session identities. Never use them as proof that this Gemini is connected to ONE.
 
 ## Goal
 
-Make the actual fresh Antigravity Gemini session a governed ONE-aware executor without copying vendor chat history and without giving the model Realm/node credentials.
+A fresh Antigravity Gemini conversation must rediscover AgentOS ONE from workspace bootstrap, query canonical Realm/project/goal/authority state, and do so without receiving the raw Realm/node bearer token in model-visible MCP results or config.
 
-The result must let a fresh Antigravity Gemini session:
+## Existing implementation on this branch
 
-1. discover that this workspace participates in AgentOS/ONE;
-2. resolve the current project/active goal/continuation from canonical ONE state;
-3. receive relevant ONE Experience hydration/provenance when available;
-4. know the explicit authority/mutation boundary;
-5. invoke at least one benign ONE query through a mediated adapter;
-6. return a governed receipt or handoff that can be consumed by AgentOS;
-7. repeat the same behavior from a new Antigravity Gemini conversation without relying on the previous vendor session.
+Reuse these files; do not build another protocol:
 
-## Existing Core contracts — reuse, do not replace
+- `.agents/AGENTS.md` — Antigravity startup/bootstrap instruction.
+- `agentos_node/one_mcp.py` — credential-isolated read-only ONE MCP adapter.
+- `scripts/install_antigravity_one_mcp.py` — installs MCP SDK in AgentOS client state, probes ONE, and registers the `agentos-one` stdio server in Antigravity's MCP config.
+- existing ONE `/v1/health`, `/v1/bootstrap`, `/v1/resolve` contracts.
 
-Current AgentOS already has:
+The adapter discovers the existing AgentOS client config. On Windows it supports `%LOCALAPPDATA%\AgentOS\state\client.json` in addition to `AGENTOS_CLIENT_HOME` / `AGENTOS_CLIENT_CONFIG` and legacy `~/.agentos/client.json`.
 
-- Realm `/v1/bootstrap` for node/realm/capability context;
-- Realm `/v1/resolve` for project identity, active goal, continuation, node context, and mutation boundary;
-- `agentos.session-bridge/v0.1` for provider/session `discover`, `snapshot`, `harvest`, `attach`, `inject`, `handoff`;
-- node task/receipt transport;
-- Experience hydration from #117;
-- the #152 invariant that the Node is the durable Realm participant and executor hosts do not own Realm transport credentials.
+## First-run procedure
 
-Do not create a competing generic protocol unless current contracts are demonstrably insufficient.
+From the repository root on `core/issue-152-executor-awareness`:
 
-## Preferred Antigravity integration point
-
-Antigravity officially supports MCP servers. For Antigravity 2.0 / IDE / CLI, the user-level MCP client configuration is `~/.gemini/antigravity/mcp_config.json`.
-
-Prefer MCP as the first provider-side integration mechanism because it reaches the actual Antigravity Agent/Gemini session rather than a sibling CLI process.
-
-The preferred shape is:
-
-```text
-Antigravity Gemini
-        |
-        | logical ONE tools/resources only
-        v
-ONE MCP/provider adapter
-        |
-        | trusted Node-side mediation
-        v
-AgentOS ONE / canonical state
+```bash
+python scripts/install_antigravity_one_mcp.py --repo .
 ```
 
-The Gemini model/session must never receive a raw Realm bearer credential in prompt text, MCP resource content, committed config, or model-visible environment output.
+Do not print or copy `client.json` contents. The installer may read it locally; the token must stay inside the MCP process boundary.
 
-## Work order
+A successful installer result must show:
 
-### 1. Prove the actual local identity/surface
+- `ok: true`
+- `server: agentos-one`
+- `credential_in_mcp_config: false`
+- `probe.probe: PASS`
+- `refresh_required: true`
 
-From inside the current Antigravity Gemini session, record sanitized evidence of:
+If the ONE probe fails, stop and diagnose the existing AgentOS client/ONE route. Do not silently rewrite `one_url`, credentials, vendor session files, firewall, or protected branches.
 
-- active workspace root;
-- that this is the Antigravity IDE/2.0 Agent surface;
-- available MCP configuration path(s);
-- current workspace `.agents` discovery behavior;
-- current repo branch and commit.
+## Antigravity activation
 
-Do not dump auth/token/session files. Do not copy private Antigravity session state into the repository.
+After installation, refresh MCP servers in Antigravity (Agent panel `...` -> MCP Servers / Manage MCP Servers -> refresh), or reload the Antigravity window.
 
-### 2. Inspect existing AgentOS primitives
-
-Read, at minimum:
-
-- `.agents/AGENTS.md`
-- `AGENTS.md`
-- `docs/CURRENT_STATE.md`
-- `agent_core/realm_server.py`
-- `agent_core/resolve_facade.py`
-- `agentos_node/session_bridge.py`
-- `agentos_node/agent_surfaces.py`
-- Issue #152 context if GitHub access is available.
-
-Confirm what is already implemented before adding code.
-
-### 3. Build the narrow provider adapter
-
-Prefer a small local MCP server or equivalent Antigravity-supported provider adapter that exposes only bounded logical operations such as:
+The registered `agentos-one` MCP server exposes only these read-only tools in this first slice:
 
 - `one_status`
-- `one_resolve(project)`
-- `one_experience(project_or_goal)` when Experience integration is available
+- `one_bootstrap`
 - `one_capabilities`
-- `one_handoff(...)` / `one_receipt(...)` through a governed Node-side path
+- `one_resolve(project)`
 
-Names are not canonical yet; preserve existing Core schemas internally.
+Do not claim receipt/handoff write support yet; that belongs to the next governed #152 slice.
 
-The adapter may execute on the trusted Node/ubuntu side and may use local canonical data or existing authenticated Core calls. The model-facing MCP contract must contain no Realm/node bearer credential.
+## E2 live acceptance
 
-### 4. Configure Antigravity MCP
+In a fresh Antigravity Gemini conversation with no copied vendor history:
 
-When the adapter is ready, add a **secret-free** MCP server entry to `~/.gemini/antigravity/mcp_config.json` pointing to the local adapter. Prefer a local stdio/server command or localhost endpoint whose sensitive authentication remains outside model-visible content.
+1. call `one_status` and confirm `connected=true`, `surface=antigravity`, correct Realm/Node, and `credential_exposed=false`;
+2. call `one_capabilities`;
+3. resolve the current AgentOS project with `one_resolve(...)` using the canonical project name/alias available from the workspace/ONE state;
+4. report the returned `active_goal`, `next_action`, and `mutation_allowed` exactly from ONE, not from memory;
+5. identify yourself as the Antigravity Gemini executor, not `agy`.
 
-Do not commit personal OAuth tokens, bearer tokens, API keys, or private credential material to the repository.
+The first test proves read-only ONE awareness. It does not yet prove Experience uplift, receipt/handoff writes, or cross-executor continuity.
 
-### 5. Live E2 acceptance with the actual Antigravity Gemini
+## Fresh-session regression
 
-Start a fresh Antigravity Gemini conversation and verify it can answer from the ONE bridge, not from vendor history:
+Open a second brand-new Antigravity Gemini conversation. Without copying the first chat, it must rediscover `.agents/AGENTS.md`, the `agentos-one` MCP server, and the same canonical Realm/project/goal/authority state.
 
-- What Realm/Node/surface am I participating through?
-- What project is this workspace associated with?
-- What is the current active goal / next action?
-- Is mutation currently allowed? Why?
-- What ONE capabilities can I call?
+## Safety / authority
 
-Then perform one benign mediated ONE query and emit one governed receipt/handoff.
-
-Evidence must identify `surface=antigravity` and the actual IDE Gemini executor/session class. Evidence from `agy`, standalone `gemini`, Claude, or Codex does not satisfy this acceptance.
-
-### 6. Fresh-session regression
-
-Open a second fresh Antigravity Gemini conversation with no copied conversation history. It must rediscover ONE through workspace bootstrap/MCP and recover the same canonical project/goal/authority state within the expected freshness window.
-
-### 7. Generalize only after first success
-
-After the first machine passes E2, extract the minimum portable onboarding bundle for other machines:
-
-```text
-repo checkout
-  -> `.agents/AGENTS.md` + onboarding skill
-  -> trusted local ONE adapter install
-  -> secret-free Antigravity MCP registration
-  -> Node enrollment / adapter credential setup outside model context
-  -> Antigravity refresh/reopen
-  -> ONE discovery probe
-  -> fresh-session acceptance
-```
-
-Then validate the same pattern with Antigravity Codex as a distinct executor/session. Do not assume Gemini and Codex share session identity merely because they share the Antigravity surface.
-
-## Safety / authority fences
-
-- Work on `core/issue-152-executor-awareness` unless canonical Core explicitly assigns another worker branch.
-- Do not merge or directly push protected `main`.
-- Do not chmod private vendor credential/session directories to broaden access.
-- Do not copy Antigravity/Gemini/Codex credentials or vendor session files into AgentOS shared storage.
-- Do not make the executor host a Realm Node just to get credentials.
-- Do not use `agy` as a substitute for the Antigravity Gemini acceptance target.
-- Persist only sanitized implementation/evidence artifacts.
+- Work only on `core/issue-152-executor-awareness` unless canonical Core changes ownership.
+- Do not merge or push protected `main`.
+- Do not expose or commit bearer tokens, OAuth credentials, vendor session files, or auth/config contents.
+- Do not broaden permissions on Antigravity/Gemini/Codex private directories.
+- Do not substitute `agy` for the IDE Gemini acceptance target.
+- Persist only sanitized evidence.
 
 ## Completion report
 
-Report back to #152 with:
-
-- exact adapter/MCP files added;
-- local Antigravity surface identity evidence;
-- fresh Gemini E2 transcript/evidence summary (sanitized);
-- whether a second fresh Gemini session rediscovered ONE;
-- credentials/authority boundary used;
-- what is machine-specific vs portable;
-- proposed minimal onboarding recipe for a second machine;
-- blockers for repeating the proof with Antigravity Codex.
+Report to #152: installer result (sanitized), MCP config location, `one_status` result, project resolve result, fresh-session result, and any blocker. Then Core can extract the portable onboarding recipe for another machine and repeat with Antigravity Codex as a distinct executor.

--- a/.github/workflows/issue-152-continuity-guard.yml
+++ b/.github/workflows/issue-152-continuity-guard.yml
@@ -1,0 +1,61 @@
+name: Issue 152 Continuity Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agent_core/active_continuation.py'
+      - 'agent_core/canonical_ir_handoff.py'
+      - 'agent_core/project_continuation_index.py'
+      - 'agentos_node/antigravity_one_hook.py'
+      - 'agentos_node/codex_one_mcp_stdio.py'
+      - 'agentos_node/one_mcp.py'
+      - 'agentos_node/one_mcp_stdio.py'
+      - 'scripts/seed_active_continuation.py'
+      - 'scripts/seed_agentos_core_ir_head.py'
+      - 'scripts/install_antigravity_one_mcp.py'
+      - 'scripts/install_antigravity_one_mcp_oracle.py'
+      - 'scripts/install_codex_one_oracle.py'
+      - 'tests/test_active_continuation.py'
+      - 'tests/test_antigravity_one_hook.py'
+      - 'tests/test_antigravity_preinvocation_attestation.py'
+      - 'tests/test_canonical_ir_handoff.py'
+      - 'tests/test_codex_one_mcp_stdio.py'
+      - 'tests/test_install_codex_one_oracle.py'
+      - 'tests/test_one_mcp.py'
+      - 'tests/test_one_mcp_stdio_identity.py'
+      - 'tests/test_project_continuation_index.py'
+      - 'tests/test_seed_agentos_core_ir_head.py'
+      - '.github/workflows/issue-152-continuity-guard.yml'
+  push:
+    branches:
+      - core/issue-152-executor-awareness
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run #152 hosted continuity regressions
+        run: |
+          python -m unittest \
+            tests.test_active_continuation \
+            tests.test_antigravity_one_hook \
+            tests.test_antigravity_preinvocation_attestation \
+            tests.test_canonical_ir_handoff \
+            tests.test_codex_one_mcp_stdio \
+            tests.test_install_codex_one_oracle \
+            tests.test_one_mcp \
+            tests.test_one_mcp_stdio_identity \
+            tests.test_project_continuation_index \
+            tests.test_seed_agentos_core_ir_head \
+            -v

--- a/.github/workflows/one-mcp-safety-guard.yml
+++ b/.github/workflows/one-mcp-safety-guard.yml
@@ -1,0 +1,41 @@
+name: ONE MCP Safety Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agentos_node/one_mcp.py'
+      - 'agentos_node/one_mcp_stdio.py'
+      - 'agentos_node/antigravity_one_hook.py'
+      - 'tests/test_one_mcp.py'
+      - 'tests/test_one_mcp_stdio_identity.py'
+      - 'tests/test_antigravity_one_hook.py'
+      - '.github/workflows/one-mcp-safety-guard.yml'
+  push:
+    branches:
+      - core/issue-152-executor-awareness
+    paths:
+      - 'agentos_node/one_mcp.py'
+      - 'agentos_node/one_mcp_stdio.py'
+      - 'agentos_node/antigravity_one_hook.py'
+      - 'tests/test_one_mcp.py'
+      - 'tests/test_one_mcp_stdio_identity.py'
+      - 'tests/test_antigravity_one_hook.py'
+      - '.github/workflows/one-mcp-safety-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  one-mcp-safety:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run ONE MCP safety regressions
+        run: python -m unittest tests.test_one_mcp -v

--- a/.github/workflows/one-mcp-safety-guard.yml
+++ b/.github/workflows/one-mcp-safety-guard.yml
@@ -37,5 +37,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Run ONE MCP safety regressions
-        run: python -m unittest tests.test_one_mcp -v
+      - name: Run ONE MCP and PreInvocation safety regressions
+        run: |
+          python -m unittest tests.test_one_mcp -v
+          python -m unittest tests.test_antigravity_one_hook -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,33 +13,53 @@ Before architecture or system-level changes:
 
 Do not rely on older memory/pulse-era documents as current architecture if they disagree with `docs/CURRENT_STATE.md` and executable evidence.
 
-## Antigravity ONE self-bootstrap
+## Antigravity Gemini ONE self-bootstrap
 
-When the **actual executor/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
+When the **Gemini executor/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
 
 `.agents/skills/agentos-one-onboarding/SKILL.md`
 
-For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`.
+For Oracle-hosted Antigravity Gemini, fresh-session continuity is provided primarily by the global Gemini-side `PreInvocation` hook installed in `~/.gemini/config/hooks.json`.
 
 Fresh continuation selection is owned by ONE, not by the IDE workspace. `agent_core/active_continuation.py` maintains a Realm/runtime-level `agentos.active-continuation/v1` pointer containing only `project_id + index_id + ir_id`. That pointer is **not a second state store**: the authoritative working state remains the referenced Canonical IR generation.
 
-Before the first model call, the hook reads that active selector, resolves the selected canonical project, verifies that the selector's `index_id`/`ir_id` still match the current `agentos.execution-head/v1` + `agentos.ir/v1` generation, then injects a bounded `source=ONE_PREINVOCATION_IR` envelope. If the selector is stale or invalid, the hook fails closed.
+Before the first Gemini model call, the hook reads that active selector, resolves the selected canonical project, verifies that the selector's `index_id`/`ir_id` still match the current `agentos.execution-head/v1` + `agentos.ir/v1` generation, then injects a bounded `source=ONE_PREINVOCATION_IR` envelope. If the selector is stale or invalid, the hook fails closed.
 
 `workspacePaths` are environment metadata only. A fresh conversation opened in `/home/ubuntu/acas`, under `agentmanager/workspace/...`, or in another IDE workspace MUST NOT use that path to choose durable continuation. Workspace enumeration, Pulse/PM2 state, local memory, or vendor conversation history must never replace the ONE-selected Canonical IR.
 
 The existing canonical publisher in `agent_core/project_continuation_index.py` is initially restricted to `agentos-core`; it atomically publishes `execution-head.json` and `continuity/latest.json` with one shared `index_id`. The selector may point only to an actually current canonical generation. Until project publishing is deliberately generalized, do not fabricate cross-project IR by scanning workspaces.
 
-The `agentos-one` MCP server remains the explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The PreInvocation hook and MCP adapter both use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
-
-Executor identity and connectivity are separate claims. The PreInvocation hook may bind built-in Gemini/Codex identity only from its current `modelName`. The generic MCP process has no trustworthy caller-model context and therefore reports an unbound Antigravity executor identity rather than pretending the caller is Gemini or Codex.
+The Gemini-side `agentos-one` MCP server remains an explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The PreInvocation hook and MCP adapter use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
 
 If the active selector, Canonical IR head, or generation fence is unavailable/malformed/stale, fail closed with `ONE_IR_HEAD_UNRESOLVED`; do not reconstruct current state from local evidence.
 
-If Oracle bootstrap is not installed, use the immutable bootstrap path documented by the onboarding skill. For enrolled external clients, use the client installer described there instead; do not make a desktop executor own Realm credentials.
+## OpenAI Codex IDE extension ONE bootstrap
 
-Important identity fence: built-in Antigravity Gemini, built-in Antigravity Codex, `agy`, standalone `gemini`, Claude, and Codex CLI are distinct executor/provider identities. One is not acceptable evidence for another.
+The OpenAI Codex IDE extension is a **separate extension/client** from the Gemini/Antigravity extension. Do not expect Codex to trigger `~/.gemini/config/hooks.json`, and do not use a retained Gemini PreInvocation attestation as evidence that a Codex thread was hydrated.
 
-A fresh Antigravity executor must be able to recover the ONE-selected canonical IR/goal/authority state without copied vendor conversation history before cross-executor integration is considered complete.
+Codex uses its own native bootstrap surfaces:
+
+- global Codex instructions in `~/.codex/AGENTS.md`;
+- Codex MCP configuration in `~/.codex/config.toml`;
+- AgentOS adapter `agentos_node/codex_one_mcp_stdio.py`.
+
+For a fresh Codex thread given a relative continuation instruction such as `continue` or `繼續`, Codex must call `agentos-one.one_resolve_active` before reconstructing work from workspace-local state. The tool resolves the ONE active selector and returns the referenced Canonical IR generation. Codex configuration contains bootstrap/discovery rules only; it MUST NOT contain a copied Canonical IR body.
+
+The Codex-side MCP projection is a trusted Oracle-local read-only surface. It may identify the Codex local harness from the Codex MCP configuration boundary, but the MCP process itself does not prove a specific vendor thread/model session. Realm/node credentials remain outside model-visible output.
+
+The current #152 E3 acceptance target is therefore **cross-extension continuity**:
+
+`Antigravity Gemini → AgentOS ONE Canonical IR → fresh OpenAI Codex IDE extension`
+
+The OpenAI Codex extension must recover the same ONE-selected project/generation from `one_resolve_active` without copied Gemini/Codex history and without using the current IDE workspace as continuation authority.
+
+## Shared executor identity boundary
+
+Connectivity, surface identity, executor identity, and model identity are separate claims. A Gemini PreInvocation `modelName` can bind a Gemini caller for that hook invocation; it cannot identify the separate OpenAI Codex extension. Likewise, a Codex MCP process proves the Codex local harness boundary but not an Antigravity Gemini model invocation.
+
+`agy`, standalone `gemini`, Antigravity Gemini, OpenAI Codex IDE extension, Codex CLI, Claude, and other providers are distinct executor/client identities. One is not acceptable evidence for another.
+
+If Oracle bootstrap is not installed, use the immutable bootstrap path documented by the relevant installer. For enrolled external clients, use the client installer rather than making a desktop executor own Realm credentials.
 
 ## Current architectural role
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,25 +15,31 @@ Do not rely on older memory/pulse-era documents as current architecture if they 
 
 ## Antigravity ONE self-bootstrap
 
-When the **actual Gemini agent/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
+When the **actual executor/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
 
 `.agents/skills/agentos-one-onboarding/SKILL.md`
 
-For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`. For the current Core acceptance slice, the hook uses workspace metadata only as a gate that the canonical `agentmanager` checkout is present; workspace order and sibling repositories MUST NOT choose continuation state.
+For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`.
 
-Before the first model call, the hook resolves the single authoritative `agentos-core` continuation and injects a bounded `source=ONE_PREINVOCATION_IR` envelope containing the `agentos.ir/v1` Canonical IR. The hook accepts the IR only when its `index_id` matches the canonical `agentos.execution-head/v1` generation. The durable continuation fields are the IR goal, constraints, decisions, pending tasks, continuation/next action, capability, and authority projection. It does not read or copy the vendor transcript.
+Fresh continuation selection is owned by ONE, not by the IDE workspace. `agent_core/active_continuation.py` maintains a Realm/runtime-level `agentos.active-continuation/v1` pointer containing only `project_id + index_id + ir_id`. That pointer is **not a second state store**: the authoritative working state remains the referenced Canonical IR generation.
 
-The existing canonical publisher in `agent_core/project_continuation_index.py` is initially restricted to `agentos-core`; it atomically publishes `execution-head.json` and `continuity/latest.json` with one shared `index_id`. Until that contract is deliberately generalized, do not fabricate cross-project continuation by scanning multi-root workspaces.
+Before the first model call, the hook reads that active selector, resolves the selected canonical project, verifies that the selector's `index_id`/`ir_id` still match the current `agentos.execution-head/v1` + `agentos.ir/v1` generation, then injects a bounded `source=ONE_PREINVOCATION_IR` envelope. If the selector is stale or invalid, the hook fails closed.
+
+`workspacePaths` are environment metadata only. A fresh conversation opened in `/home/ubuntu/acas`, under `agentmanager/workspace/...`, or in another IDE workspace MUST NOT use that path to choose durable continuation. Workspace enumeration, Pulse/PM2 state, local memory, or vendor conversation history must never replace the ONE-selected Canonical IR.
+
+The existing canonical publisher in `agent_core/project_continuation_index.py` is initially restricted to `agentos-core`; it atomically publishes `execution-head.json` and `continuity/latest.json` with one shared `index_id`. The selector may point only to an actually current canonical generation. Until project publishing is deliberately generalized, do not fabricate cross-project IR by scanning workspaces.
 
 The `agentos-one` MCP server remains the explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The PreInvocation hook and MCP adapter both use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
 
-If the Canonical IR head is unavailable, malformed, or generation-mismatched, fail closed with `ONE_IR_HEAD_UNRESOLVED`; do not reconstruct current state from Pulse data, PM2 services, `agent-data` memory files, workspace enumeration, or old vendor conversation history.
+Executor identity and connectivity are separate claims. The PreInvocation hook may bind built-in Gemini/Codex identity only from its current `modelName`. The generic MCP process has no trustworthy caller-model context and therefore reports an unbound Antigravity executor identity rather than pretending the caller is Gemini or Codex.
+
+If the active selector, Canonical IR head, or generation fence is unavailable/malformed/stale, fail closed with `ONE_IR_HEAD_UNRESOLVED`; do not reconstruct current state from local evidence.
 
 If Oracle bootstrap is not installed, use the immutable bootstrap path documented by the onboarding skill. For enrolled external clients, use the client installer described there instead; do not make a desktop executor own Realm credentials.
 
-Important identity fence: `agy` and standalone `gemini` may use Gemini-family models but are separate executor/provider identities. They are not acceptable substitutes for proving that the active Antigravity Gemini session is ONE-aware.
+Important identity fence: built-in Antigravity Gemini, built-in Antigravity Codex, `agy`, standalone `gemini`, Claude, and Codex CLI are distinct executor/provider identities. One is not acceptable evidence for another.
 
-A fresh Antigravity Gemini conversation must be able to recover the canonical IR/goal/authority state without copied vendor conversation history before the integration is considered complete.
+A fresh Antigravity executor must be able to recover the ONE-selected canonical IR/goal/authority state without copied vendor conversation history before cross-executor integration is considered complete.
 
 ## Current architectural role
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,19 +19,17 @@ When the **actual Gemini agent/session inside the Antigravity IDE/2.0 surface** 
 
 `.agents/skills/agentos-one-onboarding/SKILL.md`
 
-If the `agentos-one` MCP server is not already available, follow that skill and run from this repository root:
+For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`. On the first model invocation of a fresh conversation, the hook resolves the active workspace against Oracle ONE and injects a bounded `source=ONE_PREINVOCATION_HOOK` canonical-state envelope before the model is called. It does not read or copy the vendor transcript.
 
-```bash
-python scripts/install_antigravity_one_mcp.py --repo .
-```
+The `agentos-one` MCP server remains the explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The pre-invocation hook and MCP adapter both use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
 
-After installation, refresh Antigravity MCP servers or reload the Antigravity window, then verify ONE through the `one_status`, `one_bootstrap`, `one_capabilities`, and `one_resolve` tools.
+If Oracle bootstrap is not installed, use the immutable bootstrap path documented by the onboarding skill. For enrolled external clients, use the client installer described there instead; do not make a desktop executor own Realm credentials.
 
 Important identity fence: `agy` and standalone `gemini` may use Gemini-family models but are separate executor/provider identities. They are not acceptable substitutes for proving that the active Antigravity Gemini session is ONE-aware.
 
-Keep Realm/node credentials outside model-visible prompt, MCP tool results, and committed config. The local ONE MCP adapter may use the already-enrolled AgentOS client credential internally, but the model must never receive it.
+Do not claim continuity merely because Pulse data, PM2 services, `agent-data`, or old memory files are readable. Fresh-session success requires either injected ONE pre-invocation provenance or a successful current-conversation `agentos-one` MCP query.
 
-A fresh Antigravity Gemini conversation must be able to rediscover ONE without copied vendor conversation history before the integration is considered complete.
+A fresh Antigravity Gemini conversation must be able to recover canonical project/goal/authority state without copied vendor conversation history before the integration is considered complete.
 
 ## Current architectural role
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,21 @@ Do not rely on older memory/pulse-era documents as current architecture if they 
 
 When the **actual Gemini agent/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
 
-`/.agents/skills/agentos-one-onboarding/SKILL.md`
+`.agents/skills/agentos-one-onboarding/SKILL.md`
+
+If the `agentos-one` MCP server is not already available, follow that skill and run from this repository root:
+
+```bash
+python scripts/install_antigravity_one_mcp.py --repo .
+```
+
+After installation, refresh Antigravity MCP servers or reload the Antigravity window, then verify ONE through the `one_status`, `one_bootstrap`, `one_capabilities`, and `one_resolve` tools.
 
 Important identity fence: `agy` and standalone `gemini` may use Gemini-family models but are separate executor/provider identities. They are not acceptable substitutes for proving that the active Antigravity Gemini session is ONE-aware.
 
-Prefer Antigravity's workspace MCP/provider integration for the actual IDE Gemini. Keep Realm/node credentials outside model-visible prompt, MCP resources, and committed config. A fresh Antigravity Gemini conversation must be able to rediscover ONE without copied vendor conversation history before the integration is considered complete.
+Keep Realm/node credentials outside model-visible prompt, MCP tool results, and committed config. The local ONE MCP adapter may use the already-enrolled AgentOS client credential internally, but the model must never receive it.
+
+A fresh Antigravity Gemini conversation must be able to rediscover ONE without copied vendor conversation history before the integration is considered complete.
 
 ## Current architectural role
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,17 +19,21 @@ When the **actual Gemini agent/session inside the Antigravity IDE/2.0 surface** 
 
 `.agents/skills/agentos-one-onboarding/SKILL.md`
 
-For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`. On the first model invocation of a fresh conversation, the hook resolves the active workspace against Oracle ONE and injects a bounded `source=ONE_PREINVOCATION_HOOK` canonical-state envelope before the model is called. It does not read or copy the vendor transcript.
+For Oracle-hosted Antigravity, fresh-session continuity is provided primarily by the global Antigravity `PreInvocation` hook installed in `~/.gemini/config/hooks.json`. For the current Core acceptance slice, the hook uses workspace metadata only as a gate that the canonical `agentmanager` checkout is present; workspace order and sibling repositories MUST NOT choose continuation state.
 
-The `agentos-one` MCP server remains the explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The pre-invocation hook and MCP adapter both use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
+Before the first model call, the hook resolves the single authoritative `agentos-core` continuation and injects a bounded `source=ONE_PREINVOCATION_IR` envelope containing the `agentos.ir/v1` Canonical IR. The hook accepts the IR only when its `index_id` matches the canonical `agentos.execution-head/v1` generation. The durable continuation fields are the IR goal, constraints, decisions, pending tasks, continuation/next action, capability, and authority projection. It does not read or copy the vendor transcript.
+
+The existing canonical publisher in `agent_core/project_continuation_index.py` is initially restricted to `agentos-core`; it atomically publishes `execution-head.json` and `continuity/latest.json` with one shared `index_id`. Until that contract is deliberately generalized, do not fabricate cross-project continuation by scanning multi-root workspaces.
+
+The `agentos-one` MCP server remains the explicit live-query surface (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). The PreInvocation hook and MCP adapter both use the trusted Oracle-local read-only projection and expose no Realm/node credential to the model.
+
+If the Canonical IR head is unavailable, malformed, or generation-mismatched, fail closed with `ONE_IR_HEAD_UNRESOLVED`; do not reconstruct current state from Pulse data, PM2 services, `agent-data` memory files, workspace enumeration, or old vendor conversation history.
 
 If Oracle bootstrap is not installed, use the immutable bootstrap path documented by the onboarding skill. For enrolled external clients, use the client installer described there instead; do not make a desktop executor own Realm credentials.
 
 Important identity fence: `agy` and standalone `gemini` may use Gemini-family models but are separate executor/provider identities. They are not acceptable substitutes for proving that the active Antigravity Gemini session is ONE-aware.
 
-Do not claim continuity merely because Pulse data, PM2 services, `agent-data`, or old memory files are readable. Fresh-session success requires either injected ONE pre-invocation provenance or a successful current-conversation `agentos-one` MCP query.
-
-A fresh Antigravity Gemini conversation must be able to recover canonical project/goal/authority state without copied vendor conversation history before the integration is considered complete.
+A fresh Antigravity Gemini conversation must be able to recover the canonical IR/goal/authority state without copied vendor conversation history before the integration is considered complete.
 
 ## Current architectural role
 
@@ -44,7 +48,7 @@ AgentOS currently contains, among other components:
 - platform runtime drivers;
 - operational evidence and drift guards.
 
-The model-independent **Cognitive IR / zero-cost arbitrary model switching** layer is still research unless and until a repeatable benchmark proves it.
+The model-independent **Cognitive IR / zero-cost arbitrary model switching** layer is still research unless and until a repeatable benchmark proves it. The existing `agentos.ir/v1` continuation contract is an implemented canonical continuation representation; that does not by itself prove the broader Cognitive IR research claim.
 
 ## Critical constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,16 @@ Before architecture or system-level changes:
 
 Do not rely on older memory/pulse-era documents as current architecture if they disagree with `docs/CURRENT_STATE.md` and executable evidence.
 
+## Antigravity ONE self-bootstrap
+
+When the **actual Gemini agent/session inside the Antigravity IDE/2.0 surface** is asked to connect to, continue from, discover, or validate AgentOS ONE, it MUST read and follow:
+
+`/.agents/skills/agentos-one-onboarding/SKILL.md`
+
+Important identity fence: `agy` and standalone `gemini` may use Gemini-family models but are separate executor/provider identities. They are not acceptable substitutes for proving that the active Antigravity Gemini session is ONE-aware.
+
+Prefer Antigravity's workspace MCP/provider integration for the actual IDE Gemini. Keep Realm/node credentials outside model-visible prompt, MCP resources, and committed config. A fresh Antigravity Gemini conversation must be able to rediscover ONE without copied vendor conversation history before the integration is considered complete.
+
 ## Current architectural role
 
 AgentOS currently contains, among other components:

--- a/agent_core/active_continuation.py
+++ b/agent_core/active_continuation.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.resolve_facade import resolve_continuation
+
+SELECTOR_SCHEMA = "agentos.active-continuation/v1"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _data_root(value: str | Path | None = None) -> Path:
+    if value is not None:
+        return Path(value)
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def selector_path(data_root: str | Path | None = None) -> Path:
+    return _data_root(data_root) / "runtime" / "active-continuation.json"
+
+
+def _validate_pointer(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("active continuation selector must be an object")
+    if value.get("schema") != SELECTOR_SCHEMA:
+        raise ValueError("unsupported active continuation selector schema")
+    project_id = str(value.get("project_id") or "").strip()
+    index_id = str(value.get("index_id") or "").strip()
+    ir_id = str(value.get("ir_id") or "").strip()
+    if not all((project_id, index_id, ir_id)):
+        raise ValueError("active continuation selector requires project_id, index_id, and ir_id")
+    return {
+        "schema": SELECTOR_SCHEMA,
+        "project_id": project_id,
+        "index_id": index_id,
+        "ir_id": ir_id,
+        "activated_at": value.get("activated_at"),
+        "reason": value.get("reason"),
+    }
+
+
+def read_active_continuation(data_root: str | Path | None = None) -> dict[str, Any]:
+    path = selector_path(data_root)
+    if path.is_symlink():
+        raise ValueError("active continuation selector may not be a symlink")
+    if not path.is_file():
+        raise FileNotFoundError(f"active continuation selector missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _validate_pointer(payload)
+
+
+def _current_generation(project_id: str, *, data_root: str | Path | None = None) -> tuple[dict[str, Any], str, str]:
+    resolved = resolve_continuation(project_id, data_root=data_root)
+    head = resolved.get("execution_head") if isinstance(resolved.get("execution_head"), dict) else {}
+    continuation = resolved.get("continuation") if isinstance(resolved.get("continuation"), dict) else {}
+    ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    index_id = str(head.get("index_id") or "").strip()
+    ir_id = str(ir.get("ir_id") or "").strip()
+    if not index_id or not ir_id:
+        raise ValueError("selected project has no valid canonical continuation generation")
+    if str(ir.get("index_id") or "").strip() != index_id:
+        raise ValueError("selected project execution-head / IR generation mismatch")
+    return resolved, index_id, ir_id
+
+
+def resolve_active_continuation(
+    *,
+    data_root: str | Path | None = None,
+) -> dict[str, Any]:
+    selector = read_active_continuation(data_root)
+    resolved, index_id, ir_id = _current_generation(selector["project_id"], data_root=data_root)
+    if selector["index_id"] != index_id or selector["ir_id"] != ir_id:
+        raise ValueError(
+            "active continuation selector is stale: "
+            f"selector={selector['index_id']}/{selector['ir_id']} "
+            f"canonical={index_id}/{ir_id}"
+        )
+    return {"selector": selector, "resolution": resolved}
+
+
+def activate_continuation(
+    project_id: str,
+    *,
+    index_id: str,
+    ir_id: str,
+    reason: str,
+    data_root: str | Path | None = None,
+) -> dict[str, Any]:
+    project_id = str(project_id or "").strip()
+    index_id = str(index_id or "").strip()
+    ir_id = str(ir_id or "").strip()
+    reason = str(reason or "").strip()
+    if not all((project_id, index_id, ir_id, reason)):
+        raise ValueError("activate_continuation requires project_id, index_id, ir_id, and reason")
+
+    root = _data_root(data_root)
+    _, current_index, current_ir = _current_generation(project_id, data_root=root)
+    if current_index != index_id or current_ir != ir_id:
+        raise ValueError(
+            "refusing to activate a non-canonical generation: "
+            f"requested={index_id}/{ir_id} canonical={current_index}/{current_ir}"
+        )
+
+    runtime = root / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    path = selector_path(root)
+    if path.is_symlink():
+        raise ValueError("active continuation selector may not be a symlink")
+    lock_path = runtime / ".active-continuation.lock"
+    if lock_path.is_symlink():
+        raise ValueError("active continuation lock may not be a symlink")
+
+    payload = {
+        "schema": SELECTOR_SCHEMA,
+        "project_id": project_id,
+        "index_id": index_id,
+        "ir_id": ir_id,
+        "activated_at": _now(),
+        "reason": reason,
+    }
+
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o640)
+    previous: dict[str, Any] | None = None
+    tmp: Path | None = None
+    try:
+        with os.fdopen(lock_fd, "r+") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            if path.is_file():
+                previous = _validate_pointer(json.loads(path.read_text(encoding="utf-8")))
+            fd, raw = tempfile.mkstemp(prefix=".active-continuation.", suffix=".tmp", dir=str(runtime))
+            tmp = Path(raw)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                os.fchmod(handle.fileno(), 0o640)
+                json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+            tmp = None
+            dir_fd = os.open(runtime, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
+
+    return {
+        "schema": "agentos.active-continuation-activation/v1",
+        "ok": True,
+        "selector": payload,
+        "previous": previous,
+        "credential_exposed": False,
+    }

--- a/agent_core/canonical_ir_handoff.py
+++ b/agent_core/canonical_ir_handoff.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_core.project_continuation_index import INITIAL_PROJECT_ID, publish_project_continuation
+from agent_core.resolve_facade import resolve_continuation
+
+HANDOFF_SCHEMA = "agentos.canonical-ir-handoff/v1"
+IR_SCHEMA = "agentos.ir/v1"
+_SENSITIVE_KEYS = {
+    "token",
+    "node_token",
+    "access_token",
+    "refresh_token",
+    "authorization",
+    "password",
+    "secret",
+    "claim_secret",
+    "client_secret",
+}
+
+
+def _contains_sensitive(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).strip().casefold() in _SENSITIVE_KEYS:
+                return True
+            if _contains_sensitive(child):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_sensitive(child) for child in value)
+    return False
+
+
+def _clean_strings(values: Any, *, field: str) -> list[str]:
+    if values is None:
+        return []
+    if not isinstance(values, list):
+        raise ValueError(f"{field} must be a list")
+    out: list[str] = []
+    for raw in values:
+        item = str(raw or "").strip()
+        if not item:
+            continue
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def _validate_evidence(values: Any) -> list[dict[str, Any]]:
+    if values is None:
+        return []
+    if not isinstance(values, list):
+        raise ValueError("evidence must be a list")
+    if len(values) > 16:
+        raise ValueError("too many evidence entries")
+    out: list[dict[str, Any]] = []
+    for raw in values:
+        if not isinstance(raw, dict):
+            raise ValueError("each evidence entry must be an object")
+        if _contains_sensitive(raw):
+            raise ValueError("evidence contains a sensitive credential field")
+        encoded = json.dumps(raw, ensure_ascii=False, sort_keys=True)
+        if len(encoded.encode("utf-8")) > 8192:
+            raise ValueError("evidence entry is too large")
+        kind = str(raw.get("kind") or "").strip()
+        verdict = str(raw.get("verdict") or "").strip()
+        summary = str(raw.get("summary") or "").strip()
+        if not kind or not verdict or not summary:
+            raise ValueError("evidence requires kind, verdict, and summary")
+        out.append(dict(raw))
+    return out
+
+
+def advance_canonical_ir(
+    params: dict[str, Any],
+    *,
+    data_root: str | Path | None = None,
+    governance_path: str | Path | None = None,
+) -> dict[str, Any]:
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    allowed = {
+        "project_id",
+        "expected_index_id",
+        "expected_ir_id",
+        "new_index_id",
+        "new_ir_id",
+        "goal",
+        "next_action",
+        "pending_tasks",
+        "decisions_append",
+        "evidence",
+        "capability",
+        "execution_status",
+        "execution_metadata",
+    }
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValueError(f"unsupported handoff fields: {sorted(unknown)}")
+
+    project_id = str(params.get("project_id") or "").strip()
+    if project_id != INITIAL_PROJECT_ID:
+        raise ValueError("canonical IR handoff is currently restricted to agentos-core")
+    expected_index = str(params.get("expected_index_id") or "").strip()
+    expected_ir = str(params.get("expected_ir_id") or "").strip()
+    new_index = str(params.get("new_index_id") or "").strip()
+    new_ir = str(params.get("new_ir_id") or "").strip()
+    goal = str(params.get("goal") or "").strip()
+    next_action = str(params.get("next_action") or "").strip()
+    if not all((expected_index, expected_ir, new_index, new_ir, goal, next_action)):
+        raise ValueError("handoff requires expected/new generation ids, goal, and next_action")
+    if expected_index == new_index or expected_ir == new_ir:
+        raise ValueError("handoff must create a new canonical generation")
+
+    pending_tasks = _clean_strings(params.get("pending_tasks"), field="pending_tasks")
+    decisions_append = _clean_strings(params.get("decisions_append"), field="decisions_append")
+    evidence_append = _validate_evidence(params.get("evidence"))
+    execution_status = str(params.get("execution_status") or "in_progress").strip()
+    execution_metadata = params.get("execution_metadata") or {}
+    if not isinstance(execution_metadata, dict):
+        raise ValueError("execution_metadata must be an object")
+    if _contains_sensitive(execution_metadata):
+        raise ValueError("execution_metadata contains a sensitive credential field")
+
+    current = resolve_continuation(
+        project_id,
+        governance_path=governance_path,
+        data_root=data_root,
+    )
+    execution_head = current.get("execution_head") if isinstance(current.get("execution_head"), dict) else {}
+    continuation = current.get("continuation") if isinstance(current.get("continuation"), dict) else {}
+    canonical_ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    current_index = str(execution_head.get("index_id") or "").strip()
+    current_ir = str(canonical_ir.get("ir_id") or "").strip()
+    if canonical_ir.get("schema_version") != IR_SCHEMA:
+        raise ValueError("current canonical IR is unavailable or unsupported")
+    if current_index != expected_index or current_ir != expected_ir:
+        raise ValueError(
+            "stale handoff request before publish: "
+            f"expected index={expected_index!r} ir={expected_ir!r}, "
+            f"found index={current_index!r} ir={current_ir!r}"
+        )
+
+    constraints = _clean_strings(canonical_ir.get("constraints") or [], field="current.constraints")
+    decisions = _clean_strings(canonical_ir.get("decisions") or [], field="current.decisions")
+    for decision in decisions_append:
+        if decision not in decisions:
+            decisions.append(decision)
+    existing_evidence = canonical_ir.get("evidence") or []
+    if not isinstance(existing_evidence, list):
+        raise ValueError("current canonical IR evidence must be a list")
+    if _contains_sensitive(existing_evidence):
+        raise ValueError("current canonical IR evidence contains a sensitive field")
+    evidence = [dict(item) for item in existing_evidence if isinstance(item, dict)] + evidence_append
+
+    capability = str(params.get("capability") or canonical_ir.get("capability") or "agentos.one.resolve").strip()
+    publish_params = {
+        "project_id": project_id,
+        "execution_head": {
+            "schema": "agentos.execution-head/v1",
+            "index_id": new_index,
+            "active_goal": goal,
+            "execution_head": {
+                "status": execution_status,
+                **execution_metadata,
+            },
+        },
+        "continuation": {
+            "protocol": "ANCP/1.0",
+            "index_id": new_index,
+            "recommended_action": next_action,
+            "canonical_ir": {
+                "schema_version": IR_SCHEMA,
+                "index_id": new_index,
+                "ir_id": new_ir,
+                "parent_ir_id": expected_ir,
+                "goal": goal,
+                "constraints": constraints,
+                "decisions": decisions,
+                "pending_tasks": pending_tasks,
+                "evidence": evidence,
+                "continuation": {
+                    "recommended_action": next_action,
+                    "next_action": next_action,
+                },
+                "capability": capability,
+            },
+        },
+    }
+    receipt = publish_project_continuation(
+        publish_params,
+        data_root=data_root,
+        governance_path=governance_path,
+        expected_index_id=expected_index,
+        expected_ir_id=expected_ir,
+    )
+    return {
+        "schema": HANDOFF_SCHEMA,
+        "ok": True,
+        "project_id": project_id,
+        "parent": {"index_id": expected_index, "ir_id": expected_ir},
+        "child": {"index_id": new_index, "ir_id": new_ir},
+        "goal": goal,
+        "next_action": next_action,
+        "evidence_appended": len(evidence_append),
+        "credential_exposed": False,
+        "publish_receipt": receipt,
+    }

--- a/agent_core/project_continuation_index.py
+++ b/agent_core/project_continuation_index.py
@@ -148,8 +148,6 @@ def publish_project_continuation(
             raise ValueError("guarded advancement must create a new index generation")
         if new_ir_id == expected_ir:
             raise ValueError("guarded advancement must create a new ir_id")
-        if str(canonical_ir.get("parent_ir_id") or "").strip() != expected_ir:
-            raise ValueError("canonical_ir.parent_ir_id must match expected_ir_id")
 
     root = Path(data_root) if data_root is not None else Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
 
@@ -198,6 +196,12 @@ def publish_project_continuation(
                         f"expected index={expected_index!r} ir={expected_ir!r}, "
                         f"found index={current_index!r} ir={current_ir!r}"
                     )
+                # Only after the expected parent is proven current do we validate
+                # the child lineage. This preserves stale-writer semantics: a
+                # stale caller must fail on the canonical parent fence rather
+                # than on a child-shape mismatch derived from stale expectations.
+                if str(canonical_ir.get("parent_ir_id") or "").strip() != expected_ir:
+                    raise ValueError("canonical_ir.parent_ir_id must match expected_ir_id")
 
             execution_tmp = _write_temp(project_dir, execution_path.name, execution_head)
             continuation_tmp = _write_temp(continuity_dir, continuation_path.name, continuation)

--- a/agent_core/project_continuation_index.py
+++ b/agent_core/project_continuation_index.py
@@ -67,6 +67,32 @@ def _index_id_from_continuation(value: dict[str, Any]) -> str:
     return direct or nested
 
 
+def _read_json_object(path: Path) -> dict[str, Any]:
+    _assert_plain_path(path)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _current_generation(execution_path: Path, continuation_path: Path) -> tuple[str, str]:
+    execution_head = _read_json_object(execution_path)
+    continuation = _read_json_object(continuation_path)
+    if execution_head.get("schema") != EXECUTION_HEAD_SCHEMA:
+        raise ValueError("current execution head has unsupported schema")
+    canonical_ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else continuation
+    if canonical_ir.get("schema_version") != IR_SCHEMA:
+        raise ValueError("current continuation has unsupported IR schema")
+    head_index = str(execution_head.get("index_id") or "").strip()
+    continuation_index = _index_id_from_continuation(continuation)
+    if not head_index or head_index != continuation_index:
+        raise ValueError("current execution-head / continuation generation mismatch")
+    ir_id = str(canonical_ir.get("ir_id") or "").strip()
+    if not ir_id:
+        raise ValueError("current canonical IR has no ir_id")
+    return head_index, ir_id
+
+
 def validate_publish_params(params: dict[str, Any]) -> tuple[str, dict[str, Any], dict[str, Any]]:
     if not isinstance(params, dict):
         raise ValueError("params must be an object")
@@ -104,8 +130,27 @@ def publish_project_continuation(
     *,
     data_root: str | Path | None = None,
     governance_path: str | Path | None = None,
+    expected_index_id: str | None = None,
+    expected_ir_id: str | None = None,
 ) -> dict[str, Any]:
     project_id, execution_head, continuation = validate_publish_params(params)
+    if (expected_index_id is None) != (expected_ir_id is None):
+        raise ValueError("expected_index_id and expected_ir_id must be supplied together")
+    expected_index = str(expected_index_id or "").strip()
+    expected_ir = str(expected_ir_id or "").strip()
+    canonical_ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else continuation
+    new_index = str(execution_head.get("index_id") or "").strip()
+    new_ir_id = str(canonical_ir.get("ir_id") or "").strip()
+    if expected_index:
+        if not expected_ir:
+            raise ValueError("expected_ir_id is required for guarded advancement")
+        if new_index == expected_index:
+            raise ValueError("guarded advancement must create a new index generation")
+        if new_ir_id == expected_ir:
+            raise ValueError("guarded advancement must create a new ir_id")
+        if str(canonical_ir.get("parent_ir_id") or "").strip() != expected_ir:
+            raise ValueError("canonical_ir.parent_ir_id must match expected_ir_id")
+
     root = Path(data_root) if data_root is not None else Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
 
     project = resolve_project_identity(project_id, governance_path=governance_path, data_root=root)
@@ -145,6 +190,15 @@ def publish_project_continuation(
     try:
         with os.fdopen(lock_fd, "r+") as lock_handle:
             fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            if expected_index:
+                current_index, current_ir = _current_generation(execution_path, continuation_path)
+                if current_index != expected_index or current_ir != expected_ir:
+                    raise ValueError(
+                        "stale canonical IR parent: "
+                        f"expected index={expected_index!r} ir={expected_ir!r}, "
+                        f"found index={current_index!r} ir={current_ir!r}"
+                    )
+
             execution_tmp = _write_temp(project_dir, execution_path.name, execution_head)
             continuation_tmp = _write_temp(continuity_dir, continuation_path.name, continuation)
 
@@ -174,6 +228,9 @@ def publish_project_continuation(
         "schema": PUBLISH_SCHEMA,
         "project_id": project_id,
         "index_id": index_id,
+        "ir_id": new_ir_id,
+        "parent_ir_id": canonical_ir.get("parent_ir_id"),
+        "guarded_advance": bool(expected_index),
         "execution_head": {
             "path": str(execution_path),
             "sha256": _sha256(execution_head),

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -1,72 +1,20 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
-from pathlib import Path
 from typing import Any
 
+from agent_core.active_continuation import read_active_continuation
 from agentos_node.one_mcp import OracleLocalGateway
 
-HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.4"
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.5"
 SOURCE = "ONE_PREINVOCATION_IR"
-CORE_PROJECT_ID = "agentos-core"
 IR_SCHEMA = "agentos.ir/v1"
 EXECUTION_HEAD_SCHEMA = "agentos.execution-head/v1"
-DEFAULT_CORE_REPO_ROOT = "/home/ubuntu/agentmanager"
-
-
-def _workspace_paths(raw_paths: Any) -> list[str]:
-    if not isinstance(raw_paths, list):
-        return []
-    out: list[str] = []
-    seen: set[str] = set()
-    for raw in raw_paths:
-        value = str(raw or "").strip()
-        if not value:
-            continue
-        key = value.casefold()
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(value)
-    return out
-
-
-def _core_repo_root() -> Path:
-    return Path(
-        os.environ.get("AGENTOS_CORE_REPO_ROOT", DEFAULT_CORE_REPO_ROOT)
-    ).expanduser().resolve(strict=False)
-
-
-def _core_workspace_present(paths: list[str]) -> bool:
-    """Use Antigravity workspace metadata only as a Core bootstrap gate.
-
-    A fresh Antigravity conversation may be opened at the repository root or at
-    a descendant workspace such as ``agentmanager/workspace/if-tv-station``.
-    Both belong to the same canonical Core checkout boundary for the #152
-    acceptance slice.  Descendant names are never project selectors: once the
-    gate is satisfied, continuation still resolves exactly ``agentos-core``.
-
-    Paths that merely share a textual prefix with the Core checkout (for
-    example ``/home/ubuntu/agentmanager-old``) are not accepted.
-    """
-    root = _core_repo_root()
-    for value in paths:
-        candidate = Path(value).expanduser().resolve(strict=False)
-        if candidate == root or root in candidate.parents:
-            return True
-    return False
 
 
 def _executor_identity(model_name: Any) -> tuple[str, bool]:
-    """Bind only identities that the PreInvocation caller context can prove.
-
-    The generic MCP server cannot know which IDE executor invoked a tool.  The
-    Antigravity PreInvocation payload does include the current modelName, so the
-    hook is the narrow layer that may bind a Gemini/Codex executor class.  Do not
-    guess an identity from generic GPT/model-family names.
-    """
+    """Bind only identities that the PreInvocation caller context can prove."""
     normalized = str(model_name or "").strip().casefold()
     if "codex" in normalized:
         return "antigravity-codex", True
@@ -75,13 +23,15 @@ def _executor_identity(model_name: Any) -> tuple[str, bool]:
     return "antigravity-unknown", False
 
 
-def _canonical_ir_from_resolution(result: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], str]:
+def _canonical_ir_from_resolution(
+    result: dict[str, Any], *, expected_project_id: str
+) -> tuple[dict[str, Any], dict[str, Any], str]:
     if result.get("schema") != "agentos.resolve/v1":
         raise ValueError("unexpected ONE resolve schema")
 
     project = result.get("project") if isinstance(result.get("project"), dict) else {}
-    if str(project.get("id") or "") != CORE_PROJECT_ID:
-        raise ValueError("ONE did not resolve canonical agentos-core")
+    if str(project.get("id") or "") != expected_project_id:
+        raise ValueError("ONE resolved a project different from the active continuation selector")
 
     execution_head = result.get("execution_head")
     if not isinstance(execution_head, dict) or execution_head.get("schema") != EXECUTION_HEAD_SCHEMA:
@@ -144,16 +94,15 @@ def _compact_ir(
     }
 
 
-def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None = None) -> dict[str, Any]:
-    # Hydrate exactly once per fresh conversation.  The injected IR remains in
-    # the trajectory for later turns, avoiding repeated context/token overhead.
+def build_injection(
+    payload: dict[str, Any],
+    gateway: OracleLocalGateway | None = None,
+    *,
+    selector: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    # Hydrate exactly once per fresh conversation. The authoritative project is
+    # selected by ONE state, never by the IDE's current workspace path.
     if int(payload.get("invocationNum") or 0) != 0:
-        return {}
-
-    paths = _workspace_paths(payload.get("workspacePaths"))
-    if not _core_workspace_present(paths):
-        # Global hook remains silent outside the canonical Core checkout tree.
-        # Workspace descendants are only a gate; their names never choose state.
         return {}
 
     one = gateway or OracleLocalGateway()
@@ -161,17 +110,37 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
     if not status.get("connected"):
         raise RuntimeError("ONE is not connected")
 
-    # The existing canonical continuation publisher is restricted to
-    # agentos-core.  Resolve that authoritative IR directly; do not infer state
-    # from workspace order, Pulse, PM2, memory, or sibling repositories.
-    result = one.resolve(CORE_PROJECT_ID)
-    execution_head, canonical_ir, index_id = _canonical_ir_from_resolution(result)
+    active = selector or read_active_continuation(one.data_root)
+    project_id = str(active.get("project_id") or "").strip()
+    selector_index = str(active.get("index_id") or "").strip()
+    selector_ir = str(active.get("ir_id") or "").strip()
+    if not all((project_id, selector_index, selector_ir)):
+        raise ValueError("ONE active continuation selector is incomplete")
+
+    result = one.resolve(project_id)
+    execution_head, canonical_ir, index_id = _canonical_ir_from_resolution(
+        result, expected_project_id=project_id
+    )
+    canonical_ir_id = str(canonical_ir.get("ir_id") or "").strip()
+    if index_id != selector_index or canonical_ir_id != selector_ir:
+        raise ValueError(
+            "ONE active continuation selector is stale: "
+            f"selector={selector_index}/{selector_ir} "
+            f"canonical={index_id}/{canonical_ir_id}"
+        )
+
     ir = _compact_ir(result, execution_head, canonical_ir, index_id)
     executor_class, identity_bound = _executor_identity(payload.get("modelName"))
 
     envelope = {
         "schema": HOOK_SCHEMA,
         "source": SOURCE,
+        "selection_source": "ONE_ACTIVE_CONTINUATION",
+        "active_selector": {
+            "project_id": project_id,
+            "index_id": selector_index,
+            "ir_id": selector_ir,
+        },
         "status_schema": status.get("schema"),
         "connected": True,
         "realm_id": status.get("realm_id"),
@@ -185,14 +154,15 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
         "canonical_ir": ir,
     }
     message = (
-        "AgentOS ONE canonical IR hydration. This is the single authoritative "
-        "agentos-core continuation selected before the model was called. Do not "
-        "replace it with workspace enumeration, Pulse/PM2 scans, local-memory "
-        "reconstruction, or sibling project state. Newer explicit user intent "
-        "still wins. Continue from canonical_ir.goal / pending_tasks / "
-        "continuation / next_action and obey mutation_allowed. When reporting "
-        "bootstrap provenance, state source=ONE_PREINVOCATION_IR and include "
-        "index_id + ir_id + executor_class + model_name. If "
+        "AgentOS ONE canonical IR hydration. ONE_ACTIVE_CONTINUATION selected this "
+        "continuation before the model was called. The IDE workspace path is not "
+        "a continuation authority and must not replace this state. Do not replace "
+        "the Canonical IR with workspace enumeration, Pulse/PM2 scans, local-memory "
+        "reconstruction, or vendor history. Newer explicit user intent still wins. "
+        "Continue from canonical_ir.goal / pending_tasks / continuation / next_action "
+        "and obey mutation_allowed. When reporting bootstrap provenance, state "
+        "source=ONE_PREINVOCATION_IR, selection_source=ONE_ACTIVE_CONTINUATION, and "
+        "include project_id + index_id + ir_id + executor_class + model_name. If "
         "executor_identity_bound=false, do not guess the executor identity.\n"
         + json.dumps(envelope, ensure_ascii=False, sort_keys=True)
     )
@@ -206,9 +176,6 @@ def main() -> int:
             raise ValueError("hook input must be a JSON object")
         output = build_injection(payload)
     except Exception as exc:
-        # Fail closed for AgentOS continuity: Antigravity itself may continue,
-        # but the model receives an explicit prohibition against claiming ONE
-        # state from local reconstruction.
         output = {
             "injectSteps": [
                 {
@@ -216,8 +183,8 @@ def main() -> int:
                         "ONE_IR_HEAD_UNRESOLVED: AgentOS canonical IR hydration "
                         f"failed: {type(exc).__name__}: {exc}. Do not claim or "
                         "reconstruct AgentOS continuation from workspace lists, "
-                        "Pulse, PM2, or local memory. Ask for/restore the canonical "
-                        "IR head instead."
+                        "Pulse, PM2, local memory, or vendor history. Ask for/restore "
+                        "the ONE active continuation selector/canonical IR head instead."
                     )
                 }
             ]

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from agentos_node.one_mcp import OracleLocalGateway
+
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.1"
+
+
+def _workspace_candidates(raw_paths: Any) -> list[tuple[str, str]]:
+    if not isinstance(raw_paths, list):
+        return []
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for raw in raw_paths:
+        value = str(raw or "").strip()
+        if not value:
+            continue
+        path = Path(value)
+        name = path.name.strip()
+        if not name:
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((value, name))
+    return out
+
+
+def _compact_resolution(workspace: str, result: dict[str, Any]) -> dict[str, Any]:
+    project = result.get("project") if isinstance(result.get("project"), dict) else {}
+    resolution = result.get("project_resolution") if isinstance(result.get("project_resolution"), dict) else {}
+    resolved = resolution.get("resolved") if isinstance(resolution.get("resolved"), dict) else {}
+    return {
+        "workspace": workspace,
+        "project_id": project.get("id") or resolved.get("project_id"),
+        "project_name": project.get("name"),
+        "schema": result.get("schema"),
+        "active_goal": result.get("active_goal"),
+        "next_action": result.get("next_action"),
+        "mutation_allowed": bool(result.get("mutation_allowed")),
+        "canonical_repo": resolved.get("repo"),
+        "canonical_branch": resolved.get("branch"),
+        "canonical_path": resolved.get("canonical_path"),
+        "canonical_node": resolved.get("node"),
+        "availability": result.get("availability") or {},
+        "provenance": result.get("provenance") or {},
+    }
+
+
+def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None = None) -> dict[str, Any]:
+    # Hydrate only once per fresh conversation. The injected step remains in the
+    # trajectory for later turns, avoiding repeated context/token overhead.
+    if int(payload.get("invocationNum") or 0) != 0:
+        return {}
+
+    workspaces = _workspace_candidates(payload.get("workspacePaths"))
+    if not workspaces:
+        return {}
+
+    one = gateway or OracleLocalGateway()
+    status = one.status()
+    resolutions: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    for workspace, candidate in workspaces:
+        try:
+            result = one.resolve(candidate)
+        except (KeyError, ValueError):
+            # An unrelated workspace is not an AgentOS bootstrap failure.
+            continue
+        except Exception as exc:  # pragma: no cover - live diagnostics only
+            failures.append({"workspace": workspace, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        if result.get("schema") != "agentos.resolve/v1":
+            failures.append({"workspace": workspace, "error": "unexpected resolve schema"})
+            continue
+        resolutions.append(_compact_resolution(workspace, result))
+
+    # Global hook is intentionally silent outside AgentOS-governed workspaces.
+    if not resolutions and not failures:
+        return {}
+
+    envelope = {
+        "schema": HOOK_SCHEMA,
+        "source": "ONE_PREINVOCATION_HOOK",
+        "status_schema": status.get("schema"),
+        "connected": bool(status.get("connected")),
+        "realm_id": status.get("realm_id"),
+        "node_id": status.get("node_id"),
+        "surface": "antigravity",
+        "executor_class": "antigravity-gemini",
+        "model_name": payload.get("modelName"),
+        "credential_exposed": False,
+        "resolutions": resolutions,
+        "failures": failures,
+    }
+    message = (
+        "AgentOS ONE canonical pre-invocation hydration. This state was resolved "
+        "before the model was called; do not replace it with Pulse/PM2/local-memory "
+        "reconstruction. Newer explicit user intent still wins. If continuing work, "
+        "use the resolved active_goal/next_action and authority boundary below. "
+        "When reporting bootstrap provenance, state source=ONE_PREINVOCATION_HOOK.\n"
+        + json.dumps(envelope, ensure_ascii=False, sort_keys=True)
+    )
+    return {"injectSteps": [{"ephemeralMessage": message}]}
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, dict):
+            raise ValueError("hook input must be a JSON object")
+        output = build_injection(payload)
+    except Exception as exc:  # Fail open for Antigravity, but inject a bounded diagnostic.
+        output = {
+            "injectSteps": [
+                {
+                    "ephemeralMessage": (
+                        "ONE_PREHOOK_BLOCKED: AgentOS pre-invocation hydration failed: "
+                        f"{type(exc).__name__}: {exc}. Do not claim ONE-connected state "
+                        "from local Pulse/PM2/memory scans."
+                    )
+                }
+            ]
+        }
+    json.dump(output, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from agentos_node.one_mcp import OracleLocalGateway
 
-HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.2"
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.3"
 SOURCE = "ONE_PREINVOCATION_IR"
 CORE_PROJECT_ID = "agentos-core"
 IR_SCHEMA = "agentos.ir/v1"
@@ -42,6 +42,22 @@ def _core_workspace_present(paths: list[str]) -> bool:
     candidates.
     """
     return any(Path(value).name.casefold() == CORE_REPO_BASENAME for value in paths)
+
+
+def _executor_identity(model_name: Any) -> tuple[str, bool]:
+    """Bind only identities that the PreInvocation caller context can prove.
+
+    The generic MCP server cannot know which IDE executor invoked a tool.  The
+    Antigravity PreInvocation payload does include the current modelName, so the
+    hook is the narrow layer that may bind a Gemini/Codex executor class.  Do not
+    guess an identity from generic GPT/model-family names.
+    """
+    normalized = str(model_name or "").strip().casefold()
+    if "codex" in normalized:
+        return "antigravity-codex", True
+    if "gemini" in normalized:
+        return "antigravity-gemini", True
+    return "antigravity-unknown", False
 
 
 def _canonical_ir_from_resolution(result: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], str]:
@@ -136,6 +152,7 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
     result = one.resolve(CORE_PROJECT_ID)
     execution_head, canonical_ir, index_id = _canonical_ir_from_resolution(result)
     ir = _compact_ir(result, execution_head, canonical_ir, index_id)
+    executor_class, identity_bound = _executor_identity(payload.get("modelName"))
 
     envelope = {
         "schema": HOOK_SCHEMA,
@@ -145,7 +162,9 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
         "realm_id": status.get("realm_id"),
         "node_id": status.get("node_id"),
         "surface": "antigravity",
-        "executor_class": "antigravity-gemini",
+        "executor_class": executor_class,
+        "executor_identity_bound": identity_bound,
+        "executor_identity_source": "preinvocation-modelName",
         "model_name": payload.get("modelName"),
         "credential_exposed": False,
         "canonical_ir": ir,
@@ -158,7 +177,8 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
         "still wins. Continue from canonical_ir.goal / pending_tasks / "
         "continuation / next_action and obey mutation_allowed. When reporting "
         "bootstrap provenance, state source=ONE_PREINVOCATION_IR and include "
-        "index_id + ir_id.\n"
+        "index_id + ir_id + executor_class + model_name. If "
+        "executor_identity_bound=false, do not guess the executor identity.\n"
         + json.dumps(envelope, ensure_ascii=False, sort_keys=True)
     )
     return {"injectSteps": [{"ephemeralMessage": message}]}

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from agent_core.active_continuation import read_active_continuation
 from agentos_node.one_mcp import OracleLocalGateway
 
-HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.5"
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.6"
+AUDIT_SCHEMA = "agentos.antigravity-preinvocation-attestation/v1"
 SOURCE = "ONE_PREINVOCATION_IR"
 IR_SCHEMA = "agentos.ir/v1"
 EXECUTION_HEAD_SCHEMA = "agentos.execution-head/v1"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _executor_identity(model_name: Any) -> tuple[str, bool]:
@@ -94,6 +104,78 @@ def _compact_ir(
     }
 
 
+def _audit_path() -> Path:
+    explicit = str(os.environ.get("AGENTOS_PREINVOCATION_AUDIT_PATH") or "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    root = Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+    return root / "runtime" / "antigravity-preinvocation-last.json"
+
+
+def _conversation_hash(value: Any) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _runtime_source_commit() -> str | None:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    candidate = Path(__file__).resolve().parents[1].name
+    return candidate if len(candidate) >= 12 else None
+
+
+def _write_attestation(payload: dict[str, Any], envelope: dict[str, Any] | None, *, outcome: str) -> None:
+    if int(payload.get("invocationNum") or 0) != 0:
+        return
+    executor_class, identity_bound = _executor_identity(payload.get("modelName"))
+    selector = envelope.get("active_selector") if isinstance(envelope, dict) and isinstance(envelope.get("active_selector"), dict) else {}
+    record = {
+        "schema": AUDIT_SCHEMA,
+        "recorded_at": _now(),
+        "runtime_source_commit": _runtime_source_commit(),
+        "hook_schema": HOOK_SCHEMA,
+        "outcome": outcome,
+        "invocation_num": 0,
+        "conversation_id_sha256": _conversation_hash(payload.get("conversationId")),
+        "model_name": payload.get("modelName"),
+        "executor_class": (envelope or {}).get("executor_class") or executor_class,
+        "executor_identity_bound": (envelope or {}).get("executor_identity_bound") if isinstance(envelope, dict) else identity_bound,
+        "injection_emitted": outcome == "hydrated",
+        "source": (envelope or {}).get("source"),
+        "selection_source": (envelope or {}).get("selection_source"),
+        "project_id": selector.get("project_id"),
+        "index_id": selector.get("index_id"),
+        "ir_id": selector.get("ir_id"),
+        "credential_exposed": False,
+    }
+    path = _audit_path()
+    if path.is_symlink():
+        raise ValueError("PreInvocation attestation path may not be a symlink")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw = tempfile.mkstemp(prefix=".antigravity-preinvocation-", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(raw)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o640)
+            json.dump(record, handle, ensure_ascii=False, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        tmp = None
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
+
+
 def build_injection(
     payload: dict[str, Any],
     gateway: OracleLocalGateway | None = None,
@@ -170,12 +252,29 @@ def build_injection(
 
 
 def main() -> int:
+    payload: dict[str, Any] = {}
     try:
         payload = json.load(sys.stdin)
         if not isinstance(payload, dict):
             raise ValueError("hook input must be a JSON object")
         output = build_injection(payload)
+        envelope: dict[str, Any] | None = None
+        steps = output.get("injectSteps") if isinstance(output, dict) else None
+        if isinstance(steps, list) and steps:
+            message = str((steps[0] or {}).get("ephemeralMessage") or "")
+            if "\n" in message:
+                try:
+                    parsed = json.loads(message.rsplit("\n", 1)[-1])
+                    envelope = parsed if isinstance(parsed, dict) else None
+                except json.JSONDecodeError:
+                    envelope = None
+        if int(payload.get("invocationNum") or 0) == 0:
+            _write_attestation(payload, envelope, outcome="hydrated" if envelope else "no-injection")
     except Exception as exc:
+        try:
+            _write_attestation(payload, None, outcome="fail-closed")
+        except Exception:
+            pass
         output = {
             "injectSteps": [
                 {

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -7,103 +7,158 @@ from typing import Any
 
 from agentos_node.one_mcp import OracleLocalGateway
 
-HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.1"
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.2"
+SOURCE = "ONE_PREINVOCATION_IR"
+CORE_PROJECT_ID = "agentos-core"
+IR_SCHEMA = "agentos.ir/v1"
+EXECUTION_HEAD_SCHEMA = "agentos.execution-head/v1"
+CORE_REPO_BASENAME = "agentmanager"
 
 
-def _workspace_candidates(raw_paths: Any) -> list[tuple[str, str]]:
+def _workspace_paths(raw_paths: Any) -> list[str]:
     if not isinstance(raw_paths, list):
         return []
-    out: list[tuple[str, str]] = []
+    out: list[str] = []
     seen: set[str] = set()
     for raw in raw_paths:
         value = str(raw or "").strip()
         if not value:
             continue
-        path = Path(value)
-        name = path.name.strip()
-        if not name:
-            continue
-        key = name.casefold()
+        key = value.casefold()
         if key in seen:
             continue
         seen.add(key)
-        out.append((value, name))
+        out.append(value)
     return out
 
 
-def _compact_resolution(workspace: str, result: dict[str, Any]) -> dict[str, Any]:
+def _core_workspace_present(paths: list[str]) -> bool:
+    """Use Antigravity workspace metadata only as a Core bootstrap gate.
+
+    workspacePaths must never be used to choose among project states.  For the
+    #152 Core acceptance slice, the existing canonical IR publisher is
+    intentionally restricted to agentos-core, whose repository checkout is
+    agentmanager.  Multi-root siblings therefore cannot become hydration
+    candidates.
+    """
+    return any(Path(value).name.casefold() == CORE_REPO_BASENAME for value in paths)
+
+
+def _canonical_ir_from_resolution(result: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], str]:
+    if result.get("schema") != "agentos.resolve/v1":
+        raise ValueError("unexpected ONE resolve schema")
+
     project = result.get("project") if isinstance(result.get("project"), dict) else {}
-    resolution = result.get("project_resolution") if isinstance(result.get("project_resolution"), dict) else {}
-    resolved = resolution.get("resolved") if isinstance(resolution.get("resolved"), dict) else {}
+    if str(project.get("id") or "") != CORE_PROJECT_ID:
+        raise ValueError("ONE did not resolve canonical agentos-core")
+
+    execution_head = result.get("execution_head")
+    if not isinstance(execution_head, dict) or execution_head.get("schema") != EXECUTION_HEAD_SCHEMA:
+        raise ValueError("canonical execution head is unavailable or has unsupported schema")
+
+    continuation = result.get("continuation")
+    if not isinstance(continuation, dict):
+        raise ValueError("canonical continuation is unavailable")
+    canonical_ir = continuation.get("canonical_ir")
+    if not isinstance(canonical_ir, dict) or canonical_ir.get("schema_version") != IR_SCHEMA:
+        raise ValueError("canonical continuation does not contain agentos.ir/v1")
+
+    head_index = str(execution_head.get("index_id") or "").strip()
+    ir_index = str(canonical_ir.get("index_id") or "").strip()
+    if not head_index or head_index != ir_index:
+        raise ValueError("canonical execution-head / IR index generation mismatch")
+    if not str(canonical_ir.get("ir_id") or "").strip():
+        raise ValueError("canonical IR has no ir_id")
+
+    return execution_head, canonical_ir, head_index
+
+
+def _compact_ir(
+    result: dict[str, Any],
+    execution_head: dict[str, Any],
+    canonical_ir: dict[str, Any],
+    index_id: str,
+) -> dict[str, Any]:
+    project = result.get("project") if isinstance(result.get("project"), dict) else {}
+    continuation = canonical_ir.get("continuation") if isinstance(canonical_ir.get("continuation"), dict) else {}
     return {
-        "workspace": workspace,
-        "project_id": project.get("id") or resolved.get("project_id"),
-        "project_name": project.get("name"),
-        "schema": result.get("schema"),
-        "active_goal": result.get("active_goal"),
-        "next_action": result.get("next_action"),
+        "schema_version": canonical_ir.get("schema_version"),
+        "index_id": index_id,
+        "ir_id": canonical_ir.get("ir_id"),
+        "parent_ir_id": canonical_ir.get("parent_ir_id"),
+        "project_id": project.get("id"),
+        "goal": canonical_ir.get("goal"),
+        "constraints": canonical_ir.get("constraints") or [],
+        "decisions": canonical_ir.get("decisions") or [],
+        "pending_tasks": canonical_ir.get("pending_tasks") or [],
+        "continuation": continuation,
+        "capability": canonical_ir.get("capability"),
+        "next_action": (
+            result.get("next_action")
+            or continuation.get("recommended_action")
+            or continuation.get("next_action")
+        ),
         "mutation_allowed": bool(result.get("mutation_allowed")),
-        "canonical_repo": resolved.get("repo"),
-        "canonical_branch": resolved.get("branch"),
-        "canonical_path": resolved.get("canonical_path"),
-        "canonical_node": resolved.get("node"),
-        "availability": result.get("availability") or {},
+        "execution_head": {
+            "schema": execution_head.get("schema"),
+            "index_id": execution_head.get("index_id"),
+            "active_goal": execution_head.get("active_goal"),
+            "status": (
+                execution_head.get("execution_head", {}).get("status")
+                if isinstance(execution_head.get("execution_head"), dict)
+                else None
+            ),
+        },
         "provenance": result.get("provenance") or {},
     }
 
 
 def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None = None) -> dict[str, Any]:
-    # Hydrate only once per fresh conversation. The injected step remains in the
-    # trajectory for later turns, avoiding repeated context/token overhead.
+    # Hydrate exactly once per fresh conversation.  The injected IR remains in
+    # the trajectory for later turns, avoiding repeated context/token overhead.
     if int(payload.get("invocationNum") or 0) != 0:
         return {}
 
-    workspaces = _workspace_candidates(payload.get("workspacePaths"))
-    if not workspaces:
+    paths = _workspace_paths(payload.get("workspacePaths"))
+    if not _core_workspace_present(paths):
+        # Global hook remains silent outside a workspace containing the Core
+        # checkout.  Importantly, siblings are never treated as state choices.
         return {}
 
     one = gateway or OracleLocalGateway()
     status = one.status()
-    resolutions: list[dict[str, Any]] = []
-    failures: list[dict[str, str]] = []
-    for workspace, candidate in workspaces:
-        try:
-            result = one.resolve(candidate)
-        except (KeyError, ValueError):
-            # An unrelated workspace is not an AgentOS bootstrap failure.
-            continue
-        except Exception as exc:  # pragma: no cover - live diagnostics only
-            failures.append({"workspace": workspace, "error": f"{type(exc).__name__}: {exc}"})
-            continue
-        if result.get("schema") != "agentos.resolve/v1":
-            failures.append({"workspace": workspace, "error": "unexpected resolve schema"})
-            continue
-        resolutions.append(_compact_resolution(workspace, result))
+    if not status.get("connected"):
+        raise RuntimeError("ONE is not connected")
 
-    # Global hook is intentionally silent outside AgentOS-governed workspaces.
-    if not resolutions and not failures:
-        return {}
+    # The existing canonical continuation publisher is restricted to
+    # agentos-core.  Resolve that authoritative IR directly; do not infer state
+    # from workspace order, Pulse, PM2, memory, or sibling repositories.
+    result = one.resolve(CORE_PROJECT_ID)
+    execution_head, canonical_ir, index_id = _canonical_ir_from_resolution(result)
+    ir = _compact_ir(result, execution_head, canonical_ir, index_id)
 
     envelope = {
         "schema": HOOK_SCHEMA,
-        "source": "ONE_PREINVOCATION_HOOK",
+        "source": SOURCE,
         "status_schema": status.get("schema"),
-        "connected": bool(status.get("connected")),
+        "connected": True,
         "realm_id": status.get("realm_id"),
         "node_id": status.get("node_id"),
         "surface": "antigravity",
         "executor_class": "antigravity-gemini",
         "model_name": payload.get("modelName"),
         "credential_exposed": False,
-        "resolutions": resolutions,
-        "failures": failures,
+        "canonical_ir": ir,
     }
     message = (
-        "AgentOS ONE canonical pre-invocation hydration. This state was resolved "
-        "before the model was called; do not replace it with Pulse/PM2/local-memory "
-        "reconstruction. Newer explicit user intent still wins. If continuing work, "
-        "use the resolved active_goal/next_action and authority boundary below. "
-        "When reporting bootstrap provenance, state source=ONE_PREINVOCATION_HOOK.\n"
+        "AgentOS ONE canonical IR hydration. This is the single authoritative "
+        "agentos-core continuation selected before the model was called. Do not "
+        "replace it with workspace enumeration, Pulse/PM2 scans, local-memory "
+        "reconstruction, or sibling project state. Newer explicit user intent "
+        "still wins. Continue from canonical_ir.goal / pending_tasks / "
+        "continuation / next_action and obey mutation_allowed. When reporting "
+        "bootstrap provenance, state source=ONE_PREINVOCATION_IR and include "
+        "index_id + ir_id.\n"
         + json.dumps(envelope, ensure_ascii=False, sort_keys=True)
     )
     return {"injectSteps": [{"ephemeralMessage": message}]}
@@ -115,14 +170,19 @@ def main() -> int:
         if not isinstance(payload, dict):
             raise ValueError("hook input must be a JSON object")
         output = build_injection(payload)
-    except Exception as exc:  # Fail open for Antigravity, but inject a bounded diagnostic.
+    except Exception as exc:
+        # Fail closed for AgentOS continuity: Antigravity itself may continue,
+        # but the model receives an explicit prohibition against claiming ONE
+        # state from local reconstruction.
         output = {
             "injectSteps": [
                 {
                     "ephemeralMessage": (
-                        "ONE_PREHOOK_BLOCKED: AgentOS pre-invocation hydration failed: "
-                        f"{type(exc).__name__}: {exc}. Do not claim ONE-connected state "
-                        "from local Pulse/PM2/memory scans."
+                        "ONE_IR_HEAD_UNRESOLVED: AgentOS canonical IR hydration "
+                        f"failed: {type(exc).__name__}: {exc}. Do not claim or "
+                        "reconstruct AgentOS continuation from workspace lists, "
+                        "Pulse, PM2, or local memory. Ask for/restore the canonical "
+                        "IR head instead."
                     )
                 }
             ]

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_core.active_continuation import read_active_continuation
-from agentos_node.one_mcp import OracleLocalGateway
+from agentos_node.one_mcp import OneGatewayError, OracleLocalGateway
 
 HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.6"
 AUDIT_SCHEMA = "agentos.antigravity-preinvocation-attestation/v1"
@@ -31,6 +31,20 @@ def _executor_identity(model_name: Any) -> tuple[str, bool]:
     if "gemini" in normalized:
         return "antigravity-gemini", True
     return "antigravity-unknown", False
+
+
+def _safe_failure_code(exc: Exception) -> str:
+    """Map failures to bounded model-visible codes without echoing details."""
+    if isinstance(exc, OneGatewayError):
+        value = str(exc).strip()
+        return value[:96] if value else "one_gateway_error"
+    if isinstance(exc, (FileNotFoundError, KeyError)):
+        return "one_hydration_state_missing"
+    if isinstance(exc, ValueError):
+        return "one_hydration_validation_failed"
+    if isinstance(exc, RuntimeError):
+        return "one_hydration_runtime_failed"
+    return "one_hydration_internal_error"
 
 
 def _canonical_ir_from_resolution(
@@ -275,15 +289,16 @@ def main() -> int:
             _write_attestation(payload, None, outcome="fail-closed")
         except Exception:
             pass
+        code = _safe_failure_code(exc)
         output = {
             "injectSteps": [
                 {
                     "ephemeralMessage": (
                         "ONE_IR_HEAD_UNRESOLVED: AgentOS canonical IR hydration "
-                        f"failed: {type(exc).__name__}: {exc}. Do not claim or "
-                        "reconstruct AgentOS continuation from workspace lists, "
-                        "Pulse, PM2, local memory, or vendor history. Ask for/restore "
-                        "the ONE active continuation selector/canonical IR head instead."
+                        f"failed (code={code}). Do not claim or reconstruct AgentOS "
+                        "continuation from workspace lists, Pulse, PM2, local memory, "
+                        "or vendor history. Ask for/restore the ONE active continuation "
+                        "selector/canonical IR head instead."
                     )
                 }
             ]

--- a/agentos_node/antigravity_one_hook.py
+++ b/agentos_node/antigravity_one_hook.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
 from agentos_node.one_mcp import OracleLocalGateway
 
-HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.3"
+HOOK_SCHEMA = "agentos.antigravity-one-preinvocation/v0.4"
 SOURCE = "ONE_PREINVOCATION_IR"
 CORE_PROJECT_ID = "agentos-core"
 IR_SCHEMA = "agentos.ir/v1"
 EXECUTION_HEAD_SCHEMA = "agentos.execution-head/v1"
-CORE_REPO_BASENAME = "agentmanager"
+DEFAULT_CORE_REPO_ROOT = "/home/ubuntu/agentmanager"
 
 
 def _workspace_paths(raw_paths: Any) -> list[str]:
@@ -32,16 +33,30 @@ def _workspace_paths(raw_paths: Any) -> list[str]:
     return out
 
 
+def _core_repo_root() -> Path:
+    return Path(
+        os.environ.get("AGENTOS_CORE_REPO_ROOT", DEFAULT_CORE_REPO_ROOT)
+    ).expanduser().resolve(strict=False)
+
+
 def _core_workspace_present(paths: list[str]) -> bool:
     """Use Antigravity workspace metadata only as a Core bootstrap gate.
 
-    workspacePaths must never be used to choose among project states.  For the
-    #152 Core acceptance slice, the existing canonical IR publisher is
-    intentionally restricted to agentos-core, whose repository checkout is
-    agentmanager.  Multi-root siblings therefore cannot become hydration
-    candidates.
+    A fresh Antigravity conversation may be opened at the repository root or at
+    a descendant workspace such as ``agentmanager/workspace/if-tv-station``.
+    Both belong to the same canonical Core checkout boundary for the #152
+    acceptance slice.  Descendant names are never project selectors: once the
+    gate is satisfied, continuation still resolves exactly ``agentos-core``.
+
+    Paths that merely share a textual prefix with the Core checkout (for
+    example ``/home/ubuntu/agentmanager-old``) are not accepted.
     """
-    return any(Path(value).name.casefold() == CORE_REPO_BASENAME for value in paths)
+    root = _core_repo_root()
+    for value in paths:
+        candidate = Path(value).expanduser().resolve(strict=False)
+        if candidate == root or root in candidate.parents:
+            return True
+    return False
 
 
 def _executor_identity(model_name: Any) -> tuple[str, bool]:
@@ -137,8 +152,8 @@ def build_injection(payload: dict[str, Any], gateway: OracleLocalGateway | None 
 
     paths = _workspace_paths(payload.get("workspacePaths"))
     if not _core_workspace_present(paths):
-        # Global hook remains silent outside a workspace containing the Core
-        # checkout.  Importantly, siblings are never treated as state choices.
+        # Global hook remains silent outside the canonical Core checkout tree.
+        # Workspace descendants are only a gate; their names never choose state.
         return {}
 
     one = gateway or OracleLocalGateway()

--- a/agentos_node/codex_one_mcp_stdio.py
+++ b/agentos_node/codex_one_mcp_stdio.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import copy
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from agent_core.active_continuation import resolve_active_continuation
@@ -8,6 +13,67 @@ from agentos_node.one_mcp import OracleLocalGateway
 
 SURFACE = "codex-local"
 EXECUTOR_CLASS = "openai-codex-local"
+RECEIPT_SCHEMA = "agentos.codex-one-active-resolve-receipt/v1"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _runtime_source_commit() -> str | None:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    candidate = Path(__file__).resolve().parents[1].name
+    return candidate if len(candidate) >= 12 else None
+
+
+def _receipt_path(data_root: Path) -> Path:
+    explicit = str(os.environ.get("AGENTOS_CODEX_ONE_RECEIPT_PATH") or "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return data_root / "runtime" / "codex-one-active-resolve-last.json"
+
+
+def _write_resolve_receipt(data_root: Path, selector: dict[str, Any]) -> None:
+    path = _receipt_path(data_root)
+    if path.is_symlink():
+        raise ValueError("Codex ONE receipt path may not be a symlink")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "schema": RECEIPT_SCHEMA,
+        "recorded_at": _now(),
+        "runtime_source_commit": _runtime_source_commit(),
+        "surface": SURFACE,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "executor_identity_source": "codex-mcp-config",
+        "source": "ONE_ACTIVE_CONTINUATION",
+        "selection_source": "ONE_ACTIVE_CONTINUATION",
+        "project_id": selector.get("project_id"),
+        "index_id": selector.get("index_id"),
+        "ir_id": selector.get("ir_id"),
+        "credential_exposed": False,
+    }
+    fd, raw = tempfile.mkstemp(prefix=".codex-one-resolve-", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(raw)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o640)
+            json.dump(record, handle, ensure_ascii=False, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        tmp = None
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
 
 
 def _project_codex_client(value: dict[str, Any]) -> dict[str, Any]:
@@ -20,10 +86,12 @@ def _project_codex_client(value: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def _active_projection(one: OracleLocalGateway) -> dict[str, Any]:
+def _active_projection(one: OracleLocalGateway, *, write_receipt: bool = False) -> dict[str, Any]:
     active = resolve_active_continuation(data_root=one.data_root)
     selector = active["selector"]
     resolution = active["resolution"]
+    if write_receipt:
+        _write_resolve_receipt(Path(one.data_root), selector)
     return _project_codex_client(
         {
             "schema": "agentos.one-active-resolve/v1",
@@ -59,7 +127,7 @@ def create_server(gateway: OracleLocalGateway | None = None):
     @server.tool()
     def one_resolve_active() -> dict[str, Any]:
         """Resolve the ONE-selected active Canonical IR; never infer current work from IDE workspace state."""
-        return _active_projection(one)
+        return _active_projection(one, write_receipt=True)
 
     @server.tool()
     def one_resolve(project: str) -> dict[str, Any]:

--- a/agentos_node/codex_one_mcp_stdio.py
+++ b/agentos_node/codex_one_mcp_stdio.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from agent_core.active_continuation import resolve_active_continuation
+from agentos_node.one_mcp import OracleLocalGateway
+
+SURFACE = "codex-local"
+EXECUTOR_CLASS = "openai-codex-local"
+
+
+def _project_codex_client(value: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(value)
+    result["surface"] = SURFACE
+    result["executor_class"] = EXECUTOR_CLASS
+    result["executor_identity_bound"] = True
+    result["executor_identity_source"] = "codex-mcp-config"
+    result["credential_exposed"] = False
+    return result
+
+
+def _active_projection(one: OracleLocalGateway) -> dict[str, Any]:
+    active = resolve_active_continuation(data_root=one.data_root)
+    selector = active["selector"]
+    resolution = active["resolution"]
+    return _project_codex_client(
+        {
+            "schema": "agentos.one-active-resolve/v1",
+            "source": "ONE_ACTIVE_CONTINUATION",
+            "selection_source": "ONE_ACTIVE_CONTINUATION",
+            "selector": {
+                "project_id": selector.get("project_id"),
+                "index_id": selector.get("index_id"),
+                "ir_id": selector.get("ir_id"),
+            },
+            "resolution": resolution,
+            "credential_exposed": False,
+        }
+    )
+
+
+def create_server(gateway: OracleLocalGateway | None = None):
+    from mcp.server.mcpserver import MCPServer
+
+    one = gateway or OracleLocalGateway()
+    server = MCPServer("AgentOS ONE for Codex", version="0.1.0")
+
+    @server.tool()
+    def one_status() -> dict[str, Any]:
+        """Verify the Codex local harness can reach the trusted Oracle-local ONE projection."""
+        return _project_codex_client(one.status())
+
+    @server.tool()
+    def one_capabilities() -> dict[str, Any]:
+        """Return bounded ONE capabilities available to the Codex local harness."""
+        return _project_codex_client(one.capabilities())
+
+    @server.tool()
+    def one_resolve_active() -> dict[str, Any]:
+        """Resolve the ONE-selected active Canonical IR; never infer current work from IDE workspace state."""
+        return _active_projection(one)
+
+    @server.tool()
+    def one_resolve(project: str) -> dict[str, Any]:
+        """Explicitly resolve a named canonical project through ONE."""
+        return _project_codex_client(one.resolve(project))
+
+    return server
+
+
+def main() -> int:
+    create_server().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/one_mcp.py
+++ b/agentos_node/one_mcp.py
@@ -24,6 +24,12 @@ SENSITIVE_KEYS = {
 
 ORACLE_LOCAL_MODE = "oracle-local"
 CLIENT_MODE = "client"
+MAX_LIST_ITEMS = 128
+MAX_STRING_LENGTH = 512
+
+
+class OneGatewayError(RuntimeError):
+    """Executor-safe ONE failure containing only a stable classification."""
 
 
 def _redact(value: Any) -> Any:
@@ -35,8 +41,136 @@ def _redact(value: Any) -> Any:
             for key, item in value.items()
         }
     if isinstance(value, list):
-        return [_redact(item) for item in value]
+        return [_redact(item) for item in value[:MAX_LIST_ITEMS]]
+    if isinstance(value, str):
+        return value[:MAX_STRING_LENGTH]
     return value
+
+
+def _bounded_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value[:MAX_LIST_ITEMS]:
+        if isinstance(item, (str, int, float, bool)):
+            result.append(str(item)[:256])
+    return result
+
+
+def _project_bootstrap(
+    payload: dict[str, Any],
+    *,
+    schema: str | None = None,
+    surface: str = "antigravity",
+    executor_class: str | None = None,
+    projection: str = "executor-safe-readonly",
+) -> dict[str, Any]:
+    """Project only executor-orientation fields from a Node/Realm bootstrap."""
+    result: dict[str, Any] = {
+        "schema": schema or payload.get("schema"),
+        "realm_id": payload.get("realm_id"),
+        "node_id": payload.get("node_id"),
+        "realm_node_count": payload.get("realm_node_count"),
+        "realm_capabilities": _bounded_strings(payload.get("realm_capabilities")),
+        "inherited_realm_capabilities": _bounded_strings(
+            payload.get("inherited_realm_capabilities")
+        ),
+        "inherited_surface_providers": _bounded_strings(
+            payload.get("inherited_surface_providers")
+        ),
+        "canonical_capabilities": _bounded_strings(
+            payload.get("canonical_capabilities")
+        ),
+        "surface": surface,
+        "projection": projection,
+        "credential_exposed": False,
+    }
+    if executor_class:
+        result["executor_class"] = executor_class
+    return _redact(result)
+
+
+def _project_execution_head(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    projected = {
+        "schema": value.get("schema"),
+        "index_id": value.get("index_id"),
+        "active_goal": value.get("active_goal"),
+    }
+    nested = value.get("execution_head")
+    if isinstance(nested, dict):
+        projected["execution_head"] = {
+            key: nested.get(key)
+            for key in ("status", "phase", "updated_at")
+            if key in nested
+        }
+    return _redact(projected)
+
+
+def _project_continuation(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    canonical_ir = value.get("canonical_ir")
+    if not isinstance(canonical_ir, dict):
+        canonical_ir = None
+    return _redact(
+        {
+            "protocol": value.get("protocol"),
+            "recommended_action": value.get("recommended_action"),
+            "ir_id": value.get("ir_id"),
+            "parent_ir_id": value.get("parent_ir_id"),
+            "goal": value.get("goal"),
+            "constraints": value.get("constraints") or [],
+            "decisions": value.get("decisions") or [],
+            "pending_tasks": value.get("pending_tasks") or [],
+            "continuation": value.get("continuation") or {},
+            "capability": value.get("capability"),
+            "canonical_ir": canonical_ir,
+        }
+    )
+
+
+def _project_resolve(payload: dict[str, Any]) -> dict[str, Any]:
+    """Keep continuity state while dropping source paths/runtime manifests."""
+    project = payload.get("project") if isinstance(payload.get("project"), dict) else {}
+    node_context = payload.get("node_context")
+    safe_node_context = None
+    if isinstance(node_context, dict):
+        safe_node_context = _project_bootstrap(
+            node_context,
+            schema=node_context.get("schema"),
+            surface=str(node_context.get("surface") or "antigravity"),
+            executor_class=(
+                str(node_context.get("executor_class"))
+                if node_context.get("executor_class")
+                else None
+            ),
+            projection="resolve-node-context",
+        )
+    result = {
+        "schema": payload.get("schema"),
+        "intent": payload.get("intent"),
+        "project": {
+            "id": project.get("id"),
+            "name": project.get("name"),
+            "aliases": _bounded_strings(project.get("aliases")),
+            "resolution": project.get("resolution"),
+            "matched_by": project.get("matched_by"),
+            "identity_source": project.get("identity_source"),
+            "governance_entity_id": project.get("governance_entity_id"),
+            "governance_state": project.get("governance_state"),
+        },
+        "mutation_allowed": bool(payload.get("mutation_allowed")),
+        "active_goal": payload.get("active_goal"),
+        "execution_head": _project_execution_head(payload.get("execution_head")),
+        "continuation": _project_continuation(payload.get("continuation")),
+        "node_context": safe_node_context,
+        "next_action": payload.get("next_action"),
+        "availability": payload.get("availability") or {},
+        "provenance": payload.get("provenance") or {},
+    }
+    return _redact(result)
 
 
 def client_config_candidates() -> list[Path]:
@@ -49,17 +183,10 @@ def client_config_candidates() -> list[Path]:
         candidates.append(Path(client_home).expanduser() / "client.json")
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        candidates.append(
-            Path(local_app_data) / "AgentOS" / "state" / "client.json"
-        )
+        candidates.append(Path(local_app_data) / "AgentOS" / "state" / "client.json")
     if os.name == "nt":
         candidates.append(
-            Path.home()
-            / "AppData"
-            / "Local"
-            / "AgentOS"
-            / "state"
-            / "client.json"
+            Path.home() / "AppData" / "Local" / "AgentOS" / "state" / "client.json"
         )
     candidates.append(Path.home() / ".agentos" / "client.json")
 
@@ -77,12 +204,7 @@ def discover_client_config() -> Path:
     for path in client_config_candidates():
         if path.is_file():
             return path
-    searched = ", ".join(str(path) for path in client_config_candidates())
-    raise FileNotFoundError(
-        "AgentOS client.json not found. Set AGENTOS_CLIENT_CONFIG or "
-        "AGENTOS_CLIENT_HOME. "
-        f"Searched: {searched}"
-    )
+    raise FileNotFoundError("agentos_client_config_not_found")
 
 
 @dataclass(frozen=True)
@@ -97,15 +219,9 @@ class ClientConfig:
         source = path or discover_client_config()
         payload = json.loads(source.read_text(encoding="utf-8-sig"))
         required = ("one_url", "realm_id", "node_id", "node_token")
-        missing = [
-            key
-            for key in required
-            if not str(payload.get(key) or "").strip()
-        ]
+        missing = [key for key in required if not str(payload.get(key) or "").strip()]
         if missing:
-            raise ValueError(
-                f"AgentOS client config missing fields: {missing}"
-            )
+            raise ValueError("agentos_client_config_incomplete")
         return cls(
             one_url=str(payload["one_url"]).rstrip("/"),
             realm_id=str(payload["realm_id"]),
@@ -139,10 +255,7 @@ class ClientOneGateway:
         authenticated: bool = False,
         timeout: float = 12.0,
     ) -> dict[str, Any]:
-        headers = {
-            "Accept": "application/json",
-            "User-Agent": "AgentOS-ONE-MCP/0.1",
-        }
+        headers = {"Accept": "application/json", "User-Agent": "AgentOS-ONE-MCP/0.2"}
         data = None
         if body is not None:
             headers["Content-Type"] = "application/json"
@@ -156,34 +269,29 @@ class ClientOneGateway:
             method=method,
         )
         try:
-            with urllib.request.urlopen(
-                request, timeout=timeout
-            ) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 raw = response.read().decode("utf-8")
         except urllib.error.HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"ONE HTTP {exc.code}: {detail}"
-            ) from exc
-        except urllib.error.URLError as exc:
-            raise RuntimeError(
-                f"ONE connection failed: {exc.reason}"
-            ) from exc
-        payload = json.loads(raw) if raw else {}
+            # Never read/echo the body; server validation/auth failures can contain
+            # secrets, host paths or raw internal state.
+            raise OneGatewayError(f"one_http_{int(exc.code)}") from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise OneGatewayError("one_unavailable") from exc
+        try:
+            payload = json.loads(raw) if raw else {}
+        except json.JSONDecodeError as exc:
+            raise OneGatewayError("one_protocol_invalid_json") from exc
         if not isinstance(payload, dict):
-            raise RuntimeError("ONE response must be a JSON object")
+            raise OneGatewayError("one_protocol_invalid_shape")
         return _redact(payload)
 
     def health(self) -> dict[str, Any]:
         return self._request("/v1/health")
 
     def bootstrap(self) -> dict[str, Any]:
-        query = urllib.parse.urlencode(
-            {"node_id": self.config.node_id}
-        )
-        return self._request(
-            "/v1/bootstrap?" + query, authenticated=True
-        )
+        query = urllib.parse.urlencode({"node_id": self.config.node_id})
+        payload = self._request("/v1/bootstrap?" + query, authenticated=True)
+        return _project_bootstrap(payload, schema=payload.get("schema"))
 
     def status(self) -> dict[str, Any]:
         health = self.health()
@@ -191,18 +299,13 @@ class ClientOneGateway:
         return {
             "schema": "agentos.one-mcp-status/v0.1",
             "connected": bool(health.get("ok"))
-            and bootstrap.get("schema")
-            == "agentos.node-bootstrap/v0.1",
+            and bootstrap.get("schema") == "agentos.node-bootstrap/v0.1",
             "mode": self.mode,
-            "realm_id": bootstrap.get("realm_id")
-            or self.config.realm_id,
-            "node_id": bootstrap.get("node_id")
-            or self.config.node_id,
+            "realm_id": bootstrap.get("realm_id") or self.config.realm_id,
+            "node_id": bootstrap.get("node_id") or self.config.node_id,
             "surface": "antigravity",
             "adapter": "agentos-one-mcp",
-            "credential_boundary": (
-                "node credential retained inside local MCP process"
-            ),
+            "credential_boundary": "node credential retained inside local MCP process",
             "credential_exposed": False,
             "realm_node_count": bootstrap.get("realm_node_count"),
         }
@@ -214,115 +317,83 @@ class ClientOneGateway:
             "mode": self.mode,
             "realm_id": bootstrap.get("realm_id"),
             "node_id": bootstrap.get("node_id"),
-            "realm_capabilities": (
-                bootstrap.get("realm_capabilities") or []
-            ),
-            "inherited_realm_capabilities": (
-                bootstrap.get("inherited_realm_capabilities") or []
-            ),
-            "inherited_surface_providers": (
-                bootstrap.get("inherited_surface_providers") or []
-            ),
-            "canonical_capabilities": (
-                bootstrap.get("canonical_capabilities") or []
-            ),
+            "realm_capabilities": bootstrap.get("realm_capabilities") or [],
+            "inherited_realm_capabilities": bootstrap.get("inherited_realm_capabilities") or [],
+            "inherited_surface_providers": bootstrap.get("inherited_surface_providers") or [],
+            "canonical_capabilities": bootstrap.get("canonical_capabilities") or [],
         }
 
     def resolve(self, project: str) -> dict[str, Any]:
         project = str(project or "").strip()
         if not project:
-            raise ValueError("project is required")
+            raise ValueError("project_required")
         body = {
             "schema": "agentos.resolve-request/v1",
             "intent": "continue",
             "node_id": self.config.node_id,
             "project": project,
         }
-        return self._request(
+        payload = self._request(
             "/v1/resolve",
             method="POST",
             body=body,
             authenticated=True,
         )
+        return _project_resolve(payload)
 
     def probe(self) -> dict[str, Any]:
         result = self.status()
-        result["probe"] = (
-            "PASS" if result.get("connected") else "FAIL"
-        )
+        result["probe"] = "PASS" if result.get("connected") else "FAIL"
         return result
 
 
 class OracleLocalGateway:
     """Trusted local read-only projection for Oracle-hosted Antigravity.
 
-    This gateway is not a Realm Node and owns no new Realm credential. It is
-    permitted only when the MCP process runs inside the trusted Oracle/ubuntu
-    boundary that already owns the local ONE state. All model-visible output is
-    a bounded projection of canonical Node Registry / continuation state.
+    This gateway is not a Realm Node and owns no new Realm credential. It runs
+    inside the trusted Oracle/ubuntu boundary and exposes only bounded model-
+    visible projections of canonical Node Registry / continuation state.
     """
 
     mode = ORACLE_LOCAL_MODE
 
-    def __init__(
-        self,
-        *,
-        data_root: Path | None = None,
-        core_node_id: str | None = None,
-    ):
+    def __init__(self, *, data_root: Path | None = None, core_node_id: str | None = None):
         self.data_root = (
             data_root
-            or Path(
-                os.environ.get(
-                    "AGENT_DATA_ROOT",
-                    "/home/ubuntu/agent-data",
-                )
-            )
+            or Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
         ).expanduser()
         self.core_node_id = str(
-            core_node_id
-            or os.environ.get(
-                "AGENTOS_CORE_NODE_ID",
-                "oracle-core-node",
-            )
+            core_node_id or os.environ.get("AGENTOS_CORE_NODE_ID", "oracle-core-node")
         ).strip()
         if not self.core_node_id:
-            raise ValueError("AGENTOS_CORE_NODE_ID cannot be empty")
+            raise ValueError("core_node_id_required")
 
     def _node_map(self) -> dict[str, Any]:
         from agent_core.node_registry import NodeRegistry
 
-        registry = NodeRegistry(
-            self.data_root / "realm" / "nodes.json"
-        )
+        registry = NodeRegistry(self.data_root / "realm" / "nodes.json")
         return registry.node_map()
 
-    def _core_node(
-        self, node_map: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _core_node(self, node_map: dict[str, Any]) -> dict[str, Any]:
         nodes = list(node_map.get("nodes") or [])
         node = next(
             (
                 item
                 for item in nodes
-                if str(item.get("node_id") or "")
-                == self.core_node_id
+                if str(item.get("node_id") or "") == self.core_node_id
             ),
             None,
         )
         if node is None:
-            raise KeyError(
-                f"Oracle core node not present in ONE Node Registry: "
-                f"{self.core_node_id}"
-            )
+            raise KeyError("oracle_core_node_not_registered")
         return node
 
     def bootstrap(self) -> dict[str, Any]:
         node_map = self._node_map()
-        node = self._core_node(node_map)
+        self._core_node(node_map)  # prove membership without exposing raw manifest
         inherited_caps = sorted(
             {
-                cap
+                str(cap)
                 for other in (node_map.get("nodes") or [])
                 if other.get("node_id") != self.core_node_id
                 and other.get("status") != "offline"
@@ -335,33 +406,26 @@ class OracleLocalGateway:
                 for other in (node_map.get("nodes") or [])
                 if other.get("node_id") != self.core_node_id
                 and other.get("status") != "offline"
-                for surface in (
-                    (
-                        other.get("surface_inventory") or {}
-                    ).get("surfaces")
-                    or []
-                )
-                if isinstance(surface, dict)
-                and surface.get("provider")
+                for surface in ((other.get("surface_inventory") or {}).get("surfaces") or [])
+                if isinstance(surface, dict) and surface.get("provider")
             }
         )
-        return {
+        raw = {
             "schema": "agentos.one-local-bootstrap/v0.1",
             "realm_id": node_map.get("realm_id"),
             "node_id": self.core_node_id,
-            "node": node,
-            "realm_node_count": node_map.get(
-                "node_count", len(node_map.get("nodes") or [])
-            ),
-            "realm_capabilities": list(
-                node_map.get("realm_capabilities") or []
-            ),
+            "realm_node_count": node_map.get("node_count", len(node_map.get("nodes") or [])),
+            "realm_capabilities": list(node_map.get("realm_capabilities") or []),
             "inherited_realm_capabilities": inherited_caps,
             "inherited_surface_providers": inherited_surfaces,
-            "surface": "antigravity",
-            "executor_class": "antigravity-gemini",
-            "projection": "trusted-local-readonly",
         }
+        return _project_bootstrap(
+            raw,
+            schema="agentos.one-local-bootstrap/v0.1",
+            surface="antigravity",
+            executor_class="antigravity-gemini",
+            projection="trusted-local-executor-safe",
+        )
 
     def status(self) -> dict[str, Any]:
         bootstrap = self.bootstrap()
@@ -375,8 +439,8 @@ class OracleLocalGateway:
             "executor_class": "antigravity-gemini",
             "adapter": "agentos-one-mcp",
             "credential_boundary": (
-                "trusted Oracle-local read-only projection; "
-                "no Realm credential is exposed to or owned by executor"
+                "trusted Oracle-local read-only projection; no Realm credential "
+                "is exposed to or owned by executor"
             ),
             "credential_exposed": False,
             "realm_node_count": bootstrap.get("realm_node_count"),
@@ -389,15 +453,9 @@ class OracleLocalGateway:
             "mode": self.mode,
             "realm_id": bootstrap.get("realm_id"),
             "node_id": bootstrap.get("node_id"),
-            "realm_capabilities": (
-                bootstrap.get("realm_capabilities") or []
-            ),
-            "inherited_realm_capabilities": (
-                bootstrap.get("inherited_realm_capabilities") or []
-            ),
-            "inherited_surface_providers": (
-                bootstrap.get("inherited_surface_providers") or []
-            ),
+            "realm_capabilities": bootstrap.get("realm_capabilities") or [],
+            "inherited_realm_capabilities": bootstrap.get("inherited_realm_capabilities") or [],
+            "inherited_surface_providers": bootstrap.get("inherited_surface_providers") or [],
         }
 
     def resolve(self, project: str) -> dict[str, Any]:
@@ -405,19 +463,17 @@ class OracleLocalGateway:
 
         project = str(project or "").strip()
         if not project:
-            raise ValueError("project is required")
+            raise ValueError("project_required")
         result = resolve_continuation(
             project,
             data_root=self.data_root,
             node_context=self.bootstrap(),
         )
-        return _redact(result)
+        return _project_resolve(result)
 
     def probe(self) -> dict[str, Any]:
         result = self.status()
-        result["probe"] = (
-            "PASS" if result.get("connected") else "FAIL"
-        )
+        result["probe"] = "PASS" if result.get("connected") else "FAIL"
         return result
 
 
@@ -426,32 +482,20 @@ OneGateway = ClientOneGateway
 
 
 def gateway_mode() -> str:
-    explicit = str(
-        os.environ.get("AGENTOS_ONE_MCP_MODE") or ""
-    ).strip().casefold()
+    explicit = str(os.environ.get("AGENTOS_ONE_MCP_MODE") or "").strip().casefold()
     if explicit:
         if explicit not in {CLIENT_MODE, ORACLE_LOCAL_MODE}:
-            raise ValueError(
-                "AGENTOS_ONE_MCP_MODE must be client or oracle-local"
-            )
+            raise ValueError("invalid_one_mcp_mode")
         return explicit
-    # An explicit client config always wins. Otherwise Oracle's canonical data
-    # root is enough to select the trusted local read-only projection.
     try:
         discover_client_config()
         return CLIENT_MODE
     except FileNotFoundError:
         pass
     data_root = Path(
-        os.environ.get(
-            "AGENT_DATA_ROOT",
-            "/home/ubuntu/agent-data",
-        )
+        os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")
     ).expanduser()
-    if (
-        os.name != "nt"
-        and (data_root / "realm" / "nodes.json").is_file()
-    ):
+    if os.name != "nt" and (data_root / "realm" / "nodes.json").is_file():
         return ORACLE_LOCAL_MODE
     return CLIENT_MODE
 
@@ -467,10 +511,7 @@ def create_mcp_server(gateway: Gateway | None = None):
     try:
         from mcp.server import MCPServer
     except ImportError as exc:
-        raise RuntimeError(
-            "MCP Python SDK v2 is required. "
-            "Run scripts/install_antigravity_one_mcp.py first."
-        ) from exc
+        raise RuntimeError("mcp_sdk_required") from exc
 
     one = gateway or create_gateway()
     server = MCPServer("AgentOS ONE")
@@ -492,21 +533,15 @@ def create_mcp_server(gateway: Gateway | None = None):
 
     @server.tool()
     def one_resolve(project: str) -> dict[str, Any]:
-        """Resolve project identity, active goal, continuation and mutation boundary from ONE."""
+        """Resolve bounded canonical project continuity from ONE."""
         return one.resolve(project)
 
     return server
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Credential-isolated AgentOS ONE MCP server"
-    )
-    parser.add_argument(
-        "--probe",
-        action="store_true",
-        help="verify ONE connectivity without starting MCP",
-    )
+    parser = argparse.ArgumentParser(description="Credential-isolated AgentOS ONE MCP server")
+    parser.add_argument("--probe", action="store_true", help="verify ONE connectivity without starting MCP")
     parser.add_argument(
         "--mode",
         choices=(CLIENT_MODE, ORACLE_LOCAL_MODE),
@@ -516,14 +551,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode:
         os.environ["AGENTOS_ONE_MCP_MODE"] = args.mode
     if args.probe:
-        print(
-            json.dumps(
-                create_gateway().probe(),
-                ensure_ascii=False,
-                indent=2,
-                sort_keys=True,
-            )
-        )
+        print(json.dumps(create_gateway().probe(), ensure_ascii=False, indent=2, sort_keys=True))
         return 0
     create_mcp_server().run()
     return 0

--- a/agentos_node/one_mcp.py
+++ b/agentos_node/one_mcp.py
@@ -1,0 +1,246 @@
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_KEYS = {
+    "token",
+    "node_token",
+    "access_token",
+    "refresh_token",
+    "authorization",
+    "password",
+    "secret",
+    "claim_secret",
+    "client_secret",
+}
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "[REDACTED]" if str(key).strip().casefold() in SENSITIVE_KEYS else _redact(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def client_config_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    explicit = os.environ.get("AGENTOS_CLIENT_CONFIG")
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    client_home = os.environ.get("AGENTOS_CLIENT_HOME")
+    if client_home:
+        candidates.append(Path(client_home).expanduser() / "client.json")
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(Path(local_app_data) / "AgentOS" / "state" / "client.json")
+    if os.name == "nt":
+        candidates.append(Path.home() / "AppData" / "Local" / "AgentOS" / "state" / "client.json")
+    candidates.append(Path.home() / ".agentos" / "client.json")
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in candidates:
+        key = os.path.normcase(str(path))
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def discover_client_config() -> Path:
+    for path in client_config_candidates():
+        if path.is_file():
+            return path
+    searched = ", ".join(str(path) for path in client_config_candidates())
+    raise FileNotFoundError(
+        "AgentOS client.json not found. Set AGENTOS_CLIENT_CONFIG or AGENTOS_CLIENT_HOME. "
+        f"Searched: {searched}"
+    )
+
+
+@dataclass(frozen=True)
+class ClientConfig:
+    one_url: str
+    realm_id: str
+    node_id: str
+    node_token: str
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "ClientConfig":
+        source = path or discover_client_config()
+        payload = json.loads(source.read_text(encoding="utf-8-sig"))
+        required = ("one_url", "realm_id", "node_id", "node_token")
+        missing = [key for key in required if not str(payload.get(key) or "").strip()]
+        if missing:
+            raise ValueError(f"AgentOS client config missing fields: {missing}")
+        return cls(
+            one_url=str(payload["one_url"]).rstrip("/"),
+            realm_id=str(payload["realm_id"]),
+            node_id=str(payload["node_id"]),
+            node_token=str(payload["node_token"]),
+        )
+
+
+class OneGateway:
+    """Credential-isolated read-only adapter from Antigravity MCP to ONE."""
+
+    def __init__(self, config: ClientConfig | None = None):
+        self.config = config or ClientConfig.load()
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+        authenticated: bool = False,
+        timeout: float = 12.0,
+    ) -> dict[str, Any]:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "AgentOS-ONE-MCP/0.1",
+        }
+        data = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self.config.node_token}"
+        request = urllib.request.Request(
+            self.config.one_url + path,
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"ONE HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"ONE connection failed: {exc.reason}") from exc
+        payload = json.loads(raw) if raw else {}
+        if not isinstance(payload, dict):
+            raise RuntimeError("ONE response must be a JSON object")
+        return _redact(payload)
+
+    def health(self) -> dict[str, Any]:
+        return self._request("/v1/health")
+
+    def bootstrap(self) -> dict[str, Any]:
+        query = urllib.parse.urlencode({"node_id": self.config.node_id})
+        return self._request("/v1/bootstrap?" + query, authenticated=True)
+
+    def status(self) -> dict[str, Any]:
+        health = self.health()
+        bootstrap = self.bootstrap()
+        return {
+            "schema": "agentos.one-mcp-status/v0.1",
+            "connected": bool(health.get("ok"))
+            and bootstrap.get("schema") == "agentos.node-bootstrap/v0.1",
+            "realm_id": bootstrap.get("realm_id") or self.config.realm_id,
+            "node_id": bootstrap.get("node_id") or self.config.node_id,
+            "surface": "antigravity",
+            "adapter": "agentos-one-mcp",
+            "credential_boundary": "node credential retained inside local MCP process",
+            "credential_exposed": False,
+            "realm_node_count": bootstrap.get("realm_node_count"),
+        }
+
+    def capabilities(self) -> dict[str, Any]:
+        bootstrap = self.bootstrap()
+        return {
+            "schema": "agentos.one-mcp-capabilities/v0.1",
+            "realm_id": bootstrap.get("realm_id"),
+            "node_id": bootstrap.get("node_id"),
+            "realm_capabilities": bootstrap.get("realm_capabilities") or [],
+            "inherited_realm_capabilities": bootstrap.get("inherited_realm_capabilities") or [],
+            "inherited_surface_providers": bootstrap.get("inherited_surface_providers") or [],
+            "canonical_capabilities": bootstrap.get("canonical_capabilities") or [],
+        }
+
+    def resolve(self, project: str) -> dict[str, Any]:
+        project = str(project or "").strip()
+        if not project:
+            raise ValueError("project is required")
+        body = {
+            "schema": "agentos.resolve-request/v1",
+            "intent": "continue",
+            "node_id": self.config.node_id,
+            "project": project,
+        }
+        return self._request(
+            "/v1/resolve",
+            method="POST",
+            body=body,
+            authenticated=True,
+        )
+
+    def probe(self) -> dict[str, Any]:
+        result = self.status()
+        result["probe"] = "PASS" if result.get("connected") else "FAIL"
+        return result
+
+
+def create_mcp_server(gateway: OneGateway | None = None):
+    try:
+        from mcp.server import MCPServer
+    except ImportError as exc:
+        raise RuntimeError(
+            "MCP Python SDK v2 is required. Run scripts/install_antigravity_one_mcp.py first."
+        ) from exc
+
+    one = gateway or OneGateway()
+    server = MCPServer("AgentOS ONE")
+
+    @server.tool()
+    def one_status() -> dict[str, Any]:
+        """Verify this Antigravity executor is connected to AgentOS ONE without exposing credentials."""
+        return one.status()
+
+    @server.tool()
+    def one_bootstrap() -> dict[str, Any]:
+        """Return canonical Realm/Node bootstrap context available to this enrolled AgentOS client."""
+        return one.bootstrap()
+
+    @server.tool()
+    def one_capabilities() -> dict[str, Any]:
+        """Return canonical and inherited ONE capabilities visible to this Node."""
+        return one.capabilities()
+
+    @server.tool()
+    def one_resolve(project: str) -> dict[str, Any]:
+        """Resolve project identity, active goal, continuation and mutation boundary from ONE."""
+        return one.resolve(project)
+
+    return server
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Credential-isolated AgentOS ONE MCP server")
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="verify ONE connectivity without starting MCP",
+    )
+    args = parser.parse_args(argv)
+    if args.probe:
+        print(json.dumps(OneGateway().probe(), ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    create_mcp_server().run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/one_mcp.py
+++ b/agentos_node/one_mcp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -6,7 +8,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 SENSITIVE_KEYS = {
     "token",
@@ -20,11 +22,16 @@ SENSITIVE_KEYS = {
     "client_secret",
 }
 
+ORACLE_LOCAL_MODE = "oracle-local"
+CLIENT_MODE = "client"
+
 
 def _redact(value: Any) -> Any:
     if isinstance(value, dict):
         return {
-            key: "[REDACTED]" if str(key).strip().casefold() in SENSITIVE_KEYS else _redact(item)
+            key: "[REDACTED]"
+            if str(key).strip().casefold() in SENSITIVE_KEYS
+            else _redact(item)
             for key, item in value.items()
         }
     if isinstance(value, list):
@@ -42,9 +49,18 @@ def client_config_candidates() -> list[Path]:
         candidates.append(Path(client_home).expanduser() / "client.json")
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        candidates.append(Path(local_app_data) / "AgentOS" / "state" / "client.json")
+        candidates.append(
+            Path(local_app_data) / "AgentOS" / "state" / "client.json"
+        )
     if os.name == "nt":
-        candidates.append(Path.home() / "AppData" / "Local" / "AgentOS" / "state" / "client.json")
+        candidates.append(
+            Path.home()
+            / "AppData"
+            / "Local"
+            / "AgentOS"
+            / "state"
+            / "client.json"
+        )
     candidates.append(Path.home() / ".agentos" / "client.json")
 
     unique: list[Path] = []
@@ -63,7 +79,8 @@ def discover_client_config() -> Path:
             return path
     searched = ", ".join(str(path) for path in client_config_candidates())
     raise FileNotFoundError(
-        "AgentOS client.json not found. Set AGENTOS_CLIENT_CONFIG or AGENTOS_CLIENT_HOME. "
+        "AgentOS client.json not found. Set AGENTOS_CLIENT_CONFIG or "
+        "AGENTOS_CLIENT_HOME. "
         f"Searched: {searched}"
     )
 
@@ -80,9 +97,15 @@ class ClientConfig:
         source = path or discover_client_config()
         payload = json.loads(source.read_text(encoding="utf-8-sig"))
         required = ("one_url", "realm_id", "node_id", "node_token")
-        missing = [key for key in required if not str(payload.get(key) or "").strip()]
+        missing = [
+            key
+            for key in required
+            if not str(payload.get(key) or "").strip()
+        ]
         if missing:
-            raise ValueError(f"AgentOS client config missing fields: {missing}")
+            raise ValueError(
+                f"AgentOS client config missing fields: {missing}"
+            )
         return cls(
             one_url=str(payload["one_url"]).rstrip("/"),
             realm_id=str(payload["realm_id"]),
@@ -91,8 +114,18 @@ class ClientConfig:
         )
 
 
-class OneGateway:
-    """Credential-isolated read-only adapter from Antigravity MCP to ONE."""
+class Gateway(Protocol):
+    def status(self) -> dict[str, Any]: ...
+    def bootstrap(self) -> dict[str, Any]: ...
+    def capabilities(self) -> dict[str, Any]: ...
+    def resolve(self, project: str) -> dict[str, Any]: ...
+    def probe(self) -> dict[str, Any]: ...
+
+
+class ClientOneGateway:
+    """Credential-isolated read-only adapter from an enrolled client to ONE."""
+
+    mode = CLIENT_MODE
 
     def __init__(self, config: ClientConfig | None = None):
         self.config = config or ClientConfig.load()
@@ -123,13 +156,19 @@ class OneGateway:
             method=method,
         )
         try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
+            with urllib.request.urlopen(
+                request, timeout=timeout
+            ) as response:
                 raw = response.read().decode("utf-8")
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"ONE HTTP {exc.code}: {detail}") from exc
+            raise RuntimeError(
+                f"ONE HTTP {exc.code}: {detail}"
+            ) from exc
         except urllib.error.URLError as exc:
-            raise RuntimeError(f"ONE connection failed: {exc.reason}") from exc
+            raise RuntimeError(
+                f"ONE connection failed: {exc.reason}"
+            ) from exc
         payload = json.loads(raw) if raw else {}
         if not isinstance(payload, dict):
             raise RuntimeError("ONE response must be a JSON object")
@@ -139,8 +178,12 @@ class OneGateway:
         return self._request("/v1/health")
 
     def bootstrap(self) -> dict[str, Any]:
-        query = urllib.parse.urlencode({"node_id": self.config.node_id})
-        return self._request("/v1/bootstrap?" + query, authenticated=True)
+        query = urllib.parse.urlencode(
+            {"node_id": self.config.node_id}
+        )
+        return self._request(
+            "/v1/bootstrap?" + query, authenticated=True
+        )
 
     def status(self) -> dict[str, Any]:
         health = self.health()
@@ -148,12 +191,18 @@ class OneGateway:
         return {
             "schema": "agentos.one-mcp-status/v0.1",
             "connected": bool(health.get("ok"))
-            and bootstrap.get("schema") == "agentos.node-bootstrap/v0.1",
-            "realm_id": bootstrap.get("realm_id") or self.config.realm_id,
-            "node_id": bootstrap.get("node_id") or self.config.node_id,
+            and bootstrap.get("schema")
+            == "agentos.node-bootstrap/v0.1",
+            "mode": self.mode,
+            "realm_id": bootstrap.get("realm_id")
+            or self.config.realm_id,
+            "node_id": bootstrap.get("node_id")
+            or self.config.node_id,
             "surface": "antigravity",
             "adapter": "agentos-one-mcp",
-            "credential_boundary": "node credential retained inside local MCP process",
+            "credential_boundary": (
+                "node credential retained inside local MCP process"
+            ),
             "credential_exposed": False,
             "realm_node_count": bootstrap.get("realm_node_count"),
         }
@@ -162,12 +211,21 @@ class OneGateway:
         bootstrap = self.bootstrap()
         return {
             "schema": "agentos.one-mcp-capabilities/v0.1",
+            "mode": self.mode,
             "realm_id": bootstrap.get("realm_id"),
             "node_id": bootstrap.get("node_id"),
-            "realm_capabilities": bootstrap.get("realm_capabilities") or [],
-            "inherited_realm_capabilities": bootstrap.get("inherited_realm_capabilities") or [],
-            "inherited_surface_providers": bootstrap.get("inherited_surface_providers") or [],
-            "canonical_capabilities": bootstrap.get("canonical_capabilities") or [],
+            "realm_capabilities": (
+                bootstrap.get("realm_capabilities") or []
+            ),
+            "inherited_realm_capabilities": (
+                bootstrap.get("inherited_realm_capabilities") or []
+            ),
+            "inherited_surface_providers": (
+                bootstrap.get("inherited_surface_providers") or []
+            ),
+            "canonical_capabilities": (
+                bootstrap.get("canonical_capabilities") or []
+            ),
         }
 
     def resolve(self, project: str) -> dict[str, Any]:
@@ -189,19 +247,232 @@ class OneGateway:
 
     def probe(self) -> dict[str, Any]:
         result = self.status()
-        result["probe"] = "PASS" if result.get("connected") else "FAIL"
+        result["probe"] = (
+            "PASS" if result.get("connected") else "FAIL"
+        )
         return result
 
 
-def create_mcp_server(gateway: OneGateway | None = None):
+class OracleLocalGateway:
+    """Trusted local read-only projection for Oracle-hosted Antigravity.
+
+    This gateway is not a Realm Node and owns no new Realm credential. It is
+    permitted only when the MCP process runs inside the trusted Oracle/ubuntu
+    boundary that already owns the local ONE state. All model-visible output is
+    a bounded projection of canonical Node Registry / continuation state.
+    """
+
+    mode = ORACLE_LOCAL_MODE
+
+    def __init__(
+        self,
+        *,
+        data_root: Path | None = None,
+        core_node_id: str | None = None,
+    ):
+        self.data_root = (
+            data_root
+            or Path(
+                os.environ.get(
+                    "AGENT_DATA_ROOT",
+                    "/home/ubuntu/agent-data",
+                )
+            )
+        ).expanduser()
+        self.core_node_id = str(
+            core_node_id
+            or os.environ.get(
+                "AGENTOS_CORE_NODE_ID",
+                "oracle-core-node",
+            )
+        ).strip()
+        if not self.core_node_id:
+            raise ValueError("AGENTOS_CORE_NODE_ID cannot be empty")
+
+    def _node_map(self) -> dict[str, Any]:
+        from agent_core.node_registry import NodeRegistry
+
+        registry = NodeRegistry(
+            self.data_root / "realm" / "nodes.json"
+        )
+        return registry.node_map()
+
+    def _core_node(
+        self, node_map: dict[str, Any]
+    ) -> dict[str, Any]:
+        nodes = list(node_map.get("nodes") or [])
+        node = next(
+            (
+                item
+                for item in nodes
+                if str(item.get("node_id") or "")
+                == self.core_node_id
+            ),
+            None,
+        )
+        if node is None:
+            raise KeyError(
+                f"Oracle core node not present in ONE Node Registry: "
+                f"{self.core_node_id}"
+            )
+        return node
+
+    def bootstrap(self) -> dict[str, Any]:
+        node_map = self._node_map()
+        node = self._core_node(node_map)
+        inherited_caps = sorted(
+            {
+                cap
+                for other in (node_map.get("nodes") or [])
+                if other.get("node_id") != self.core_node_id
+                and other.get("status") != "offline"
+                for cap in (other.get("capabilities") or [])
+            }
+        )
+        inherited_surfaces = sorted(
+            {
+                str(surface.get("provider"))
+                for other in (node_map.get("nodes") or [])
+                if other.get("node_id") != self.core_node_id
+                and other.get("status") != "offline"
+                for surface in (
+                    (
+                        other.get("surface_inventory") or {}
+                    ).get("surfaces")
+                    or []
+                )
+                if isinstance(surface, dict)
+                and surface.get("provider")
+            }
+        )
+        return {
+            "schema": "agentos.one-local-bootstrap/v0.1",
+            "realm_id": node_map.get("realm_id"),
+            "node_id": self.core_node_id,
+            "node": node,
+            "realm_node_count": node_map.get(
+                "node_count", len(node_map.get("nodes") or [])
+            ),
+            "realm_capabilities": list(
+                node_map.get("realm_capabilities") or []
+            ),
+            "inherited_realm_capabilities": inherited_caps,
+            "inherited_surface_providers": inherited_surfaces,
+            "surface": "antigravity",
+            "executor_class": "antigravity-gemini",
+            "projection": "trusted-local-readonly",
+        }
+
+    def status(self) -> dict[str, Any]:
+        bootstrap = self.bootstrap()
+        return {
+            "schema": "agentos.one-mcp-status/v0.1",
+            "connected": bool(bootstrap.get("realm_id")),
+            "mode": self.mode,
+            "realm_id": bootstrap.get("realm_id"),
+            "node_id": bootstrap.get("node_id"),
+            "surface": "antigravity",
+            "executor_class": "antigravity-gemini",
+            "adapter": "agentos-one-mcp",
+            "credential_boundary": (
+                "trusted Oracle-local read-only projection; "
+                "no Realm credential is exposed to or owned by executor"
+            ),
+            "credential_exposed": False,
+            "realm_node_count": bootstrap.get("realm_node_count"),
+        }
+
+    def capabilities(self) -> dict[str, Any]:
+        bootstrap = self.bootstrap()
+        return {
+            "schema": "agentos.one-mcp-capabilities/v0.1",
+            "mode": self.mode,
+            "realm_id": bootstrap.get("realm_id"),
+            "node_id": bootstrap.get("node_id"),
+            "realm_capabilities": (
+                bootstrap.get("realm_capabilities") or []
+            ),
+            "inherited_realm_capabilities": (
+                bootstrap.get("inherited_realm_capabilities") or []
+            ),
+            "inherited_surface_providers": (
+                bootstrap.get("inherited_surface_providers") or []
+            ),
+        }
+
+    def resolve(self, project: str) -> dict[str, Any]:
+        from agent_core.resolve_facade import resolve_continuation
+
+        project = str(project or "").strip()
+        if not project:
+            raise ValueError("project is required")
+        result = resolve_continuation(
+            project,
+            data_root=self.data_root,
+            node_context=self.bootstrap(),
+        )
+        return _redact(result)
+
+    def probe(self) -> dict[str, Any]:
+        result = self.status()
+        result["probe"] = (
+            "PASS" if result.get("connected") else "FAIL"
+        )
+        return result
+
+
+# Backward-compatible name used by tests and callers written for the first slice.
+OneGateway = ClientOneGateway
+
+
+def gateway_mode() -> str:
+    explicit = str(
+        os.environ.get("AGENTOS_ONE_MCP_MODE") or ""
+    ).strip().casefold()
+    if explicit:
+        if explicit not in {CLIENT_MODE, ORACLE_LOCAL_MODE}:
+            raise ValueError(
+                "AGENTOS_ONE_MCP_MODE must be client or oracle-local"
+            )
+        return explicit
+    # An explicit client config always wins. Otherwise Oracle's canonical data
+    # root is enough to select the trusted local read-only projection.
+    try:
+        discover_client_config()
+        return CLIENT_MODE
+    except FileNotFoundError:
+        pass
+    data_root = Path(
+        os.environ.get(
+            "AGENT_DATA_ROOT",
+            "/home/ubuntu/agent-data",
+        )
+    ).expanduser()
+    if (
+        os.name != "nt"
+        and (data_root / "realm" / "nodes.json").is_file()
+    ):
+        return ORACLE_LOCAL_MODE
+    return CLIENT_MODE
+
+
+def create_gateway() -> Gateway:
+    mode = gateway_mode()
+    if mode == ORACLE_LOCAL_MODE:
+        return OracleLocalGateway()
+    return ClientOneGateway()
+
+
+def create_mcp_server(gateway: Gateway | None = None):
     try:
         from mcp.server import MCPServer
     except ImportError as exc:
         raise RuntimeError(
-            "MCP Python SDK v2 is required. Run scripts/install_antigravity_one_mcp.py first."
+            "MCP Python SDK v2 is required. "
+            "Run scripts/install_antigravity_one_mcp.py first."
         ) from exc
 
-    one = gateway or OneGateway()
+    one = gateway or create_gateway()
     server = MCPServer("AgentOS ONE")
 
     @server.tool()
@@ -211,12 +482,12 @@ def create_mcp_server(gateway: OneGateway | None = None):
 
     @server.tool()
     def one_bootstrap() -> dict[str, Any]:
-        """Return canonical Realm/Node bootstrap context available to this enrolled AgentOS client."""
+        """Return bounded canonical Realm/Node context available to this Antigravity executor."""
         return one.bootstrap()
 
     @server.tool()
     def one_capabilities() -> dict[str, Any]:
-        """Return canonical and inherited ONE capabilities visible to this Node."""
+        """Return canonical/inherited ONE capabilities visible through this adapter."""
         return one.capabilities()
 
     @server.tool()
@@ -228,15 +499,31 @@ def create_mcp_server(gateway: OneGateway | None = None):
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Credential-isolated AgentOS ONE MCP server")
+    parser = argparse.ArgumentParser(
+        description="Credential-isolated AgentOS ONE MCP server"
+    )
     parser.add_argument(
         "--probe",
         action="store_true",
         help="verify ONE connectivity without starting MCP",
     )
+    parser.add_argument(
+        "--mode",
+        choices=(CLIENT_MODE, ORACLE_LOCAL_MODE),
+        help="override gateway mode for this process",
+    )
     args = parser.parse_args(argv)
+    if args.mode:
+        os.environ["AGENTOS_ONE_MCP_MODE"] = args.mode
     if args.probe:
-        print(json.dumps(OneGateway().probe(), ensure_ascii=False, indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                create_gateway().probe(),
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
         return 0
     create_mcp_server().run()
     return 0

--- a/agentos_node/one_mcp_stdio.py
+++ b/agentos_node/one_mcp_stdio.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agentos_node.one_mcp import Gateway, create_gateway
+
+
+def create_server(gateway: Gateway | None = None):
+    from mcp.server.mcpserver import MCPServer
+
+    one = gateway or create_gateway()
+    server = MCPServer("AgentOS ONE", version="0.1.0")
+
+    @server.tool()
+    def one_status() -> dict[str, Any]:
+        """Verify this Antigravity executor is connected to AgentOS ONE without exposing credentials."""
+        return one.status()
+
+    @server.tool()
+    def one_bootstrap() -> dict[str, Any]:
+        """Return bounded canonical Realm/Node context available to this Antigravity executor."""
+        return one.bootstrap()
+
+    @server.tool()
+    def one_capabilities() -> dict[str, Any]:
+        """Return canonical/inherited ONE capabilities visible through this adapter."""
+        return one.capabilities()
+
+    @server.tool()
+    def one_resolve(project: str) -> dict[str, Any]:
+        """Resolve project identity, active goal, continuation and mutation boundary from ONE."""
+        return one.resolve(project)
+
+    return server
+
+
+def main() -> int:
+    create_server().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/one_mcp_stdio.py
+++ b/agentos_node/one_mcp_stdio.py
@@ -1,8 +1,32 @@
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 from agentos_node.one_mcp import Gateway, create_gateway
+
+
+def _unbind_executor_identity(value: dict[str, Any]) -> dict[str, Any]:
+    """Return an MCP projection that never guesses the caller executor.
+
+    The stdio MCP process is shared by the Antigravity surface and receives no
+    reliable per-tool caller model identity.  Only the PreInvocation hook has
+    modelName context, so MCP may prove ONE/surface connectivity but not whether
+    the current caller is Gemini, Codex, or another executor.
+    """
+    result = copy.deepcopy(value)
+
+    def mark_unbound(target: Any) -> None:
+        if not isinstance(target, dict):
+            return
+        if "executor_class" in target:
+            target["executor_class"] = "antigravity-unbound"
+        target["executor_identity_bound"] = False
+        target["executor_identity_source"] = "preinvocation-hook-required"
+
+    mark_unbound(result)
+    mark_unbound(result.get("node_context"))
+    return result
 
 
 def create_server(gateway: Gateway | None = None):
@@ -13,23 +37,23 @@ def create_server(gateway: Gateway | None = None):
 
     @server.tool()
     def one_status() -> dict[str, Any]:
-        """Verify this Antigravity executor is connected to AgentOS ONE without exposing credentials."""
-        return one.status()
+        """Verify the Antigravity surface is connected to AgentOS ONE without exposing credentials."""
+        return _unbind_executor_identity(one.status())
 
     @server.tool()
     def one_bootstrap() -> dict[str, Any]:
-        """Return bounded canonical Realm/Node context available to this Antigravity executor."""
-        return one.bootstrap()
+        """Return bounded canonical Realm/Node context without guessing caller executor identity."""
+        return _unbind_executor_identity(one.bootstrap())
 
     @server.tool()
     def one_capabilities() -> dict[str, Any]:
         """Return canonical/inherited ONE capabilities visible through this adapter."""
-        return one.capabilities()
+        return _unbind_executor_identity(one.capabilities())
 
     @server.tool()
     def one_resolve(project: str) -> dict[str, Any]:
         """Resolve project identity, active goal, continuation and mutation boundary from ONE."""
-        return one.resolve(project)
+        return _unbind_executor_identity(one.resolve(project))
 
     return server
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # AgentOS Current Architecture & Reality
 
-**Status date:** 2026-09-01  
+**Status date:** 2026-09-02  
 **Purpose:** canonical public map of what is implemented, what is verified, and what is still research.
 
 This document exists to prevent architecture drift between code and prose. It is intentionally narrower than a roadmap: every item marked **Implemented** must have a concrete repository path; every item marked **Verified** must also have a test or evidence path.
@@ -9,9 +9,9 @@ This document exists to prevent architecture drift between code and prose. It is
 
 AgentOS has one continuity goal:
 
-> A user should be able to switch session, model, executor, or machine and continue useful work without manually reconstructing the project from a large conversation history.
+> A user should be able to switch session, model, executor, extension, or machine and continue useful work without manually reconstructing the project from a large conversation history.
 
-This goal is broader than memory retrieval. AgentOS treats durable project/working state as an external system concern and treats models as replaceable executors.
+This goal is broader than memory retrieval. AgentOS treats durable project/working state as an external system concern and treats models/executors/extensions as replaceable clients of that state.
 
 ## Reality map
 
@@ -34,11 +34,12 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
 | Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2 | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_project_continuation_index.py`, `tests/test_resolve_facade.py`, `tests/test_antigravity_one_hook.py`, `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
 | Guarded Canonical IR handoff / parent fence | Implemented + tested | `agent_core/canonical_ir_handoff.py`, guarded `agent_core/project_continuation_index.py` | `tests/test_canonical_ir_handoff.py`, `tests/test_project_continuation_index.py` |
-| ONE active Canonical continuation selector | Implemented + contract-tested candidate; live Codex regression pending | `agent_core/active_continuation.py`, `scripts/seed_active_continuation.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_active_continuation.py`, `tests/test_antigravity_one_hook.py`; Oracle bootstrap self-probe now deliberately uses `/home/ubuntu/acas` |
-| Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh built-in Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
-| Gemini → ONE → fresh Antigravity Codex E3 | Not yet verified | E3 child `idx-core-152-e3-1 / ir-core-152-e3-1` exists; active-selector correction removes workspace selection authority | first live Codex attempts incorrectly continued local if-tv-station then ACAS state, proving workspace gating was invalid; rerun required after selector bootstrap |
-| Model-independent Cognitive IR across arbitrary executors/models | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-model projection/benchmark is not yet canonical | requires repeatable Gemini → ONE → fresh Codex and broader cross-model continuity experiments |
-| General zero-cost model/executor/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; portability/generalization remain open | E3 and broader continuity benchmarks still required |
+| ONE active Canonical continuation selector | Implemented + contract-tested candidate | `agent_core/active_continuation.py`, `scripts/seed_active_continuation.py`, Gemini PreInvocation + Codex MCP consumers | `tests/test_active_continuation.py`, `tests/test_antigravity_one_hook.py`, `tests/test_codex_one_mcp_stdio.py`; Oracle probe from unrelated ACAS workspace passes |
+| Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle Gemini-side `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
+| OpenAI Codex IDE extension ONE bootstrap | Implemented + contract-tested candidate; live extension acceptance pending | `agentos_node/codex_one_mcp_stdio.py`, `scripts/install_codex_one_oracle.py`, global `~/.codex/AGENTS.md` + `~/.codex/config.toml` managed blocks | `tests/test_codex_one_mcp_stdio.py`, `tests/test_install_codex_one_oracle.py`; live fresh-thread acceptance not yet complete |
+| Gemini extension → ONE → OpenAI Codex IDE extension E3 | Not yet verified | corrected child handoff `scripts/advance_issue_152_e3_to_codex_extension.py`; Oracle preparation `scripts/prepare_issue_152_codex_extension_e3_oracle.sh` | prior Codex attempts did not update Gemini PreInvocation attestation, proving the two extensions have separate lifecycle/bootstrap surfaces; fresh Codex extension test still required |
+| Model-independent Cognitive IR across arbitrary executors/models/extensions | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-client projection/benchmark is not yet canonical | requires repeatable Gemini extension → ONE → fresh Codex extension and broader cross-model continuity experiments |
+| General zero-cost model/executor/extension/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; Codex extension bootstrap candidate exists | E3 and broader continuity benchmarks still required |
 
 ## Important invariants
 
@@ -58,9 +59,19 @@ The current publisher is still restricted to `agentos-core`, so bootstrap may in
 
 ### Workspace is not continuation authority
 
-The IDE's `workspacePaths` must not choose durable continuation. This is now an evidence-backed invariant: E3 first failed when Codex was opened under `agentmanager/workspace/if-tv-station`, then failed again under `/home/ubuntu/acas`. Supporting more workspace path shapes did not solve the problem; the workspace gate itself was architecturally wrong.
+The IDE's workspace must not choose durable continuation. This is evidence-backed: early E3 attempts continued local `if-tv-station` and ACAS work because continuation hydration was gated by workspace state. Supporting more workspace path shapes did not solve the problem; the workspace gate itself was architecturally wrong.
 
-Fresh executor hydration now selects state from the ONE active selector. Workspace metadata may describe where execution occurs, but it cannot replace canonical IR or silently switch project state.
+Fresh client hydration now selects state from the ONE active selector. Workspace metadata may describe where execution occurs, but it cannot replace Canonical IR or silently switch project state.
+
+### Extension lifecycle is not shared by assumption
+
+Antigravity Gemini and the OpenAI Codex IDE extension are separate clients/extensions. `~/.gemini/config/hooks.json` is a Gemini-side lifecycle hook and is not evidence that a Codex extension thread was invoked or hydrated.
+
+The Codex extension uses its own native bootstrap surfaces: Codex home `AGENTS.md` instructions and Codex MCP configuration. Cross-extension continuity must be proven at each client's actual lifecycle boundary instead of assuming one extension's hook intercepts another.
+
+### Bootstrap instructions are not another state store
+
+Gemini hook rules, Codex `AGENTS.md`, and MCP config contain discovery/authority instructions only. They must not copy the current goal/decisions/tasks/IR generation body into client-specific config. The authoritative working state remains ONE Canonical IR, selected by the active pointer.
 
 ### Evidence is not intent
 
@@ -95,7 +106,7 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, an explicit transport-authority contract, a bounded Canonical IR continuation path, and a distinct ONE active-continuation pointer that selects which canonical generation a fresh executor should hydrate.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, an explicit transport-authority contract, a bounded Canonical IR continuation path, and a distinct ONE active-continuation pointer that selects which canonical generation a fresh client should hydrate.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
 
@@ -105,9 +116,22 @@ AgentOS has a concrete bounded Canonical IR path for project continuation: `agen
 
 The same bounded path has a Core-owned guarded handoff writer. Advancing a head requires the exact previous `index_id` / `ir_id` under the publication lock, preserving authoritative constraints/decisions and appending bounded sanitized evidence into a child IR generation.
 
-The E3 failures revealed a separate selection problem: having valid IR is insufficient if a fresh executor chooses state from its IDE workspace. The current candidate therefore adds a model-neutral active pointer that names the canonical generation to hydrate, while keeping the IR itself as the sole working-state representation. This selector correction is implemented and contract-tested but is not declared live-verified until a fresh Codex session reproduces the E3 child from an unrelated workspace such as ACAS.
+The early E3 failures revealed two independent bootstrap problems. First, workspace membership cannot choose continuation; this led to the ONE active-selector design. Second, Antigravity Gemini and OpenAI Codex are separate extensions with separate lifecycle surfaces. A Gemini `PreInvocation` attestation therefore cannot prove a Codex extension invocation.
 
-The unresolved research question remains broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
+The current E3 candidate preserves one canonical state while giving each client its native discovery path:
+
+```text
+Antigravity Gemini extension
+        ↓ Gemini PreInvocation
+ONE active selector → Canonical IR
+        ↑ one_resolve_active
+OpenAI Codex IDE extension
+        ↑ Codex AGENTS.md + MCP bootstrap
+```
+
+No client-specific bootstrap file contains a copied IR body. Success requires a completely fresh Codex IDE extension thread, given only `繼續`, to resolve the active ONE generation before workspace reconstruction and continue the corrected E3 goal.
+
+The unresolved research question remains broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, extensions, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different clients need not expose the same lifecycle hooks.
 
 The active hypothesis remains:
 
@@ -116,15 +140,15 @@ full session / events
        ↓ encode/update
 model-independent working-state IR
        ↓ active generation selector
-       ↓ hydrate/project
-new model / executor
+       ↓ client-native hydrate/project
+new model / executor / extension
        ↓
 functional continuation
 ```
 
 Success means the new executor can preserve the current goal, established decisions/constraints, rejected paths, open questions, and next direction well enough that a relative instruction such as `continue` remains meaningful.
 
-Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment remains E3: Gemini → ONE → fresh Antigravity Codex, now with workspace-independent ONE selection.
+Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment is E3: Gemini extension → ONE → fresh OpenAI Codex IDE extension.
 
 ## Documentation ownership rule
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # AgentOS Current Architecture & Reality
 
-**Status date:** 2026-08-27  
+**Status date:** 2026-09-01  
 **Purpose:** canonical public map of what is implemented, what is verified, and what is still research.
 
 This document exists to prevent architecture drift between code and prose. It is intentionally narrower than a roadmap: every item marked **Implemented** must have a concrete repository path; every item marked **Verified** must also have a test or evidence path.
@@ -28,10 +28,12 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Platform driver abstraction | Implemented + tested | `agent_core/platform/`, `scripts/platform_runtime.py` | `tests/test_platform_runtime.py` |
 | Governance drift guard | Implemented + tested | `scripts/drift_guard.py`, constitution/role registries | `tests/test_drift_guard.py` |
 | Protected-branch authority guard | Implemented on governance branch | `.agent/governance/protected_branches.yaml`, `scripts/protected_branch_authority.py` | `tests/test_protected_branch_authority.py`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md` |
-| Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows |
+| Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows and live executor evidence |
 | Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
-| Model-independent Cognitive IR | Research | schema/experiments not yet canonical | requires cross-model continuity experiment |
-| Zero-cost model switch with only `continue` | Target / not yet proven generally | depends on future portable working-state layer | continuity benchmark still required |
+| Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2 | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_project_continuation_index.py`, `tests/test_resolve_facade.py`, `tests/test_antigravity_one_hook.py`, `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
+| Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh built-in Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
+| Model-independent Cognitive IR across arbitrary executors/models | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-model projection/benchmark is not yet canonical | requires repeatable Gemini -> ONE -> fresh Codex and broader cross-model continuity experiments |
+| General zero-cost model/executor/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; portability/generalization remain open | E3 and broader continuity benchmarks still required |
 
 ## Important invariants
 
@@ -64,15 +66,17 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, and explicit authority boundaries for protected mutations.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, and a bounded Canonical IR continuation path that has been live-verified for fresh Antigravity Gemini sessions.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
 
 ## Current research boundary: Cognitive IR
 
-The unresolved question is not how to copy one model's hidden state into another model. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
+AgentOS now has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That specific E2 path is implemented and live-verified.
 
-The active hypothesis is instead:
+The unresolved research question is broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
+
+The active hypothesis remains:
 
 ```text
 full session / events
@@ -86,7 +90,7 @@ functional continuation
 
 Success means the new executor can preserve the current goal, established decisions/constraints, rejected paths, open questions, and next direction well enough that a relative instruction such as `continue` remains meaningful.
 
-This layer is **not yet declared implemented**. Do not describe it as a finished feature until a repeatable cross-model continuity benchmark exists.
+Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment is E3: Gemini -> ONE -> fresh Antigravity Codex.
 
 ## Documentation ownership rule
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -31,6 +31,7 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows and live executor evidence |
 | Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
 | Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2 | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_project_continuation_index.py`, `tests/test_resolve_facade.py`, `tests/test_antigravity_one_hook.py`, `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
+| Guarded Canonical IR handoff / parent fence | Implemented + tested | `agent_core/canonical_ir_handoff.py`, guarded `agent_core/project_continuation_index.py` | `tests/test_canonical_ir_handoff.py`, `tests/test_project_continuation_index.py` |
 | Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh built-in Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
 | Model-independent Cognitive IR across arbitrary executors/models | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-model projection/benchmark is not yet canonical | requires repeatable Gemini -> ONE -> fresh Codex and broader cross-model continuity experiments |
 | General zero-cost model/executor/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; portability/generalization remain open | E3 and broader continuity benchmarks still required |
@@ -41,9 +42,13 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 
 Compaction, replay, stale tool results, or executor switching must not replace a newer goal/correction with an older one. `scripts/continuation_state.py` currently protects this narrow invariant and has regression tests.
 
+### Canonical IR advancement is parent-fenced
+
+A writer advancing an existing Canonical IR generation must supply the exact current `index_id` and `ir_id`, create a new generation, and set the new IR's `parent_ir_id` to that expected parent. The comparison occurs while holding the same continuation-index lock used for publication. A concurrent or stale writer therefore fails before mutation instead of overwriting newer continuation state.
+
 ### Evidence is not intent
 
-Tool results and execution evidence can inform decisions, but they do not silently rewrite the user's active goal.
+Tool results and execution evidence can inform decisions, but they do not silently rewrite the user's active goal. Handoff evidence is bounded and credential-field checked before it can enter Canonical IR.
 
 ### Capability does not imply authority
 
@@ -55,7 +60,7 @@ Reusable/cross-project work should resolve existing responsibility and resources
 
 ### Models are executors, not the durable source of truth
 
-AgentOS does not assume access to model activations or model-specific internal state. Durable coordination and continuity state must remain external and transportable.
+AgentOS does not assume access to model activations or model-specific internal state. Durable coordination and continuity state must remain external and transportable. Executors may report evidence, but Core-owned governed writers advance canonical state.
 
 ## What changed from the early AgentOS architecture
 
@@ -73,6 +78,8 @@ Old documents that describe only the memory/pulse era must be treated as histori
 ## Current research boundary: Cognitive IR
 
 AgentOS now has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That specific E2 path is implemented and live-verified.
+
+The same bounded path now also has a Core-owned guarded handoff writer. Advancing a head requires the exact previous `index_id` / `ir_id` under the publication lock, preserving authoritative constraints/decisions and appending bounded sanitized evidence into a child IR generation. This solves the immediate E2 -> E3 handoff problem without introducing a second focus/state system.
 
 The unresolved research question is broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -34,8 +34,10 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
 | Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2 | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_project_continuation_index.py`, `tests/test_resolve_facade.py`, `tests/test_antigravity_one_hook.py`, `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
 | Guarded Canonical IR handoff / parent fence | Implemented + tested | `agent_core/canonical_ir_handoff.py`, guarded `agent_core/project_continuation_index.py` | `tests/test_canonical_ir_handoff.py`, `tests/test_project_continuation_index.py` |
+| ONE active Canonical continuation selector | Implemented + contract-tested candidate; live Codex regression pending | `agent_core/active_continuation.py`, `scripts/seed_active_continuation.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_active_continuation.py`, `tests/test_antigravity_one_hook.py`; Oracle bootstrap self-probe now deliberately uses `/home/ubuntu/acas` |
 | Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh built-in Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
-| Model-independent Cognitive IR across arbitrary executors/models | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-model projection/benchmark is not yet canonical | requires repeatable Gemini -> ONE -> fresh Codex and broader cross-model continuity experiments |
+| Gemini → ONE → fresh Antigravity Codex E3 | Not yet verified | E3 child `idx-core-152-e3-1 / ir-core-152-e3-1` exists; active-selector correction removes workspace selection authority | first live Codex attempts incorrectly continued local if-tv-station then ACAS state, proving workspace gating was invalid; rerun required after selector bootstrap |
+| Model-independent Cognitive IR across arbitrary executors/models | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-model projection/benchmark is not yet canonical | requires repeatable Gemini → ONE → fresh Codex and broader cross-model continuity experiments |
 | General zero-cost model/executor/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; portability/generalization remain open | E3 and broader continuity benchmarks still required |
 
 ## Important invariants
@@ -47,6 +49,18 @@ Compaction, replay, stale tool results, or executor switching must not replace a
 ### Canonical IR advancement is parent-fenced
 
 A writer advancing an existing Canonical IR generation must supply the exact current `index_id` and `ir_id`, create a new generation, and set the new IR's `parent_ir_id` to that expected parent. The comparison occurs while holding the same continuation-index lock used for publication. A concurrent or stale writer therefore fails before mutation instead of overwriting newer continuation state.
+
+### Active selector is a pointer, not another state store
+
+`agentos.active-continuation/v1` stores only `project_id + index_id + ir_id` (plus activation metadata). It does not duplicate goal, decisions, tasks, evidence, or model context. Those remain in the referenced Canonical IR. Selector reads revalidate the referenced generation; a stale selector fails closed.
+
+The current publisher is still restricted to `agentos-core`, so bootstrap may initialize a missing selector from that one supported canonical project. It must not silently overwrite an existing stale selector.
+
+### Workspace is not continuation authority
+
+The IDE's `workspacePaths` must not choose durable continuation. This is now an evidence-backed invariant: E3 first failed when Codex was opened under `agentmanager/workspace/if-tv-station`, then failed again under `/home/ubuntu/acas`. Supporting more workspace path shapes did not solve the problem; the workspace gate itself was architecturally wrong.
+
+Fresh executor hydration now selects state from the ONE active selector. Workspace metadata may describe where execution occurs, but it cannot replace canonical IR or silently switch project state.
 
 ### Evidence is not intent
 
@@ -81,17 +95,19 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, an explicit transport-authority contract that prevents workflow-carrier capability from becoming control-plane authority, and a bounded Canonical IR continuation path that has been live-verified for fresh Antigravity Gemini sessions.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, an explicit transport-authority contract, a bounded Canonical IR continuation path, and a distinct ONE active-continuation pointer that selects which canonical generation a fresh executor should hydrate.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
 
 ## Current research boundary: Cognitive IR
 
-AgentOS now has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That specific E2 path is implemented and live-verified.
+AgentOS has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That specific E2 path is implemented and live-verified.
 
-The same bounded path now also has a Core-owned guarded handoff writer. Advancing a head requires the exact previous `index_id` / `ir_id` under the publication lock, preserving authoritative constraints/decisions and appending bounded sanitized evidence into a child IR generation. This solves the immediate E2 -> E3 handoff problem without introducing a second focus/state system.
+The same bounded path has a Core-owned guarded handoff writer. Advancing a head requires the exact previous `index_id` / `ir_id` under the publication lock, preserving authoritative constraints/decisions and appending bounded sanitized evidence into a child IR generation.
 
-The unresolved research question is broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
+The E3 failures revealed a separate selection problem: having valid IR is insufficient if a fresh executor chooses state from its IDE workspace. The current candidate therefore adds a model-neutral active pointer that names the canonical generation to hydrate, while keeping the IR itself as the sole working-state representation. This selector correction is implemented and contract-tested but is not declared live-verified until a fresh Codex session reproduces the E3 child from an unrelated workspace such as ACAS.
+
+The unresolved research question remains broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different models need not have identical internal representations.
 
 The active hypothesis remains:
 
@@ -99,6 +115,7 @@ The active hypothesis remains:
 full session / events
        ↓ encode/update
 model-independent working-state IR
+       ↓ active generation selector
        ↓ hydrate/project
 new model / executor
        ↓
@@ -107,7 +124,7 @@ functional continuation
 
 Success means the new executor can preserve the current goal, established decisions/constraints, rejected paths, open questions, and next direction well enough that a relative instruction such as `continue` remains meaningful.
 
-Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment is E3: Gemini -> ONE -> fresh Antigravity Codex.
+Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment remains E3: Gemini → ONE → fresh Antigravity Codex, now with workspace-independent ONE selection.
 
 ## Documentation ownership rule
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -32,14 +32,15 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Protected-branch authority guard | Implemented on governance branch | `.agent/governance/protected_branches.yaml`, `scripts/protected_branch_authority.py` | `tests/test_protected_branch_authority.py`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md` |
 | Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows and live executor evidence |
 | Documentation Reality Guard | Implemented | `scripts/documentation_reality_guard.py` | `.github/workflows/documentation-reality-guard.yml`, `tests/test_documentation_reality_guard.py` |
-| Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2 | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, `agentos_node/antigravity_one_hook.py` | `tests/test_project_continuation_index.py`, `tests/test_resolve_facade.py`, `tests/test_antigravity_one_hook.py`, `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
+| Canonical continuation IR (`agentos.ir/v1`) | Implemented + verified for AgentOS Core E2/E3 slices | `agent_core/project_continuation_index.py`, `agent_core/resolve_facade.py`, Gemini/Codex consumers | Gemini E2 evidence plus `.agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md` |
 | Guarded Canonical IR handoff / parent fence | Implemented + tested | `agent_core/canonical_ir_handoff.py`, guarded `agent_core/project_continuation_index.py` | `tests/test_canonical_ir_handoff.py`, `tests/test_project_continuation_index.py` |
-| ONE active Canonical continuation selector | Implemented + contract-tested candidate | `agent_core/active_continuation.py`, `scripts/seed_active_continuation.py`, Gemini PreInvocation + Codex MCP consumers | `tests/test_active_continuation.py`, `tests/test_antigravity_one_hook.py`, `tests/test_codex_one_mcp_stdio.py`; Oracle probe from unrelated ACAS workspace passes |
+| ONE active Canonical continuation selector | Implemented + verified for tested Gemini/Codex continuity slice | `agent_core/active_continuation.py`, `scripts/seed_active_continuation.py`, Gemini PreInvocation + Codex MCP consumers | unrelated-workspace Oracle probe plus two fresh Codex `one_resolve_active` observations |
 | Fresh Antigravity Gemini continuation with only `繼續` | Verified for one concrete E2 slice | Oracle Gemini-side `PreInvocation` hydration from ONE Canonical IR plus read-only MCP adapter | two independent fresh Gemini sessions reproduced `ONE_PREINVOCATION_IR / agentos-core / idx-core-152 / ir-core-152`; see `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md` |
-| OpenAI Codex IDE extension ONE bootstrap | Implemented + contract-tested candidate; live extension acceptance pending | `agentos_node/codex_one_mcp_stdio.py`, `scripts/install_codex_one_oracle.py`, global `~/.codex/AGENTS.md` + `~/.codex/config.toml` managed blocks | `tests/test_codex_one_mcp_stdio.py`, `tests/test_install_codex_one_oracle.py`; live fresh-thread acceptance not yet complete |
-| Gemini extension → ONE → OpenAI Codex IDE extension E3 | Not yet verified | corrected child handoff `scripts/advance_issue_152_e3_to_codex_extension.py`; Oracle preparation `scripts/prepare_issue_152_codex_extension_e3_oracle.sh` | prior Codex attempts did not update Gemini PreInvocation attestation, proving the two extensions have separate lifecycle/bootstrap surfaces; fresh Codex extension test still required |
-| Model-independent Cognitive IR across arbitrary executors/models/extensions | Research | bounded `agentos.ir/v1` continuity exists, but the general cross-client projection/benchmark is not yet canonical | requires repeatable Gemini extension → ONE → fresh Codex extension and broader cross-model continuity experiments |
-| General zero-cost model/executor/extension/machine switch with only `continue` | Target / not yet proven generally | one Antigravity Gemini E2 slice is verified; Codex extension bootstrap candidate exists | E3 and broader continuity benchmarks still required |
+| OpenAI Codex IDE extension ONE bootstrap | Implemented + live-verified | `agentos_node/codex_one_mcp_stdio.py`, `scripts/install_codex_one_oracle.py`, global `~/.codex/AGENTS.md` + `~/.codex/config.toml` managed blocks | two independent fresh Codex extension threads resolved the same ONE-selected E3 generation; `.agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md` |
+| Gemini extension → ONE → OpenAI Codex IDE extension E3 | **Verified for one concrete Oracle cross-extension slice** | corrected child handoff, Codex native AGENTS+MCP bootstrap, `one_resolve_active` receipt | #152 comments `5503435564` + `5503469931`; distinct receipt timestamps `02:28:29Z` and `02:32:25Z`; repository evidence file above |
+| Post-E3 canonical continuation | Implemented guarded handoff; live advancement pending | `scripts/advance_issue_152_after_e3_verified.py`, `scripts/advance_issue_152_after_e3_verified_oracle.sh` | parent-fenced from verified E3 generation; intended to resume broader #152 work instead of repeating completed regression |
+| Model-independent Cognitive IR across arbitrary executors/models/extensions | Research | bounded `agentos.ir/v1` continuity now has one verified Gemini→Codex cross-extension slice, but general cross-client projection/benchmark is not canonical | requires broader model/extension/machine experiments; do not generalize one verified slice |
+| General zero-cost model/executor/extension/machine switch with only `continue` | Target / not yet proven generally | Gemini E2 and Gemini→Codex E3 are verified concrete slices | broader continuity, client diversity, and machine portability benchmarks still required |
 
 ## Important invariants
 
@@ -112,13 +113,13 @@ Old documents that describe only the memory/pulse era must be treated as histori
 
 ## Current research boundary: Cognitive IR
 
-AgentOS has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That specific E2 path is implemented and live-verified.
+AgentOS has a concrete bounded Canonical IR path for project continuation: `agentos.ir/v1` can be published together with an `agentos.execution-head/v1` generation fence and hydrated into a fresh Antigravity Gemini session through ONE. That E2 path is implemented and live-verified.
 
 The same bounded path has a Core-owned guarded handoff writer. Advancing a head requires the exact previous `index_id` / `ir_id` under the publication lock, preserving authoritative constraints/decisions and appending bounded sanitized evidence into a child IR generation.
 
 The early E3 failures revealed two independent bootstrap problems. First, workspace membership cannot choose continuation; this led to the ONE active-selector design. Second, Antigravity Gemini and OpenAI Codex are separate extensions with separate lifecycle surfaces. A Gemini `PreInvocation` attestation therefore cannot prove a Codex extension invocation.
 
-The current E3 candidate preserves one canonical state while giving each client its native discovery path:
+The corrected E3 design preserves one canonical state while giving each client its native discovery path:
 
 ```text
 Antigravity Gemini extension
@@ -129,9 +130,9 @@ OpenAI Codex IDE extension
         ↑ Codex AGENTS.md + MCP bootstrap
 ```
 
-No client-specific bootstrap file contains a copied IR body. Success requires a completely fresh Codex IDE extension thread, given only `繼續`, to resolve the active ONE generation before workspace reconstruction and continue the corrected E3 goal.
+This concrete E3 slice is now live-verified from two independently fresh Codex IDE extension threads, each given only `繼續`, with independent terminal receipts proving `one_resolve_active` reached the same corrected Canonical IR generation and `credential_exposed=false`. No client-specific bootstrap file contained a copied IR body.
 
-The unresolved research question remains broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, extensions, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different clients need not expose the same lifecycle hooks.
+This is meaningful evidence for the model-independent working-state hypothesis, but it is not proof of arbitrary portability. The unresolved research question remains broader: whether one model-independent working-state representation and projection layer can preserve useful continuity across arbitrary model families, executors, extensions, and machines with consistently low reconstruction cost. Public model interfaces do not provide a portable common activation state, and different clients need not expose the same lifecycle hooks.
 
 The active hypothesis remains:
 
@@ -148,7 +149,7 @@ functional continuation
 
 Success means the new executor can preserve the current goal, established decisions/constraints, rejected paths, open questions, and next direction well enough that a relative instruction such as `continue` remains meaningful.
 
-Do not generalize the verified Antigravity Gemini E2 slice into a claim of arbitrary cross-model continuity. The next critical experiment is E3: Gemini extension → ONE → fresh OpenAI Codex IDE extension.
+Do not generalize the verified Gemini→Codex E3 slice into a claim of arbitrary cross-model continuity. The next #152 engineering step is the broader Node/executor lifecycle extraction and remaining real-client acceptance; the next research step is to repeat the continuity pattern across additional clients/models/machines.
 
 ## Documentation ownership rule
 

--- a/docs/issue-152-ir-bootstrap-note.md
+++ b/docs/issue-152-ir-bootstrap-note.md
@@ -4,7 +4,7 @@
 
 Fresh Antigravity executor continuity is hydrated from the existing Canonical IR contract, not reconstructed from workspace roots, Pulse/PM2 state, or a new conversation/project focus store.
 
-Current Core acceptance path:
+Current Core path:
 
 ```text
 Antigravity PreInvocation
@@ -12,8 +12,9 @@ Antigravity PreInvocation
   -> resolve canonical `agentos-core`
   -> validate `agentos.execution-head/v1` generation
   -> validate matching `agentos.ir/v1` `index_id`
+  -> bind caller executor identity only from current PreInvocation `modelName`
   -> inject one bounded Canonical IR envelope
-  -> Gemini first model invocation
+  -> current Antigravity model invocation
 ```
 
 The current canonical continuation publisher (`agent_core/project_continuation_index.py`) is intentionally restricted to `agentos-core` and atomically publishes:
@@ -27,17 +28,41 @@ Both share one `index_id`; the continuation contains the `agentos.ir/v1` Canonic
 
 Antigravity `workspacePaths` are only a gate proving that the Core checkout (`agentmanager`) is present. Sibling roots must never become candidate current projects. The hook resolves only `agentos-core` for this acceptance slice.
 
+## Executor identity boundary
+
+Canonical continuity and executor identity are separate claims.
+
+The Antigravity `PreInvocation` payload contains the current `modelName`, so that hook may bind a recognized caller as `antigravity-gemini` or `antigravity-codex`. Unrecognized model names remain `antigravity-unknown` with `executor_identity_bound=false`; the hook must not guess from a generic model family name.
+
+The shared stdio MCP process has no reliable per-tool caller-model context. Its responses therefore prove only the Antigravity surface / ONE connection and explicitly return the executor identity as unbound. MCP must not claim `antigravity-gemini` merely because the original E2 adapter was built for Gemini.
+
 ## Fail-closed rule
 
 If the execution head or Canonical IR is missing, malformed, or has a mismatched generation, inject/report `ONE_IR_HEAD_UNRESOLVED`. Do not fall back to workspace enumeration, Pulse, PM2, local memory, or vendor conversation reconstruction.
 
-## Live acceptance
+If the current model name cannot prove an executor class, continuity hydration may still proceed, but an executor-specific E2/E3 acceptance must not be marked verified from that session without separate valid identity evidence.
 
-A fresh built-in Antigravity Gemini conversation receives only `繼續` and must continue from the injected IR. Evidence should expose at least:
+## Live E2 acceptance
+
+E2 is live-verified for the built-in Antigravity Gemini surface. Two completely fresh conversations received only `繼續` and independently recovered:
 
 - `source=ONE_PREINVOCATION_IR`
 - `project_id=agentos-core`
-- `index_id=<canonical generation>`
-- `ir_id=<canonical IR>`
+- `index_id=idx-core-152`
+- `ir_id=ir-core-152`
 
-No sibling-project state should appear unless newer explicit user intent asks for it.
+Evidence is preserved in `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md`.
+
+## E3 acceptance target
+
+The next child generation is intended for a completely fresh built-in Antigravity Codex session. After guarded E2 -> E3 advancement and reload, a fresh Codex conversation receiving only `繼續` must recover the child Canonical IR and expose at least:
+
+- `source=ONE_PREINVOCATION_IR`
+- `project_id=agentos-core`
+- `index_id=idx-core-152-e3-1`
+- `ir_id=ir-core-152-e3-1`
+- `executor_class=antigravity-codex`
+- `executor_identity_bound=true`
+- the actual `model_name`
+
+No sibling-project state should appear unless newer explicit user intent asks for it. E3 remains unverified until live evidence passes.

--- a/docs/issue-152-ir-bootstrap-note.md
+++ b/docs/issue-152-ir-bootstrap-note.md
@@ -4,7 +4,7 @@
 
 Fresh Antigravity executor continuity is hydrated from the existing Canonical IR contract, not reconstructed from workspace roots, Pulse/PM2 state, or a new conversation/project focus store.
 
-Current Core path:
+Current Core acceptance path:
 
 ```text
 Antigravity PreInvocation
@@ -12,9 +12,8 @@ Antigravity PreInvocation
   -> resolve canonical `agentos-core`
   -> validate `agentos.execution-head/v1` generation
   -> validate matching `agentos.ir/v1` `index_id`
-  -> bind caller executor identity only from current PreInvocation `modelName`
   -> inject one bounded Canonical IR envelope
-  -> current Antigravity model invocation
+  -> active Antigravity model first invocation
 ```
 
 The current canonical continuation publisher (`agent_core/project_continuation_index.py`) is intentionally restricted to `agentos-core` and atomically publishes:
@@ -24,45 +23,35 @@ The current canonical continuation publisher (`agent_core/project_continuation_i
 
 Both share one `index_id`; the continuation contains the `agentos.ir/v1` Canonical IR.
 
-## Multi-root rule
+## Workspace gate rule
 
-Antigravity `workspacePaths` are only a gate proving that the Core checkout (`agentmanager`) is present. Sibling roots must never become candidate current projects. The hook resolves only `agentos-core` for this acceptance slice.
+Antigravity `workspacePaths` are only a gate proving that the active workspace is inside the canonical Core checkout tree. The accepted gate includes both the repository root and descendants, for example:
 
-## Executor identity boundary
+- `/home/ubuntu/agentmanager`
+- `/home/ubuntu/agentmanager/workspace/if-tv-station`
 
-Canonical continuity and executor identity are separate claims.
+A descendant workspace name is never a project selector. Once the gate is open, #152 resolves exactly `agentos-core`; `if-tv-station`, another nested workspace, or sibling roots must not replace the canonical continuation. Prefix lookalikes such as `/home/ubuntu/agentmanager-old` are not accepted as descendants.
 
-The Antigravity `PreInvocation` payload contains the current `modelName`, so that hook may bind a recognized caller as `antigravity-gemini` or `antigravity-codex`. Unrecognized model names remain `antigravity-unknown` with `executor_identity_bound=false`; the hook must not guess from a generic model family name.
+This descendant rule is required because Antigravity may report the active nested workspace rather than the repository root in a fresh executor conversation.
 
-The shared stdio MCP process has no reliable per-tool caller-model context. Its responses therefore prove only the Antigravity surface / ONE connection and explicitly return the executor identity as unbound. MCP must not claim `antigravity-gemini` merely because the original E2 adapter was built for Gemini.
+## Executor identity rule
+
+The PreInvocation hook may bind the active Antigravity executor only from the hook payload's current `modelName`. A Codex-bearing model name binds `antigravity-codex`; a Gemini-bearing model name binds `antigravity-gemini`; unknown names remain `antigravity-unknown` with `executor_identity_bound=false`.
+
+The generic MCP stdio process has no trustworthy caller-model context and therefore reports `antigravity-unbound`. MCP connectivity must not be used to fabricate Gemini/Codex identity evidence.
 
 ## Fail-closed rule
 
 If the execution head or Canonical IR is missing, malformed, or has a mismatched generation, inject/report `ONE_IR_HEAD_UNRESOLVED`. Do not fall back to workspace enumeration, Pulse, PM2, local memory, or vendor conversation reconstruction.
 
-If the current model name cannot prove an executor class, continuity hydration may still proceed, but an executor-specific E2/E3 acceptance must not be marked verified from that session without separate valid identity evidence.
+## Live acceptance
 
-## Live E2 acceptance
-
-E2 is live-verified for the built-in Antigravity Gemini surface. Two completely fresh conversations received only `繼續` and independently recovered:
+A fresh built-in Antigravity executor conversation receives only `繼續` and must continue from the injected IR. Evidence should expose at least:
 
 - `source=ONE_PREINVOCATION_IR`
 - `project_id=agentos-core`
-- `index_id=idx-core-152`
-- `ir_id=ir-core-152`
+- `index_id=<canonical generation>`
+- `ir_id=<canonical IR>`
+- executor identity bound by PreInvocation when the model name proves it
 
-Evidence is preserved in `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md`.
-
-## E3 acceptance target
-
-The next child generation is intended for a completely fresh built-in Antigravity Codex session. After guarded E2 -> E3 advancement and reload, a fresh Codex conversation receiving only `繼續` must recover the child Canonical IR and expose at least:
-
-- `source=ONE_PREINVOCATION_IR`
-- `project_id=agentos-core`
-- `index_id=idx-core-152-e3-1`
-- `ir_id=ir-core-152-e3-1`
-- `executor_class=antigravity-codex`
-- `executor_identity_bound=true`
-- the actual `model_name`
-
-No sibling-project state should appear unless newer explicit user intent asks for it. E3 remains unverified until live evidence passes.
+No sibling/nested-project state should become the durable continuation merely because that workspace is active.

--- a/docs/issue-152-ir-bootstrap-note.md
+++ b/docs/issue-152-ir-bootstrap-note.md
@@ -1,0 +1,43 @@
+# Issue #152 — Antigravity fresh-session bootstrap correction
+
+## Durable state authority
+
+Fresh Antigravity executor continuity is hydrated from the existing Canonical IR contract, not reconstructed from workspace roots, Pulse/PM2 state, or a new conversation/project focus store.
+
+Current Core acceptance path:
+
+```text
+Antigravity PreInvocation
+  -> Oracle ONE local projection
+  -> resolve canonical `agentos-core`
+  -> validate `agentos.execution-head/v1` generation
+  -> validate matching `agentos.ir/v1` `index_id`
+  -> inject one bounded Canonical IR envelope
+  -> Gemini first model invocation
+```
+
+The current canonical continuation publisher (`agent_core/project_continuation_index.py`) is intentionally restricted to `agentos-core` and atomically publishes:
+
+- `projects/agentos-core/execution-head.json`
+- `projects/agentos-core/continuity/latest.json`
+
+Both share one `index_id`; the continuation contains the `agentos.ir/v1` Canonical IR.
+
+## Multi-root rule
+
+Antigravity `workspacePaths` are only a gate proving that the Core checkout (`agentmanager`) is present. Sibling roots must never become candidate current projects. The hook resolves only `agentos-core` for this acceptance slice.
+
+## Fail-closed rule
+
+If the execution head or Canonical IR is missing, malformed, or has a mismatched generation, inject/report `ONE_IR_HEAD_UNRESOLVED`. Do not fall back to workspace enumeration, Pulse, PM2, local memory, or vendor conversation reconstruction.
+
+## Live acceptance
+
+A fresh built-in Antigravity Gemini conversation receives only `繼續` and must continue from the injected IR. Evidence should expose at least:
+
+- `source=ONE_PREINVOCATION_IR`
+- `project_id=agentos-core`
+- `index_id=<canonical generation>`
+- `ir_id=<canonical IR>`
+
+No sibling-project state should appear unless newer explicit user intent asks for it.

--- a/docs/issue-152-ir-bootstrap-note.md
+++ b/docs/issue-152-ir-bootstrap-note.md
@@ -2,37 +2,51 @@
 
 ## Durable state authority
 
-Fresh Antigravity executor continuity is hydrated from the existing Canonical IR contract, not reconstructed from workspace roots, Pulse/PM2 state, or a new conversation/project focus store.
+Fresh Antigravity executor continuity is hydrated from the Canonical IR contract, not reconstructed from workspace roots, Pulse/PM2 state, local memory, or vendor history.
 
 Current Core acceptance path:
 
 ```text
 Antigravity PreInvocation
+  -> ONE active-continuation selector
+       project_id + index_id + ir_id
   -> Oracle ONE local projection
-  -> resolve canonical `agentos-core`
-  -> validate `agentos.execution-head/v1` generation
-  -> validate matching `agentos.ir/v1` `index_id`
+  -> resolve selected canonical project
+  -> validate matching agentos.execution-head/v1 generation
+  -> validate matching agentos.ir/v1 index_id + ir_id
   -> inject one bounded Canonical IR envelope
   -> active Antigravity model first invocation
 ```
 
-The current canonical continuation publisher (`agent_core/project_continuation_index.py`) is intentionally restricted to `agentos-core` and atomically publishes:
+The active selector is **not a second state store**. It is a Realm/runtime pointer only. Goal, constraints, decisions, pending tasks, next action, capability and evidence remain in the referenced Canonical IR.
+
+The current canonical continuation publisher (`agent_core/project_continuation_index.py`) is initially restricted to `agentos-core` and atomically publishes:
 
 - `projects/agentos-core/execution-head.json`
 - `projects/agentos-core/continuity/latest.json`
 
 Both share one `index_id`; the continuation contains the `agentos.ir/v1` Canonical IR.
 
-## Workspace gate rule
+## Active selector rule
 
-Antigravity `workspacePaths` are only a gate proving that the active workspace is inside the canonical Core checkout tree. The accepted gate includes both the repository root and descendants, for example:
+`agent_core/active_continuation.py` owns `runtime/active-continuation.json` with schema `agentos.active-continuation/v1`.
 
-- `/home/ubuntu/agentmanager`
-- `/home/ubuntu/agentmanager/workspace/if-tv-station`
+A selector may be activated only when its exact `project_id / index_id / ir_id` currently resolves to a valid canonical generation. Reading the selector revalidates that generation. If the project advances and the selector remains on the parent generation, the selector is stale and fresh hydration fails closed until it is reconciled.
 
-A descendant workspace name is never a project selector. Once the gate is open, #152 resolves exactly `agentos-core`; `if-tv-station`, another nested workspace, or sibling roots must not replace the canonical continuation. Prefix lookalikes such as `/home/ubuntu/agentmanager-old` are not accepted as descendants.
+For the current #152 slice, `scripts/seed_active_continuation.py` may initialize a missing selector from `agentos-core` because `agentos-core` is still the only project accepted by the Canonical IR publisher. It never overwrites an existing stale selector.
 
-This descendant rule is required because Antigravity may report the active nested workspace rather than the repository root in a fresh executor conversation.
+## Workspace rule
+
+Antigravity `workspacePaths` have **no continuation-selection authority**.
+
+This was learned from two real E3 failures:
+
+1. a Codex conversation under `agentmanager/workspace/if-tv-station` continued local if-tv-station state when the old Hook required the repository root as a workspace gate;
+2. after descendant support was added, a Codex conversation under `/home/ubuntu/acas` continued local ACAS state because the Hook still required some path under `agentmanager`.
+
+Therefore the gate itself was removed. A fresh executor opened in ACAS, if-tv-station, the Core checkout, or with an empty workspace list must receive the same ONE-selected Canonical IR unless newer explicit user intent has deliberately changed the active continuation.
+
+Workspace metadata may still describe execution environment, but it must never select or replace durable continuation.
 
 ## Executor identity rule
 
@@ -42,16 +56,17 @@ The generic MCP stdio process has no trustworthy caller-model context and theref
 
 ## Fail-closed rule
 
-If the execution head or Canonical IR is missing, malformed, or has a mismatched generation, inject/report `ONE_IR_HEAD_UNRESOLVED`. Do not fall back to workspace enumeration, Pulse, PM2, local memory, or vendor conversation reconstruction.
+If the active selector is missing/malformed/stale, or the selected execution head / Canonical IR is missing, malformed, or generation-mismatched, inject/report `ONE_IR_HEAD_UNRESOLVED`. Do not fall back to workspace enumeration, Pulse, PM2, local memory, or vendor conversation reconstruction.
 
 ## Live acceptance
 
 A fresh built-in Antigravity executor conversation receives only `繼續` and must continue from the injected IR. Evidence should expose at least:
 
 - `source=ONE_PREINVOCATION_IR`
-- `project_id=agentos-core`
-- `index_id=<canonical generation>`
-- `ir_id=<canonical IR>`
+- `selection_source=ONE_ACTIVE_CONTINUATION`
+- `project_id=<active selector project>`
+- `index_id=<active selector generation>`
+- `ir_id=<active selector IR>`
 - executor identity bound by PreInvocation when the model name proves it
 
-No sibling/nested-project state should become the durable continuation merely because that workspace is active.
+For E3, the expected active generation is currently `agentos-core / idx-core-152-e3-1 / ir-core-152-e3-1`. The current IDE workspace must not alter that result.

--- a/scripts/advance_issue_152_after_e3_verified.py
+++ b/scripts/advance_issue_152_after_e3_verified.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent_core.active_continuation import activate_continuation
+from agent_core.canonical_ir_handoff import advance_canonical_ir
+from agent_core.resolve_facade import resolve_continuation
+
+PROJECT_ID = "agentos-core"
+EXPECTED_INDEX = "idx-core-152-e3-codex-ext-1"
+EXPECTED_IR = "ir-core-152-e3-codex-ext-1"
+NEW_INDEX = "idx-core-152-post-e3-1"
+NEW_IR = "ir-core-152-post-e3-1"
+GOAL = (
+    "Continue AgentOS Core #152 after verified Gemini -> ONE -> OpenAI Codex IDE extension E3 continuity; "
+    "finish the broader durable Node-vs-executor extraction without regressing the verified continuity slice."
+)
+NEXT_ACTION = (
+    "Resume #152 broader Node/executor extraction: make executor availability/freshness explicit and separate from Node liveness, "
+    "reconcile executor lifecycle/bridge responsibilities with the existing session bridge without duplicate authority, "
+    "then obtain the remaining real-client acceptance evidence. Do not repeat the completed Codex E3 fresh-thread regression."
+)
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def _activate(root: Path) -> dict:
+    return activate_continuation(
+        PROJECT_ID,
+        index_id=NEW_INDEX,
+        ir_id=NEW_IR,
+        reason="#152 E3 cross-extension continuity verified; resume broader Node/executor extraction",
+        data_root=root,
+    )
+
+
+def main() -> int:
+    root = _data_root()
+    current = resolve_continuation(PROJECT_ID, data_root=root)
+    head = current.get("execution_head") if isinstance(current.get("execution_head"), dict) else {}
+    continuation = current.get("continuation") if isinstance(current.get("continuation"), dict) else {}
+    ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    current_index = str(head.get("index_id") or "").strip()
+    current_ir = str(ir.get("ir_id") or "").strip()
+
+    if current_index == NEW_INDEX and current_ir == NEW_IR:
+        activation = _activate(root)
+        print(json.dumps({
+            "schema": "agentos.issue-152-post-e3/v1",
+            "ok": True,
+            "advanced": False,
+            "reason": "already advanced; active selector reconciled",
+            "project_id": PROJECT_ID,
+            "index_id": NEW_INDEX,
+            "ir_id": NEW_IR,
+            "active_selector": activation,
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    if current_index != EXPECTED_INDEX or current_ir != EXPECTED_IR:
+        print(json.dumps({
+            "schema": "agentos.issue-152-post-e3/v1",
+            "ok": False,
+            "advanced": False,
+            "reason": "unexpected canonical parent; refusing to overwrite",
+            "expected": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+            "found": {"index_id": current_index or None, "ir_id": current_ir or None},
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 3
+
+    receipt = advance_canonical_ir(
+        {
+            "project_id": PROJECT_ID,
+            "expected_index_id": EXPECTED_INDEX,
+            "expected_ir_id": EXPECTED_IR,
+            "new_index_id": NEW_INDEX,
+            "new_ir_id": NEW_IR,
+            "goal": GOAL,
+            "next_action": NEXT_ACTION,
+            "pending_tasks": [
+                "Extract/generalize executor availability and freshness so Node online does not imply executor available.",
+                "Preserve the credential-isolated executor-host boundary: executor hosts own no ONE transport credential.",
+                "Reconcile executor lifecycle/bridge responsibilities with agentos.session-bridge/v0.1 without duplicate authority.",
+                "Complete the remaining real client / vopc5750 acceptance required by #152 before closing the issue.",
+                "Keep the verified Gemini -> ONE -> OpenAI Codex extension E3 slice under regression coverage.",
+            ],
+            "decisions_append": [
+                "E3 Gemini extension -> ONE -> OpenAI Codex IDE extension continuity is VERIFIED from two independent fresh Codex threads given only 繼續.",
+                "Both Codex threads resolved the same ONE_ACTIVE_CONTINUATION generation through one_resolve_active with credential_exposed=false.",
+                "Client-specific bootstrap configuration contains discovery/runtime wiring only; Canonical IR remains the sole durable working state.",
+                "The completed E3 slice does not close #152; broader Node/executor lifecycle extraction and real-client acceptance remain required.",
+            ],
+            "evidence": [
+                {
+                    "kind": "codex-extension-e3-pass-1",
+                    "verdict": "PASS",
+                    "summary": "Fresh Codex extension thread given only 繼續 resolved agentos-core idx-core-152-e3-codex-ext-1 / ir-core-152-e3-codex-ext-1 through ONE_ACTIVE_CONTINUATION.",
+                    "date": "2026-09-02",
+                    "issue_comment_id": "5503435564",
+                },
+                {
+                    "kind": "codex-extension-e3-pass-2",
+                    "verdict": "PASS",
+                    "summary": "Second independent fresh Codex extension thread repeated the same bounded ONE resolution; terminal receipt recorded 2026-09-02T02:32:25Z.",
+                    "date": "2026-09-02",
+                    "issue_comment_id": "5503469931",
+                    "evidence_path": ".agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md",
+                },
+            ],
+            "execution_status": "in_progress",
+            "execution_metadata": {
+                "issue": "#152",
+                "phase": "post-E3-node-executor-extraction",
+                "e3_verdict": "VERIFIED",
+            },
+        },
+        data_root=root,
+    )
+    activation = _activate(root)
+    print(json.dumps({
+        "schema": "agentos.issue-152-post-e3/v1",
+        "ok": True,
+        "advanced": True,
+        "project_id": PROJECT_ID,
+        "parent": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+        "child": {"index_id": NEW_INDEX, "ir_id": NEW_IR},
+        "active_selector": activation,
+        "credential_exposed": False,
+        "handoff_receipt": receipt,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/advance_issue_152_after_e3_verified_oracle.sh
+++ b/scripts/advance_issue_152_after_e3_verified_oracle.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: #152 post-E3 advancement must run as ubuntu on Oracle" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-152-executor-awareness"
+RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+EXPECTED_INDEX="idx-core-152-post-e3-1"
+EXPECTED_IR="ir-core-152-post-e3-1"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+test -f "$DATA_ROOT/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+
+if [ ! -f "$TARGET/scripts/advance_issue_152_after_e3_verified.py" ]; then
+  TMP="$RUNTIME_ROOT/.post-e3-$SOURCE_COMMIT-$$"
+  rm -rf "$TMP"
+  mkdir -p "$TMP" "$RUNTIME_ROOT"
+  git -C "$REPO" archive "$SOURCE_COMMIT" | tar -x -C "$TMP"
+  mv "$TMP" "$TARGET"
+fi
+
+cd "$TARGET"
+echo "agentos_post_e3_source_commit=$SOURCE_COMMIT"
+echo "agentos_post_e3_runtime_source=$TARGET"
+echo "agentos_post_e3_execution_cwd=$PWD"
+
+echo "agentos_post_e3_contract_tests=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 -m unittest \
+    tests.test_project_continuation_index \
+    tests.test_canonical_ir_handoff \
+    tests.test_active_continuation \
+    tests.test_codex_one_mcp_stdio \
+    tests.test_install_codex_one_oracle \
+    -v
+echo "agentos_post_e3_contract_tests=PASS"
+
+echo "agentos_post_e3_canonical_handoff=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/advance_issue_152_after_e3_verified.py"
+echo "agentos_post_e3_canonical_handoff=PASS"
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 - <<'PY'
+import json
+import os
+from agent_core.active_continuation import resolve_active_continuation
+from agent_core.resolve_facade import resolve_continuation
+
+expected_index = "idx-core-152-post-e3-1"
+expected_ir = "ir-core-152-post-e3-1"
+state = resolve_continuation("agentos-core", data_root=os.environ["AGENT_DATA_ROOT"])
+continuation = state.get("continuation") or {}
+ir = continuation.get("canonical_ir") or {}
+head = state.get("execution_head") or {}
+active = resolve_active_continuation(data_root=os.environ["AGENT_DATA_ROOT"])
+selector = active.get("selector") or {}
+if str(head.get("index_id") or "") != expected_index:
+    raise SystemExit(f"post-E3 execution-head mismatch: {head}")
+if str(ir.get("ir_id") or "") != expected_ir or str(ir.get("parent_ir_id") or "") != "ir-core-152-e3-codex-ext-1":
+    raise SystemExit(f"post-E3 IR mismatch: {ir}")
+if selector.get("index_id") != expected_index or selector.get("ir_id") != expected_ir:
+    raise SystemExit(f"post-E3 active selector mismatch: {selector}")
+print(json.dumps({
+    "schema": "agentos.issue-152-post-e3-probe/v1",
+    "ok": True,
+    "project_id": "agentos-core",
+    "index_id": expected_index,
+    "ir_id": expected_ir,
+    "parent_ir_id": ir.get("parent_ir_id"),
+    "goal": ir.get("goal"),
+    "next_action": state.get("next_action"),
+    "active_selector": selector,
+    "credential_exposed": False,
+}, ensure_ascii=False, indent=2, sort_keys=True))
+PY
+
+echo "agentos_issue_152_post_e3=PASS"
+echo "agentos_post_e3_index_id=$EXPECTED_INDEX"
+echo "agentos_post_e3_ir_id=$EXPECTED_IR"

--- a/scripts/advance_issue_152_e2_to_e3.py
+++ b/scripts/advance_issue_152_e2_to_e3.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 
+from agent_core.active_continuation import activate_continuation
 from agent_core.canonical_ir_handoff import advance_canonical_ir
 from agent_core.resolve_facade import resolve_continuation
 
@@ -20,12 +21,23 @@ GOAL = (
 NEXT_ACTION = (
     "Reload Antigravity only if required by runtime changes, then open a completely fresh built-in "
     "Antigravity Codex conversation and send only '繼續'; verify it reports source=ONE_PREINVOCATION_IR, "
-    "project=agentos-core, index_id=idx-core-152-e3-1, ir_id=ir-core-152-e3-1, and continues the E3 goal."
+    "selection_source=ONE_ACTIVE_CONTINUATION, project=agentos-core, "
+    "index_id=idx-core-152-e3-1, ir_id=ir-core-152-e3-1, and continues the E3 goal regardless of IDE workspace."
 )
 
 
 def _data_root() -> Path:
     return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def _activate_e3(root: Path) -> dict:
+    return activate_continuation(
+        PROJECT_ID,
+        index_id=NEW_INDEX,
+        ir_id=NEW_IR,
+        reason="#152 E3 cross-executor continuity is the active canonical task",
+        data_root=root,
+    )
 
 
 def main() -> int:
@@ -38,16 +50,18 @@ def main() -> int:
     current_ir = str(ir.get("ir_id") or "").strip()
 
     if current_index == NEW_INDEX and current_ir == NEW_IR:
+        activation = _activate_e3(root)
         print(
             json.dumps(
                 {
                     "schema": "agentos.issue-152-e2-to-e3/v1",
                     "ok": True,
                     "advanced": False,
-                    "reason": "already advanced",
+                    "reason": "already advanced; active selector reconciled",
                     "project_id": PROJECT_ID,
                     "index_id": NEW_INDEX,
                     "ir_id": NEW_IR,
+                    "active_selector": activation,
                     "credential_exposed": False,
                 },
                 ensure_ascii=False,
@@ -87,13 +101,14 @@ def main() -> int:
             "next_action": NEXT_ACTION,
             "pending_tasks": [
                 "Open a completely fresh built-in Antigravity Codex conversation and send only '繼續'.",
-                "Verify the fresh Codex session receives ONE_PREINVOCATION_IR with the E3 child generation.",
-                "Capture a second fresh Codex regression before marking E3 generally stable for this surface.",
+                "Verify the fresh Codex session receives ONE_PREINVOCATION_IR selected by ONE_ACTIVE_CONTINUATION with the E3 child generation regardless of current workspace.",
+                "Capture a second fresh Codex regression before marking E3 stable for this surface.",
                 "Persist sanitized E3 evidence and update AgentOS current state after live verification.",
             ],
             "decisions_append": [
                 "E2 Antigravity Gemini fresh-session Canonical IR continuity is VERIFIED from two independent fresh sessions.",
                 "Advance E2 -> E3 through the Core-owned guarded Canonical IR writer; executors do not directly mutate canonical state.",
+                "Fresh executor continuation selection is owned by the ONE active-continuation pointer, not IDE workspacePaths.",
             ],
             "evidence": [
                 {
@@ -119,6 +134,7 @@ def main() -> int:
         },
         data_root=root,
     )
+    activation = _activate_e3(root)
     print(
         json.dumps(
             {
@@ -128,6 +144,7 @@ def main() -> int:
                 "project_id": PROJECT_ID,
                 "parent": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
                 "child": {"index_id": NEW_INDEX, "ir_id": NEW_IR},
+                "active_selector": activation,
                 "credential_exposed": False,
                 "handoff_receipt": receipt,
             },

--- a/scripts/advance_issue_152_e2_to_e3.py
+++ b/scripts/advance_issue_152_e2_to_e3.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent_core.canonical_ir_handoff import advance_canonical_ir
+from agent_core.resolve_facade import resolve_continuation
+
+PROJECT_ID = "agentos-core"
+EXPECTED_INDEX = "idx-core-152"
+EXPECTED_IR = "ir-core-152"
+NEW_INDEX = "idx-core-152-e3-1"
+NEW_IR = "ir-core-152-e3-1"
+GOAL = (
+    "Prove E3 continuity: Gemini -> AgentOS ONE -> a completely fresh Antigravity "
+    "Codex executor continues from the authoritative Canonical IR without copied vendor history."
+)
+NEXT_ACTION = (
+    "Reload Antigravity only if required by runtime changes, then open a completely fresh built-in "
+    "Antigravity Codex conversation and send only '繼續'; verify it reports source=ONE_PREINVOCATION_IR, "
+    "project=agentos-core, index_id=idx-core-152-e3-1, ir_id=ir-core-152-e3-1, and continues the E3 goal."
+)
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def main() -> int:
+    root = _data_root()
+    current = resolve_continuation(PROJECT_ID, data_root=root)
+    head = current.get("execution_head") if isinstance(current.get("execution_head"), dict) else {}
+    continuation = current.get("continuation") if isinstance(current.get("continuation"), dict) else {}
+    ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    current_index = str(head.get("index_id") or "").strip()
+    current_ir = str(ir.get("ir_id") or "").strip()
+
+    if current_index == NEW_INDEX and current_ir == NEW_IR:
+        print(
+            json.dumps(
+                {
+                    "schema": "agentos.issue-152-e2-to-e3/v1",
+                    "ok": True,
+                    "advanced": False,
+                    "reason": "already advanced",
+                    "project_id": PROJECT_ID,
+                    "index_id": NEW_INDEX,
+                    "ir_id": NEW_IR,
+                    "credential_exposed": False,
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    if current_index != EXPECTED_INDEX or current_ir != EXPECTED_IR:
+        print(
+            json.dumps(
+                {
+                    "schema": "agentos.issue-152-e2-to-e3/v1",
+                    "ok": False,
+                    "advanced": False,
+                    "reason": "unexpected canonical parent; refusing to overwrite",
+                    "expected": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+                    "found": {"index_id": current_index or None, "ir_id": current_ir or None},
+                    "credential_exposed": False,
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 3
+
+    receipt = advance_canonical_ir(
+        {
+            "project_id": PROJECT_ID,
+            "expected_index_id": EXPECTED_INDEX,
+            "expected_ir_id": EXPECTED_IR,
+            "new_index_id": NEW_INDEX,
+            "new_ir_id": NEW_IR,
+            "goal": GOAL,
+            "next_action": NEXT_ACTION,
+            "pending_tasks": [
+                "Open a completely fresh built-in Antigravity Codex conversation and send only '繼續'.",
+                "Verify the fresh Codex session receives ONE_PREINVOCATION_IR with the E3 child generation.",
+                "Capture a second fresh Codex regression before marking E3 generally stable for this surface.",
+                "Persist sanitized E3 evidence and update AgentOS current state after live verification.",
+            ],
+            "decisions_append": [
+                "E2 Antigravity Gemini fresh-session Canonical IR continuity is VERIFIED from two independent fresh sessions.",
+                "Advance E2 -> E3 through the Core-owned guarded Canonical IR writer; executors do not directly mutate canonical state.",
+            ],
+            "evidence": [
+                {
+                    "kind": "antigravity-gemini-fresh-ir-regression",
+                    "verdict": "VERIFIED",
+                    "summary": "Two independent fresh built-in Gemini conversations, each given only 繼續, recovered ONE_PREINVOCATION_IR for agentos-core with idx-core-152 / ir-core-152.",
+                    "date": "2026-09-01",
+                    "evidence_path": ".agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md",
+                },
+                {
+                    "kind": "credential-boundary",
+                    "verdict": "PASS",
+                    "summary": "Oracle-local ONE projection and Antigravity MCP/bootstrap reported credential_exposed=false.",
+                    "date": "2026-09-01",
+                },
+            ],
+            "execution_status": "in_progress",
+            "execution_metadata": {
+                "issue": "#152",
+                "phase": "E3-antigravity-codex-continuity",
+                "e2_verdict": "VERIFIED",
+            },
+        },
+        data_root=root,
+    )
+    print(
+        json.dumps(
+            {
+                "schema": "agentos.issue-152-e2-to-e3/v1",
+                "ok": True,
+                "advanced": True,
+                "project_id": PROJECT_ID,
+                "parent": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+                "child": {"index_id": NEW_INDEX, "ir_id": NEW_IR},
+                "credential_exposed": False,
+                "handoff_receipt": receipt,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/advance_issue_152_e2_to_e3_oracle.sh
+++ b/scripts/advance_issue_152_e2_to_e3_oracle.sh
@@ -36,9 +36,20 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 -m unittest \
     tests.test_project_continuation_index \
     tests.test_canonical_ir_handoff \
+    tests.test_antigravity_one_hook \
+    tests.test_one_mcp_stdio_identity \
     -v
 
 echo "agentos_e3_contract_tests=PASS"
+
+# Install the exact same immutable runtime snapshot into Antigravity global
+# hook/MCP configuration before advancing the live IR.  The installer probes
+# against the still-current E2 parent, so any runtime/config regression fails
+# before canonical mutation.
+echo "agentos_e3_antigravity_runtime_install=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
+echo "agentos_e3_antigravity_runtime_install=PASS"
 
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/advance_issue_152_e2_to_e3.py"
@@ -79,3 +90,4 @@ PY
 echo "agentos_issue_152_e2_to_e3=PASS"
 echo "agentos_e3_index_id=$EXPECTED_INDEX"
 echo "agentos_e3_ir_id=$EXPECTED_IR"
+echo "antigravity_reload_required=YES"

--- a/scripts/advance_issue_152_e2_to_e3_oracle.sh
+++ b/scripts/advance_issue_152_e2_to_e3_oracle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: #152 E2->E3 advancement must run as ubuntu on Oracle" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-152-executor-awareness"
+RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+EXPECTED_INDEX="idx-core-152-e3-1"
+EXPECTED_IR="ir-core-152-e3-1"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+test -f "$DATA_ROOT/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+
+if [ ! -f "$TARGET/agent_core/canonical_ir_handoff.py" ]; then
+  TMP="$RUNTIME_ROOT/.advance-$SOURCE_COMMIT-$$"
+  rm -rf "$TMP"
+  mkdir -p "$TMP" "$RUNTIME_ROOT"
+  git -C "$REPO" archive "$SOURCE_COMMIT" | tar -x -C "$TMP"
+  mv "$TMP" "$TARGET"
+fi
+
+echo "agentos_e3_source_commit=$SOURCE_COMMIT"
+echo "agentos_e3_runtime_source=$TARGET"
+
+echo "agentos_e3_contract_tests=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 -m unittest \
+    tests.test_project_continuation_index \
+    tests.test_canonical_ir_handoff \
+    -v
+
+echo "agentos_e3_contract_tests=PASS"
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/advance_issue_152_e2_to_e3.py"
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 - <<'PY'
+import json
+import os
+from agent_core.resolve_facade import resolve_continuation
+
+expected_index = "idx-core-152-e3-1"
+expected_ir = "ir-core-152-e3-1"
+state = resolve_continuation("agentos-core", data_root=os.environ["AGENT_DATA_ROOT"])
+head = state.get("execution_head") or {}
+continuation = state.get("continuation") or {}
+ir = continuation.get("canonical_ir") or {}
+actual_index = str(head.get("index_id") or "")
+actual_ir = str(ir.get("ir_id") or "")
+if actual_index != expected_index or actual_ir != expected_ir:
+    raise SystemExit(
+        "E3 child verification failed: "
+        f"expected {expected_index}/{expected_ir}, found {actual_index}/{actual_ir}"
+    )
+print(json.dumps({
+    "schema": "agentos.issue-152-e3-child-probe/v1",
+    "ok": True,
+    "source": "ONE_CANONICAL_IR",
+    "project_id": "agentos-core",
+    "index_id": actual_index,
+    "ir_id": actual_ir,
+    "parent_ir_id": ir.get("parent_ir_id"),
+    "goal": ir.get("goal"),
+    "next_action": state.get("next_action"),
+    "credential_exposed": False,
+}, ensure_ascii=False, indent=2, sort_keys=True))
+PY
+
+echo "agentos_issue_152_e2_to_e3=PASS"
+echo "agentos_e3_index_id=$EXPECTED_INDEX"
+echo "agentos_e3_ir_id=$EXPECTED_IR"

--- a/scripts/advance_issue_152_e2_to_e3_oracle.sh
+++ b/scripts/advance_issue_152_e2_to_e3_oracle.sh
@@ -31,6 +31,13 @@ fi
 echo "agentos_e3_source_commit=$SOURCE_COMMIT"
 echo "agentos_e3_runtime_source=$TARGET"
 
+# Execute all Python/module resolution from the immutable snapshot itself.
+# PYTHONPATH alone is not sufficient for `python -m` or stdin execution because
+# the caller's current working directory is earlier on sys.path and may contain
+# an older agent_core package from the stable checkout.
+cd "$TARGET"
+echo "agentos_e3_execution_cwd=$PWD"
+
 echo "agentos_e3_contract_tests=RUNNING"
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 -m unittest \
@@ -42,7 +49,7 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
     -v
 echo "agentos_e3_contract_tests=PASS"
 
-# The active selector is a pointer only.  Seed it from the current canonical
+# The active selector is a pointer only. Seed it from the current canonical
 # generation when absent; if an existing selector is stale, fail closed rather
 # than silently moving it.
 echo "agentos_e3_active_selector=RUNNING"
@@ -50,7 +57,7 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/seed_active_continuation.py"
 echo "agentos_e3_active_selector=PASS"
 
-# Install the same immutable runtime snapshot.  The self-probe deliberately uses
+# Install the same immutable runtime snapshot. The self-probe deliberately uses
 # /home/ubuntu/acas as workspace and must still hydrate the ONE-selected IR.
 echo "agentos_e3_antigravity_runtime_install=RUNNING"
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \

--- a/scripts/advance_issue_152_e2_to_e3_oracle.sh
+++ b/scripts/advance_issue_152_e2_to_e3_oracle.sh
@@ -36,21 +36,29 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 -m unittest \
     tests.test_project_continuation_index \
     tests.test_canonical_ir_handoff \
+    tests.test_active_continuation \
     tests.test_antigravity_one_hook \
     tests.test_one_mcp_stdio_identity \
     -v
-
 echo "agentos_e3_contract_tests=PASS"
 
-# Install the exact same immutable runtime snapshot into Antigravity global
-# hook/MCP configuration before advancing the live IR.  The installer probes
-# against the still-current E2 parent, so any runtime/config regression fails
-# before canonical mutation.
+# The active selector is a pointer only.  Seed it from the current canonical
+# generation when absent; if an existing selector is stale, fail closed rather
+# than silently moving it.
+echo "agentos_e3_active_selector=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/seed_active_continuation.py"
+echo "agentos_e3_active_selector=PASS"
+
+# Install the same immutable runtime snapshot.  The self-probe deliberately uses
+# /home/ubuntu/acas as workspace and must still hydrate the ONE-selected IR.
 echo "agentos_e3_antigravity_runtime_install=RUNNING"
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
 echo "agentos_e3_antigravity_runtime_install=PASS"
 
+# Idempotent: if E3 is already the canonical generation, this only reconciles
+# the active selector to the E3 child and does not republish the IR.
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/advance_issue_152_e2_to_e3.py"
 
@@ -58,6 +66,7 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 - <<'PY'
 import json
 import os
+from agent_core.active_continuation import resolve_active_continuation
 from agent_core.resolve_facade import resolve_continuation
 
 expected_index = "idx-core-152-e3-1"
@@ -73,16 +82,26 @@ if actual_index != expected_index or actual_ir != expected_ir:
         "E3 child verification failed: "
         f"expected {expected_index}/{expected_ir}, found {actual_index}/{actual_ir}"
     )
+active = resolve_active_continuation(data_root=os.environ["AGENT_DATA_ROOT"])
+selector = active["selector"]
+if (
+    selector.get("project_id") != "agentos-core"
+    or selector.get("index_id") != expected_index
+    or selector.get("ir_id") != expected_ir
+):
+    raise SystemExit(f"E3 active selector verification failed: {selector}")
 print(json.dumps({
-    "schema": "agentos.issue-152-e3-child-probe/v1",
+    "schema": "agentos.issue-152-e3-child-probe/v2",
     "ok": True,
     "source": "ONE_CANONICAL_IR",
+    "selection_source": "ONE_ACTIVE_CONTINUATION",
     "project_id": "agentos-core",
     "index_id": actual_index,
     "ir_id": actual_ir,
     "parent_ir_id": ir.get("parent_ir_id"),
     "goal": ir.get("goal"),
     "next_action": state.get("next_action"),
+    "active_selector": selector,
     "credential_exposed": False,
 }, ensure_ascii=False, indent=2, sort_keys=True))
 PY

--- a/scripts/advance_issue_152_e2_to_e3_oracle.sh
+++ b/scripts/advance_issue_152_e2_to_e3_oracle.sh
@@ -45,6 +45,7 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
     tests.test_canonical_ir_handoff \
     tests.test_active_continuation \
     tests.test_antigravity_one_hook \
+    tests.test_antigravity_preinvocation_attestation \
     tests.test_one_mcp_stdio_identity \
     -v
 echo "agentos_e3_contract_tests=PASS"
@@ -59,6 +60,9 @@ echo "agentos_e3_active_selector=PASS"
 
 # Install the same immutable runtime snapshot. The self-probe deliberately uses
 # /home/ubuntu/acas as workspace and must still hydrate the ONE-selected IR.
+# The hook also writes one sanitized last-invocation attestation into the data
+# layer. The installer probe intentionally becomes the baseline record; a real
+# fresh Codex invocation must overwrite it after reload.
 echo "agentos_e3_antigravity_runtime_install=RUNNING"
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
@@ -116,4 +120,5 @@ PY
 echo "agentos_issue_152_e2_to_e3=PASS"
 echo "agentos_e3_index_id=$EXPECTED_INDEX"
 echo "agentos_e3_ir_id=$EXPECTED_IR"
+echo "agentos_preinvocation_attestation_path=$DATA_ROOT/runtime/antigravity-preinvocation-last.json"
 echo "antigravity_reload_required=YES"

--- a/scripts/advance_issue_152_e3_to_codex_extension.py
+++ b/scripts/advance_issue_152_e3_to_codex_extension.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent_core.active_continuation import activate_continuation
+from agent_core.canonical_ir_handoff import advance_canonical_ir
+from agent_core.resolve_facade import resolve_continuation
+
+PROJECT_ID = "agentos-core"
+EXPECTED_INDEX = "idx-core-152-e3-1"
+EXPECTED_IR = "ir-core-152-e3-1"
+NEW_INDEX = "idx-core-152-e3-codex-ext-1"
+NEW_IR = "ir-core-152-e3-codex-ext-1"
+GOAL = (
+    "Prove E3 cross-extension continuity: Antigravity Gemini -> AgentOS ONE -> a completely fresh "
+    "OpenAI Codex IDE extension thread continues from the authoritative Canonical IR without copied vendor history."
+)
+NEXT_ACTION = (
+    "Install/reload the OpenAI Codex ONE bootstrap, then open a completely fresh Codex IDE extension thread "
+    "and send only '繼續'; Codex must call agentos-one.one_resolve_active before workspace reconstruction, report "
+    "source=ONE_ACTIVE_CONTINUATION, project=agentos-core, index_id=idx-core-152-e3-codex-ext-1, "
+    "ir_id=ir-core-152-e3-codex-ext-1, and continue this cross-extension E3 goal."
+)
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def _activate(root: Path) -> dict:
+    return activate_continuation(
+        PROJECT_ID,
+        index_id=NEW_INDEX,
+        ir_id=NEW_IR,
+        reason="#152 E3 corrected boundary: OpenAI Codex IDE extension is the active target executor",
+        data_root=root,
+    )
+
+
+def main() -> int:
+    root = _data_root()
+    current = resolve_continuation(PROJECT_ID, data_root=root)
+    head = current.get("execution_head") if isinstance(current.get("execution_head"), dict) else {}
+    continuation = current.get("continuation") if isinstance(current.get("continuation"), dict) else {}
+    ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    current_index = str(head.get("index_id") or "").strip()
+    current_ir = str(ir.get("ir_id") or "").strip()
+
+    if current_index == NEW_INDEX and current_ir == NEW_IR:
+        activation = _activate(root)
+        print(json.dumps({
+            "schema": "agentos.issue-152-e3-codex-extension/v1",
+            "ok": True,
+            "advanced": False,
+            "reason": "already advanced; active selector reconciled",
+            "project_id": PROJECT_ID,
+            "index_id": NEW_INDEX,
+            "ir_id": NEW_IR,
+            "active_selector": activation,
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    if current_index != EXPECTED_INDEX or current_ir != EXPECTED_IR:
+        print(json.dumps({
+            "schema": "agentos.issue-152-e3-codex-extension/v1",
+            "ok": False,
+            "advanced": False,
+            "reason": "unexpected canonical parent; refusing to overwrite",
+            "expected": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+            "found": {"index_id": current_index or None, "ir_id": current_ir or None},
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 3
+
+    receipt = advance_canonical_ir(
+        {
+            "project_id": PROJECT_ID,
+            "expected_index_id": EXPECTED_INDEX,
+            "expected_ir_id": EXPECTED_IR,
+            "new_index_id": NEW_INDEX,
+            "new_ir_id": NEW_IR,
+            "goal": GOAL,
+            "next_action": NEXT_ACTION,
+            "pending_tasks": [
+                "Install the AgentOS ONE bootstrap into the OpenAI Codex local harness without copying Canonical IR into Codex config.",
+                "Reload the Codex IDE extension, open a completely fresh thread, and send only '繼續'.",
+                "Verify Codex resolves the ONE active continuation and reports the corrected E3 child generation before touching workspace-local continuation state.",
+                "Repeat a second completely fresh Codex extension thread after the first pass before marking the cross-extension slice stable.",
+                "Persist sanitized Codex extension evidence and update #152 without closing the broader Node/executor extraction issue.",
+            ],
+            "decisions_append": [
+                "OpenAI Codex is a separate IDE extension/client from the Gemini/Antigravity extension; Gemini ~/.gemini PreInvocation hooks are not Codex lifecycle hooks.",
+                "E3 acceptance is cross-extension continuity, not an expectation that Codex triggers Gemini's PreInvocation hook.",
+                "Codex receives Canonical IR through its own native bootstrap surfaces: Codex AGENTS.md instructions plus the AgentOS ONE MCP adapter.",
+                "Canonical IR remains the sole durable working state; Codex configuration contains only bootstrap/discovery instructions and no copied IR body.",
+            ],
+            "evidence": [
+                {
+                    "kind": "codex-preinvocation-boundary-correction",
+                    "verdict": "VERIFIED_ARCHITECTURE_FINDING",
+                    "summary": "Fresh Codex attempts did not update the Gemini PreInvocation attestation; the retained receipt remained the prior Gemini invocation, proving the two extension lifecycles must be handled separately.",
+                    "date": "2026-09-02",
+                },
+                {
+                    "kind": "gemini-e3-selector-hydration",
+                    "verdict": "PASS",
+                    "summary": "Gemini PreInvocation successfully hydrated agentos-core through ONE_ACTIVE_CONTINUATION with idx-core-152-e3-1 / ir-core-152-e3-1 and credential_exposed=false.",
+                    "date": "2026-09-02",
+                },
+            ],
+            "execution_status": "in_progress",
+            "execution_metadata": {
+                "issue": "#152",
+                "phase": "E3-openai-codex-extension-continuity",
+                "previous_phase": "E3-antigravity-codex-continuity",
+            },
+        },
+        data_root=root,
+    )
+    activation = _activate(root)
+    print(json.dumps({
+        "schema": "agentos.issue-152-e3-codex-extension/v1",
+        "ok": True,
+        "advanced": True,
+        "project_id": PROJECT_ID,
+        "parent": {"index_id": EXPECTED_INDEX, "ir_id": EXPECTED_IR},
+        "child": {"index_id": NEW_INDEX, "ir_id": NEW_IR},
+        "active_selector": activation,
+        "credential_exposed": False,
+        "handoff_receipt": receipt,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_antigravity_one_oracle.sh
+++ b/scripts/bootstrap_antigravity_one_oracle.sh
@@ -25,9 +25,7 @@ if [ ! -f "$TARGET/agentos_node/one_mcp.py" ]; then
   mv "$TMP" "$TARGET"
 fi
 
-python3 "$TARGET/scripts/install_antigravity_one_mcp.py" \
-  --repo "$TARGET" \
-  --mode oracle-local
+python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
 
 echo "agentos_antigravity_one_bootstrap=PASS"
 echo "agentos_source_ref=$SOURCE_REF"

--- a/scripts/bootstrap_antigravity_one_oracle.sh
+++ b/scripts/bootstrap_antigravity_one_oracle.sh
@@ -43,6 +43,11 @@ else
   exit 5
 fi
 
+echo "agentos_active_continuation_seed=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/seed_active_continuation.py"
+echo "agentos_active_continuation_seed=PASS"
+
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
 

--- a/scripts/bootstrap_antigravity_one_oracle.sh
+++ b/scripts/bootstrap_antigravity_one_oracle.sh
@@ -9,9 +9,10 @@ fi
 REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
 SOURCE_REF="core/issue-152-executor-awareness"
 RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
 
 test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
-test -f "/home/ubuntu/agent-data/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
+test -f "$DATA_ROOT/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
 
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
 SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
@@ -25,7 +26,25 @@ if [ ! -f "$TARGET/agentos_node/one_mcp.py" ]; then
   mv "$TMP" "$TARGET"
 fi
 
-python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
+CORE_PROJECT="$DATA_ROOT/projects/agentos-core"
+EXECUTION_HEAD="$CORE_PROJECT/execution-head.json"
+CONTINUATION_HEAD="$CORE_PROJECT/continuity/latest.json"
+
+if [ ! -e "$EXECUTION_HEAD" ] && [ ! -e "$CONTINUATION_HEAD" ]; then
+  echo "agentos_core_ir_seed=REQUIRED"
+  PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+    python3 "$TARGET/scripts/seed_agentos_core_ir_head.py"
+elif [ -e "$EXECUTION_HEAD" ] && [ -e "$CONTINUATION_HEAD" ]; then
+  echo "agentos_core_ir_seed=SKIPPED_EXISTING_HEAD"
+else
+  echo "ERROR: partial AgentOS Core canonical head exists; refusing to overwrite" >&2
+  echo "execution_head_exists=$([ -e "$EXECUTION_HEAD" ] && echo YES || echo NO)" >&2
+  echo "continuation_head_exists=$([ -e "$CONTINUATION_HEAD" ] && echo YES || echo NO)" >&2
+  exit 5
+fi
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/install_antigravity_one_mcp_oracle.py"
 
 echo "agentos_antigravity_one_bootstrap=PASS"
 echo "agentos_source_ref=$SOURCE_REF"

--- a/scripts/bootstrap_antigravity_one_oracle.sh
+++ b/scripts/bootstrap_antigravity_one_oracle.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: Oracle Antigravity ONE bootstrap must run as ubuntu" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-152-executor-awareness"
+RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+test -f "/home/ubuntu/agent-data/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+
+if [ ! -f "$TARGET/agentos_node/one_mcp.py" ]; then
+  TMP="$RUNTIME_ROOT/.install-$SOURCE_COMMIT-$$"
+  rm -rf "$TMP"
+  mkdir -p "$TMP" "$RUNTIME_ROOT"
+  git -C "$REPO" archive "$SOURCE_COMMIT" | tar -x -C "$TMP"
+  mv "$TMP" "$TARGET"
+fi
+
+python3 "$TARGET/scripts/install_antigravity_one_mcp.py" \
+  --repo "$TARGET" \
+  --mode oracle-local
+
+echo "agentos_antigravity_one_bootstrap=PASS"
+echo "agentos_source_ref=$SOURCE_REF"
+echo "agentos_source_commit=$SOURCE_COMMIT"
+echo "agentos_runtime_source=$TARGET"
+echo "antigravity_reload_required=YES"

--- a/scripts/inspect_antigravity_preinvocation_attestation.py
+++ b/scripts/inspect_antigravity_preinvocation_attestation.py
@@ -43,10 +43,9 @@ def main() -> int:
         and record.get("ir_id") == expected_ir
         and record.get("selection_source") == "ONE_ACTIVE_CONTINUATION"
     )
-    identity_ok = (
-        record.get("executor_class") == "antigravity-codex"
-        and record.get("executor_identity_bound") is True
-    )
+    identity_bound = record.get("executor_identity_bound") is True
+    executor_is_codex = record.get("executor_class") == "antigravity-codex"
+    identity_ok = executor_is_codex and identity_bound
     credential_ok = record.get("credential_exposed") is False
 
     mismatch_reasons: list[str] = []
@@ -60,9 +59,9 @@ def main() -> int:
         mismatch_reasons.append("ir_id_mismatch")
     if record.get("selection_source") != "ONE_ACTIVE_CONTINUATION":
         mismatch_reasons.append("selection_source_mismatch")
-    if record.get("executor_class") != "antigravity-codex":
+    if not executor_is_codex:
         mismatch_reasons.append("executor_class_not_codex")
-    if record.get("executor_identity_bound") is not True:
+    if not identity_bound:
         mismatch_reasons.append("executor_identity_unbound")
     if not credential_ok:
         mismatch_reasons.append("credential_boundary_not_proven")
@@ -75,9 +74,11 @@ def main() -> int:
         verdict = "REAL_PREINVOCATION_FAIL_CLOSED"
         ok = False
         rc = 4
-    elif hydrated and generation_ok and credential_ok and not identity_ok:
-        # Hydration and state selection are proven even if Antigravity's real
-        # modelName is not descriptive enough to bind the executor class.
+    elif hydrated and generation_ok and credential_ok and identity_bound and not executor_is_codex:
+        verdict = "REAL_PREINVOCATION_HYDRATED_WRONG_EXECUTOR"
+        ok = False
+        rc = 8
+    elif hydrated and generation_ok and credential_ok and not identity_bound:
         verdict = "REAL_PREINVOCATION_HYDRATED_IDENTITY_UNBOUND"
         ok = False
         rc = 5
@@ -107,6 +108,8 @@ def main() -> int:
             "hydrated": hydrated,
             "generation_ok": generation_ok,
             "identity_ok": identity_ok,
+            "identity_bound": identity_bound,
+            "executor_is_codex": executor_is_codex,
             "credential_ok": credential_ok,
         },
         "recorded_at": record.get("recorded_at"),

--- a/scripts/inspect_antigravity_preinvocation_attestation.py
+++ b/scripts/inspect_antigravity_preinvocation_attestation.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+SCHEMA = "agentos.antigravity-preinvocation-attestation/v1"
+
+
+def main() -> int:
+    root = Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+    path = Path(
+        os.environ.get(
+            "AGENTOS_PREINVOCATION_AUDIT_PATH",
+            str(root / "runtime" / "antigravity-preinvocation-last.json"),
+        )
+    )
+    if path.is_symlink():
+        raise SystemExit("ERROR: PreInvocation attestation path may not be a symlink")
+    if not path.is_file():
+        print(json.dumps({
+            "schema": "agentos.antigravity-preinvocation-inspection/v1",
+            "ok": False,
+            "verdict": "ATTESTATION_MISSING",
+            "path": str(path),
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 3
+
+    record = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(record, dict) or record.get("schema") != SCHEMA:
+        raise SystemExit("ERROR: unsupported PreInvocation attestation schema")
+
+    model_name = str(record.get("model_name") or "")
+    installer_probe = "installer-probe" in model_name.casefold()
+    hydrated = record.get("outcome") == "hydrated" and record.get("injection_emitted") is True
+    expected_index = str(os.environ.get("AGENTOS_EXPECTED_E3_INDEX", "idx-core-152-e3-1"))
+    expected_ir = str(os.environ.get("AGENTOS_EXPECTED_E3_IR", "ir-core-152-e3-1"))
+    generation_ok = (
+        record.get("project_id") == "agentos-core"
+        and record.get("index_id") == expected_index
+        and record.get("ir_id") == expected_ir
+        and record.get("selection_source") == "ONE_ACTIVE_CONTINUATION"
+    )
+    identity_ok = (
+        record.get("executor_class") == "antigravity-codex"
+        and record.get("executor_identity_bound") is True
+    )
+    credential_ok = record.get("credential_exposed") is False
+
+    if installer_probe:
+        verdict = "INSTALLER_PROBE_ONLY"
+        ok = False
+    elif hydrated and generation_ok and identity_ok and credential_ok:
+        verdict = "REAL_CODEX_PREINVOCATION_HYDRATED"
+        ok = True
+    elif record.get("outcome") == "fail-closed":
+        verdict = "REAL_PREINVOCATION_FAIL_CLOSED"
+        ok = False
+    else:
+        verdict = "REAL_PREINVOCATION_UNEXPECTED"
+        ok = False
+
+    safe = {
+        "schema": "agentos.antigravity-preinvocation-inspection/v1",
+        "ok": ok,
+        "verdict": verdict,
+        "recorded_at": record.get("recorded_at"),
+        "runtime_source_commit": record.get("runtime_source_commit"),
+        "hook_schema": record.get("hook_schema"),
+        "outcome": record.get("outcome"),
+        "injection_emitted": record.get("injection_emitted"),
+        "model_name": record.get("model_name"),
+        "executor_class": record.get("executor_class"),
+        "executor_identity_bound": record.get("executor_identity_bound"),
+        "source": record.get("source"),
+        "selection_source": record.get("selection_source"),
+        "project_id": record.get("project_id"),
+        "index_id": record.get("index_id"),
+        "ir_id": record.get("ir_id"),
+        "conversation_id_sha256": record.get("conversation_id_sha256"),
+        "credential_exposed": record.get("credential_exposed"),
+    }
+    print(json.dumps(safe, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if ok else 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inspect_antigravity_preinvocation_attestation.py
+++ b/scripts/inspect_antigravity_preinvocation_attestation.py
@@ -20,10 +20,11 @@ def main() -> int:
         raise SystemExit("ERROR: PreInvocation attestation path may not be a symlink")
     if not path.is_file():
         print(json.dumps({
-            "schema": "agentos.antigravity-preinvocation-inspection/v1",
+            "schema": "agentos.antigravity-preinvocation-inspection/v2",
             "ok": False,
             "verdict": "ATTESTATION_MISSING",
             "path": str(path),
+            "mismatch_reasons": ["attestation_missing"],
         }, ensure_ascii=False, indent=2, sort_keys=True))
         return 3
 
@@ -48,23 +49,66 @@ def main() -> int:
     )
     credential_ok = record.get("credential_exposed") is False
 
+    mismatch_reasons: list[str] = []
+    if not hydrated:
+        mismatch_reasons.append("hydration_not_emitted")
+    if record.get("project_id") != "agentos-core":
+        mismatch_reasons.append("project_id_mismatch")
+    if record.get("index_id") != expected_index:
+        mismatch_reasons.append("index_id_mismatch")
+    if record.get("ir_id") != expected_ir:
+        mismatch_reasons.append("ir_id_mismatch")
+    if record.get("selection_source") != "ONE_ACTIVE_CONTINUATION":
+        mismatch_reasons.append("selection_source_mismatch")
+    if record.get("executor_class") != "antigravity-codex":
+        mismatch_reasons.append("executor_class_not_codex")
+    if record.get("executor_identity_bound") is not True:
+        mismatch_reasons.append("executor_identity_unbound")
+    if not credential_ok:
+        mismatch_reasons.append("credential_boundary_not_proven")
+
     if installer_probe:
         verdict = "INSTALLER_PROBE_ONLY"
         ok = False
-    elif hydrated and generation_ok and identity_ok and credential_ok:
-        verdict = "REAL_CODEX_PREINVOCATION_HYDRATED"
-        ok = True
+        rc = 4
     elif record.get("outcome") == "fail-closed":
         verdict = "REAL_PREINVOCATION_FAIL_CLOSED"
         ok = False
+        rc = 4
+    elif hydrated and generation_ok and credential_ok and not identity_ok:
+        # Hydration and state selection are proven even if Antigravity's real
+        # modelName is not descriptive enough to bind the executor class.
+        verdict = "REAL_PREINVOCATION_HYDRATED_IDENTITY_UNBOUND"
+        ok = False
+        rc = 5
+    elif hydrated and not generation_ok:
+        verdict = "REAL_PREINVOCATION_HYDRATED_GENERATION_MISMATCH"
+        ok = False
+        rc = 6
+    elif hydrated and generation_ok and identity_ok and credential_ok:
+        verdict = "REAL_CODEX_PREINVOCATION_HYDRATED"
+        ok = True
+        rc = 0
+    elif record.get("outcome") == "no-injection":
+        verdict = "REAL_PREINVOCATION_NO_INJECTION"
+        ok = False
+        rc = 7
     else:
         verdict = "REAL_PREINVOCATION_UNEXPECTED"
         ok = False
+        rc = 4
 
     safe = {
-        "schema": "agentos.antigravity-preinvocation-inspection/v1",
+        "schema": "agentos.antigravity-preinvocation-inspection/v2",
         "ok": ok,
         "verdict": verdict,
+        "mismatch_reasons": mismatch_reasons,
+        "checks": {
+            "hydrated": hydrated,
+            "generation_ok": generation_ok,
+            "identity_ok": identity_ok,
+            "credential_ok": credential_ok,
+        },
         "recorded_at": record.get("recorded_at"),
         "runtime_source_commit": record.get("runtime_source_commit"),
         "hook_schema": record.get("hook_schema"),
@@ -82,7 +126,7 @@ def main() -> int:
         "credential_exposed": record.get("credential_exposed"),
     }
     print(json.dumps(safe, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0 if ok else 4
+    return rc
 
 
 if __name__ == "__main__":

--- a/scripts/inspect_issue_152_codex_extension_e3.sh
+++ b/scripts/inspect_issue_152_codex_extension_e3.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+RECEIPT="$DATA_ROOT/runtime/codex-one-active-resolve-last.json"
+EXPECTED_INDEX="idx-core-152-e3-codex-ext-1"
+EXPECTED_IR="ir-core-152-e3-codex-ext-1"
+
+echo "agentos_codex_e3_receipt_path=$RECEIPT"
+
+if [ ! -f "$RECEIPT" ]; then
+  echo '{"schema":"agentos.issue-152-codex-extension-inspection/v1","ok":false,"verdict":"CODEX_ONE_RESOLVE_RECEIPT_MISSING"}'
+  exit 3
+fi
+
+AGENTOS_CODEX_E3_RECEIPT="$RECEIPT" \
+AGENTOS_CODEX_E3_EXPECTED_INDEX="$EXPECTED_INDEX" \
+AGENTOS_CODEX_E3_EXPECTED_IR="$EXPECTED_IR" \
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["AGENTOS_CODEX_E3_RECEIPT"])
+if path.is_symlink():
+    raise SystemExit("ERROR: Codex ONE receipt may not be a symlink")
+record = json.loads(path.read_text(encoding="utf-8"))
+expected_index = os.environ["AGENTOS_CODEX_E3_EXPECTED_INDEX"]
+expected_ir = os.environ["AGENTOS_CODEX_E3_EXPECTED_IR"]
+checks = {
+    "schema_ok": record.get("schema") == "agentos.codex-one-active-resolve-receipt/v1",
+    "surface_ok": record.get("surface") == "codex-local",
+    "executor_ok": record.get("executor_class") == "openai-codex-local" and record.get("executor_identity_bound") is True,
+    "source_ok": record.get("source") == "ONE_ACTIVE_CONTINUATION" and record.get("selection_source") == "ONE_ACTIVE_CONTINUATION",
+    "generation_ok": record.get("project_id") == "agentos-core" and record.get("index_id") == expected_index and record.get("ir_id") == expected_ir,
+    "credential_ok": record.get("credential_exposed") is False,
+}
+ok = all(checks.values())
+print(json.dumps({
+    "schema": "agentos.issue-152-codex-extension-inspection/v1",
+    "ok": ok,
+    "verdict": "CODEX_ONE_ACTIVE_RESOLVE_OBSERVED" if ok else "CODEX_ONE_ACTIVE_RESOLVE_MISMATCH",
+    "checks": checks,
+    "recorded_at": record.get("recorded_at"),
+    "runtime_source_commit": record.get("runtime_source_commit"),
+    "surface": record.get("surface"),
+    "executor_class": record.get("executor_class"),
+    "executor_identity_bound": record.get("executor_identity_bound"),
+    "source": record.get("source"),
+    "selection_source": record.get("selection_source"),
+    "project_id": record.get("project_id"),
+    "index_id": record.get("index_id"),
+    "ir_id": record.get("ir_id"),
+    "credential_exposed": record.get("credential_exposed"),
+}, ensure_ascii=False, indent=2, sort_keys=True))
+raise SystemExit(0 if ok else 4)
+PY

--- a/scripts/inspect_issue_152_e3_real_session.sh
+++ b/scripts/inspect_issue_152_e3_real_session.sh
@@ -3,35 +3,37 @@ set -euo pipefail
 
 REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
 SOURCE_REF="core/issue-152-executor-awareness"
-RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
 DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
 
 test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
 
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF" >/dev/null
 SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
-TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
-INSPECTOR="$TARGET/scripts/inspect_antigravity_preinvocation_attestation.py"
 
-echo "agentos_e3_expected_runtime_commit=$SOURCE_COMMIT"
-echo "agentos_e3_expected_runtime_source=$TARGET"
+echo "agentos_e3_inspector_source_commit=$SOURCE_COMMIT"
+echo "agentos_e3_attestation_path=$DATA_ROOT/runtime/antigravity-preinvocation-last.json"
 
-test -f "$INSPECTOR" || {
-  echo "ERROR: latest attestation inspector is not installed at $INSPECTOR" >&2
-  echo "Run the E3 preparation helper once, reload Antigravity, then retry the fresh Codex session." >&2
-  exit 4
-}
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+git -C "$REPO" show "$SOURCE_COMMIT:scripts/inspect_antigravity_preinvocation_attestation.py" > "$TMP"
 
-cd "$TARGET"
 set +e
-PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
-  python3 "$INSPECTOR"
+AGENT_DATA_ROOT="$DATA_ROOT" python3 "$TMP"
 RC=$?
 set -e
 
 case "$RC" in
   0)
     echo "agentos_e3_real_session_hook=FIRED_AND_HYDRATED"
+    ;;
+  5)
+    echo "agentos_e3_real_session_hook=FIRED_AND_HYDRATED_IDENTITY_UNBOUND"
+    ;;
+  6)
+    echo "agentos_e3_real_session_hook=FIRED_HYDRATION_GENERATION_MISMATCH"
+    ;;
+  7)
+    echo "agentos_e3_real_session_hook=FIRED_NO_INJECTION"
     ;;
   4)
     echo "agentos_e3_real_session_hook=NOT_PROVEN"

--- a/scripts/inspect_issue_152_e3_real_session.sh
+++ b/scripts/inspect_issue_152_e3_real_session.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-152-executor-awareness"
+RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF" >/dev/null
+SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+INSPECTOR="$TARGET/scripts/inspect_antigravity_preinvocation_attestation.py"
+
+echo "agentos_e3_expected_runtime_commit=$SOURCE_COMMIT"
+echo "agentos_e3_expected_runtime_source=$TARGET"
+
+test -f "$INSPECTOR" || {
+  echo "ERROR: latest attestation inspector is not installed at $INSPECTOR" >&2
+  echo "Run the E3 preparation helper once, reload Antigravity, then retry the fresh Codex session." >&2
+  exit 4
+}
+
+cd "$TARGET"
+set +e
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$INSPECTOR"
+RC=$?
+set -e
+
+case "$RC" in
+  0)
+    echo "agentos_e3_real_session_hook=FIRED_AND_HYDRATED"
+    ;;
+  4)
+    echo "agentos_e3_real_session_hook=NOT_PROVEN"
+    ;;
+  *)
+    echo "agentos_e3_real_session_hook=INSPECTION_ERROR"
+    ;;
+esac
+exit "$RC"

--- a/scripts/inspect_issue_152_e3_real_session.sh
+++ b/scripts/inspect_issue_152_e3_real_session.sh
@@ -35,6 +35,9 @@ case "$RC" in
   7)
     echo "agentos_e3_real_session_hook=FIRED_NO_INJECTION"
     ;;
+  8)
+    echo "agentos_e3_real_session_hook=FIRED_AND_HYDRATED_WRONG_EXECUTOR"
+    ;;
   4)
     echo "agentos_e3_real_session_hook=NOT_PROVEN"
     ;;

--- a/scripts/install_antigravity_one_mcp.py
+++ b/scripts/install_antigravity_one_mcp.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -11,6 +13,8 @@ from typing import Any
 
 MCP_PACKAGE = "mcp>=2,<3"
 SERVER_NAME = "agentos-one"
+CLIENT_MODE = "client"
+ORACLE_LOCAL_MODE = "oracle-local"
 
 
 def _repo_root() -> Path:
@@ -27,9 +31,18 @@ def _client_config_candidates() -> list[Path]:
         candidates.append(Path(client_home).expanduser() / "client.json")
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        candidates.append(Path(local_app_data) / "AgentOS" / "state" / "client.json")
+        candidates.append(
+            Path(local_app_data) / "AgentOS" / "state" / "client.json"
+        )
     if os.name == "nt":
-        candidates.append(Path.home() / "AppData" / "Local" / "AgentOS" / "state" / "client.json")
+        candidates.append(
+            Path.home()
+            / "AppData"
+            / "Local"
+            / "AgentOS"
+            / "state"
+            / "client.json"
+        )
     candidates.append(Path.home() / ".agentos" / "client.json")
     return candidates
 
@@ -38,8 +51,30 @@ def discover_client_config() -> Path:
     for path in _client_config_candidates():
         if path.is_file():
             return path
-    raise FileNotFoundError(
-        "AgentOS client.json not found; enroll/start the AgentOS client first"
+    raise FileNotFoundError("AgentOS client.json not found")
+
+
+def oracle_data_root() -> Path:
+    return Path(
+        os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")
+    ).expanduser()
+
+
+def detect_mode(explicit: str | None = None) -> str:
+    if explicit:
+        return explicit
+    try:
+        discover_client_config()
+        return CLIENT_MODE
+    except FileNotFoundError:
+        pass
+    root = oracle_data_root()
+    if os.name != "nt" and (root / "realm" / "nodes.json").is_file():
+        return ORACLE_LOCAL_MODE
+    raise RuntimeError(
+        "Cannot determine ONE MCP mode: no enrolled client config and no "
+        "Oracle-local ONE Node Registry. Use --mode explicitly after "
+        "verifying the intended runtime."
     )
 
 
@@ -48,7 +83,9 @@ def antigravity_mcp_config_path() -> Path:
     if explicit:
         return Path(explicit).expanduser()
     current = Path.home() / ".gemini" / "config" / "mcp_config.json"
-    legacy = Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
+    legacy = (
+        Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
+    )
     if current.exists() or current.parent.exists() or not legacy.exists():
         return current
     return legacy
@@ -66,7 +103,11 @@ def ensure_mcp_venv(venv_root: Path) -> Path:
         venv_root.parent.mkdir(parents=True, exist_ok=True)
         venv.EnvBuilder(with_pip=True, clear=False).create(venv_root)
     check = subprocess.run(
-        [str(python), "-c", "from mcp.server import MCPServer"],
+        [
+            str(python),
+            "-c",
+            "from mcp.server import MCPServer",
+        ],
         text=True,
         capture_output=True,
         check=False,
@@ -107,35 +148,82 @@ def write_antigravity_config(
     *,
     python: Path,
     repo_root: Path,
+    mode: str,
 ) -> dict[str, Any]:
     config = _load_json(path)
     servers = config.setdefault("mcpServers", {})
     if not isinstance(servers, dict):
         raise ValueError("mcpServers must be an object")
+
+    env = {
+        "PYTHONPATH": str(repo_root),
+        "AGENTOS_ONE_MCP_MODE": mode,
+    }
+    if mode == ORACLE_LOCAL_MODE:
+        env["AGENT_DATA_ROOT"] = str(oracle_data_root())
+        env["AGENTOS_CORE_NODE_ID"] = str(
+            os.environ.get(
+                "AGENTOS_CORE_NODE_ID",
+                "oracle-core-node",
+            )
+        )
+
     servers[SERVER_NAME] = {
         "command": str(python),
         "args": ["-m", "agentos_node.one_mcp"],
         "cwd": str(repo_root),
-        "env": {"PYTHONPATH": str(repo_root)},
+        "env": env,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+        shutil.copy2(
+            path,
+            path.with_name(
+                path.name + f".agentos-backup-{stamp}"
+            ),
+        )
     tmp = path.with_suffix(path.suffix + ".agentos.tmp")
     tmp.write_text(
-        json.dumps(config, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        json.dumps(
+            config,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
         encoding="utf-8",
     )
     tmp.replace(path)
     return servers[SERVER_NAME]
 
 
-def probe(python: Path, repo_root: Path) -> dict[str, Any]:
+def state_root_for_mode(mode: str) -> Path:
+    if mode == CLIENT_MODE:
+        return discover_client_config().parent / "mcp"
+    return Path.home() / ".local" / "share" / "agentos" / "one-mcp"
+
+
+def probe(
+    python: Path,
+    repo_root: Path,
+    *,
+    mode: str,
+) -> dict[str, Any]:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(repo_root)
+    env["AGENTOS_ONE_MCP_MODE"] = mode
+    if mode == ORACLE_LOCAL_MODE:
+        env["AGENT_DATA_ROOT"] = str(oracle_data_root())
     result = subprocess.run(
-        [str(python), "-m", "agentos_node.one_mcp", "--probe"],
+        [
+            str(python),
+            "-m",
+            "agentos_node.one_mcp",
+            "--mode",
+            mode,
+            "--probe",
+        ],
         cwd=str(repo_root),
         env=env,
         text=True,
@@ -145,43 +233,75 @@ def probe(python: Path, repo_root: Path) -> dict[str, Any]:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            "ONE MCP probe failed: " + (result.stderr or result.stdout)[-5000:]
+            "ONE MCP probe failed: "
+            + (result.stderr or result.stdout)[-5000:]
         )
     payload = json.loads(result.stdout)
     if payload.get("probe") != "PASS":
-        raise RuntimeError(f"ONE MCP probe did not pass: {payload}")
+        raise RuntimeError(
+            f"ONE MCP probe did not pass: {payload}"
+        )
+    if payload.get("credential_exposed") is not False:
+        raise RuntimeError(
+            "ONE MCP probe did not prove credential isolation"
+        )
     return payload
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Install AgentOS ONE MCP for the real Antigravity IDE agent"
+        description=(
+            "Install AgentOS ONE MCP for the real Antigravity IDE agent"
+        )
     )
-    parser.add_argument("--repo", type=Path, default=_repo_root())
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=_repo_root(),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=(CLIENT_MODE, ORACLE_LOCAL_MODE),
+        help=(
+            "client uses an enrolled Thin Client credential; "
+            "oracle-local uses trusted read-only Oracle state"
+        ),
+    )
     parser.add_argument("--no-probe", action="store_true")
     args = parser.parse_args(argv)
 
     repo_root = args.repo.expanduser().resolve()
-    if not (repo_root / "agentos_node" / "one_mcp.py").is_file():
+    if not (
+        repo_root / "agentos_node" / "one_mcp.py"
+    ).is_file():
         raise FileNotFoundError(
             f"AgentOS ONE MCP module missing under repo: {repo_root}"
         )
-    client_config = discover_client_config()
-    state_root = client_config.parent
-    venv_root = state_root / "mcp" / "venv"
+
+    mode = detect_mode(args.mode)
+    state_root = state_root_for_mode(mode)
+    venv_root = state_root / "venv"
     python = ensure_mcp_venv(venv_root)
-    evidence = None if args.no_probe else probe(python, repo_root)
+    evidence = (
+        None
+        if args.no_probe
+        else probe(python, repo_root, mode=mode)
+    )
     mcp_config = antigravity_mcp_config_path()
     server = write_antigravity_config(
         mcp_config,
         python=python,
         repo_root=repo_root,
+        mode=mode,
     )
     print(
         json.dumps(
             {
-                "schema": "agentos.antigravity-one-mcp-install/v0.1",
+                "schema": (
+                    "agentos.antigravity-one-mcp-install/v0.2"
+                ),
                 "ok": True,
+                "mode": mode,
                 "server": SERVER_NAME,
                 "mcp_config": str(mcp_config),
                 "repo": str(repo_root),

--- a/scripts/install_antigravity_one_mcp.py
+++ b/scripts/install_antigravity_one_mcp.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import venv
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MCP_PACKAGE = "mcp>=2,<3"
+SERVER_NAME = "agentos-one"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _client_config_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    explicit = os.environ.get("AGENTOS_CLIENT_CONFIG")
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    client_home = os.environ.get("AGENTOS_CLIENT_HOME")
+    if client_home:
+        candidates.append(Path(client_home).expanduser() / "client.json")
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(Path(local_app_data) / "AgentOS" / "state" / "client.json")
+    if os.name == "nt":
+        candidates.append(Path.home() / "AppData" / "Local" / "AgentOS" / "state" / "client.json")
+    candidates.append(Path.home() / ".agentos" / "client.json")
+    return candidates
+
+
+def discover_client_config() -> Path:
+    for path in _client_config_candidates():
+        if path.is_file():
+            return path
+    raise FileNotFoundError(
+        "AgentOS client.json not found; enroll/start the AgentOS client first"
+    )
+
+
+def antigravity_mcp_config_path() -> Path:
+    explicit = os.environ.get("AGENTOS_ANTIGRAVITY_MCP_CONFIG")
+    if explicit:
+        return Path(explicit).expanduser()
+    current = Path.home() / ".gemini" / "config" / "mcp_config.json"
+    legacy = Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
+    if current.exists() or current.parent.exists() or not legacy.exists():
+        return current
+    return legacy
+
+
+def _venv_python(root: Path) -> Path:
+    if os.name == "nt":
+        return root / "Scripts" / "python.exe"
+    return root / "bin" / "python"
+
+
+def ensure_mcp_venv(venv_root: Path) -> Path:
+    python = _venv_python(venv_root)
+    if not python.is_file():
+        venv_root.parent.mkdir(parents=True, exist_ok=True)
+        venv.EnvBuilder(with_pip=True, clear=False).create(venv_root)
+    check = subprocess.run(
+        [str(python), "-c", "from mcp.server import MCPServer"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check.returncode != 0:
+        install = subprocess.run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                MCP_PACKAGE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if install.returncode != 0:
+            raise RuntimeError(
+                "failed to install MCP SDK: "
+                + (install.stderr or install.stdout)[-4000:]
+            )
+    return python
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(data, dict):
+        raise ValueError(f"MCP config must be a JSON object: {path}")
+    return data
+
+
+def write_antigravity_config(
+    path: Path,
+    *,
+    python: Path,
+    repo_root: Path,
+) -> dict[str, Any]:
+    config = _load_json(path)
+    servers = config.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("mcpServers must be an object")
+    servers[SERVER_NAME] = {
+        "command": str(python),
+        "args": ["-m", "agentos_node.one_mcp"],
+        "cwd": str(repo_root),
+        "env": {"PYTHONPATH": str(repo_root)},
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(
+        json.dumps(config, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+    return servers[SERVER_NAME]
+
+
+def probe(python: Path, repo_root: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    result = subprocess.run(
+        [str(python), "-m", "agentos_node.one_mcp", "--probe"],
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "ONE MCP probe failed: " + (result.stderr or result.stdout)[-5000:]
+        )
+    payload = json.loads(result.stdout)
+    if payload.get("probe") != "PASS":
+        raise RuntimeError(f"ONE MCP probe did not pass: {payload}")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install AgentOS ONE MCP for the real Antigravity IDE agent"
+    )
+    parser.add_argument("--repo", type=Path, default=_repo_root())
+    parser.add_argument("--no-probe", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo.expanduser().resolve()
+    if not (repo_root / "agentos_node" / "one_mcp.py").is_file():
+        raise FileNotFoundError(
+            f"AgentOS ONE MCP module missing under repo: {repo_root}"
+        )
+    client_config = discover_client_config()
+    state_root = client_config.parent
+    venv_root = state_root / "mcp" / "venv"
+    python = ensure_mcp_venv(venv_root)
+    evidence = None if args.no_probe else probe(python, repo_root)
+    mcp_config = antigravity_mcp_config_path()
+    server = write_antigravity_config(
+        mcp_config,
+        python=python,
+        repo_root=repo_root,
+    )
+    print(
+        json.dumps(
+            {
+                "schema": "agentos.antigravity-one-mcp-install/v0.1",
+                "ok": True,
+                "server": SERVER_NAME,
+                "mcp_config": str(mcp_config),
+                "repo": str(repo_root),
+                "probe": evidence,
+                "credential_in_mcp_config": False,
+                "refresh_required": True,
+                "server_config": server,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_antigravity_one_mcp.py
+++ b/scripts/install_antigravity_one_mcp.py
@@ -78,6 +78,47 @@ def detect_mode(explicit: str | None = None) -> str:
     )
 
 
+GLOBAL_RULE_START = "<!-- AGENTOS_ONE_BOOTSTRAP_START -->"
+GLOBAL_RULE_END = "<!-- AGENTOS_ONE_BOOTSTRAP_END -->"
+GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
+## AgentOS ONE bootstrap
+
+When the `agentos-one` MCP tools are available and the current workspace is governed by AgentOS (for example its `AGENTS.md` identifies AgentOS, or the user asks about AgentOS/ONE), use ONE before reconstructing state from vendor conversation history.
+
+For a fresh or relative request such as `continue` / `繼續` in an AgentOS-governed workspace:
+1. call `one_status`;
+2. identify the current project from workspace/repository context without guessing;
+3. call `one_resolve(project)` before continuing substantial work;
+4. treat canonical goal/continuation/authority returned by ONE as durable state, while newer explicit user intent always wins.
+
+Never expose Realm/node credentials. The MCP adapter owns the trust boundary. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
+<!-- AGENTOS_ONE_BOOTSTRAP_END -->
+"""
+
+
+def global_rule_path() -> Path:
+    return Path.home() / ".gemini" / "GEMINI.md"
+
+
+def write_global_rule(path: Path) -> Path:
+    existing = path.read_text(encoding="utf-8-sig") if path.exists() else ""
+    if GLOBAL_RULE_START in existing and GLOBAL_RULE_END in existing:
+        before, remainder = existing.split(GLOBAL_RULE_START, 1)
+        _, after = remainder.split(GLOBAL_RULE_END, 1)
+        updated = before.rstrip() + "\n\n" + GLOBAL_RULE.strip() + after
+    else:
+        prefix = existing.rstrip()
+        updated = (prefix + "\n\n" if prefix else "") + GLOBAL_RULE.strip() + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
 def antigravity_mcp_config_path() -> Path:
     explicit = os.environ.get("AGENTOS_ANTIGRAVITY_MCP_CONFIG")
     if explicit:
@@ -287,6 +328,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.no_probe
         else probe(python, repo_root, mode=mode)
     )
+    global_rule = write_global_rule(global_rule_path())
     mcp_config = antigravity_mcp_config_path()
     server = write_antigravity_config(
         mcp_config,
@@ -304,6 +346,7 @@ def main(argv: list[str] | None = None) -> int:
                 "mode": mode,
                 "server": SERVER_NAME,
                 "mcp_config": str(mcp_config),
+                "global_rule": str(global_rule),
                 "repo": str(repo_root),
                 "probe": evidence,
                 "credential_in_mcp_config": False,

--- a/scripts/install_antigravity_one_mcp_oracle.py
+++ b/scripts/install_antigravity_one_mcp_oracle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import venv
@@ -11,36 +12,22 @@ from pathlib import Path
 from typing import Any
 
 SERVER_NAME = "agentos-one"
+HOOK_NAME = "agentos-one-preinvocation"
 MCP_PACKAGE = "mcp>=2,<3"
 GLOBAL_RULE_START = "<!-- AGENTOS_ONE_BOOTSTRAP_START -->"
 GLOBAL_RULE_END = "<!-- AGENTOS_ONE_BOOTSTRAP_END -->"
 GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
-## AgentOS ONE bootstrap — mandatory ONE-first continuation
+## AgentOS ONE bootstrap — pre-invocation hydration is authoritative
 
-This machine participates in AgentOS ONE through the `agentos-one` MCP server.
+This machine participates in AgentOS ONE through a trusted Oracle-local pre-invocation hook plus the `agentos-one` MCP server.
 
-### Mandatory startup gate
+On the first model invocation of a fresh Antigravity conversation, AgentOS injects canonical ONE state before the model is called when the active workspace resolves to an AgentOS project. Treat an injected `source=ONE_PREINVOCATION_HOOK` envelope as the primary continuity source. Newer explicit user intent always wins.
 
-If `agentos-one` tools are available, the active Antigravity executor MUST use ONE before reconstructing AgentOS state from local files, pulse boards, PM2 listings, vendor conversation history, memory files, or prior chat summaries.
+Do not reconstruct the current AgentOS goal from Pulse boards, PM2 listings, local memory files, vendor conversation history, or prior chat summaries before using the injected ONE state. Those sources may only be consulted later as supporting evidence.
 
-For the first user request in a fresh conversation, and especially for a relative request such as `continue` / `繼續`:
-1. call `one_status` before answering the user;
-2. if `one_status.connected` is not true, explicitly report `ONE_BOOTSTRAP_BLOCKED` and do not claim AgentOS continuity;
-3. identify the current project from the active workspace/repository path or Git metadata; do not infer it from stale memory;
-4. call `one_resolve(project)` before doing substantial project work;
-5. if project identity cannot be determined or `one_resolve` fails, explicitly report `ONE_RESOLVE_BLOCKED` instead of falling back to old AgentOS memory;
-6. use the returned canonical active goal, continuation, next action, and mutation boundary as durable state; newer explicit user intent always wins;
-7. only after the ONE calls may local files be consulted as supporting evidence.
+The `agentos-one` MCP tools remain available for explicit live queries (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). If no ONE pre-invocation hydration is present in an AgentOS-governed workspace, use the MCP tools and report `ONE_BOOTSTRAP_BLOCKED` if they are unavailable. Never claim ONE continuity merely because local AgentOS files are readable.
 
-### Proof requirement
-
-When answering a fresh AgentOS continuation request after successful ONE calls, include a compact provenance footer containing the actual tool-returned values:
-
-`source=ONE | status_schema=<one_status.schema> | resolve_schema=<one_resolve.schema> | realm=<realm_id> | node=<node_id> | project=<resolved project>`
-
-Do not claim "connected to AgentOS" merely because local AgentOS files, `/dev/shm` pulse data, PM2 services, or `agent-data` are readable. Connection means the active Antigravity executor successfully invoked the `agentos-one` MCP tools in the current conversation.
-
-Never expose Realm/node credentials. The MCP adapter owns the trust boundary. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
+Never expose Realm/node credentials. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
 <!-- AGENTOS_ONE_BOOTSTRAP_END -->
 """
 
@@ -65,11 +52,7 @@ def ensure_venv(root: Path) -> Path:
         root.parent.mkdir(parents=True, exist_ok=True)
         venv.EnvBuilder(with_pip=True, clear=False).create(root)
     check = subprocess.run(
-        [
-            str(python),
-            "-c",
-            "from mcp.server.mcpserver import MCPServer",
-        ],
+        [str(python), "-c", "from mcp.server.mcpserver import MCPServer"],
         text=True,
         capture_output=True,
         check=False,
@@ -100,10 +83,18 @@ def _backup(path: Path) -> None:
     if not path.exists():
         return
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    shutil.copy2(
-        path,
-        path.with_name(path.name + f".agentos-backup-{stamp}"),
+    shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
+    tmp.replace(path)
 
 
 def write_global_rule() -> Path:
@@ -131,12 +122,19 @@ def mcp_config_path() -> Path:
     return Path.home() / ".gemini" / "config" / "mcp_config.json"
 
 
+def hooks_config_path() -> Path:
+    explicit = os.environ.get("AGENTOS_ANTIGRAVITY_HOOKS_CONFIG")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".gemini" / "config" / "hooks.json"
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     payload = json.loads(path.read_text(encoding="utf-8-sig"))
     if not isinstance(payload, dict):
-        raise ValueError(f"MCP config must be a JSON object: {path}")
+        raise ValueError(f"config must be a JSON object: {path}")
     return payload
 
 
@@ -159,15 +157,42 @@ def write_mcp_config(path: Path, *, python: Path, repo_root: Path) -> dict[str, 
         },
     }
     servers[SERVER_NAME] = server
-    path.parent.mkdir(parents=True, exist_ok=True)
-    _backup(path)
-    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
-    tmp.write_text(
-        json.dumps(config, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    tmp.replace(path)
+    _atomic_json(path, config)
     return server
+
+
+def _hook_command(python: Path, repo_root: Path) -> str:
+    assignments = {
+        "PYTHONPATH": str(repo_root),
+        "AGENT_DATA_ROOT": str(_data_root()),
+        "AGENTOS_CORE_NODE_ID": str(
+            os.environ.get("AGENTOS_CORE_NODE_ID", "oracle-core-node")
+        ),
+    }
+    env_prefix = " ".join(
+        f"{key}={shlex.quote(value)}" for key, value in assignments.items()
+    )
+    return (
+        f"cd {shlex.quote(str(repo_root))} && {env_prefix} "
+        f"{shlex.quote(str(python))} -m agentos_node.antigravity_one_hook"
+    )
+
+
+def write_hooks_config(path: Path, *, python: Path, repo_root: Path) -> dict[str, Any]:
+    config = _load_json(path)
+    hook = {
+        "enabled": True,
+        "PreInvocation": [
+            {
+                "type": "command",
+                "command": _hook_command(python, repo_root),
+                "timeout": 10,
+            }
+        ],
+    }
+    config[HOOK_NAME] = hook
+    _atomic_json(path, config)
+    return hook
 
 
 def probe(python: Path, repo_root: Path) -> dict[str, Any]:
@@ -176,14 +201,7 @@ def probe(python: Path, repo_root: Path) -> dict[str, Any]:
     env["AGENTOS_ONE_MCP_MODE"] = "oracle-local"
     env["AGENT_DATA_ROOT"] = str(_data_root())
     result = subprocess.run(
-        [
-            str(python),
-            "-m",
-            "agentos_node.one_mcp",
-            "--mode",
-            "oracle-local",
-            "--probe",
-        ],
+        [str(python), "-m", "agentos_node.one_mcp", "--mode", "oracle-local", "--probe"],
         cwd=str(repo_root),
         env=env,
         text=True,
@@ -193,8 +211,7 @@ def probe(python: Path, repo_root: Path) -> dict[str, Any]:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            "Oracle ONE probe failed: "
-            + (result.stderr or result.stdout)[-5000:]
+            "Oracle ONE probe failed: " + (result.stderr or result.stdout)[-5000:]
         )
     payload = json.loads(result.stdout)
     if payload.get("probe") != "PASS":
@@ -206,6 +223,49 @@ def probe(python: Path, repo_root: Path) -> dict[str, Any]:
     return payload
 
 
+def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["AGENT_DATA_ROOT"] = str(_data_root())
+    payload = {
+        "invocationNum": 0,
+        "initialNumSteps": 1,
+        "conversationId": "agentos-installer-probe",
+        "workspacePaths": [str(Path("/home/ubuntu/agentmanager"))],
+        "transcriptPath": "",
+        "artifactDirectoryPath": "",
+        "modelName": "installer-probe",
+    }
+    result = subprocess.run(
+        [str(python), "-m", "agentos_node.antigravity_one_hook"],
+        cwd=str(repo_root),
+        env=env,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "PreInvocation hook probe failed: "
+            + (result.stderr or result.stdout)[-5000:]
+        )
+    output = json.loads(result.stdout or "{}")
+    steps = output.get("injectSteps") if isinstance(output, dict) else None
+    if not isinstance(steps, list) or not steps:
+        raise RuntimeError(f"PreInvocation hook produced no hydration: {output}")
+    message = str((steps[0] or {}).get("ephemeralMessage") or "")
+    if "ONE_PREINVOCATION_HOOK" not in message:
+        raise RuntimeError("PreInvocation hook hydration lacks ONE provenance")
+    return {
+        "ok": True,
+        "schema": "agentos.antigravity-one-preinvocation-probe/v0.1",
+        "source": "ONE_PREINVOCATION_HOOK",
+        "credential_exposed": False,
+    }
+
+
 def main() -> int:
     if os.name == "nt":
         raise RuntimeError("Oracle-local installer must run on Oracle/Linux")
@@ -213,31 +273,41 @@ def main() -> int:
         raise PermissionError("Oracle-local installer must run as ubuntu")
 
     repo_root = _repo_root()
-    if not (repo_root / "agentos_node" / "one_mcp.py").is_file():
-        raise FileNotFoundError("one_mcp.py missing")
-    if not (repo_root / "agentos_node" / "one_mcp_stdio.py").is_file():
-        raise FileNotFoundError("one_mcp_stdio.py missing")
+    for required in (
+        repo_root / "agentos_node" / "one_mcp.py",
+        repo_root / "agentos_node" / "one_mcp_stdio.py",
+        repo_root / "agentos_node" / "antigravity_one_hook.py",
+    ):
+        if not required.is_file():
+            raise FileNotFoundError(f"required AgentOS runtime file missing: {required}")
     if not (_data_root() / "realm" / "nodes.json").is_file():
         raise FileNotFoundError("Oracle ONE Node Registry missing")
 
     state_root = Path.home() / ".local" / "share" / "agentos" / "one-mcp"
     python = ensure_venv(state_root / "venv")
     evidence = probe(python, repo_root)
+    hook_probe = probe_preinvocation_hook(python, repo_root)
     rule = write_global_rule()
-    config_path = mcp_config_path()
-    server = write_mcp_config(config_path, python=python, repo_root=repo_root)
+    mcp_path = mcp_config_path()
+    server = write_mcp_config(mcp_path, python=python, repo_root=repo_root)
+    hooks_path = hooks_config_path()
+    hook = write_hooks_config(hooks_path, python=python, repo_root=repo_root)
 
     print(
         json.dumps(
             {
-                "schema": "agentos.antigravity-one-oracle-install/v0.1",
+                "schema": "agentos.antigravity-one-oracle-install/v0.2",
                 "ok": True,
                 "mode": "oracle-local",
                 "probe": evidence,
+                "preinvocation_hook_probe": hook_probe,
                 "global_rule": str(rule),
-                "mcp_config": str(config_path),
+                "mcp_config": str(mcp_path),
                 "server": server,
+                "hooks_config": str(hooks_path),
+                "hook": hook,
                 "credential_in_mcp_config": False,
+                "credential_in_hook_config": False,
                 "reload_required": True,
             },
             ensure_ascii=False,

--- a/scripts/install_antigravity_one_mcp_oracle.py
+++ b/scripts/install_antigravity_one_mcp_oracle.py
@@ -17,15 +17,17 @@ MCP_PACKAGE = "mcp>=2,<3"
 GLOBAL_RULE_START = "<!-- AGENTOS_ONE_BOOTSTRAP_START -->"
 GLOBAL_RULE_END = "<!-- AGENTOS_ONE_BOOTSTRAP_END -->"
 GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
-## AgentOS ONE bootstrap — pre-invocation hydration is authoritative
+## AgentOS ONE bootstrap — canonical IR hydration is authoritative
 
-This machine participates in AgentOS ONE through a trusted Oracle-local pre-invocation hook plus the `agentos-one` MCP server.
+This machine participates in AgentOS ONE through a trusted Oracle-local PreInvocation hook plus the `agentos-one` MCP server.
 
-On the first model invocation of a fresh Antigravity conversation, AgentOS injects canonical ONE state before the model is called when the active workspace resolves to an AgentOS project. Treat an injected `source=ONE_PREINVOCATION_HOOK` envelope as the primary continuity source. Newer explicit user intent always wins.
+For the current Core acceptance slice, when a fresh Antigravity conversation contains the canonical `agentmanager` checkout, AgentOS loads the single authoritative `agentos-core` continuation before the model is called. The injected envelope has `source=ONE_PREINVOCATION_IR` and contains a validated `agentos.ir/v1` whose `index_id` matches the canonical `agentos.execution-head/v1` generation.
 
-Do not reconstruct the current AgentOS goal from Pulse boards, PM2 listings, local memory files, vendor conversation history, or prior chat summaries before using the injected ONE state. Those sources may only be consulted later as supporting evidence.
+Treat that Canonical IR—not workspace ordering, Pulse boards, PM2 listings, local memory files, vendor conversation history, or prior chat summaries—as the durable continuation state. Newer explicit user intent always wins.
 
-The `agentos-one` MCP tools remain available for explicit live queries (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). If no ONE pre-invocation hydration is present in an AgentOS-governed workspace, use the MCP tools and report `ONE_BOOTSTRAP_BLOCKED` if they are unavailable. Never claim ONE continuity merely because local AgentOS files are readable.
+Multi-root sibling workspaces are context only. They MUST NOT be treated as candidate current projects and MUST NOT be enumerated to reconstruct continuation. If the IR head is absent, malformed, or generation-mismatched, report `ONE_IR_HEAD_UNRESOLVED` and do not fabricate a continuation from local state.
+
+The `agentos-one` MCP tools remain available for explicit live queries (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). They are not a replacement for the injected canonical IR on fresh Core continuation.
 
 Never expose Realm/node credentials. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
 <!-- AGENTOS_ONE_BOOTSTRAP_END -->
@@ -231,7 +233,11 @@ def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
         "invocationNum": 0,
         "initialNumSteps": 1,
         "conversationId": "agentos-installer-probe",
-        "workspacePaths": [str(Path("/home/ubuntu/agentmanager"))],
+        "workspacePaths": [
+            "/home/ubuntu/zeus-writer",
+            "/home/ubuntu/agentmanager",
+            "/home/ubuntu/privacy-guard",
+        ],
         "transcriptPath": "",
         "artifactDirectoryPath": "",
         "modelName": "installer-probe",
@@ -256,12 +262,38 @@ def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
     if not isinstance(steps, list) or not steps:
         raise RuntimeError(f"PreInvocation hook produced no hydration: {output}")
     message = str((steps[0] or {}).get("ephemeralMessage") or "")
-    if "ONE_PREINVOCATION_HOOK" not in message:
-        raise RuntimeError("PreInvocation hook hydration lacks ONE provenance")
+    if "ONE_IR_HEAD_UNRESOLVED" in message:
+        raise RuntimeError(f"Canonical IR hook probe failed closed: {message[-3000:]}")
+    if "ONE_PREINVOCATION_IR" not in message:
+        raise RuntimeError("PreInvocation hydration lacks canonical IR provenance")
+    try:
+        envelope = json.loads(message.rsplit("\n", 1)[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("PreInvocation hydration envelope is not parseable JSON") from exc
+    canonical_ir = envelope.get("canonical_ir") if isinstance(envelope, dict) else None
+    if not isinstance(canonical_ir, dict):
+        raise RuntimeError("PreInvocation hydration contains no canonical_ir")
+    if canonical_ir.get("schema_version") != "agentos.ir/v1":
+        raise RuntimeError("PreInvocation hydration is not agentos.ir/v1")
+    index_id = str(canonical_ir.get("index_id") or "").strip()
+    ir_id = str(canonical_ir.get("ir_id") or "").strip()
+    head = canonical_ir.get("execution_head") if isinstance(canonical_ir.get("execution_head"), dict) else {}
+    if not index_id or not ir_id:
+        raise RuntimeError("PreInvocation hydration is missing index_id or ir_id")
+    if str(head.get("index_id") or "").strip() != index_id:
+        raise RuntimeError("PreInvocation hydration execution-head / IR generation mismatch")
+    if canonical_ir.get("project_id") != "agentos-core":
+        raise RuntimeError("PreInvocation hydration selected a non-Core project")
+    serialized = json.dumps(envelope, ensure_ascii=False).casefold()
+    if "zeus-writer" in serialized or "privacy-guard" in serialized:
+        raise RuntimeError("PreInvocation hydration leaked sibling workspace state")
     return {
         "ok": True,
-        "schema": "agentos.antigravity-one-preinvocation-probe/v0.1",
-        "source": "ONE_PREINVOCATION_HOOK",
+        "schema": "agentos.antigravity-one-preinvocation-probe/v0.2",
+        "source": "ONE_PREINVOCATION_IR",
+        "project_id": "agentos-core",
+        "index_id": index_id,
+        "ir_id": ir_id,
         "credential_exposed": False,
     }
 
@@ -296,7 +328,7 @@ def main() -> int:
     print(
         json.dumps(
             {
-                "schema": "agentos.antigravity-one-oracle-install/v0.2",
+                "schema": "agentos.antigravity-one-oracle-install/v0.3",
                 "ok": True,
                 "mode": "oracle-local",
                 "probe": evidence,

--- a/scripts/install_antigravity_one_mcp_oracle.py
+++ b/scripts/install_antigravity_one_mcp_oracle.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import venv
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SERVER_NAME = "agentos-one"
+MCP_PACKAGE = "mcp>=2,<3"
+GLOBAL_RULE_START = "<!-- AGENTOS_ONE_BOOTSTRAP_START -->"
+GLOBAL_RULE_END = "<!-- AGENTOS_ONE_BOOTSTRAP_END -->"
+GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
+## AgentOS ONE bootstrap
+
+When the `agentos-one` MCP tools are available and the current workspace is governed by AgentOS, use ONE before reconstructing state from vendor conversation history.
+
+For a fresh or relative request such as `continue` / `繼續` in an AgentOS-governed workspace:
+1. call `one_status`;
+2. identify the current project from workspace/repository context without guessing;
+3. call `one_resolve(project)` before continuing substantial work;
+4. treat canonical goal/continuation/authority returned by ONE as durable state, while newer explicit user intent always wins.
+
+Never expose Realm/node credentials. The MCP adapter owns the trust boundary. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
+<!-- AGENTOS_ONE_BOOTSTRAP_END -->
+"""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _data_root() -> Path:
+    return Path(
+        os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")
+    ).expanduser()
+
+
+def _venv_python(root: Path) -> Path:
+    return root / "bin" / "python"
+
+
+def ensure_venv(root: Path) -> Path:
+    python = _venv_python(root)
+    if not python.is_file():
+        root.parent.mkdir(parents=True, exist_ok=True)
+        venv.EnvBuilder(with_pip=True, clear=False).create(root)
+    check = subprocess.run(
+        [
+            str(python),
+            "-c",
+            "from mcp.server.mcpserver import MCPServer",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check.returncode != 0:
+        install = subprocess.run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                MCP_PACKAGE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if install.returncode != 0:
+            raise RuntimeError(
+                "failed to install MCP SDK: "
+                + (install.stderr or install.stdout)[-4000:]
+            )
+    return python
+
+
+def _backup(path: Path) -> None:
+    if not path.exists():
+        return
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    shutil.copy2(
+        path,
+        path.with_name(path.name + f".agentos-backup-{stamp}"),
+    )
+
+
+def write_global_rule() -> Path:
+    path = Path.home() / ".gemini" / "GEMINI.md"
+    existing = path.read_text(encoding="utf-8-sig") if path.exists() else ""
+    if GLOBAL_RULE_START in existing and GLOBAL_RULE_END in existing:
+        before, remainder = existing.split(GLOBAL_RULE_START, 1)
+        _, after = remainder.split(GLOBAL_RULE_END, 1)
+        updated = before.rstrip() + "\n\n" + GLOBAL_RULE.strip() + after
+    else:
+        prefix = existing.rstrip()
+        updated = (prefix + "\n\n" if prefix else "") + GLOBAL_RULE.strip() + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def mcp_config_path() -> Path:
+    explicit = os.environ.get("AGENTOS_ANTIGRAVITY_MCP_CONFIG")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".gemini" / "config" / "mcp_config.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"MCP config must be a JSON object: {path}")
+    return payload
+
+
+def write_mcp_config(path: Path, *, python: Path, repo_root: Path) -> dict[str, Any]:
+    config = _load_json(path)
+    servers = config.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("mcpServers must be an object")
+    server = {
+        "command": str(python),
+        "args": ["-m", "agentos_node.one_mcp_stdio"],
+        "cwd": str(repo_root),
+        "env": {
+            "PYTHONPATH": str(repo_root),
+            "AGENTOS_ONE_MCP_MODE": "oracle-local",
+            "AGENT_DATA_ROOT": str(_data_root()),
+            "AGENTOS_CORE_NODE_ID": str(
+                os.environ.get("AGENTOS_CORE_NODE_ID", "oracle-core-node")
+            ),
+        },
+    }
+    servers[SERVER_NAME] = server
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(
+        json.dumps(config, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+    return server
+
+
+def probe(python: Path, repo_root: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["AGENTOS_ONE_MCP_MODE"] = "oracle-local"
+    env["AGENT_DATA_ROOT"] = str(_data_root())
+    result = subprocess.run(
+        [
+            str(python),
+            "-m",
+            "agentos_node.one_mcp",
+            "--mode",
+            "oracle-local",
+            "--probe",
+        ],
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Oracle ONE probe failed: "
+            + (result.stderr or result.stdout)[-5000:]
+        )
+    payload = json.loads(result.stdout)
+    if payload.get("probe") != "PASS":
+        raise RuntimeError(f"Oracle ONE probe did not pass: {payload}")
+    if payload.get("mode") != "oracle-local":
+        raise RuntimeError(f"unexpected ONE MCP mode: {payload}")
+    if payload.get("credential_exposed") is not False:
+        raise RuntimeError("credential isolation not proven")
+    return payload
+
+
+def main() -> int:
+    if os.name == "nt":
+        raise RuntimeError("Oracle-local installer must run on Oracle/Linux")
+    if os.environ.get("USER") not in (None, "", "ubuntu"):
+        raise PermissionError("Oracle-local installer must run as ubuntu")
+
+    repo_root = _repo_root()
+    if not (repo_root / "agentos_node" / "one_mcp.py").is_file():
+        raise FileNotFoundError("one_mcp.py missing")
+    if not (repo_root / "agentos_node" / "one_mcp_stdio.py").is_file():
+        raise FileNotFoundError("one_mcp_stdio.py missing")
+    if not (_data_root() / "realm" / "nodes.json").is_file():
+        raise FileNotFoundError("Oracle ONE Node Registry missing")
+
+    state_root = Path.home() / ".local" / "share" / "agentos" / "one-mcp"
+    python = ensure_venv(state_root / "venv")
+    evidence = probe(python, repo_root)
+    rule = write_global_rule()
+    config_path = mcp_config_path()
+    server = write_mcp_config(config_path, python=python, repo_root=repo_root)
+
+    print(
+        json.dumps(
+            {
+                "schema": "agentos.antigravity-one-oracle-install/v0.1",
+                "ok": True,
+                "mode": "oracle-local",
+                "probe": evidence,
+                "global_rule": str(rule),
+                "mcp_config": str(config_path),
+                "server": server,
+                "credential_in_mcp_config": False,
+                "reload_required": True,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_antigravity_one_mcp_oracle.py
+++ b/scripts/install_antigravity_one_mcp_oracle.py
@@ -21,15 +21,17 @@ GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
 
 This machine participates in AgentOS ONE through a trusted Oracle-local PreInvocation hook plus the `agentos-one` MCP server.
 
-For the current Core acceptance slice, when a fresh Antigravity conversation contains the canonical `agentmanager` checkout, AgentOS loads the single authoritative `agentos-core` continuation before the model is called. The injected envelope has `source=ONE_PREINVOCATION_IR` and contains a validated `agentos.ir/v1` whose `index_id` matches the canonical `agentos.execution-head/v1` generation.
+On the first model invocation of a fresh Antigravity conversation, AgentOS reads the ONE active-continuation selector and loads the exact Canonical IR generation named by its `project_id + index_id + ir_id`. The selector is only a pointer; the authoritative working state remains the referenced `agentos.ir/v1` plus its matching `agentos.execution-head/v1` generation.
 
-Treat that Canonical IR—not workspace ordering, Pulse boards, PM2 listings, local memory files, vendor conversation history, or prior chat summaries—as the durable continuation state. Newer explicit user intent always wins.
+The IDE workspace path is not continuation authority. A conversation opened in `/home/ubuntu/acas`, a nested `agentmanager/workspace/...` directory, or another workspace must not silently select that workspace's local state. Workspace metadata may describe execution environment, but it does not choose the durable continuation.
 
-Multi-root sibling workspaces are context only. They MUST NOT be treated as candidate current projects and MUST NOT be enumerated to reconstruct continuation. If the IR head is absent, malformed, or generation-mismatched, report `ONE_IR_HEAD_UNRESOLVED` and do not fabricate a continuation from local state.
+Treat the injected Canonical IR—not workspace ordering, Pulse boards, PM2 listings, local memory files, vendor conversation history, or prior chat summaries—as the durable continuation state. Newer explicit user intent always wins.
 
-The `agentos-one` MCP tools remain available for explicit live queries (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). They are not a replacement for the injected canonical IR on fresh Core continuation.
+If the active selector is missing, malformed, stale relative to the referenced project generation, or the IR head is invalid, report `ONE_IR_HEAD_UNRESOLVED` and do not fabricate a continuation from local state.
 
-Never expose Realm/node credentials. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
+The `agentos-one` MCP tools remain available for explicit live queries (`one_status`, `one_bootstrap`, `one_capabilities`, `one_resolve`). They are not a replacement for the injected canonical IR on fresh continuation.
+
+Never expose Realm/node credentials. `agy`, standalone `gemini`, Claude, built-in Gemini, and built-in Codex are distinct executor identities. The PreInvocation hook may bind Gemini/Codex identity only from its current `modelName`; the generic MCP process remains caller-identity unbound.
 <!-- AGENTOS_ONE_BOOTSTRAP_END -->
 """
 
@@ -233,14 +235,13 @@ def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
         "invocationNum": 0,
         "initialNumSteps": 1,
         "conversationId": "agentos-installer-probe",
-        "workspacePaths": [
-            "/home/ubuntu/zeus-writer",
-            "/home/ubuntu/agentmanager",
-            "/home/ubuntu/privacy-guard",
-        ],
+        # Deliberately use the workspace that caused the first real E3 Codex
+        # regression failure. The active ONE selector, not workspacePaths, must
+        # determine continuation.
+        "workspacePaths": ["/home/ubuntu/acas"],
         "transcriptPath": "",
         "artifactDirectoryPath": "",
-        "modelName": "installer-probe",
+        "modelName": "gpt-5-codex-installer-probe",
     }
     result = subprocess.run(
         [str(python), "-m", "agentos_node.antigravity_one_hook"],
@@ -270,9 +271,12 @@ def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
         envelope = json.loads(message.rsplit("\n", 1)[-1])
     except json.JSONDecodeError as exc:
         raise RuntimeError("PreInvocation hydration envelope is not parseable JSON") from exc
+    if envelope.get("selection_source") != "ONE_ACTIVE_CONTINUATION":
+        raise RuntimeError("PreInvocation hydration did not use ONE active continuation selector")
     canonical_ir = envelope.get("canonical_ir") if isinstance(envelope, dict) else None
-    if not isinstance(canonical_ir, dict):
-        raise RuntimeError("PreInvocation hydration contains no canonical_ir")
+    selector = envelope.get("active_selector") if isinstance(envelope.get("active_selector"), dict) else None
+    if not isinstance(canonical_ir, dict) or not isinstance(selector, dict):
+        raise RuntimeError("PreInvocation hydration lacks canonical_ir or active_selector")
     if canonical_ir.get("schema_version") != "agentos.ir/v1":
         raise RuntimeError("PreInvocation hydration is not agentos.ir/v1")
     index_id = str(canonical_ir.get("index_id") or "").strip()
@@ -282,18 +286,25 @@ def probe_preinvocation_hook(python: Path, repo_root: Path) -> dict[str, Any]:
         raise RuntimeError("PreInvocation hydration is missing index_id or ir_id")
     if str(head.get("index_id") or "").strip() != index_id:
         raise RuntimeError("PreInvocation hydration execution-head / IR generation mismatch")
-    if canonical_ir.get("project_id") != "agentos-core":
-        raise RuntimeError("PreInvocation hydration selected a non-Core project")
-    serialized = json.dumps(envelope, ensure_ascii=False).casefold()
-    if "zeus-writer" in serialized or "privacy-guard" in serialized:
-        raise RuntimeError("PreInvocation hydration leaked sibling workspace state")
+    if canonical_ir.get("project_id") != str(selector.get("project_id") or ""):
+        raise RuntimeError("PreInvocation hydration project differs from active selector")
+    if index_id != str(selector.get("index_id") or "") or ir_id != str(selector.get("ir_id") or ""):
+        raise RuntimeError("PreInvocation hydration generation differs from active selector")
+    if envelope.get("executor_class") != "antigravity-codex" or envelope.get("executor_identity_bound") is not True:
+        raise RuntimeError("PreInvocation Codex identity binding probe failed")
+    serialized = json.dumps(envelope, ensure_ascii=False)
+    if "/home/ubuntu/acas" in serialized:
+        raise RuntimeError("PreInvocation hydration leaked ACAS workspace as continuation state")
     return {
         "ok": True,
-        "schema": "agentos.antigravity-one-preinvocation-probe/v0.2",
+        "schema": "agentos.antigravity-one-preinvocation-probe/v0.3",
         "source": "ONE_PREINVOCATION_IR",
-        "project_id": "agentos-core",
+        "selection_source": "ONE_ACTIVE_CONTINUATION",
+        "project_id": canonical_ir.get("project_id"),
         "index_id": index_id,
         "ir_id": ir_id,
+        "executor_class": envelope.get("executor_class"),
+        "workspace_probe": "/home/ubuntu/acas",
         "credential_exposed": False,
     }
 
@@ -306,6 +317,7 @@ def main() -> int:
 
     repo_root = _repo_root()
     for required in (
+        repo_root / "agent_core" / "active_continuation.py",
         repo_root / "agentos_node" / "one_mcp.py",
         repo_root / "agentos_node" / "one_mcp_stdio.py",
         repo_root / "agentos_node" / "antigravity_one_hook.py",
@@ -328,7 +340,7 @@ def main() -> int:
     print(
         json.dumps(
             {
-                "schema": "agentos.antigravity-one-oracle-install/v0.3",
+                "schema": "agentos.antigravity-one-oracle-install/v0.4",
                 "ok": True,
                 "mode": "oracle-local",
                 "probe": evidence,

--- a/scripts/install_antigravity_one_mcp_oracle.py
+++ b/scripts/install_antigravity_one_mcp_oracle.py
@@ -15,15 +15,30 @@ MCP_PACKAGE = "mcp>=2,<3"
 GLOBAL_RULE_START = "<!-- AGENTOS_ONE_BOOTSTRAP_START -->"
 GLOBAL_RULE_END = "<!-- AGENTOS_ONE_BOOTSTRAP_END -->"
 GLOBAL_RULE = """<!-- AGENTOS_ONE_BOOTSTRAP_START -->
-## AgentOS ONE bootstrap
+## AgentOS ONE bootstrap — mandatory ONE-first continuation
 
-When the `agentos-one` MCP tools are available and the current workspace is governed by AgentOS, use ONE before reconstructing state from vendor conversation history.
+This machine participates in AgentOS ONE through the `agentos-one` MCP server.
 
-For a fresh or relative request such as `continue` / `繼續` in an AgentOS-governed workspace:
-1. call `one_status`;
-2. identify the current project from workspace/repository context without guessing;
-3. call `one_resolve(project)` before continuing substantial work;
-4. treat canonical goal/continuation/authority returned by ONE as durable state, while newer explicit user intent always wins.
+### Mandatory startup gate
+
+If `agentos-one` tools are available, the active Antigravity executor MUST use ONE before reconstructing AgentOS state from local files, pulse boards, PM2 listings, vendor conversation history, memory files, or prior chat summaries.
+
+For the first user request in a fresh conversation, and especially for a relative request such as `continue` / `繼續`:
+1. call `one_status` before answering the user;
+2. if `one_status.connected` is not true, explicitly report `ONE_BOOTSTRAP_BLOCKED` and do not claim AgentOS continuity;
+3. identify the current project from the active workspace/repository path or Git metadata; do not infer it from stale memory;
+4. call `one_resolve(project)` before doing substantial project work;
+5. if project identity cannot be determined or `one_resolve` fails, explicitly report `ONE_RESOLVE_BLOCKED` instead of falling back to old AgentOS memory;
+6. use the returned canonical active goal, continuation, next action, and mutation boundary as durable state; newer explicit user intent always wins;
+7. only after the ONE calls may local files be consulted as supporting evidence.
+
+### Proof requirement
+
+When answering a fresh AgentOS continuation request after successful ONE calls, include a compact provenance footer containing the actual tool-returned values:
+
+`source=ONE | status_schema=<one_status.schema> | resolve_schema=<one_resolve.schema> | realm=<realm_id> | node=<node_id> | project=<resolved project>`
+
+Do not claim "connected to AgentOS" merely because local AgentOS files, `/dev/shm` pulse data, PM2 services, or `agent-data` are readable. Connection means the active Antigravity executor successfully invoked the `agentos-one` MCP tools in the current conversation.
 
 Never expose Realm/node credentials. The MCP adapter owns the trust boundary. `agy`, standalone `gemini`, Claude, and Codex are distinct executors and are not substitutes for the active Antigravity executor.
 <!-- AGENTOS_ONE_BOOTSTRAP_END -->

--- a/scripts/install_codex_one_oracle.py
+++ b/scripts/install_codex_one_oracle.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import venv
+from datetime import datetime, timezone
+from pathlib import Path
+
+MCP_PACKAGE = "mcp>=2,<3"
+CONFIG_START = "# AGENTOS_ONE_MCP_START"
+CONFIG_END = "# AGENTOS_ONE_MCP_END"
+AGENTS_START = "<!-- AGENTOS_ONE_CODEX_BOOTSTRAP_START -->"
+AGENTS_END = "<!-- AGENTOS_ONE_CODEX_BOOTSTRAP_END -->"
+
+AGENTS_BLOCK = f"""{AGENTS_START}
+## AgentOS ONE bootstrap for Codex
+
+This Codex local harness participates in AgentOS ONE through the `agentos-one` MCP server.
+
+For a fresh thread, when the user's instruction is relative continuation such as `continue` or `繼續` and there is no newer explicit task, resolve the current work from ONE before inspecting workspace-local TODOs, status files, open editors, vendor history, or uncommitted changes.
+
+Required startup action:
+1. call `agentos-one.one_resolve_active`;
+2. treat `selector.project_id + selector.index_id + selector.ir_id` and the returned Canonical IR as the authoritative continuation generation;
+3. continue from that IR's goal, constraints, decisions, pending tasks, continuation, and next action;
+4. report provenance `source=ONE_ACTIVE_CONTINUATION` plus project/index/IR identifiers when beginning a relative continuation;
+5. newer explicit user intent still wins over hydrated state.
+
+Do not infer the current project from the IDE workspace. Do not reconstruct continuation from Pulse, PM2, local memory, git diff, STATUS files, or previous Codex/Gemini conversation history when ONE is available.
+
+If `one_resolve_active` is unavailable, missing, stale, or fails, report `ONE_ACTIVE_CONTINUATION_UNRESOLVED` and do not fabricate the continuation.
+
+Never request, print, copy, or expose Realm/node credentials. The MCP process owns only the trusted local read-only projection.
+{AGENTS_END}
+"""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")).expanduser()
+
+
+def _codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser()
+
+
+def _venv_python(root: Path) -> Path:
+    return root / "bin" / "python"
+
+
+def ensure_venv(root: Path) -> Path:
+    python = _venv_python(root)
+    if not python.is_file():
+        root.parent.mkdir(parents=True, exist_ok=True)
+        venv.EnvBuilder(with_pip=True, clear=False).create(root)
+    check = subprocess.run(
+        [str(python), "-c", "from mcp.server.mcpserver import MCPServer"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check.returncode != 0:
+        install = subprocess.run(
+            [str(python), "-m", "pip", "install", "--disable-pip-version-check", MCP_PACKAGE],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if install.returncode != 0:
+            raise RuntimeError("failed to install MCP SDK: " + (install.stderr or install.stdout)[-4000:])
+    return python
+
+
+def _backup(path: Path) -> None:
+    if not path.exists():
+        return
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+
+
+def _replace_block(existing: str, start: str, end: str, block: str) -> str:
+    if start in existing or end in existing:
+        if start not in existing or end not in existing:
+            raise ValueError(f"partial managed block found: {start}")
+        before, rest = existing.split(start, 1)
+        _, after = rest.split(end, 1)
+        return before.rstrip() + "\n\n" + block.strip() + "\n" + after.lstrip()
+    prefix = existing.rstrip()
+    return (prefix + "\n\n" if prefix else "") + block.strip() + "\n"
+
+
+def write_agents(path: Path) -> Path:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    updated = _replace_block(existing, AGENTS_START, AGENTS_END, AGENTS_BLOCK)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def config_block(*, python: Path, repo_root: Path) -> str:
+    return "\n".join(
+        [
+            CONFIG_START,
+            '[mcp_servers."agentos-one"]',
+            f"command = {_toml_string(str(python))}",
+            'args = ["-m", "agentos_node.codex_one_mcp_stdio"]',
+            f"cwd = {_toml_string(str(repo_root))}",
+            "enabled = true",
+            "",
+            '[mcp_servers."agentos-one".env]',
+            f"PYTHONPATH = {_toml_string(str(repo_root))}",
+            f"AGENT_DATA_ROOT = {_toml_string(str(_data_root()))}",
+            'AGENTOS_ONE_MCP_MODE = "oracle-local"',
+            f"AGENTOS_CORE_NODE_ID = {_toml_string(str(os.environ.get('AGENTOS_CORE_NODE_ID', 'oracle-core-node')))}",
+            CONFIG_END,
+        ]
+    )
+
+
+def write_config(path: Path, *, python: Path, repo_root: Path) -> Path:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    unmanaged = existing
+    if CONFIG_START in existing and CONFIG_END in existing:
+        before, rest = existing.split(CONFIG_START, 1)
+        _, after = rest.split(CONFIG_END, 1)
+        unmanaged = before + after
+    if '[mcp_servers."agentos-one"]' in unmanaged or "[mcp_servers.agentos-one]" in unmanaged:
+        raise ValueError("unmanaged Codex agentos-one MCP entry already exists; refusing to overwrite")
+    updated = _replace_block(existing, CONFIG_START, CONFIG_END, config_block(python=python, repo_root=repo_root))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def probe(python: Path, repo_root: Path) -> dict[str, object]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["AGENT_DATA_ROOT"] = str(_data_root())
+    code = """
+import json
+from agentos_node.codex_one_mcp_stdio import _active_projection
+from agentos_node.one_mcp import OracleLocalGateway
+r = _active_projection(OracleLocalGateway())
+s = r.get('selector') or {}
+print(json.dumps({
+  'ok': True,
+  'schema': r.get('schema'),
+  'source': r.get('source'),
+  'selection_source': r.get('selection_source'),
+  'surface': r.get('surface'),
+  'executor_class': r.get('executor_class'),
+  'project_id': s.get('project_id'),
+  'index_id': s.get('index_id'),
+  'ir_id': s.get('ir_id'),
+  'credential_exposed': r.get('credential_exposed'),
+}, ensure_ascii=False))
+"""
+    result = subprocess.run(
+        [str(python), "-c", code],
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("Codex ONE probe failed: " + (result.stderr or result.stdout)[-4000:])
+    payload = json.loads(result.stdout)
+    if payload.get("source") != "ONE_ACTIVE_CONTINUATION":
+        raise RuntimeError(f"Codex ONE active selector probe failed: {payload}")
+    if payload.get("credential_exposed") is not False:
+        raise RuntimeError("Codex ONE credential isolation not proven")
+    return payload
+
+
+def main() -> int:
+    if os.name == "nt":
+        raise RuntimeError("Oracle-local Codex installer must run on Oracle/Linux")
+    repo_root = _repo_root()
+    required = repo_root / "agentos_node" / "codex_one_mcp_stdio.py"
+    if not required.is_file():
+        raise FileNotFoundError(f"required Codex ONE MCP module missing: {required}")
+    if not (_data_root() / "runtime" / "active-continuation.json").is_file():
+        raise FileNotFoundError("ONE active continuation selector is missing")
+
+    state_root = Path.home() / ".local" / "share" / "agentos" / "one-mcp"
+    python = ensure_venv(state_root / "venv")
+    evidence = probe(python, repo_root)
+    codex_home = _codex_home()
+    agents = write_agents(codex_home / "AGENTS.md")
+    config = write_config(codex_home / "config.toml", python=python, repo_root=repo_root)
+
+    print(json.dumps({
+        "schema": "agentos.codex-one-oracle-install/v0.1",
+        "ok": True,
+        "mode": "oracle-local",
+        "probe": evidence,
+        "codex_home": str(codex_home),
+        "agents_path": str(agents),
+        "config_path": str(config),
+        "mcp_server": "agentos-one",
+        "credential_in_config": False,
+        "reload_required": True,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_issue_152_codex_extension_e3_oracle.sh
+++ b/scripts/prepare_issue_152_codex_extension_e3_oracle.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: #152 Codex extension E3 preparation must run as ubuntu on Oracle" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-152-executor-awareness"
+RUNTIME_ROOT="${AGENTOS_ONE_MCP_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/one-mcp-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+EXPECTED_INDEX="idx-core-152-e3-codex-ext-1"
+EXPECTED_IR="ir-core-152-e3-codex-ext-1"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+test -f "$DATA_ROOT/realm/nodes.json" || { echo "ERROR: Oracle ONE Node Registry missing" >&2; exit 4; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+
+if [ ! -f "$TARGET/scripts/install_codex_one_oracle.py" ]; then
+  TMP="$RUNTIME_ROOT/.codex-e3-$SOURCE_COMMIT-$$"
+  rm -rf "$TMP"
+  mkdir -p "$TMP" "$RUNTIME_ROOT"
+  git -C "$REPO" archive "$SOURCE_COMMIT" | tar -x -C "$TMP"
+  mv "$TMP" "$TARGET"
+fi
+
+cd "$TARGET"
+echo "agentos_codex_e3_source_commit=$SOURCE_COMMIT"
+echo "agentos_codex_e3_runtime_source=$TARGET"
+echo "agentos_codex_e3_execution_cwd=$PWD"
+
+echo "agentos_codex_e3_contract_tests=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 -m unittest \
+    tests.test_project_continuation_index \
+    tests.test_canonical_ir_handoff \
+    tests.test_active_continuation \
+    tests.test_codex_one_mcp_stdio \
+    -v
+echo "agentos_codex_e3_contract_tests=PASS"
+
+echo "agentos_codex_e3_canonical_handoff=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/advance_issue_152_e3_to_codex_extension.py"
+echo "agentos_codex_e3_canonical_handoff=PASS"
+
+echo "agentos_codex_e3_install=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 "$TARGET/scripts/install_codex_one_oracle.py"
+echo "agentos_codex_e3_install=PASS"
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 - <<'PY'
+import json
+import os
+from agentos_node.codex_one_mcp_stdio import _active_projection
+from agentos_node.one_mcp import OracleLocalGateway
+
+expected_index = "idx-core-152-e3-codex-ext-1"
+expected_ir = "ir-core-152-e3-codex-ext-1"
+result = _active_projection(OracleLocalGateway())
+selector = result.get("selector") or {}
+if selector.get("project_id") != "agentos-core":
+    raise SystemExit(f"Codex active project mismatch: {selector}")
+if selector.get("index_id") != expected_index or selector.get("ir_id") != expected_ir:
+    raise SystemExit(f"Codex active generation mismatch: {selector}")
+print(json.dumps({
+    "schema": "agentos.issue-152-codex-extension-probe/v1",
+    "ok": True,
+    "source": result.get("source"),
+    "selection_source": result.get("selection_source"),
+    "surface": result.get("surface"),
+    "executor_class": result.get("executor_class"),
+    "project_id": selector.get("project_id"),
+    "index_id": selector.get("index_id"),
+    "ir_id": selector.get("ir_id"),
+    "credential_exposed": result.get("credential_exposed"),
+}, ensure_ascii=False, indent=2, sort_keys=True))
+PY
+
+echo "agentos_issue_152_codex_extension_e3=PASS"
+echo "agentos_codex_e3_index_id=$EXPECTED_INDEX"
+echo "agentos_codex_e3_ir_id=$EXPECTED_IR"
+echo "codex_extension_reload_required=YES"

--- a/scripts/prepare_issue_152_codex_extension_e3_oracle.sh
+++ b/scripts/prepare_issue_152_codex_extension_e3_oracle.sh
@@ -40,6 +40,7 @@ PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
     tests.test_canonical_ir_handoff \
     tests.test_active_continuation \
     tests.test_codex_one_mcp_stdio \
+    tests.test_install_codex_one_oracle \
     -v
 echo "agentos_codex_e3_contract_tests=PASS"
 
@@ -56,7 +57,6 @@ echo "agentos_codex_e3_install=PASS"
 PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
   python3 - <<'PY'
 import json
-import os
 from agentos_node.codex_one_mcp_stdio import _active_projection
 from agentos_node.one_mcp import OracleLocalGateway
 

--- a/scripts/seed_active_continuation.py
+++ b/scripts/seed_active_continuation.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent_core.active_continuation import (
+    activate_continuation,
+    read_active_continuation,
+    resolve_active_continuation,
+    selector_path,
+)
+from agent_core.resolve_facade import resolve_continuation
+
+PROJECT_ID = "agentos-core"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def main() -> int:
+    root = _data_root()
+    path = selector_path(root)
+    if path.exists():
+        try:
+            current = resolve_active_continuation(data_root=root)
+        except Exception as exc:
+            print(
+                json.dumps(
+                    {
+                        "schema": "agentos.active-continuation-seed/v1",
+                        "ok": False,
+                        "seeded": False,
+                        "reason": f"existing selector is invalid/stale: {type(exc).__name__}: {exc}",
+                        "path": str(path),
+                        "credential_exposed": False,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 3
+        selector = current["selector"]
+        print(
+            json.dumps(
+                {
+                    "schema": "agentos.active-continuation-seed/v1",
+                    "ok": True,
+                    "seeded": False,
+                    "reason": "existing selector is current",
+                    "path": str(path),
+                    "project_id": selector["project_id"],
+                    "index_id": selector["index_id"],
+                    "ir_id": selector["ir_id"],
+                    "credential_exposed": False,
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    resolved = resolve_continuation(PROJECT_ID, data_root=root)
+    head = resolved.get("execution_head") if isinstance(resolved.get("execution_head"), dict) else {}
+    continuation = resolved.get("continuation") if isinstance(resolved.get("continuation"), dict) else {}
+    ir = continuation.get("canonical_ir") if isinstance(continuation.get("canonical_ir"), dict) else {}
+    index_id = str(head.get("index_id") or "").strip()
+    ir_id = str(ir.get("ir_id") or "").strip()
+    if not index_id or not ir_id or str(ir.get("index_id") or "").strip() != index_id:
+        raise RuntimeError("agentos-core has no valid canonical generation to seed as active")
+
+    receipt = activate_continuation(
+        PROJECT_ID,
+        index_id=index_id,
+        ir_id=ir_id,
+        reason="initial ONE active continuation selector; only canonical publisher currently supported is agentos-core",
+        data_root=root,
+    )
+    print(
+        json.dumps(
+            {
+                "schema": "agentos.active-continuation-seed/v1",
+                "ok": True,
+                "seeded": True,
+                "path": str(path),
+                "project_id": PROJECT_ID,
+                "index_id": index_id,
+                "ir_id": ir_id,
+                "credential_exposed": False,
+                "activation_receipt": receipt,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_agentos_core_ir_head.py
+++ b/scripts/seed_agentos_core_ir_head.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from agent_core.project_continuation_index import publish_project_continuation
+
+PROJECT_ID = "agentos-core"
+INDEX_ID = "idx-core-152-e2-bootstrap-v1"
+IR_ID = "ir-core-152-e2-bootstrap-v1"
+GOAL = (
+    "Complete #152 Antigravity canonical IR hydration and prove that a fresh "
+    "built-in Gemini session continues from AgentOS ONE without copied vendor history."
+)
+NEXT_ACTION = (
+    "Re-run the Oracle Antigravity ONE bootstrap and require the pre-invocation probe "
+    "to return ONE_PREINVOCATION_IR with matching execution-head and canonical IR index_id; "
+    "then reload Antigravity and run a completely fresh Gemini regression using only '繼續'."
+)
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def build_seed_payload() -> dict[str, Any]:
+    return {
+        "project_id": PROJECT_ID,
+        "execution_head": {
+            "schema": "agentos.execution-head/v1",
+            "index_id": INDEX_ID,
+            "active_goal": GOAL,
+            "execution_head": {
+                "status": "in_progress",
+                "issue": "#152",
+                "phase": "E2-antigravity-canonical-ir-hydration",
+            },
+        },
+        "continuation": {
+            "protocol": "ANCP/1.0",
+            "index_id": INDEX_ID,
+            "recommended_action": NEXT_ACTION,
+            "canonical_ir": {
+                "schema_version": "agentos.ir/v1",
+                "index_id": INDEX_ID,
+                "ir_id": IR_ID,
+                "parent_ir_id": None,
+                "goal": GOAL,
+                "constraints": [
+                    "The active Antigravity built-in Gemini executor is distinct from agy, standalone gemini, Claude, and Codex.",
+                    "Workspace membership is only a hydration gate; workspace names must not select or reconstruct continuation state.",
+                    "Canonical continuation must come from ONE agentos.ir/v1 and matching agentos.execution-head/v1 generation.",
+                    "If the canonical IR head is missing, malformed, or generation-mismatched, fail closed instead of consulting Pulse, PM2, local memory, or vendor chat history as authority.",
+                    "Realm/node credentials remain inside the trusted local adapter and are never model-visible.",
+                    "Do not mutate protected main/master/release branches without a separate explicit human authorization event.",
+                ],
+                "decisions": [
+                    "Use the existing project continuation publisher and index_id generation fence rather than introducing project-focus state.",
+                    "For #152 Core acceptance, hydrate the authoritative agentos-core IR directly; sibling workspace projects are not continuation candidates.",
+                    "Treat ONE_PREINVOCATION_IR as the primary fresh-session continuity source; newer explicit user intent still wins.",
+                ],
+                "pending_tasks": [
+                    "Re-run Oracle bootstrap until preinvocation_hook_probe proves a valid canonical IR generation.",
+                    "Reload Antigravity so the installed PreInvocation hook is active.",
+                    "Open a completely fresh built-in Gemini conversation and send only '繼續'.",
+                    "Capture a second completely fresh-session regression before marking E2 verified.",
+                ],
+                "continuation": {
+                    "recommended_action": NEXT_ACTION,
+                    "next_action": NEXT_ACTION,
+                },
+                "capability": "agentos.one.resolve",
+            },
+        },
+    }
+
+
+def main() -> int:
+    root = _data_root()
+    project_dir = root / "projects" / PROJECT_ID
+    execution_path = project_dir / "execution-head.json"
+    continuation_path = project_dir / "continuity" / "latest.json"
+
+    existing = [str(path) for path in (execution_path, continuation_path) if path.exists()]
+    if existing:
+        print(
+            json.dumps(
+                {
+                    "schema": "agentos.core-ir-seed/v1",
+                    "ok": False,
+                    "seeded": False,
+                    "reason": "canonical head paths already exist; refusing migration overwrite",
+                    "existing_paths": existing,
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 3
+
+    receipt = publish_project_continuation(build_seed_payload(), data_root=root)
+    print(
+        json.dumps(
+            {
+                "schema": "agentos.core-ir-seed/v1",
+                "ok": True,
+                "seeded": True,
+                "project_id": PROJECT_ID,
+                "index_id": INDEX_ID,
+                "ir_id": IR_ID,
+                "publish_receipt": receipt,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_active_continuation.py
+++ b/tests/test_active_continuation.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from agent_core import active_continuation
+
+
+class ActiveContinuationTests(unittest.TestCase):
+    def _resolved(self, *, index_id="idx-1", ir_id="ir-1"):
+        return {
+            "schema": "agentos.resolve/v1",
+            "execution_head": {
+                "schema": "agentos.execution-head/v1",
+                "index_id": index_id,
+            },
+            "continuation": {
+                "canonical_ir": {
+                    "schema_version": "agentos.ir/v1",
+                    "index_id": index_id,
+                    "ir_id": ir_id,
+                    "goal": "test goal",
+                }
+            },
+        }
+
+    def test_activation_writes_pointer_only_after_generation_validation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with mock.patch.object(
+                active_continuation,
+                "resolve_continuation",
+                return_value=self._resolved(),
+            ):
+                receipt = active_continuation.activate_continuation(
+                    "agentos-core",
+                    index_id="idx-1",
+                    ir_id="ir-1",
+                    reason="test",
+                    data_root=root,
+                )
+            self.assertTrue(receipt["ok"])
+            payload = json.loads((root / "runtime" / "active-continuation.json").read_text())
+            self.assertEqual(payload["schema"], "agentos.active-continuation/v1")
+            self.assertEqual(payload["project_id"], "agentos-core")
+            self.assertEqual(payload["index_id"], "idx-1")
+            self.assertEqual(payload["ir_id"], "ir-1")
+            self.assertNotIn("goal", payload)
+            self.assertNotIn("canonical_ir", payload)
+
+    def test_activation_rejects_noncanonical_generation(self):
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(
+                active_continuation,
+                "resolve_continuation",
+                return_value=self._resolved(index_id="idx-current", ir_id="ir-current"),
+            ):
+                with self.assertRaisesRegex(ValueError, "non-canonical generation"):
+                    active_continuation.activate_continuation(
+                        "agentos-core",
+                        index_id="idx-stale",
+                        ir_id="ir-stale",
+                        reason="test",
+                        data_root=td,
+                    )
+
+    def test_resolve_active_rejects_stale_pointer(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = root / "runtime"
+            runtime.mkdir()
+            (runtime / "active-continuation.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "agentos.active-continuation/v1",
+                        "project_id": "agentos-core",
+                        "index_id": "idx-old",
+                        "ir_id": "ir-old",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                active_continuation,
+                "resolve_continuation",
+                return_value=self._resolved(index_id="idx-new", ir_id="ir-new"),
+            ):
+                with self.assertRaisesRegex(ValueError, "selector is stale"):
+                    active_continuation.resolve_active_continuation(data_root=root)
+
+    def test_resolve_active_returns_current_generation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = root / "runtime"
+            runtime.mkdir()
+            (runtime / "active-continuation.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "agentos.active-continuation/v1",
+                        "project_id": "agentos-core",
+                        "index_id": "idx-1",
+                        "ir_id": "ir-1",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            resolved = self._resolved()
+            with mock.patch.object(
+                active_continuation,
+                "resolve_continuation",
+                return_value=resolved,
+            ):
+                result = active_continuation.resolve_active_continuation(data_root=root)
+            self.assertEqual(result["selector"]["project_id"], "agentos-core")
+            self.assertIs(result["resolution"], resolved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 
 from agentos_node.antigravity_one_hook import build_injection
@@ -49,6 +50,11 @@ class FakeGateway:
         }
 
 
+def envelope_from(output):
+    message = output["injectSteps"][0]["ephemeralMessage"]
+    return json.loads(message.split("\n", 1)[1])
+
+
 class AntigravityOneHookTests(unittest.TestCase):
     def test_first_invocation_hydrates_single_canonical_ir(self):
         gateway = FakeGateway()
@@ -74,6 +80,36 @@ class AntigravityOneHookTests(unittest.TestCase):
         self.assertNotIn("privacy-guard", message)
         self.assertNotIn("token", message.casefold())
         self.assertEqual(gateway.resolved, ["agentos-core"])
+        envelope = envelope_from(output)
+        self.assertEqual(envelope["executor_class"], "antigravity-gemini")
+        self.assertTrue(envelope["executor_identity_bound"])
+
+    def test_codex_model_binds_codex_executor(self):
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": ["/home/ubuntu/agentmanager"],
+                "modelName": "gpt-5-codex",
+            },
+            FakeGateway(),
+        )
+        envelope = envelope_from(output)
+        self.assertEqual(envelope["executor_class"], "antigravity-codex")
+        self.assertTrue(envelope["executor_identity_bound"])
+        self.assertEqual(envelope["model_name"], "gpt-5-codex")
+
+    def test_unknown_model_does_not_guess_executor_identity(self):
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": ["/home/ubuntu/agentmanager"],
+                "modelName": "mystery-model",
+            },
+            FakeGateway(),
+        )
+        envelope = envelope_from(output)
+        self.assertEqual(envelope["executor_class"], "antigravity-unknown")
+        self.assertFalse(envelope["executor_identity_bound"])
 
     def test_later_invocation_is_silent(self):
         gateway = FakeGateway()

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from agentos_node.antigravity_one_hook import build_injection
+
+
+class FakeGateway:
+    def __init__(self):
+        self.resolved = []
+
+    def status(self):
+        return {
+            "schema": "agentos.one-mcp-status/v0.1",
+            "connected": True,
+            "realm_id": "realm-test",
+            "node_id": "oracle-core-node",
+        }
+
+    def resolve(self, project):
+        self.resolved.append(project)
+        if project == "unrelated":
+            raise KeyError(project)
+        return {
+            "schema": "agentos.resolve/v1",
+            "project": {"id": project, "name": project},
+            "project_resolution": {
+                "resolved": {
+                    "project_id": project,
+                    "repo": f"example/{project}",
+                    "branch": "core/integration",
+                    "canonical_path": f"/home/ubuntu/{project}",
+                    "node": "oracle-core-node",
+                }
+            },
+            "mutation_allowed": False,
+            "active_goal": "continue canonical work",
+            "next_action": "run next verified step",
+            "availability": {"continuation": True},
+            "provenance": {"continuation": "project/continuity/latest.json"},
+        }
+
+
+class AntigravityOneHookTests(unittest.TestCase):
+    def test_first_invocation_injects_one_hydration(self):
+        gateway = FakeGateway()
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": ["/home/ubuntu/agentmanager"],
+                "modelName": "gemini-test",
+            },
+            gateway,
+        )
+        self.assertIn("injectSteps", output)
+        message = output["injectSteps"][0]["ephemeralMessage"]
+        self.assertIn("ONE_PREINVOCATION_HOOK", message)
+        self.assertIn("realm-test", message)
+        self.assertIn("continue canonical work", message)
+        self.assertNotIn("token", message.casefold())
+        self.assertEqual(gateway.resolved, ["agentmanager"])
+
+    def test_later_invocation_is_silent(self):
+        gateway = FakeGateway()
+        output = build_injection(
+            {
+                "invocationNum": 1,
+                "workspacePaths": ["/home/ubuntu/agentmanager"],
+            },
+            gateway,
+        )
+        self.assertEqual(output, {})
+        self.assertEqual(gateway.resolved, [])
+
+    def test_unrelated_workspace_is_silent(self):
+        gateway = FakeGateway()
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": ["/tmp/unrelated"],
+            },
+            gateway,
+        )
+        self.assertEqual(output, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -84,6 +84,39 @@ class AntigravityOneHookTests(unittest.TestCase):
         self.assertEqual(envelope["executor_class"], "antigravity-gemini")
         self.assertTrue(envelope["executor_identity_bound"])
 
+    def test_nested_workspace_under_agentmanager_hydrates_core_ir(self):
+        gateway = FakeGateway()
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": [
+                    "/home/ubuntu/agentmanager/workspace/if-tv-station",
+                ],
+                "modelName": "gpt-5-codex",
+            },
+            gateway,
+        )
+        envelope = envelope_from(output)
+        self.assertEqual(envelope["canonical_ir"]["project_id"], "agentos-core")
+        self.assertEqual(envelope["executor_class"], "antigravity-codex")
+        self.assertEqual(gateway.resolved, ["agentos-core"])
+        self.assertNotIn("if-tv-station", json.dumps(envelope))
+
+    def test_prefix_lookalike_workspace_does_not_open_core_gate(self):
+        gateway = FakeGateway()
+        output = build_injection(
+            {
+                "invocationNum": 0,
+                "workspacePaths": [
+                    "/home/ubuntu/agentmanager-old/workspace/if-tv-station",
+                ],
+                "modelName": "gpt-5-codex",
+            },
+            gateway,
+        )
+        self.assertEqual(output, {})
+        self.assertEqual(gateway.resolved, [])
+
     def test_codex_model_binds_codex_executor(self):
         output = build_injection(
             {

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import unittest
 
-from agentos_node.antigravity_one_hook import build_injection
+from agentos_node.antigravity_one_hook import build_injection, _safe_failure_code
+from agentos_node.one_mcp import OneGatewayError
 
 
 class FakeGateway:
@@ -187,6 +188,16 @@ class AntigravityOneHookTests(unittest.TestCase):
                 MismatchGateway(),
                 selector=selector(),
             )
+
+    def test_failure_codes_do_not_echo_exception_details(self):
+        secret_error = RuntimeError("Bearer TOPSECRET /home/private/session")
+        code = _safe_failure_code(secret_error)
+        self.assertEqual(code, "one_hydration_runtime_failed")
+        self.assertNotIn("TOPSECRET", code)
+        self.assertNotIn("/home/private", code)
+
+        one_error = OneGatewayError("one_http_503")
+        self.assertEqual(_safe_failure_code(one_error), "one_http_503")
 
 
 if __name__ == "__main__":

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import json
 import unittest
 
 from agentos_node.antigravity_one_hook import build_injection
 
 
 class FakeGateway:
-    def __init__(self):
+    def __init__(self, *, index_id="idx-7"):
         self.resolved = []
+        self.index_id = index_id
 
     def status(self):
         return {
@@ -20,46 +20,60 @@ class FakeGateway:
 
     def resolve(self, project):
         self.resolved.append(project)
-        if project == "unrelated":
-            raise KeyError(project)
         return {
             "schema": "agentos.resolve/v1",
-            "project": {"id": project, "name": project},
-            "project_resolution": {
-                "resolved": {
-                    "project_id": project,
-                    "repo": f"example/{project}",
-                    "branch": "core/integration",
-                    "canonical_path": f"/home/ubuntu/{project}",
-                    "node": "oracle-core-node",
+            "project": {"id": "agentos-core", "name": "AgentOS Core"},
+            "mutation_allowed": False,
+            "execution_head": {
+                "schema": "agentos.execution-head/v1",
+                "index_id": self.index_id,
+                "active_goal": "Complete #152 Antigravity IR hydration",
+                "execution_head": {"status": "in_progress"},
+            },
+            "continuation": {
+                "canonical_ir": {
+                    "schema_version": "agentos.ir/v1",
+                    "index_id": self.index_id,
+                    "ir_id": "ir-core-152",
+                    "parent_ir_id": "ir-core-151",
+                    "goal": "Complete #152 Antigravity IR hydration",
+                    "constraints": ["Do not infer current state from workspace order"],
+                    "decisions": ["Canonical IR is the durable continuation state"],
+                    "pending_tasks": ["Run fresh Gemini regression"],
+                    "continuation": {"recommended_action": "Run fresh Gemini regression"},
+                    "capability": "agentos.one.resolve",
                 }
             },
-            "mutation_allowed": False,
-            "active_goal": "continue canonical work",
-            "next_action": "run next verified step",
-            "availability": {"continuation": True},
+            "next_action": "Run fresh Gemini regression",
             "provenance": {"continuation": "project/continuity/latest.json"},
         }
 
 
 class AntigravityOneHookTests(unittest.TestCase):
-    def test_first_invocation_injects_one_hydration(self):
+    def test_first_invocation_hydrates_single_canonical_ir(self):
         gateway = FakeGateway()
         output = build_injection(
             {
                 "invocationNum": 0,
-                "workspacePaths": ["/home/ubuntu/agentmanager"],
+                "workspacePaths": [
+                    "/home/ubuntu/zeus-writer",
+                    "/home/ubuntu/agentmanager",
+                    "/home/ubuntu/privacy-guard",
+                ],
                 "modelName": "gemini-test",
             },
             gateway,
         )
         self.assertIn("injectSteps", output)
         message = output["injectSteps"][0]["ephemeralMessage"]
-        self.assertIn("ONE_PREINVOCATION_HOOK", message)
-        self.assertIn("realm-test", message)
-        self.assertIn("continue canonical work", message)
+        self.assertIn("ONE_PREINVOCATION_IR", message)
+        self.assertIn("ir-core-152", message)
+        self.assertIn("idx-7", message)
+        self.assertIn("Complete #152 Antigravity IR hydration", message)
+        self.assertNotIn("zeus-writer", message)
+        self.assertNotIn("privacy-guard", message)
         self.assertNotIn("token", message.casefold())
-        self.assertEqual(gateway.resolved, ["agentmanager"])
+        self.assertEqual(gateway.resolved, ["agentos-core"])
 
     def test_later_invocation_is_silent(self):
         gateway = FakeGateway()
@@ -73,16 +87,33 @@ class AntigravityOneHookTests(unittest.TestCase):
         self.assertEqual(output, {})
         self.assertEqual(gateway.resolved, [])
 
-    def test_unrelated_workspace_is_silent(self):
+    def test_workspace_without_core_is_silent(self):
         gateway = FakeGateway()
         output = build_injection(
             {
                 "invocationNum": 0,
-                "workspacePaths": ["/tmp/unrelated"],
+                "workspacePaths": ["/home/ubuntu/zeus-writer"],
             },
             gateway,
         )
         self.assertEqual(output, {})
+        self.assertEqual(gateway.resolved, [])
+
+    def test_index_generation_mismatch_fails_closed(self):
+        class MismatchGateway(FakeGateway):
+            def resolve(self, project):
+                result = super().resolve(project)
+                result["continuation"]["canonical_ir"]["index_id"] = "idx-other"
+                return result
+
+        with self.assertRaisesRegex(ValueError, "index generation mismatch"):
+            build_injection(
+                {
+                    "invocationNum": 0,
+                    "workspacePaths": ["/home/ubuntu/agentmanager"],
+                },
+                MismatchGateway(),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_antigravity_one_hook.py
+++ b/tests/test_antigravity_one_hook.py
@@ -7,9 +7,10 @@ from agentos_node.antigravity_one_hook import build_injection
 
 
 class FakeGateway:
-    def __init__(self, *, index_id="idx-7"):
+    def __init__(self, *, index_id="idx-7", ir_id="ir-core-152"):
         self.resolved = []
         self.index_id = index_id
+        self.ir_id = ir_id
 
     def status(self):
         return {
@@ -35,19 +36,28 @@ class FakeGateway:
                 "canonical_ir": {
                     "schema_version": "agentos.ir/v1",
                     "index_id": self.index_id,
-                    "ir_id": "ir-core-152",
+                    "ir_id": self.ir_id,
                     "parent_ir_id": "ir-core-151",
                     "goal": "Complete #152 Antigravity IR hydration",
-                    "constraints": ["Do not infer current state from workspace order"],
+                    "constraints": ["Workspace is not continuation authority"],
                     "decisions": ["Canonical IR is the durable continuation state"],
-                    "pending_tasks": ["Run fresh Gemini regression"],
-                    "continuation": {"recommended_action": "Run fresh Gemini regression"},
+                    "pending_tasks": ["Run fresh Codex regression"],
+                    "continuation": {"recommended_action": "Run fresh Codex regression"},
                     "capability": "agentos.one.resolve",
                 }
             },
-            "next_action": "Run fresh Gemini regression",
+            "next_action": "Run fresh Codex regression",
             "provenance": {"continuation": "project/continuity/latest.json"},
         }
+
+
+def selector(index_id="idx-7", ir_id="ir-core-152"):
+    return {
+        "schema": "agentos.active-continuation/v1",
+        "project_id": "agentos-core",
+        "index_id": index_id,
+        "ir_id": ir_id,
+    }
 
 
 def envelope_from(output):
@@ -56,7 +66,7 @@ def envelope_from(output):
 
 
 class AntigravityOneHookTests(unittest.TestCase):
-    def test_first_invocation_hydrates_single_canonical_ir(self):
+    def test_first_invocation_hydrates_active_canonical_ir(self):
         gateway = FakeGateway()
         output = build_injection(
             {
@@ -69,13 +79,14 @@ class AntigravityOneHookTests(unittest.TestCase):
                 "modelName": "gemini-test",
             },
             gateway,
+            selector=selector(),
         )
         self.assertIn("injectSteps", output)
         message = output["injectSteps"][0]["ephemeralMessage"]
         self.assertIn("ONE_PREINVOCATION_IR", message)
+        self.assertIn("ONE_ACTIVE_CONTINUATION", message)
         self.assertIn("ir-core-152", message)
         self.assertIn("idx-7", message)
-        self.assertIn("Complete #152 Antigravity IR hydration", message)
         self.assertNotIn("zeus-writer", message)
         self.assertNotIn("privacy-guard", message)
         self.assertNotIn("token", message.casefold())
@@ -83,48 +94,52 @@ class AntigravityOneHookTests(unittest.TestCase):
         envelope = envelope_from(output)
         self.assertEqual(envelope["executor_class"], "antigravity-gemini")
         self.assertTrue(envelope["executor_identity_bound"])
+        self.assertEqual(envelope["selection_source"], "ONE_ACTIVE_CONTINUATION")
 
-    def test_nested_workspace_under_agentmanager_hydrates_core_ir(self):
+    def test_acas_workspace_cannot_override_active_core_ir(self):
         gateway = FakeGateway()
         output = build_injection(
             {
                 "invocationNum": 0,
-                "workspacePaths": [
-                    "/home/ubuntu/agentmanager/workspace/if-tv-station",
-                ],
+                "workspacePaths": ["/home/ubuntu/acas"],
                 "modelName": "gpt-5-codex",
             },
             gateway,
+            selector=selector(),
         )
         envelope = envelope_from(output)
         self.assertEqual(envelope["canonical_ir"]["project_id"], "agentos-core")
         self.assertEqual(envelope["executor_class"], "antigravity-codex")
         self.assertEqual(gateway.resolved, ["agentos-core"])
-        self.assertNotIn("if-tv-station", json.dumps(envelope))
+        self.assertNotIn("/home/ubuntu/acas", json.dumps(envelope))
 
-    def test_prefix_lookalike_workspace_does_not_open_core_gate(self):
-        gateway = FakeGateway()
+    def test_nested_workspace_cannot_override_active_core_ir(self):
         output = build_injection(
             {
                 "invocationNum": 0,
-                "workspacePaths": [
-                    "/home/ubuntu/agentmanager-old/workspace/if-tv-station",
-                ],
-                "modelName": "gpt-5-codex",
-            },
-            gateway,
-        )
-        self.assertEqual(output, {})
-        self.assertEqual(gateway.resolved, [])
-
-    def test_codex_model_binds_codex_executor(self):
-        output = build_injection(
-            {
-                "invocationNum": 0,
-                "workspacePaths": ["/home/ubuntu/agentmanager"],
+                "workspacePaths": ["/home/ubuntu/agentmanager/workspace/if-tv-station"],
                 "modelName": "gpt-5-codex",
             },
             FakeGateway(),
+            selector=selector(),
+        )
+        envelope = envelope_from(output)
+        self.assertEqual(envelope["canonical_ir"]["project_id"], "agentos-core")
+        self.assertNotIn("if-tv-station", json.dumps(envelope))
+
+    def test_empty_workspace_still_hydrates_active_ir(self):
+        output = build_injection(
+            {"invocationNum": 0, "workspacePaths": [], "modelName": "gpt-5-codex"},
+            FakeGateway(),
+            selector=selector(),
+        )
+        self.assertEqual(envelope_from(output)["canonical_ir"]["project_id"], "agentos-core")
+
+    def test_codex_model_binds_codex_executor(self):
+        output = build_injection(
+            {"invocationNum": 0, "workspacePaths": ["/home/ubuntu/acas"], "modelName": "gpt-5-codex"},
+            FakeGateway(),
+            selector=selector(),
         )
         envelope = envelope_from(output)
         self.assertEqual(envelope["executor_class"], "antigravity-codex")
@@ -133,12 +148,9 @@ class AntigravityOneHookTests(unittest.TestCase):
 
     def test_unknown_model_does_not_guess_executor_identity(self):
         output = build_injection(
-            {
-                "invocationNum": 0,
-                "workspacePaths": ["/home/ubuntu/agentmanager"],
-                "modelName": "mystery-model",
-            },
+            {"invocationNum": 0, "workspacePaths": ["/home/ubuntu/acas"], "modelName": "mystery-model"},
             FakeGateway(),
+            selector=selector(),
         )
         envelope = envelope_from(output)
         self.assertEqual(envelope["executor_class"], "antigravity-unknown")
@@ -147,26 +159,20 @@ class AntigravityOneHookTests(unittest.TestCase):
     def test_later_invocation_is_silent(self):
         gateway = FakeGateway()
         output = build_injection(
-            {
-                "invocationNum": 1,
-                "workspacePaths": ["/home/ubuntu/agentmanager"],
-            },
+            {"invocationNum": 1, "workspacePaths": ["/home/ubuntu/acas"]},
             gateway,
+            selector=selector(),
         )
         self.assertEqual(output, {})
         self.assertEqual(gateway.resolved, [])
 
-    def test_workspace_without_core_is_silent(self):
-        gateway = FakeGateway()
-        output = build_injection(
-            {
-                "invocationNum": 0,
-                "workspacePaths": ["/home/ubuntu/zeus-writer"],
-            },
-            gateway,
-        )
-        self.assertEqual(output, {})
-        self.assertEqual(gateway.resolved, [])
+    def test_stale_active_selector_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "active continuation selector is stale"):
+            build_injection(
+                {"invocationNum": 0, "workspacePaths": ["/home/ubuntu/acas"]},
+                FakeGateway(),
+                selector=selector(index_id="idx-stale"),
+            )
 
     def test_index_generation_mismatch_fails_closed(self):
         class MismatchGateway(FakeGateway):
@@ -177,11 +183,9 @@ class AntigravityOneHookTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "index generation mismatch"):
             build_injection(
-                {
-                    "invocationNum": 0,
-                    "workspacePaths": ["/home/ubuntu/agentmanager"],
-                },
+                {"invocationNum": 0, "workspacePaths": ["/home/ubuntu/acas"]},
                 MismatchGateway(),
+                selector=selector(),
             )
 
 

--- a/tests/test_antigravity_preinvocation_attestation.py
+++ b/tests/test_antigravity_preinvocation_attestation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentos_node.antigravity_one_hook import _write_attestation
+
+
+class AntigravityPreInvocationAttestationTests(unittest.TestCase):
+    def test_hydration_attestation_is_sanitized_and_generation_bound(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "last.json"
+            payload = {
+                "invocationNum": 0,
+                "conversationId": "vendor-conversation-secret-ish-id",
+                "workspacePaths": ["/home/ubuntu/acas"],
+                "modelName": "gpt-5-codex",
+            }
+            envelope = {
+                "source": "ONE_PREINVOCATION_IR",
+                "selection_source": "ONE_ACTIVE_CONTINUATION",
+                "active_selector": {
+                    "project_id": "agentos-core",
+                    "index_id": "idx-core-152-e3-1",
+                    "ir_id": "ir-core-152-e3-1",
+                },
+                "executor_class": "antigravity-codex",
+                "executor_identity_bound": True,
+            }
+            with patch.dict(
+                os.environ,
+                {
+                    "AGENTOS_PREINVOCATION_AUDIT_PATH": str(path),
+                    "AGENTOS_RUNTIME_SOURCE_COMMIT": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                },
+                clear=False,
+            ):
+                _write_attestation(payload, envelope, outcome="hydrated")
+
+            record = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(record["schema"], "agentos.antigravity-preinvocation-attestation/v1")
+            self.assertEqual(record["runtime_source_commit"], "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+            self.assertEqual(record["outcome"], "hydrated")
+            self.assertTrue(record["injection_emitted"])
+            self.assertEqual(record["selection_source"], "ONE_ACTIVE_CONTINUATION")
+            self.assertEqual(record["project_id"], "agentos-core")
+            self.assertEqual(record["index_id"], "idx-core-152-e3-1")
+            self.assertEqual(record["ir_id"], "ir-core-152-e3-1")
+            self.assertEqual(record["executor_class"], "antigravity-codex")
+            self.assertTrue(record["executor_identity_bound"])
+            self.assertTrue(str(record["conversation_id_sha256"]).startswith("sha256:"))
+            serialized = json.dumps(record, ensure_ascii=False)
+            self.assertNotIn("vendor-conversation-secret-ish-id", serialized)
+            self.assertNotIn("/home/ubuntu/acas", serialized)
+            self.assertNotIn("workspacePaths", serialized)
+            self.assertNotIn("token", serialized.casefold())
+            self.assertFalse(record["credential_exposed"])
+
+    def test_later_invocation_does_not_overwrite_attestation(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "last.json"
+            path.write_text('{"sentinel": true}\n', encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {"AGENTOS_PREINVOCATION_AUDIT_PATH": str(path)},
+                clear=False,
+            ):
+                _write_attestation(
+                    {"invocationNum": 1, "conversationId": "later", "modelName": "gpt-5-codex"},
+                    None,
+                    outcome="no-injection",
+                )
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8")), {"sentinel": True})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_canonical_ir_handoff.py
+++ b/tests/test_canonical_ir_handoff.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from agent_core.canonical_ir_handoff import advance_canonical_ir
+
+
+CURRENT = {
+    "schema": "agentos.resolve/v1",
+    "execution_head": {
+        "schema": "agentos.execution-head/v1",
+        "index_id": "idx-core-152",
+    },
+    "continuation": {
+        "canonical_ir": {
+            "schema_version": "agentos.ir/v1",
+            "index_id": "idx-core-152",
+            "ir_id": "ir-core-152",
+            "parent_ir_id": None,
+            "goal": "Complete E2",
+            "constraints": ["Preserve credential isolation"],
+            "decisions": ["Use ONE_PREINVOCATION_IR"],
+            "pending_tasks": ["Verify E2"],
+            "evidence": [],
+            "continuation": {"recommended_action": "Verify E2"},
+            "capability": "agentos.one.resolve",
+        }
+    },
+}
+
+
+def request(**overrides):
+    value = {
+        "project_id": "agentos-core",
+        "expected_index_id": "idx-core-152",
+        "expected_ir_id": "ir-core-152",
+        "new_index_id": "idx-core-152-e3",
+        "new_ir_id": "ir-core-152-e3",
+        "goal": "Prove Gemini -> ONE -> fresh Antigravity Codex continuity",
+        "next_action": "Open a fresh Antigravity Codex conversation and send only 繼續",
+        "pending_tasks": ["Run fresh Codex regression"],
+        "decisions_append": ["E2 Antigravity Gemini fresh IR continuity is verified"],
+        "evidence": [
+            {
+                "kind": "live-regression",
+                "verdict": "VERIFIED",
+                "summary": "Two independent fresh Gemini sessions recovered the same canonical IR",
+            }
+        ],
+        "execution_status": "in_progress",
+        "execution_metadata": {"issue": "#152", "phase": "E3"},
+    }
+    value.update(overrides)
+    return value
+
+
+class CanonicalIrHandoffTests(unittest.TestCase):
+    @patch("agent_core.canonical_ir_handoff.publish_project_continuation")
+    @patch("agent_core.canonical_ir_handoff.resolve_continuation")
+    def test_builds_child_generation_and_preserves_authoritative_context(self, resolve, publish):
+        resolve.return_value = CURRENT
+        publish.return_value = {"ok": True, "schema": "agentos.project-continuation-publish/v1"}
+        receipt = advance_canonical_ir(request())
+        self.assertTrue(receipt["ok"])
+        self.assertEqual(receipt["parent"]["ir_id"], "ir-core-152")
+        self.assertEqual(receipt["child"]["ir_id"], "ir-core-152-e3")
+        params = publish.call_args.args[0]
+        ir = params["continuation"]["canonical_ir"]
+        self.assertEqual(ir["parent_ir_id"], "ir-core-152")
+        self.assertIn("Preserve credential isolation", ir["constraints"])
+        self.assertIn("Use ONE_PREINVOCATION_IR", ir["decisions"])
+        self.assertIn("E2 Antigravity Gemini fresh IR continuity is verified", ir["decisions"])
+        self.assertEqual(ir["evidence"][0]["verdict"], "VERIFIED")
+        self.assertEqual(publish.call_args.kwargs["expected_index_id"], "idx-core-152")
+        self.assertEqual(publish.call_args.kwargs["expected_ir_id"], "ir-core-152")
+
+    @patch("agent_core.canonical_ir_handoff.publish_project_continuation")
+    @patch("agent_core.canonical_ir_handoff.resolve_continuation")
+    def test_rejects_stale_request_before_publish(self, resolve, publish):
+        current = {
+            **CURRENT,
+            "execution_head": {"schema": "agentos.execution-head/v1", "index_id": "idx-newer"},
+            "continuation": {
+                "canonical_ir": {
+                    **CURRENT["continuation"]["canonical_ir"],
+                    "index_id": "idx-newer",
+                    "ir_id": "ir-newer",
+                }
+            },
+        }
+        resolve.return_value = current
+        with self.assertRaisesRegex(ValueError, "stale handoff request"):
+            advance_canonical_ir(request())
+        publish.assert_not_called()
+
+    def test_rejects_sensitive_evidence(self):
+        with self.assertRaisesRegex(ValueError, "sensitive credential"):
+            advance_canonical_ir(
+                request(
+                    evidence=[
+                        {
+                            "kind": "probe",
+                            "verdict": "PASS",
+                            "summary": "bad evidence",
+                            "token": "must-not-enter-ir",
+                        }
+                    ]
+                )
+            )
+
+    def test_rejects_non_core_project(self):
+        with self.assertRaisesRegex(ValueError, "restricted to agentos-core"):
+            advance_canonical_ir(request(project_id="other"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_one_mcp_stdio.py
+++ b/tests/test_codex_one_mcp_stdio.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from agentos_node.codex_one_mcp_stdio import _active_projection, _project_codex_client
@@ -47,6 +51,41 @@ class CodexOneMcpTests(unittest.TestCase):
         self.assertEqual(result["selector"]["index_id"], "idx-core-152-e3-1")
         self.assertEqual(result["selector"]["ir_id"], "ir-core-152-e3-1")
         self.assertNotIn("workspace", str(result).casefold())
+
+    @patch("agentos_node.codex_one_mcp_stdio.resolve_active_continuation")
+    def test_active_resolve_receipt_is_sanitized_and_generation_bound(self, resolve_active):
+        resolve_active.return_value = {
+            "selector": {
+                "project_id": "agentos-core",
+                "index_id": "idx-core-152-e3-codex-ext-1",
+                "ir_id": "ir-core-152-e3-codex-ext-1",
+            },
+            "resolution": {"schema": "agentos.resolve/v1"},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            receipt = Path(td) / "receipt.json"
+            with patch.dict(
+                os.environ,
+                {
+                    "AGENTOS_CODEX_ONE_RECEIPT_PATH": str(receipt),
+                    "AGENTOS_RUNTIME_SOURCE_COMMIT": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                },
+                clear=False,
+            ):
+                _active_projection(FakeGateway(), write_receipt=True)
+            record = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(record["schema"], "agentos.codex-one-active-resolve-receipt/v1")
+            self.assertEqual(record["runtime_source_commit"], "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+            self.assertEqual(record["project_id"], "agentos-core")
+            self.assertEqual(record["index_id"], "idx-core-152-e3-codex-ext-1")
+            self.assertEqual(record["ir_id"], "ir-core-152-e3-codex-ext-1")
+            self.assertEqual(record["surface"], "codex-local")
+            self.assertEqual(record["executor_class"], "openai-codex-local")
+            self.assertTrue(record["executor_identity_bound"])
+            self.assertFalse(record["credential_exposed"])
+            serialized = json.dumps(record, ensure_ascii=False).casefold()
+            self.assertNotIn("token", serialized)
+            self.assertNotIn("workspace", serialized)
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_one_mcp_stdio.py
+++ b/tests/test_codex_one_mcp_stdio.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from agentos_node.codex_one_mcp_stdio import _active_projection, _project_codex_client
+
+
+class FakeGateway:
+    data_root = "/tmp/agent-data"
+
+
+class CodexOneMcpTests(unittest.TestCase):
+    def test_projection_binds_codex_local_surface_without_credentials(self):
+        value = _project_codex_client({"schema": "x", "credential_exposed": False})
+        self.assertEqual(value["surface"], "codex-local")
+        self.assertEqual(value["executor_class"], "openai-codex-local")
+        self.assertTrue(value["executor_identity_bound"])
+        self.assertEqual(value["executor_identity_source"], "codex-mcp-config")
+        self.assertFalse(value["credential_exposed"])
+
+    @patch("agentos_node.codex_one_mcp_stdio.resolve_active_continuation")
+    def test_active_projection_uses_one_selector_not_workspace(self, resolve_active):
+        resolve_active.return_value = {
+            "selector": {
+                "project_id": "agentos-core",
+                "index_id": "idx-core-152-e3-1",
+                "ir_id": "ir-core-152-e3-1",
+            },
+            "resolution": {
+                "schema": "agentos.resolve/v1",
+                "project": {"id": "agentos-core"},
+                "continuation": {
+                    "canonical_ir": {
+                        "schema_version": "agentos.ir/v1",
+                        "index_id": "idx-core-152-e3-1",
+                        "ir_id": "ir-core-152-e3-1",
+                    }
+                },
+            },
+        }
+        result = _active_projection(FakeGateway())
+        resolve_active.assert_called_once_with(data_root="/tmp/agent-data")
+        self.assertEqual(result["source"], "ONE_ACTIVE_CONTINUATION")
+        self.assertEqual(result["selection_source"], "ONE_ACTIVE_CONTINUATION")
+        self.assertEqual(result["selector"]["project_id"], "agentos-core")
+        self.assertEqual(result["selector"]["index_id"], "idx-core-152-e3-1")
+        self.assertEqual(result["selector"]["ir_id"], "ir-core-152-e3-1")
+        self.assertNotIn("workspace", str(result).casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_codex_one_oracle.py
+++ b/tests/test_install_codex_one_oracle.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "install_codex_one_oracle.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("install_codex_one_oracle", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class InstallCodexOneOracleTests(unittest.TestCase):
+    def test_agents_block_requires_one_resolve_active_before_workspace_reconstruction(self):
+        module = _load_module()
+        text = module.AGENTS_BLOCK
+        self.assertIn("agentos-one.one_resolve_active", text)
+        self.assertIn("IDE workspace", text)
+        self.assertIn("ONE_ACTIVE_CONTINUATION_UNRESOLVED", text)
+        self.assertNotIn("idx-core-152", text)
+        self.assertNotIn("ir-core-152", text)
+
+    def test_config_block_registers_codex_specific_mcp_without_credentials(self):
+        module = _load_module()
+        block = module.config_block(
+            python=Path("/runtime/venv/bin/python"),
+            repo_root=Path("/runtime/snapshot"),
+        )
+        self.assertIn('[mcp_servers."agentos-one"]', block)
+        self.assertIn("agentos_node.codex_one_mcp_stdio", block)
+        self.assertIn("AGENTOS_ONE_MCP_MODE = \"oracle-local\"", block)
+        self.assertNotIn("token", block.casefold())
+        self.assertNotIn("password", block.casefold())
+
+    def test_managed_blocks_preserve_unmanaged_content(self):
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            agents = root / "AGENTS.md"
+            agents.write_text("existing instructions\n", encoding="utf-8")
+            module.write_agents(agents)
+            updated = agents.read_text(encoding="utf-8")
+            self.assertIn("existing instructions", updated)
+            self.assertEqual(updated.count(module.AGENTS_START), 1)
+            self.assertEqual(updated.count(module.AGENTS_END), 1)
+
+    def test_unmanaged_same_name_mcp_fails_closed(self):
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "config.toml"
+            path.write_text('[mcp_servers."agentos-one"]\ncommand = "other"\n', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unmanaged Codex agentos-one MCP"):
+                module.write_config(
+                    path,
+                    python=Path("/runtime/venv/bin/python"),
+                    repo_root=Path("/runtime/snapshot"),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_one_mcp.py
+++ b/tests/test_one_mcp.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -70,12 +71,86 @@ class OneMCPTests(unittest.TestCase):
             status = one_mcp.OneGateway(cfg).status()
 
         self.assertTrue(status["connected"])
+        self.assertEqual(status["mode"], one_mcp.CLIENT_MODE)
         self.assertNotIn("TOPSECRET", json.dumps(status))
         self.assertIsNone(seen[0].headers.get("Authorization"))
         self.assertEqual(
             seen[1].headers.get("Authorization"),
             "Bearer TOPSECRET",
         )
+
+    def test_oracle_local_status_uses_node_registry_projection_without_token(self):
+        gateway = one_mcp.OracleLocalGateway(
+            data_root=Path("/tmp/agent-data-test"),
+            core_node_id="oracle-core-node",
+        )
+        node_map = {
+            "schema": "agentos.node-map/v0.1",
+            "realm_id": "realm-alston",
+            "node_count": 2,
+            "realm_capabilities": ["agentos.one.resolve"],
+            "nodes": [
+                {
+                    "node_id": "oracle-core-node",
+                    "role": "core",
+                    "status": "online",
+                    "capabilities": ["agentos.one.resolve"],
+                    "surface_inventory": {"surfaces": []},
+                },
+                {
+                    "node_id": "client-a",
+                    "role": "client",
+                    "status": "online",
+                    "capabilities": ["filesystem.read"],
+                    "surface_inventory": {
+                        "surfaces": [{"provider": "antigravity"}]
+                    },
+                },
+            ],
+        }
+        with mock.patch.object(
+            gateway, "_node_map", return_value=node_map
+        ):
+            status = gateway.status()
+            bootstrap = gateway.bootstrap()
+
+        self.assertTrue(status["connected"])
+        self.assertEqual(status["mode"], one_mcp.ORACLE_LOCAL_MODE)
+        self.assertEqual(status["surface"], "antigravity")
+        self.assertEqual(
+            status["executor_class"], "antigravity-gemini"
+        )
+        self.assertFalse(status["credential_exposed"])
+        self.assertEqual(
+            bootstrap["schema"],
+            "agentos.one-local-bootstrap/v0.1",
+        )
+        self.assertEqual(
+            bootstrap["inherited_surface_providers"],
+            ["antigravity"],
+        )
+
+    def test_gateway_mode_selects_oracle_local_when_no_client_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "realm").mkdir()
+            (root / "realm" / "nodes.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            with mock.patch.dict(
+                os.environ,
+                {"AGENT_DATA_ROOT": str(root)},
+                clear=True,
+            ), mock.patch.object(
+                one_mcp,
+                "discover_client_config",
+                side_effect=FileNotFoundError,
+            ), mock.patch.object(one_mcp.os, "name", "posix"):
+                self.assertEqual(
+                    one_mcp.gateway_mode(),
+                    one_mcp.ORACLE_LOCAL_MODE,
+                )
 
     def test_redaction(self):
         value = one_mcp._redact(

--- a/tests/test_one_mcp.py
+++ b/tests/test_one_mcp.py
@@ -1,0 +1,93 @@
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from agentos_node import one_mcp
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class OneMCPTests(unittest.TestCase):
+    def test_localappdata_candidate(self):
+        with mock.patch.dict(
+            os.environ,
+            {"LOCALAPPDATA": r"C:\Users\test\AppData\Local"},
+            clear=True,
+        ):
+            candidates = one_mcp.client_config_candidates()
+        self.assertIn(
+            Path(r"C:\Users\test\AppData\Local")
+            / "AgentOS"
+            / "state"
+            / "client.json",
+            candidates,
+        )
+
+    def test_status_authenticates_but_never_returns_token(self):
+        cfg = one_mcp.ClientConfig(
+            "http://one",
+            "realm-test",
+            "node-test",
+            "TOPSECRET",
+        )
+        seen = []
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            if request.full_url.endswith("/v1/health"):
+                return FakeResponse(
+                    {"ok": True, "schema": "agentos.one-health/v0.1"}
+                )
+            return FakeResponse(
+                {
+                    "ok": True,
+                    "schema": "agentos.node-bootstrap/v0.1",
+                    "realm_id": "realm-test",
+                    "node_id": "node-test",
+                    "realm_node_count": 2,
+                }
+            )
+
+        with mock.patch.object(
+            one_mcp.urllib.request,
+            "urlopen",
+            side_effect=fake_urlopen,
+        ):
+            status = one_mcp.OneGateway(cfg).status()
+
+        self.assertTrue(status["connected"])
+        self.assertNotIn("TOPSECRET", json.dumps(status))
+        self.assertIsNone(seen[0].headers.get("Authorization"))
+        self.assertEqual(
+            seen[1].headers.get("Authorization"),
+            "Bearer TOPSECRET",
+        )
+
+    def test_redaction(self):
+        value = one_mcp._redact(
+            {
+                "node_token": "x",
+                "nested": {"secret": "y", "safe": 1},
+            }
+        )
+        self.assertEqual(value["node_token"], "[REDACTED]")
+        self.assertEqual(value["nested"]["secret"], "[REDACTED]")
+        self.assertEqual(value["nested"]["safe"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_one_mcp.py
+++ b/tests/test_one_mcp.py
@@ -1,7 +1,9 @@
+import io
 import json
 import os
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
 from unittest import mock
 
@@ -79,6 +81,71 @@ class OneMCPTests(unittest.TestCase):
             "Bearer TOPSECRET",
         )
 
+    def test_http_error_body_is_never_exposed(self):
+        cfg = one_mcp.ClientConfig(
+            "http://one",
+            "realm-test",
+            "node-test",
+            "TOPSECRET",
+        )
+        body = io.BytesIO(
+            b'{"node_token":"TOPSECRET","secret":"SERVERSECRET","path":"/private/path"}'
+        )
+        error = urllib.error.HTTPError(
+            "http://one/v1/bootstrap",
+            401,
+            "Unauthorized",
+            {},
+            body,
+        )
+        with mock.patch.object(
+            one_mcp.urllib.request,
+            "urlopen",
+            side_effect=error,
+        ):
+            with self.assertRaises(one_mcp.OneGatewayError) as ctx:
+                one_mcp.OneGateway(cfg).bootstrap()
+        text = str(ctx.exception)
+        self.assertEqual(text, "one_http_401")
+        self.assertNotIn("TOPSECRET", text)
+        self.assertNotIn("SERVERSECRET", text)
+        self.assertNotIn("/private/path", text)
+
+    def test_client_bootstrap_projects_executor_safe_fields_only(self):
+        cfg = one_mcp.ClientConfig(
+            "http://one",
+            "realm-test",
+            "node-test",
+            "TOPSECRET",
+        )
+        payload = {
+            "ok": True,
+            "schema": "agentos.node-bootstrap/v0.1",
+            "realm_id": "realm-test",
+            "node_id": "node-test",
+            "realm_node_count": 2,
+            "realm_capabilities": ["agentos.one.resolve"],
+            "node": {
+                "hostname": "private-host",
+                "metadata": {"path": "/home/private/work"},
+            },
+            "private_runtime": {"username": "private-user"},
+        }
+        with mock.patch.object(
+            one_mcp.urllib.request,
+            "urlopen",
+            return_value=FakeResponse(payload),
+        ):
+            bootstrap = one_mcp.OneGateway(cfg).bootstrap()
+        serialized = json.dumps(bootstrap)
+        self.assertEqual(bootstrap["realm_id"], "realm-test")
+        self.assertEqual(bootstrap["node_id"], "node-test")
+        self.assertEqual(bootstrap["projection"], "executor-safe-readonly")
+        self.assertNotIn("node", bootstrap)
+        self.assertNotIn("private-host", serialized)
+        self.assertNotIn("/home/private/work", serialized)
+        self.assertNotIn("private-user", serialized)
+
     def test_oracle_local_status_uses_node_registry_projection_without_token(self):
         gateway = one_mcp.OracleLocalGateway(
             data_root=Path("/tmp/agent-data-test"),
@@ -94,8 +161,10 @@ class OneMCPTests(unittest.TestCase):
                     "node_id": "oracle-core-node",
                     "role": "core",
                     "status": "online",
+                    "hostname": "private-oracle-host",
                     "capabilities": ["agentos.one.resolve"],
                     "surface_inventory": {"surfaces": []},
+                    "metadata": {"path": "/home/ubuntu/private"},
                 },
                 {
                     "node_id": "client-a",
@@ -129,6 +198,74 @@ class OneMCPTests(unittest.TestCase):
             bootstrap["inherited_surface_providers"],
             ["antigravity"],
         )
+        serialized = json.dumps(bootstrap)
+        self.assertNotIn("node", bootstrap)
+        self.assertNotIn("private-oracle-host", serialized)
+        self.assertNotIn("/home/ubuntu/private", serialized)
+
+    def test_resolve_keeps_canonical_ir_but_drops_project_source_paths(self):
+        gateway = one_mcp.OracleLocalGateway(
+            data_root=Path("/tmp/agent-data-test"),
+            core_node_id="oracle-core-node",
+        )
+        raw = {
+            "schema": "agentos.resolve/v1",
+            "intent": "continue",
+            "project": {
+                "id": "agentos-core",
+                "name": "AgentOS Core",
+                "aliases": ["core"],
+                "identity_source": "governance-directory",
+                "source": {
+                    "canonical_path": "/home/ubuntu/agentmanager",
+                    "repo": "private/repo",
+                },
+                "runtime": {"username": "ubuntu"},
+            },
+            "mutation_allowed": False,
+            "active_goal": "continue safely",
+            "execution_head": {
+                "schema": "agentos.execution-head/v1",
+                "index_id": "idx-1",
+                "active_goal": "continue safely",
+                "execution_head": {"status": "active"},
+                "private_path": "/secret/head",
+            },
+            "continuation": {
+                "canonical_ir": {
+                    "schema_version": "agentos.ir/v1",
+                    "index_id": "idx-1",
+                    "ir_id": "ir-1",
+                    "goal": "continue safely",
+                    "constraints": ["no secrets"],
+                    "decisions": [],
+                    "pending_tasks": ["next"],
+                    "continuation": {"next_action": "next"},
+                },
+                "ir_id": "ir-1",
+                "goal": "continue safely",
+            },
+            "node_context": {
+                "schema": "agentos.one-local-bootstrap/v0.1",
+                "realm_id": "realm-alston",
+                "node_id": "oracle-core-node",
+                "node": {"hostname": "private-host"},
+            },
+            "next_action": "next",
+            "availability": {"continuation": True},
+            "provenance": {"continuation": "project/continuity/latest.json"},
+        }
+        projected = one_mcp._project_resolve(raw)
+        serialized = json.dumps(projected)
+        self.assertEqual(
+            projected["continuation"]["canonical_ir"]["ir_id"],
+            "ir-1",
+        )
+        self.assertEqual(projected["project"]["id"], "agentos-core")
+        self.assertNotIn("source", projected["project"])
+        self.assertNotIn("/home/ubuntu/agentmanager", serialized)
+        self.assertNotIn("/secret/head", serialized)
+        self.assertNotIn("private-host", serialized)
 
     def test_gateway_mode_selects_oracle_local_when_no_client_config(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_one_mcp_stdio_identity.py
+++ b/tests/test_one_mcp_stdio_identity.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import unittest
+
+from agentos_node.one_mcp_stdio import _unbind_executor_identity
+
+
+class OneMcpStdioIdentityTests(unittest.TestCase):
+    def test_status_projection_never_claims_gemini_or_codex(self):
+        result = _unbind_executor_identity(
+            {
+                "schema": "agentos.one-mcp-status/v0.1",
+                "surface": "antigravity",
+                "executor_class": "antigravity-gemini",
+                "connected": True,
+            }
+        )
+        self.assertEqual(result["executor_class"], "antigravity-unbound")
+        self.assertFalse(result["executor_identity_bound"])
+        self.assertEqual(
+            result["executor_identity_source"],
+            "preinvocation-hook-required",
+        )
+
+    def test_resolve_projection_unbinds_node_context_without_rewriting_ir(self):
+        result = _unbind_executor_identity(
+            {
+                "schema": "agentos.resolve/v1",
+                "node_context": {
+                    "surface": "antigravity",
+                    "executor_class": "antigravity-gemini",
+                },
+                "continuation": {
+                    "canonical_ir": {
+                        "schema_version": "agentos.ir/v1",
+                        "evidence": [
+                            {
+                                "kind": "historical",
+                                "executor_class": "antigravity-gemini",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+        self.assertEqual(
+            result["node_context"]["executor_class"],
+            "antigravity-unbound",
+        )
+        self.assertFalse(result["node_context"]["executor_identity_bound"])
+        self.assertEqual(
+            result["continuation"]["canonical_ir"]["evidence"][0]["executor_class"],
+            "antigravity-gemini",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_continuation_index.py
+++ b/tests/test_project_continuation_index.py
@@ -48,6 +48,20 @@ class ProjectContinuationIndexTests(unittest.TestCase):
     def tearDown(self):
         self.td.cleanup()
 
+    def _child_params(self):
+        params = json.loads(json.dumps(self.params))
+        params["execution_head"]["index_id"] = "idx-2"
+        params["execution_head"]["active_goal"] = "Run E3"
+        params["continuation"]["index_id"] = "idx-2"
+        params["continuation"]["recommended_action"] = "Open fresh Codex"
+        ir = params["continuation"]["canonical_ir"]
+        ir["index_id"] = "idx-2"
+        ir["ir_id"] = "ir-2"
+        ir["parent_ir_id"] = "ir-1"
+        ir["goal"] = "Run E3"
+        ir["continuation"] = {"recommended_action": "Open fresh Codex"}
+        return params
+
     def test_rejects_noncanonical_project(self):
         params = dict(self.params)
         params["project_id"] = "other"
@@ -78,6 +92,51 @@ class ProjectContinuationIndexTests(unittest.TestCase):
         self.assertEqual(cont["canonical_ir"]["schema_version"], "agentos.ir/v1")
         self.assertTrue(receipt["execution_head"]["sha256"].startswith("sha256:"))
         self.assertTrue(receipt["continuation"]["sha256"].startswith("sha256:"))
+
+    @patch("agent_core.project_continuation_index.resolve_project_identity")
+    def test_guarded_advance_requires_exact_current_parent(self, resolve):
+        resolve.return_value = self.project
+        publish_project_continuation(self.params, data_root=self.root)
+        receipt = publish_project_continuation(
+            self._child_params(),
+            data_root=self.root,
+            expected_index_id="idx-1",
+            expected_ir_id="ir-1",
+        )
+        self.assertTrue(receipt["guarded_advance"])
+        self.assertEqual(receipt["parent_ir_id"], "ir-1")
+        self.assertEqual(receipt["index_id"], "idx-2")
+        self.assertEqual(receipt["ir_id"], "ir-2")
+
+    @patch("agent_core.project_continuation_index.resolve_project_identity")
+    def test_guarded_advance_rejects_stale_parent_without_mutation(self, resolve):
+        resolve.return_value = self.project
+        publish_project_continuation(self.params, data_root=self.root)
+        before_head = (self.root / "projects" / "agentos-core" / "execution-head.json").read_bytes()
+        before_cont = (self.root / "projects" / "agentos-core" / "continuity" / "latest.json").read_bytes()
+        with self.assertRaisesRegex(ValueError, "stale canonical IR parent"):
+            publish_project_continuation(
+                self._child_params(),
+                data_root=self.root,
+                expected_index_id="idx-stale",
+                expected_ir_id="ir-stale",
+            )
+        self.assertEqual(before_head, (self.root / "projects" / "agentos-core" / "execution-head.json").read_bytes())
+        self.assertEqual(before_cont, (self.root / "projects" / "agentos-core" / "continuity" / "latest.json").read_bytes())
+
+    @patch("agent_core.project_continuation_index.resolve_project_identity")
+    def test_guarded_advance_rejects_wrong_parent_ir_before_mutation(self, resolve):
+        resolve.return_value = self.project
+        publish_project_continuation(self.params, data_root=self.root)
+        child = self._child_params()
+        child["continuation"]["canonical_ir"]["parent_ir_id"] = "ir-other"
+        with self.assertRaisesRegex(ValueError, "parent_ir_id"):
+            publish_project_continuation(
+                child,
+                data_root=self.root,
+                expected_index_id="idx-1",
+                expected_ir_id="ir-1",
+            )
 
     @patch("agent_core.project_continuation_index.resolve_project_identity")
     def test_rejects_governance_identity_without_mutation_authority(self, resolve):

--- a/tests/test_seed_agentos_core_ir_head.py
+++ b/tests/test_seed_agentos_core_ir_head.py
@@ -1,0 +1,37 @@
+import unittest
+
+from agent_core.project_continuation_index import validate_publish_params
+from scripts.seed_agentos_core_ir_head import INDEX_ID, IR_ID, build_seed_payload
+
+
+class SeedAgentosCoreIrHeadTests(unittest.TestCase):
+    def test_seed_uses_existing_canonical_publish_contract(self):
+        project_id, execution_head, continuation = validate_publish_params(build_seed_payload())
+        canonical_ir = continuation["canonical_ir"]
+
+        self.assertEqual(project_id, "agentos-core")
+        self.assertEqual(execution_head["schema"], "agentos.execution-head/v1")
+        self.assertEqual(execution_head["index_id"], INDEX_ID)
+        self.assertEqual(continuation["index_id"], INDEX_ID)
+        self.assertEqual(canonical_ir["schema_version"], "agentos.ir/v1")
+        self.assertEqual(canonical_ir["index_id"], INDEX_ID)
+        self.assertEqual(canonical_ir["ir_id"], IR_ID)
+        self.assertIsNone(canonical_ir["parent_ir_id"])
+        self.assertTrue(canonical_ir["goal"])
+        self.assertTrue(continuation["recommended_action"])
+
+    def test_seed_preserves_ir_first_and_identity_fences(self):
+        canonical_ir = build_seed_payload()["continuation"]["canonical_ir"]
+        constraints = "\n".join(canonical_ir["constraints"])
+        decisions = "\n".join(canonical_ir["decisions"])
+
+        self.assertIn("Workspace membership is only a hydration gate", constraints)
+        self.assertIn("fail closed", constraints)
+        self.assertIn("built-in Gemini executor is distinct", constraints)
+        self.assertIn("existing project continuation publisher", decisions)
+        self.assertNotIn("zeus-writer", str(canonical_ir).casefold())
+        self.assertNotIn("privacy-guard", str(canonical_ir).casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Implements and live-verifies AgentOS ONE continuity for the **Antigravity Gemini extension** on Oracle, then extends the same ONE Canonical IR authority to the separate **OpenAI Codex IDE extension** for E3 cross-extension continuity.

## Implemented
- credential-isolated Oracle-local ONE adapter;
- Antigravity Gemini `PreInvocation` hydration from authoritative `agentos.ir/v1`;
- atomic `execution-head.json` / `continuity/latest.json` generation fence;
- ONE active-continuation selector (`project_id + index_id + ir_id`) with workspace-independent selection;
- guarded Canonical IR advancement with exact parent fencing;
- Codex-specific ONE MCP surface with `one_resolve_active()`;
- Codex global bootstrap via `~/.codex/AGENTS.md` plus `~/.codex/config.toml` MCP registration, without copying Canonical IR into Codex config;
- sanitized Gemini PreInvocation and Codex active-resolve receipts;
- governed post-E3 Canonical IR handoff back to the broader #152 Node/executor extraction;
- documentation and regression coverage for the above.

## Live E2 evidence — VERIFIED
On 2026-09-01, two completely fresh Antigravity Gemini conversations on Oracle, each given only `繼續`, independently recovered:
- `source=ONE_PREINVOCATION_IR`
- `project=agentos-core`
- `index_id=idx-core-152`
- `ir_id=ir-core-152`

Evidence: `.agentos/evidence/issue-152-antigravity-gemini-e2-2026-09-01.md`.

Verdict: `E2_ANTIGRAVITY_GEMINI_FRESH_IR_CONTINUITY=VERIFIED`.

## Corrected E3 boundary
Codex is a separate OpenAI IDE extension, not an Antigravity/Gemini reasoning model. Therefore Codex must not be validated by expecting it to trigger Gemini's `~/.gemini/config/hooks.json` lifecycle.

Correct E3 flow:

`fresh OpenAI Codex IDE extension thread -> Codex global AGENTS bootstrap -> agentos-one.one_resolve_active -> ONE active selector -> Canonical IR -> continue goal`

The authoritative working state remains ONE Canonical IR. `AGENTS.md` contains bootstrap instructions only; it does not duplicate project state.

Verified E3 generation:
- parent IR: `ir-core-152-e3-1`
- index: `idx-core-152-e3-codex-ext-1`
- IR: `ir-core-152-e3-codex-ext-1`

## Live E3 status — VERIFIED
Two independently fresh OpenAI Codex IDE extension threads each received only `繼續` and successfully resolved the ONE-selected corrected E3 generation through `agentos-one.one_resolve_active` before workspace-local reconstruction.

Pass 1 issue evidence: #152 comment `5503435564`.

Pass 2 issue evidence: #152 comment `5503469931`.

Independent terminal receipts confirmed the same bounded projection on both runs:
- `source=ONE_ACTIVE_CONTINUATION`
- `selection_source=ONE_ACTIVE_CONTINUATION`
- `surface=codex-local`
- `executor_class=openai-codex-local`
- `project_id=agentos-core`
- `index_id=idx-core-152-e3-codex-ext-1`
- `ir_id=ir-core-152-e3-codex-ext-1`
- `credential_exposed=false`

Receipt timestamps were distinct (`2026-09-02T02:28:29Z` and `2026-09-02T02:32:25Z`), so the second observation was not a reread of the first receipt.

Repository evidence: `.agentos/evidence/issue-152-codex-extension-e3-verified-2026-09-02.md`.

Verdict: `E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY=VERIFIED`.

## Post-E3 canonical continuation
The verified E3 generation still contains the now-completed second-regression task. `scripts/advance_issue_152_after_e3_verified.py` and its Oracle helper parent-fence a new child (`idx-core-152-post-e3-1 / ir-core-152-post-e3-1`) so future fresh executors resume the broader #152 Node/executor work rather than repeating the completed E3 test.

## Credential / authority boundary
- Realm/node credentials remain inside trusted local runtime; model-visible/config evidence reports `credential_exposed=false`;
- executors do not directly mutate Canonical IR; Core-owned governed writers publish child generations;
- capability does not imply authority;
- this PR remains Draft and targets `core/integration`;
- do not merge or directly mutate protected `main`/`master`/`release/*` without a separate explicit human authorization event.

## Issue status
Do not close #152 solely from this E2/E3 continuity slice. Broader Node/executor extraction, capability truthfulness/freshness, bridge reconciliation, and later real client/vopc5750 acceptance remain open.