### PR TITLE
Core #179: enforce ChatGPT → ONE transport routing

### DIFF
--- a/.github/workflows/transport-routing-guard.yml
+++ b/.github/workflows/transport-routing-guard.yml
@@ -1,0 +1,73 @@
+name: Transport Routing Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+      - main
+    paths:
+      - agent_core/transport_routing.py
+      - governance/transport-routing.json
+      - tests/test_transport_routing.py
+      - docs/CHATGPT_ONE_TRANSPORT.md
+      - AGENTS.md
+      - docs/CURRENT_STATE.md
+      - .github/workflows/transport-routing-guard.yml
+  push:
+    branches:
+      - core/integration
+    paths:
+      - agent_core/transport_routing.py
+      - governance/transport-routing.json
+      - tests/test_transport_routing.py
+      - docs/CHATGPT_ONE_TRANSPORT.md
+      - AGENTS.md
+      - docs/CURRENT_STATE.md
+      - .github/workflows/transport-routing-guard.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  routing-authority:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test transport authority resolver
+        run: python3 -m unittest tests.test_transport_routing -v
+
+      - name: Validate documentation coupling
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          BASE="${PR_BASE_SHA:-}"
+          if [[ -z "$BASE" ]]; then
+            BASE="${PUSH_BEFORE_SHA:-}"
+          fi
+          if [[ -z "$BASE" || "$BASE" =~ ^0+$ ]]; then
+            python3 scripts/documentation_reality_guard.py
+          else
+            python3 scripts/documentation_reality_guard.py --base "$BASE"
+          fi
+
+      - name: Assert policy forbids Actions for control-plane intents
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          policy = json.loads(Path('governance/transport-routing.json').read_text(encoding='utf-8'))
+          control = policy['intent_classes']['control_plane']
+          assert 'github_actions' not in control['allowed_transports']
+          assert 'github_actions' in control['forbidden_implicit_fallbacks']
+          assert policy['failure_semantics']['control_plane_transport_unavailable'] == 'fail_closed'
+          assert policy['failure_semantics']['control_plane_transport_error'] == 'surface_error_no_workflow_fallback'
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,22 @@ The model-independent **Cognitive IR / zero-cost arbitrary model switching** lay
 - Claims in documentation must be backed by implementation paths; verified claims also need tests/evidence.
 - **Capability does not imply authority.** A tool being available or a PR being mergeable does not authorize a protected-branch mutation.
 
