### PR TITLE
release(agentos): publish Claude OAuth identity fix from #72

### DIFF
--- a/agentos_node/antigravity_relay_worker.py
+++ b/agentos_node/antigravity_relay_worker.py
@@ -27,11 +27,16 @@ def _utc_now() -> str:
 
 
 def discover_executor() -> list[str] | None:
+    # Preserve the ubuntu-owned Claude/Antigravity login identity. Claude
+    # `--bare` intentionally bypasses OAuth/keychain subscription auth,
+    # which is incompatible with this relay boundary. `--print` remains
+    # the fixed non-interactive execution mode; capsules still cannot
+    # provide argv, credentials, provider selection, or timeout values.
     explicit = os.environ.get("AGENTOS_ANTIGRAVITY_EXECUTOR")
     if explicit:
         candidate = Path(explicit).expanduser()
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            return [str(candidate), "--bare", "--print", "--output-format", "text", "--effort", "low"]
+            return [str(candidate), "--print", "--output-format", "text", "--effort", "low"]
     patterns = [
         str(Path.home() / ".antigravity-ide-server/extensions/anthropic.claude-code-*-linux-arm64/resources/native-binary/claude"),
         str(Path.home() / ".antigravity-ide-server/extensions/anthropic.claude-code-*/resources/native-binary/claude"),
@@ -42,7 +47,7 @@ def discover_executor() -> list[str] | None:
     for item in sorted(set(matches), reverse=True):
         candidate = Path(item)
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            return [str(candidate), "--bare", "--print", "--output-format", "text", "--effort", "low"]
+            return [str(candidate), "--print", "--output-format", "text", "--effort", "low"]
     return None
 
 

--- a/tests/test_antigravity_relay_worker.py
+++ b/tests/test_antigravity_relay_worker.py
@@ -6,8 +6,9 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest.mock import patch
 
-from agentos_node.antigravity_relay_worker import AntigravityRelayWorker
+from agentos_node.antigravity_relay_worker import AntigravityRelayWorker, discover_executor
 
 
 class AntigravityRelayWorkerTests(unittest.TestCase):
@@ -47,6 +48,28 @@ class AntigravityRelayWorkerTests(unittest.TestCase):
             self.assertTrue(result["timed_out"])
             self.assertEqual(result["returncode"], 124)
             self.assertLess(elapsed, 5.0)
+
+    def test_claude_discovery_preserves_ubuntu_oauth_identity(self) -> None:
+        fake_binary = Path(
+            "/home/ubuntu/.antigravity-ide-server/extensions/"
+            "anthropic.claude-code-2.1.251-linux-arm64/resources/native-binary/claude"
+        )
+        with (
+            patch.dict(
+                "agentos_node.antigravity_relay_worker.os.environ",
+                {"AGENTOS_ANTIGRAVITY_EXECUTOR": str(fake_binary)},
+                clear=False,
+            ),
+            patch.object(Path, "is_file", return_value=True),
+            patch("agentos_node.antigravity_relay_worker.os.access", return_value=True),
+        ):
+            executor = discover_executor()
+        self.assertIsNotNone(executor)
+        self.assertEqual(executor[0], str(fake_binary))
+        self.assertIn("--print", executor)
+        self.assertIn("--output-format", executor)
+        self.assertIn("--effort", executor)
+        self.assertNotIn("--bare", executor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

Narrow protected-main publication candidate for Core #72 after the root-cause patch was accepted and merged to `core/integration` via PR #172 (`71df8276fa4c71ad18cd0363d4f526c4ec4089c6`).

`main` and `core/integration` are materially diverged, so this PR intentionally does **not** merge/sync the integration branch. It performs accepted-delta extraction onto the current `main` API only.

## Exact delta

Current `main` still forces Claude Code:

`--bare --print --output-format text --effort low`

Anthropic's current Claude Code documentation states that `--bare` does not read OAuth/keychain subscription authentication. That conflicts with the existing AgentOS design in which the ubuntu-owned Antigravity relay is deliberately preserving the ubuntu user's logged-in Claude identity.

This publication candidate therefore only:
- removes `--bare` from explicit/discovered Claude executor argv on current `main`;
- keeps fixed non-interactive `--print --output-format text --effort low`;
- adds one regression proving discovered Claude argv cannot reintroduce `--bare`.

## Provenance

- Core issue: #72
- accepted integration PR: #172
- integration merge: `71df8276fa4c71ad18cd0363d4f526c4ec4089c6`
- publication branch created directly from current `main` `d9861082afc65cb4afce474a46c025c4161df638`
- compare vs `main`: exactly two changed files

## Safety / non-authorities

No timeout increase, credential readback/copy/relocation, chmod/sudo workaround, user-setting mutation, generic shell, arbitrary argv, provider selection, or unrelated Core integration changes.

**Draft / explicit publication approval required.** Opening this PR is not authorization to merge protected `main`.

Even after publication, #72 is not complete until the live ubuntu-owned relay executes a deterministic Claude smoke successfully with `ok=true`, `timed_out=false`, `returncode=0`, and the expected token. The resulting runtime receipt is the final acceptance gate.