### PR TITLE
governance(layoutlib): require explicit capability-gateway install

### DIFF
--- a/.github/workflows/oracle-install-layoutlib-capability-gateway.yml
+++ b/.github/workflows/oracle-install-layoutlib-capability-gateway.yml
@@ -1,15 +1,13 @@
 name: Oracle Install LayoutLib Capability Gateway
 
+# Installing/restarting a product-specific persistent service is an explicit
+# runtime authority event. Generic AgentOS capability implementation pushes
+# must not implicitly mutate the LayoutLib runtime.
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - '.github/workflows/oracle-install-layoutlib-capability-gateway.yml'
-      - 'agentos_node/capability_http.py'
-      - 'agentos_node/capability_store.py'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: layoutlib-capability-gateway-install
@@ -107,19 +105,11 @@ jobs:
             ps -eo user,group,pid,etime,args | grep '[a]gentos_node.capability_http' || true
             echo 'local_capability_gateway=PASS'
           } | tee "$OUT"
-      - name: Commit install evidence
+      - name: Upload install evidence
         if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          cp .agentos/evidence/layoutlib-capability-gateway-install.txt /tmp/layoutlib-capability-gateway-install.txt 2>/dev/null || true
-          git fetch origin main
-          git reset --hard origin/main
-          mkdir -p .agentos/evidence
-          cp /tmp/layoutlib-capability-gateway-install.txt .agentos/evidence/layoutlib-capability-gateway-install.txt 2>/dev/null || true
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add .agentos/evidence/layoutlib-capability-gateway-install.txt 2>/dev/null || true
-          git diff --cached --quiet && exit 0
-          git commit -m 'evidence(layoutlib): capability gateway user service install'
-          git push origin HEAD:main
+        uses: actions/upload-artifact@v4
+        with:
+          name: layoutlib-capability-gateway-install-evidence
+          path: .agentos/evidence/layoutlib-capability-gateway-install.txt
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## Problem

#175 deployment-carrier audit found another generic-Core -> product-runtime coupling in `oracle-install-layoutlib-capability-gateway.yml`.

The historical workflow triggers on pushes to generic Core modules:
- `agentos_node/capability_http.py`
- `agentos_node/capability_store.py`

but its job performs a real **LayoutLib-specific persistent runtime mutation**: installs/updates `layoutlab-capability-gateway.service`, enables/starts the user service (or nohup fallback), binds `127.0.0.1:8767`, and writes a LayoutLib capability experience smoke into the persistent capability store.

Therefore an unrelated Core capability implementation change can implicitly reinstall/restart a product-specific service. The historical evidence step also used `contents: write` and directly pushed `HEAD:main`.

## Immediate fail-closed fence

This PR changes only the workflow authority surface:
- `workflow_dispatch` only;
- `permissions: contents: read`;
- preserve the existing bounded install/health/ingest procedure unchanged;
- replace direct repository evidence commit/push with `actions/upload-artifact@v4`.

It does not install, restart, or otherwise mutate the gateway merely by opening this PR. Because the pushed workflow definition itself no longer has a `push` trigger, the fence branch does not intentionally dispatch the install.

## Relationship

- #175 owns the broader product deployment carrier audit.
- #118 owns repository/product boundary cleanup.
- #96 / LayoutLib product migration still owns long-term carrier retirement.

This is an immediate safety fence only; it does not make agentmanager the permanent owner of LayoutLib deployment.

## Authority

Draft protected-main governance candidate. Explicit publication approval is required. Opening/passing this PR is not authorization to merge `main` or execute the install workflow.