+## Transport Routing Authority Rule
+
+For AgentOS Realm/Node/control-plane work, transport selection is authority-driven rather than convenience-driven. Read `docs/CHATGPT_ONE_TRANSPORT.md` and `governance/transport-routing.json`.
+
+Typed control-plane intents may use, in priority order when available:
+
+1. native/direct ONE transport;
+2. an AgentOS MCP/App bounded adapter;
+3. the current ChatGPT Bootstrap Control Inbox (#50).
+
+**GitHub Actions is not a generic fallback for control-plane work.** If all authorized ONE-side transports are unavailable or fail, surface that failure. Do not start or repurpose a workflow merely because a GitHub Actions runner can reach Oracle.
+
+GitHub Actions is an allowed carrier only for an explicitly classified workflow intent such as CI/tests, build/package, explicit release/deployment, or a separately authorized evidence workflow.
+
+Evaluate typed routing with `agent_core.transport_routing.resolve_transport`. Unknown intent classes and unauthorized requested transports fail closed.
+
 ## Protected Branch Authority Rule
 
 For `main`, `master`, and `release/*`:
@@ -81,6 +97,7 @@ CI enforces the same rule. Treat a documentation-drift failure as an architectur
 python3 scripts/continuation_state.py --self-test
 python3 -m unittest tests.test_continuation_state tests.test_control_plane -v
 python3 -m unittest tests.test_protected_branch_authority -v
+python3 -m unittest tests.test_transport_routing -v
 python3 scripts/documentation_reality_guard.py
 ```
 

--- a/agent_core/transport_routing.py
+++ b/agent_core/transport_routing.py
@@ -1,0 +1,117 @@
+"""Authority-driven transport routing for AgentOS control and workflow intents.
+
+This module deliberately does not classify natural-language prompts. Callers must
+supply a typed intent class. The resolver's job is narrower and security-relevant:
+choose only among transports already authorized for that class and fail closed
+when none are available.
+
+In particular, GitHub Actions is never a generic fallback for AgentOS control-plane
+work. A transport failure does not expand authority.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_POLICY_PATH = ROOT / "governance" / "transport-routing.json"
+
+
+class TransportRoutingError(RuntimeError):
+    """Base class for transport-routing failures."""
+
+
+class UnknownIntentClass(TransportRoutingError):
+    """Raised when the caller supplies an undeclared intent class."""
+
+
+class UnauthorizedTransport(TransportRoutingError):
+    """Raised when a requested transport lacks authority for the intent class."""
+
+
+class TransportUnavailable(TransportRoutingError):
+    """Raised when no authorized transport is currently available."""
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    intent_class: str
+    transport: str
+    authority: str
+    policy_id: str
+
+
+def load_policy(path: Path | str = DEFAULT_POLICY_PATH) -> dict:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        policy = json.load(handle)
+    if policy.get("schema") != "agentos.transport-routing/v1":
+        raise TransportRoutingError("unsupported transport-routing policy schema")
+    return policy
+
+
+def _available_set(available_transports: Iterable[str] | Mapping[str, bool]) -> set[str]:
+    if isinstance(available_transports, Mapping):
+        return {name for name, available in available_transports.items() if available}
+    return set(available_transports)
+
+
+def resolve_transport(
+    intent_class: str,
+    available_transports: Iterable[str] | Mapping[str, bool],
+    *,
+    requested_transport: str | None = None,
+    policy: dict | None = None,
+) -> RouteDecision:
+    """Resolve one authorized transport deterministically.
+
+    `intent_class` must already be typed by the caller (currently `control_plane`
+    or `workflow`). `available_transports` is only a liveness/capability snapshot;
+    it never grants authority.
+
+    If `requested_transport` is supplied it is still checked against the declared
+    allowlist. This prevents a caller from forcing GitHub Actions for a control-plane
+    intent merely because an Actions runner is reachable.
+    """
+
+    active_policy = policy or load_policy()
+    intent = active_policy.get("intent_classes", {}).get(intent_class)
+    if intent is None:
+        raise UnknownIntentClass(f"unknown intent class: {intent_class}")
+
+    allowed = tuple(intent.get("allowed_transports", ()))
+    available = _available_set(available_transports)
+
+    if requested_transport is not None:
+        if requested_transport not in allowed:
+            raise UnauthorizedTransport(
+                f"transport {requested_transport!r} is not authorized for intent class {intent_class!r}"
+            )
+        if requested_transport not in available:
+            raise TransportUnavailable(
+                f"authorized transport {requested_transport!r} is unavailable for intent class {intent_class!r}"
+            )
+        selected = requested_transport
+    else:
+        priority = active_policy.get("transport_priority", ())
+        selected = next(
+            (transport for transport in priority if transport in allowed and transport in available),
+            None,
+        )
+        if selected is None:
+            raise TransportUnavailable(
+                f"no authorized transport available for intent class {intent_class!r}; "
+                "authority is not expanded by fallback"
+            )
+
+    transport = active_policy.get("transports", {}).get(selected)
+    if not transport:
+        raise TransportRoutingError(f"selected transport is undeclared: {selected}")
+
+    return RouteDecision(
+        intent_class=intent_class,
+        transport=selected,
+        authority=str(transport.get("authority", "unknown")),
+        policy_id=str(active_policy.get("policy_id", "unknown")),
+    )

--- a/docs/CHATGPT_ONE_TRANSPORT.md
+++ b/docs/CHATGPT_ONE_TRANSPORT.md
@@ -1,0 +1,67 @@
+# ChatGPT → ONE Transport Authority
+
+Status: Core #179 implementation candidate. This document defines transport-selection authority; it does not claim that ChatGPT Web already has a native direct ONE tool.
+
+## Current reality
+
+ChatGPT Web has a working bootstrap path into AgentOS ONE through GitHub Issue #50:
+
+```text
+ChatGPT Web
+  -> ChatGPT GitHub connector
+  -> Bootstrap Control Inbox (#50)
+  -> Oracle bridge
+  -> ONE
+```
+
+The GitHub issue/comment layer is a temporary transport mailbox. It is not the control-plane authority. ONE remains authoritative for allowed actions and Node/Realm routing.
+
+The bootstrap transport is intentionally replaceable by an AgentOS MCP/App without changing ONE or Node contracts.
+
+Separately, Core #152 / PR #167 is implementing an MCP adapter for the Antigravity built-in Gemini executor. That work does not by itself make ChatGPT Web a native ONE/MCP client.
+
+## Routing invariant
+
+Transport selection is authority-driven, not convenience-driven.
+
+For a typed AgentOS control-plane intent, resolve transports in this order when they are both authorized and available:
+
+1. `one_direct`
+2. `agentos_mcp_app`
+3. `control_inbox`
+
+`github_actions` is not in the allowed set for control-plane intents.
+
+For explicitly typed workflow intents (CI, tests, build, package, release, deployment, declared evidence workflow), `github_actions` is an allowed workflow carrier.
+
+## Fail-closed rule
+
+A ONE-side failure does not expand authority.
+
+If `one_direct`, `agentos_mcp_app`, and `control_inbox` are unavailable or fail, a control-plane request fails as a transport/control-plane error. The caller must not start a GitHub Actions workflow merely because an Oracle self-hosted runner is reachable.
+
+This is the transport equivalent of the Core invariant:
+
+> Capability does not imply authority.
+
+## Intent examples
+
+Control-plane intents include Realm/Node status and discovery, capability/governance resolution, governed executor discovery/liveness, session handoff, declared runtime control, and governed node execution requests.
+
+Workflow intents include CI/tests, build/package, explicit release, explicit deployment, and separately authorized evidence workflows.
+
+Natural-language classification is intentionally outside `agent_core.transport_routing`. A caller must first produce a typed intent; the resolver then enforces the transport authority for that class. Unknown intent classes fail closed.
+
+## Machine contract
+
+- Policy: `governance/transport-routing.json`
+- Resolver: `agent_core/transport_routing.py`
+- Regression tests: `tests/test_transport_routing.py`
+
+The policy requires deterministic routing for the same typed intent and availability snapshot. Switching conversation, model, or executor must not change the authorized carrier merely because a different tool looks convenient.
+
+## Acceptance boundary
+
+The static resolver/tests prove the no-fallback authority rule, but they do not alone prove ChatGPT Web transport transparency.
+
+Core #179 remains incomplete until a fresh ChatGPT conversation demonstrates a Realm/Node control-plane request resolving through Control Inbox/ONE with no Actions workflow invocation. A later AgentOS MCP/App may replace Control Inbox after equivalent acceptance evidence exists.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # AgentOS Current Architecture & Reality
 
-**Status date:** 2026-08-27  
+**Status date:** 2026-09-01  
 **Purpose:** canonical public map of what is implemented, what is verified, and what is still research.
 
 This document exists to prevent architecture drift between code and prose. It is intentionally narrower than a roadmap: every item marked **Implemented** must have a concrete repository path; every item marked **Verified** must also have a test or evidence path.
@@ -26,6 +26,9 @@ This goal is broader than memory retrieval. AgentOS treats durable project/worki
 | Resource registry / world-state lookup | Implemented + tested | `agent_core/resource_registry.py` | `tests/test_resource_registry.py` |
 | Realm / cross-node fabric | Implemented slices + tested | `agent_core/realm_fabric.py`, `agent_core/realm_server.py`, `agent_core/realm_cli.py` | `tests/test_realm_fabric.py`, `.agentos/commands/` |
 | Platform driver abstraction | Implemented + tested | `agent_core/platform/`, `scripts/platform_runtime.py` | `tests/test_platform_runtime.py` |
+| ChatGPT bootstrap transport into ONE | Implemented bootstrap; live regression still required | Bootstrap Control Inbox #50 → Oracle bridge → ONE | Issue #50 control command/result evidence; `docs/CHATGPT_ONE_TRANSPORT.md` |
+| Authority-driven transport routing | Implemented + tested candidate | `agent_core/transport_routing.py`, `governance/transport-routing.json` | `tests/test_transport_routing.py`; fresh ChatGPT session acceptance pending in #179 |
+| Antigravity Gemini ONE MCP awareness | Implementation candidate / not accepted | PR #167 `agentos_node/one_mcp.py` | fresh built-in Gemini E2/E3 acceptance still pending |
 | Governance drift guard | Implemented + tested | `scripts/drift_guard.py`, constitution/role registries | `tests/test_drift_guard.py` |
 | Protected-branch authority guard | Implemented on governance branch | `.agent/governance/protected_branches.yaml`, `scripts/protected_branch_authority.py` | `tests/test_protected_branch_authority.py`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md` |
 | Evidence-first operational acceptance | Implemented | `.agentos/evidence/` | live acceptance files committed by workflows |
@@ -45,7 +48,15 @@ Tool results and execution evidence can inform decisions, but they do not silent
 
 ### Capability does not imply authority
 
-The presence of a mutation tool, a mergeable pull request, or passing CI does not authorize a protected-branch mutation. Agents must stop at `AWAITING_HUMAN_APPROVAL` until an explicit human authorization exists. See `.agent/governance/protected_branches.yaml` and `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md`.
+The presence of a mutation tool, a mergeable pull request, a reachable Actions runner, or passing CI does not create authority for a different class of operation. Agents must stop at `AWAITING_HUMAN_APPROVAL` for protected publication, and control-plane work must not opportunistically switch to GitHub Actions because ONE-side transport is unavailable.
+
+See `.agent/governance/protected_branches.yaml`, `docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md`, and `docs/CHATGPT_ONE_TRANSPORT.md`.
+
+### Transport failure does not expand authority
+
+For typed Realm/Node/control-plane intents, the authorized transport order is direct ONE → AgentOS MCP/App → Bootstrap Control Inbox. GitHub Actions is not in that allowlist and is not a failure fallback. GitHub Actions is reserved for explicitly typed workflow intents such as CI/tests, build/package, release, deployment, or separately authorized evidence workflows.
+
+The current ChatGPT Web path is therefore not yet a native direct ONE connection. It is a bootstrap path through GitHub comments into an Oracle bridge and then ONE. The GitHub mailbox is transport only; ONE remains the control-plane authority. The target is to replace that mailbox with an AgentOS MCP/App after equivalent acceptance evidence exists.
 
 ### Discover before invent
 
@@ -64,7 +75,7 @@ Early documentation centered on:
 - manual `/report` handoff;
 - Logic/Data separation as the main architectural idea.
 
-Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, and explicit authority boundaries for protected mutations.
+Those mechanisms are historical foundations, not an adequate description of current AgentOS. Current code additionally contains explicit continuation reconciliation, a persistent control plane, node/capability governance, resource state, Realm cross-node execution, platform abstractions, committed execution evidence, documentation reality checks, explicit authority boundaries for protected mutations, and an explicit transport-authority contract that prevents workflow-carrier capability from becoming control-plane authority.
 
 Old documents that describe only the memory/pulse era must be treated as historical unless they link back to this file.
 

--- a/governance/transport-routing.json
+++ b/governance/transport-routing.json
@@ -1,0 +1,87 @@
+{
+  "schema": "agentos.transport-routing/v1",
+  "policy_id": "core-chatgpt-one-routing",
+  "description": "Authority-driven transport selection for AgentOS intents. Availability never grants authority and GitHub Actions is not a generic fallback for ONE control-plane work.",
+  "transport_priority": [
+    "one_direct",
+    "agentos_mcp_app",
+    "control_inbox",
+    "github_actions"
+  ],
+  "transports": {
+    "one_direct": {
+      "kind": "agentos_control",
+      "authority": "ONE",
+      "status": "preferred_when_available"
+    },
+    "agentos_mcp_app": {
+      "kind": "agentos_control",
+      "authority": "ONE_via_bounded_adapter",
+      "status": "target"
+    },
+    "control_inbox": {
+      "kind": "agentos_control",
+      "authority": "ONE_via_bootstrap_bridge",
+      "status": "current_chatgpt_bootstrap",
+      "evidence": "issue/50"
+    },
+    "github_actions": {
+      "kind": "workflow_carrier",
+      "authority": "explicit_workflow_only",
+      "status": "available_for_declared_workflow_intents"
+    }
+  },
+  "intent_classes": {
+    "control_plane": {
+      "allowed_transports": [
+        "one_direct",
+        "agentos_mcp_app",
+        "control_inbox"
+      ],
+      "forbidden_implicit_fallbacks": [
+        "github_actions"
+      ],
+      "examples": [
+        "realm.status",
+        "realm.discovery",
+        "node.inspect",
+        "node.status",
+        "capability.resolve",
+        "governance.resolve",
+        "executor.discovery",
+        "executor.liveness",
+        "session.handoff",
+        "runtime.control",
+        "runtime.rollout",
+        "governed.node.execute"
+      ]
+    },
+    "workflow": {
+      "allowed_transports": [
+        "github_actions"
+      ],
+      "requires_explicit_workflow_intent": true,
+      "examples": [
+        "ci",
+        "test",
+        "build",
+        "package",
+        "release",
+        "deployment",
+        "evidence.workflow"
+      ]
+    }
+  },
+  "failure_semantics": {
+    "control_plane_transport_unavailable": "fail_closed",
+    "control_plane_transport_error": "surface_error_no_workflow_fallback",
+    "github_actions_available_but_unauthorized": "reject"
+  },
+  "invariants": [
+    "capability_does_not_imply_authority",
+    "same_classified_intent_and_availability_snapshot_resolves_deterministically",
+    "control_plane_intents_never_implicitly_route_to_github_actions",
+    "transport_failure_does_not_expand_authority",
+    "github_actions_requires_explicit_workflow_classification"
+  ]
+}

--- a/tests/test_transport_routing.py
+++ b/tests/test_transport_routing.py
@@ -1,0 +1,80 @@
+import unittest
+
+from agent_core.transport_routing import (
+    TransportUnavailable,
+    UnauthorizedTransport,
+    UnknownIntentClass,
+    resolve_transport,
+)
+
+
+class TransportRoutingTests(unittest.TestCase):
+    def test_control_plane_prefers_direct_one(self):
+        decision = resolve_transport(
+            "control_plane",
+            {"one_direct", "agentos_mcp_app", "control_inbox", "github_actions"},
+        )
+        self.assertEqual(decision.transport, "one_direct")
+
+    def test_control_plane_uses_mcp_before_control_inbox(self):
+        decision = resolve_transport(
+            "control_plane",
+            {"agentos_mcp_app", "control_inbox", "github_actions"},
+        )
+        self.assertEqual(decision.transport, "agentos_mcp_app")
+
+    def test_current_chatgpt_bootstrap_uses_control_inbox(self):
+        decision = resolve_transport(
+            "control_plane",
+            {"control_inbox", "github_actions"},
+        )
+        self.assertEqual(decision.transport, "control_inbox")
+
+    def test_control_plane_never_falls_back_to_github_actions(self):
+        with self.assertRaises(TransportUnavailable):
+            resolve_transport("control_plane", {"github_actions"})
+
+    def test_explicit_github_actions_is_rejected_for_control_plane(self):
+        with self.assertRaises(UnauthorizedTransport):
+            resolve_transport(
+                "control_plane",
+                {"control_inbox", "github_actions"},
+                requested_transport="github_actions",
+            )
+
+    def test_transport_failure_does_not_expand_authority(self):
+        # The caller reports the ONE-side transports unavailable after a failure.
+        # Reachable Actions must still not become authorized as a side effect.
+        with self.assertRaises(TransportUnavailable):
+            resolve_transport(
+                "control_plane",
+                {
+                    "one_direct": False,
+                    "agentos_mcp_app": False,
+                    "control_inbox": False,
+                    "github_actions": True,
+                },
+            )
+
+    def test_explicit_workflow_routes_to_github_actions(self):
+        decision = resolve_transport("workflow", {"github_actions"})
+        self.assertEqual(decision.transport, "github_actions")
+
+    def test_workflow_cannot_borrow_control_transport(self):
+        with self.assertRaises(TransportUnavailable):
+            resolve_transport("workflow", {"control_inbox"})
+
+    def test_same_snapshot_is_deterministic(self):
+        available = {"control_inbox", "github_actions"}
+        first = resolve_transport("control_plane", available)
+        second = resolve_transport("control_plane", reversed(tuple(available)))
+        self.assertEqual(first, second)
+        self.assertEqual(first.transport, "control_inbox")
+
+    def test_unknown_intent_fails_closed(self):
+        with self.assertRaises(UnknownIntentClass):
+            resolve_transport("whatever_is_convenient", {"github_actions"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements the static/executable routing slice of #179.

### New contract
- `governance/transport-routing.json` defines authority-driven transport classes and priority.
- `agent_core/transport_routing.py` resolves only typed intents and fails closed.
- `tests/test_transport_routing.py` covers direct ONE/MCP/Inbox priority, deterministic same-snapshot routing, explicit workflow routing, and the critical no-GitHub-Actions-fallback rule.

### Documentation
- `docs/CHATGPT_ONE_TRANSPORT.md` records current reality: ChatGPT Web currently reaches ONE through Bootstrap Control Inbox #50; GitHub is the mailbox transport, ONE is the authority.
- `AGENTS.md` makes the routing authority rule required agent behavior.
- `docs/CURRENT_STATE.md` records implemented/tested candidate state and the remaining live acceptance boundary.

## Security / authority property

For `control_plane`, `github_actions` is not an allowed transport. If direct ONE, MCP/App, and Control Inbox are unavailable, resolution raises `TransportUnavailable`; reachability of an Actions runner does not expand authority.

GitHub Actions remains valid for the separate `workflow` intent class (CI/tests/build/package/explicit release/deployment/evidence workflow).

## Acceptance still outstanding

This PR intentionally does not claim full ChatGPT Node transport transparency. After static tests pass, #179 still requires a fresh ChatGPT conversation to issue a Realm/Node control-plane request through Control Inbox/ONE with no Actions workflow invocation.

## Boundaries

- does not close #50;
- does not own #105 GUI certification;
- does not own #152 / PR #167 Antigravity Gemini MCP;
- no protected-main mutation;
- no arbitrary shell/argv;
- no deployment-generation advance.
