### PR TITLE
governance(layoutlib): require explicit dispatch for official deploy carrier

### DIFF
--- a/.github/workflows/oracle-layoutlab-official-v2.yml
+++ b/.github/workflows/oracle-layoutlab-official-v2.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
@@ -25,21 +25,11 @@ jobs:
         shell: bash
         run: python3 scripts/deploy_layoutlab_official_v2.py
 
-      - name: Commit deployment evidence
+      - name: Upload deployment evidence
         if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          E=.agentos/evidence/layoutlab-official-v2.txt
-          test -f "$E" || exit 0
-          cp "$E" /tmp/layoutlab-official-v2.txt
-          git fetch origin main
-          git reset --hard origin/main
-          mkdir -p .agentos/evidence
-          cp /tmp/layoutlab-official-v2.txt "$E"
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add "$E"
-          git diff --cached --quiet && exit 0
-          git commit -m 'evidence(layoutlab): official v2 deployment acceptance'
-          git push origin HEAD:main
+        uses: actions/upload-artifact@v4
+        with:
+          name: layoutlab-official-v2-deployment-evidence
+          path: .agentos/evidence/layoutlab-official-v2.txt
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/oracle-layoutlab-official-v2.yml
+++ b/.github/workflows/oracle-layoutlab-official-v2.yml
@@ -1,14 +1,11 @@
 name: Oracle Layout Lab Official V2
 
+# Product deployment is an explicit authority event. Do not bind it to generic
+# AgentOS/Core file pushes: an unrelated relay change previously triggered a
+# live Layout Lab deployment. Canonical product/release work must dispatch this
+# workflow intentionally with its own acceptance context.
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - '.github/workflows/oracle-layoutlab-official-v2.yml'
-      - 'scripts/deploy_layoutlab_official_v2.py'
-      - 'scripts/layoutlab_api.py'
-      - 'agentos_node/antigravity_relay.py'
-      - 'agentos_node/antigravity_relay_worker.py'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Incident / motivation

While preparing the narrow #72 Claude OAuth publication candidate (#173), a push that changed only `agentos_node/antigravity_relay_worker.py` unexpectedly triggered `Oracle Layout Lab Official V2` run `33363888093`.

That workflow is a real product deployment carrier, not a test: it invokes `scripts/deploy_layoutlab_official_v2.py`, which can bootstrap/harden LayoutLib, allocate the API port, submit an Antigravity executor capsule authorized to modify the Layout Lab systemd/reverse-proxy path, and verify the public site.

The deploy script imports/uses the generic `agentos_node.antigravity_relay` client; it does **not** import `antigravity_relay_worker.py`. Binding product deployment to any relay-worker source push therefore couples unrelated Core publication to a Layout product authority event.

## Observed incident

- trigger: push on `release/issue-72-claude-oauth-publication` @ `18aa166f00a3b2df4e8deb3e793f67afe22551a1`
- workflow run: `33363888093`
- Oracle runner: `instance-20260129-0852`
- real deploy step executed
- deploy conclusion: FAIL because Antigravity deployment receipt was not `ok=true`
- **side-effect state is UNKNOWN**, not assumed unchanged, because the executor was authorized to perform bounded deployment changes before returning its failed receipt
- final evidence push to `main` was correctly rejected by repository rules (`GH013`, PR + required-check enforcement)

This run is not #72 evidence and must not be treated as #96/Layout acceptance.

## Fix

Make `Oracle Layout Lab Official V2` **workflow_dispatch-only**.

Product deployment is an explicit release-authority event. Generic Core/source pushes must never implicitly cause it. This also avoids a bootstrap trap where editing the workflow or another listed Core dependency could itself redeploy the product.

## Scope

One workflow file only. No deployment is performed by this PR. No Layout source, runtime, service, web config, DNS/TLS/firewall, or protected `main` is mutated by opening it.

## Follow-up acceptance

Before the next intentional Layout deployment, perform read-only verification of the current public UI/API and relevant service/proxy state because incident run `33363888093` reached the executor boundary before failing.

## Authority

Draft protected-main governance candidate. Explicit publication approval is required. Opening this PR is not approval to merge `main`.

#173 should remain blocked from protected-main merge until this trigger coupling is removed or an equivalent fail-closed release fence is accepted.