### PR TITLE
Core #151: integrate durable Agent Employee Runtime

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -1,0 +1,44 @@
+name: Employee Runtime Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+      - main
+    paths:
+      - 'agent_core/employee_runtime.py'
+      - 'agent_core/role_runtime.py'
+      - 'tests/test_employee_runtime.py'
+      - 'tests/test_role_runtime.py'
+      - '.agent/roles/**'
+      - '.github/workflows/employee-runtime-guard.yml'
+  push:
+    branches:
+      - core/integration
+    paths:
+      - 'agent_core/employee_runtime.py'
+      - 'agent_core/role_runtime.py'
+      - 'tests/test_employee_runtime.py'
+      - 'tests/test_role_runtime.py'
+      - '.agent/roles/**'
+      - '.github/workflows/employee-runtime-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  employee-runtime:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install role parser dependency
+        run: python -m pip install PyYAML
+      - name: Run employee runtime regressions
+        run: python -m unittest tests.test_employee_runtime -v
+      - name: Run role hydration regressions
+        run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_runtime.py
+++ b/agent_core/employee_runtime.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+VALID_ASSIGNMENT_STATES = {"pending", "active", "blocked", "handoff", "completed", "cancelled"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_id(value: str) -> str:
+    value = value.strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError(f"unsafe id: {value!r}")
+    return value
+
+
+def _atomic_json_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return dict(default)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object in {path}")
+    return data
+
+
+@dataclass(slots=True)
+class ExecutorBinding:
+    provider: str = "unbound"
+    model: str = ""
+    session_id: str = ""
+    bound_at: str = ""
+
+
+@dataclass(slots=True)
+class AgentInstance:
+    agent_id: str
+    display_name: str
+    role_ids: list[str] = field(default_factory=list)
+    skill_ids: list[str] = field(default_factory=list)
+    memory_namespace: str = ""
+    executor: ExecutorBinding = field(default_factory=ExecutorBinding)
+    status: str = "available"
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class Assignment:
+    assignment_id: str
+    goal: str
+    employee_id: str
+    state: str = "pending"
+    parent_assignment_id: str | None = None
+    thread_head: str = ""
+    constraints: list[str] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class AgentMessage:
+    message_id: str
+    sender_id: str
+    recipient_id: str
+    subject: str
+    payload: dict[str, Any]
+    assignment_id: str | None = None
+    created_at: str = ""
+    read_at: str = ""
+
+
+class EmployeeRuntime:
+    """Small durable kernel for AgentOS employee identity and assignment state.
+
+    This runtime deliberately stores *references* to roles and skills. Hydrating those
+    references into an effective role contract is handled by the role runtime so that
+    employee identity stays independent from role-file representation and executor.
+    """
+
+    def __init__(self, root: str | os.PathLike[str]) -> None:
+        self.root = Path(root)
+        self.employees_dir = self.root / "employees"
+        self.assignments_dir = self.root / "assignments"
+        self.messages_dir = self.root / "messages"
+        self.memory_dir = self.root / "memory"
+
+    def create_employee(
+        self,
+        agent_id: str,
+        display_name: str,
+        *,
+        role_ids: list[str] | None = None,
+        skill_ids: list[str] | None = None,
+    ) -> AgentInstance:
+        agent_id = _safe_id(agent_id)
+        path = self.employees_dir / f"{agent_id}.json"
+        if path.exists():
+            raise FileExistsError(f"employee already exists: {agent_id}")
+        now = _now()
+        employee = AgentInstance(
+            agent_id=agent_id,
+            display_name=display_name.strip() or agent_id,
+            role_ids=list(role_ids or []),
+            skill_ids=list(skill_ids or []),
+            memory_namespace=f"employee:{agent_id}",
+            created_at=now,
+            updated_at=now,
+        )
+        _atomic_json_write(path, asdict(employee))
+        return employee
+
+    def get_employee(self, agent_id: str) -> AgentInstance:
+        agent_id = _safe_id(agent_id)
+        data = _read_json(self.employees_dir / f"{agent_id}.json", {})
+        if not data:
+            raise FileNotFoundError(agent_id)
+        data["executor"] = ExecutorBinding(**data.get("executor", {}))
+        return AgentInstance(**data)
+
+    def bind_executor(self, agent_id: str, *, provider: str, model: str = "", session_id: str = "") -> AgentInstance:
+        employee = self.get_employee(agent_id)
+        employee.executor = ExecutorBinding(
+            provider=provider,
+            model=model,
+            session_id=session_id,
+            bound_at=_now(),
+        )
+        employee.updated_at = _now()
+        _atomic_json_write(self.employees_dir / f"{employee.agent_id}.json", asdict(employee))
+        return employee
+
+    def create_assignment(
+        self,
+        assignment_id: str,
+        employee_id: str,
+        goal: str,
+        *,
+        parent_assignment_id: str | None = None,
+        thread_head: str = "",
+        constraints: list[str] | None = None,
+    ) -> Assignment:
+        assignment_id = _safe_id(assignment_id)
+        employee_id = _safe_id(employee_id)
+        self.get_employee(employee_id)
+        path = self.assignments_dir / f"{assignment_id}.json"
+        if path.exists():
+            raise FileExistsError(f"assignment already exists: {assignment_id}")
+        now = _now()
+        assignment = Assignment(
+            assignment_id=assignment_id,
+            goal=goal,
+            employee_id=employee_id,
+            parent_assignment_id=parent_assignment_id,
+            thread_head=thread_head,
+            constraints=list(constraints or []),
+            created_at=now,
+            updated_at=now,
+        )
+        _atomic_json_write(path, asdict(assignment))
+        return assignment
+
+    def get_assignment(self, assignment_id: str) -> Assignment:
+        assignment_id = _safe_id(assignment_id)
+        data = _read_json(self.assignments_dir / f"{assignment_id}.json", {})
+        if not data:
+            raise FileNotFoundError(assignment_id)
+        return Assignment(**data)
+
+    def update_assignment(
+        self,
+        assignment_id: str,
+        *,
+        state: str | None = None,
+        thread_head: str | None = None,
+        result: dict[str, Any] | None = None,
+    ) -> Assignment:
+        assignment = self.get_assignment(assignment_id)
+        if state is not None:
+            if state not in VALID_ASSIGNMENT_STATES:
+                raise ValueError(f"invalid assignment state: {state}")
+            assignment.state = state
+        if thread_head is not None:
+            assignment.thread_head = thread_head
+        if result is not None:
+            assignment.result = result
+        assignment.updated_at = _now()
+        _atomic_json_write(self.assignments_dir / f"{assignment.assignment_id}.json", asdict(assignment))
+        return assignment
+
+    def write_memory(self, agent_id: str, key: str, value: Any) -> None:
+        agent_id = _safe_id(agent_id)
+        self.get_employee(agent_id)
+        key = _safe_id(key)
+        path = self.memory_dir / agent_id / f"{key}.json"
+        _atomic_json_write(path, {"value": value, "updated_at": _now()})
+
+    def read_memory(self, agent_id: str, key: str) -> Any:
+        agent_id = _safe_id(agent_id)
+        key = _safe_id(key)
+        data = _read_json(self.memory_dir / agent_id / f"{key}.json", {})
+        if not data:
+            raise FileNotFoundError(key)
+        return data.get("value")
+
+    def send_message(
+        self,
+        message_id: str,
+        sender_id: str,
+        recipient_id: str,
+        subject: str,
+        payload: dict[str, Any],
+        *,
+        assignment_id: str | None = None,
+    ) -> AgentMessage:
+        message_id = _safe_id(message_id)
+        sender_id = _safe_id(sender_id)
+        recipient_id = _safe_id(recipient_id)
+        self.get_employee(sender_id)
+        self.get_employee(recipient_id)
+        now = _now()
+        message = AgentMessage(
+            message_id=message_id,
+            sender_id=sender_id,
+            recipient_id=recipient_id,
+            subject=subject,
+            payload=payload,
+            assignment_id=assignment_id,
+            created_at=now,
+        )
+        path = self.messages_dir / recipient_id / f"{message_id}.json"
+        if path.exists():
+            raise FileExistsError(f"message already exists: {message_id}")
+        _atomic_json_write(path, asdict(message))
+        return message
+
+    def list_inbox(self, agent_id: str) -> list[AgentMessage]:
+        agent_id = _safe_id(agent_id)
+        inbox = self.messages_dir / agent_id
+        if not inbox.exists():
+            return []
+        messages: list[AgentMessage] = []
+        for path in sorted(inbox.glob("*.json")):
+            messages.append(AgentMessage(**_read_json(path, {})))
+        return messages

--- a/agent_core/role_runtime.py
+++ b/agent_core/role_runtime.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(slots=True)
+class EffectiveRoleContract:
+    role_id: str
+    name: str
+    kind: str
+    status: str
+    source: str | None
+    purpose: str
+    must_obey: list[str] = field(default_factory=list)
+    may: list[str] = field(default_factory=list)
+    must_not: list[str] = field(default_factory=list)
+    capabilities: list[str] = field(default_factory=list)
+    outputs: list[str] = field(default_factory=list)
+    upstream_roles: list[str] = field(default_factory=list)
+    handoff_to: list[str] = field(default_factory=list)
+
+
+class RoleRegistry:
+    """Machine-hydrates role contracts from the canonical role registry.
+
+    The registry is authoritative for role identity/status/relationships. Human-readable
+    source documents remain supporting contract text; runtime must not infer authority
+    by scraping arbitrary prose.
+    """
+
+    def __init__(self, registry_path: str | Path) -> None:
+        self.registry_path = Path(registry_path)
+        raw = yaml.safe_load(self.registry_path.read_text(encoding="utf-8")) or {}
+        roles = raw.get("roles", [])
+        if not isinstance(roles, list):
+            raise ValueError("role registry roles must be a list")
+        self.schema_version = str(raw.get("schema_version", ""))
+        self.role_set_version = str(raw.get("role_set_version", ""))
+        self._roles: dict[str, dict[str, Any]] = {}
+        for role in roles:
+            if not isinstance(role, dict) or not role.get("id"):
+                raise ValueError("each role must be an object with id")
+            role_id = str(role["id"])
+            if role_id in self._roles:
+                raise ValueError(f"duplicate role id: {role_id}")
+            self._roles[role_id] = role
+
+    def ids(self, *, include_proposed: bool = False) -> list[str]:
+        result = []
+        for role_id, role in self._roles.items():
+            if include_proposed or role.get("status") == "active":
+                result.append(role_id)
+        return sorted(result)
+
+    def resolve(self, role_id: str) -> EffectiveRoleContract:
+        if role_id not in self._roles:
+            raise KeyError(role_id)
+        role = self._roles[role_id]
+        if role.get("status") != "active":
+            raise ValueError(f"role is not active: {role_id}")
+
+        visited: set[str] = set()
+        ordered: list[dict[str, Any]] = []
+
+        def walk(current_id: str) -> None:
+            if current_id in visited:
+                return
+            visited.add(current_id)
+            current = self._roles.get(current_id)
+            if current is None:
+                raise KeyError(f"unknown upstream role: {current_id}")
+            if current.get("status") != "active":
+                raise ValueError(f"upstream role is not active: {current_id}")
+            for parent in current.get("upstream_roles", []) or []:
+                walk(str(parent))
+            ordered.append(current)
+
+        walk(role_id)
+
+        def merged_list(key: str) -> list[str]:
+            result: list[str] = []
+            for item in ordered:
+                for value in item.get(key, []) or []:
+                    value = str(value)
+                    if value not in result:
+                        result.append(value)
+            return result
+
+        return EffectiveRoleContract(
+            role_id=role_id,
+            name=str(role.get("name", role_id)),
+            kind=str(role.get("kind", "")),
+            status=str(role.get("status", "")),
+            source=role.get("source"),
+            purpose=str(role.get("purpose", "")),
+            must_obey=merged_list("must_obey"),
+            may=merged_list("may"),
+            must_not=merged_list("must_not"),
+            capabilities=merged_list("capabilities"),
+            outputs=merged_list("outputs"),
+            upstream_roles=[str(value) for value in (role.get("upstream_roles", []) or [])],
+            handoff_to=[str(value) for value in (role.get("handoff_to", []) or [])],
+        )
+
+    def hydrate_employee_roles(self, role_ids: list[str]) -> list[EffectiveRoleContract]:
+        if not role_ids:
+            raise ValueError("employee must have at least one role")
+        return [self.resolve(role_id) for role_id in role_ids]

--- a/tests/test_employee_runtime.py
+++ b/tests/test_employee_runtime.py
@@ -1,0 +1,88 @@
+import tempfile
+import unittest
+
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+class EmployeeRuntimeTest(unittest.TestCase):
+    def test_identity_survives_executor_rebinding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = EmployeeRuntime(tmp)
+            employee = runtime.create_employee(
+                "spec-steward",
+                "Spec Steward",
+                role_ids=["governance.spec_steward"],
+            )
+            self.assertEqual(employee.memory_namespace, "employee:spec-steward")
+
+            first = runtime.bind_executor(
+                "spec-steward", provider="claude", model="claude", session_id="s1"
+            )
+            second = runtime.bind_executor(
+                "spec-steward", provider="codex", model="gpt", session_id="s2"
+            )
+
+            self.assertEqual(first.agent_id, second.agent_id)
+            self.assertEqual(second.role_ids, ["governance.spec_steward"])
+            self.assertEqual(second.memory_namespace, "employee:spec-steward")
+            self.assertEqual(second.executor.provider, "codex")
+
+    def test_assignment_and_thread_head_are_durable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = EmployeeRuntime(tmp)
+            runtime.create_employee("spec-steward", "Spec Steward")
+            runtime.create_assignment(
+                "spec-audit-1",
+                "spec-steward",
+                "audit unresolved AgentOS specs",
+                thread_head="thread:root",
+            )
+            runtime.update_assignment(
+                "spec-audit-1", state="active", thread_head="thread:spec-audit"
+            )
+
+            restarted = EmployeeRuntime(tmp)
+            assignment = restarted.get_assignment("spec-audit-1")
+            self.assertEqual(assignment.state, "active")
+            self.assertEqual(assignment.thread_head, "thread:spec-audit")
+
+    def test_employee_memory_is_namespaced(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = EmployeeRuntime(tmp)
+            runtime.create_employee("weaver", "Weaver")
+            runtime.create_employee("claw", "Claw")
+            runtime.write_memory("weaver", "current", {"spec": "A"})
+            runtime.write_memory("claw", "current", {"risk": "B"})
+            self.assertEqual(runtime.read_memory("weaver", "current"), {"spec": "A"})
+            self.assertEqual(runtime.read_memory("claw", "current"), {"risk": "B"})
+
+    def test_local_inbox_is_durable_but_not_cross_node_claim(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = EmployeeRuntime(tmp)
+            runtime.create_employee("weaver", "Weaver")
+            runtime.create_employee("paw", "Paw")
+            runtime.send_message(
+                "handoff-1",
+                "weaver",
+                "paw",
+                "implementation handoff",
+                {"spec": "bounded"},
+                assignment_id="a1",
+            )
+            restarted = EmployeeRuntime(tmp)
+            inbox = restarted.list_inbox("paw")
+            self.assertEqual(len(inbox), 1)
+            self.assertEqual(inbox[0].sender_id, "weaver")
+            self.assertEqual(inbox[0].assignment_id, "a1")
+
+    def test_rejects_invalid_assignment_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = EmployeeRuntime(tmp)
+            runtime.create_employee("keeper", "Keeper")
+            runtime.create_assignment("a1", "keeper", "guard")
+            with self.assertRaises(ValueError):
+                runtime.update_assignment("a1", state="magically_done")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_runtime.py
+++ b/tests/test_role_runtime.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from agent_core.role_runtime import RoleRegistry
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / ".agent" / "roles" / "registry.yaml"
+
+
+class RoleRuntimeTest(unittest.TestCase):
+    def test_active_role_registry_is_machine_hydratable(self):
+        registry = RoleRegistry(REGISTRY)
+        ids = registry.ids()
+        self.assertIn("governance.spec_steward", ids)
+        self.assertIn("sector.paw", ids)
+        self.assertNotIn("governance.arbiter", ids)
+
+    def test_proposed_role_cannot_be_activated_as_runtime_contract(self):
+        registry = RoleRegistry(REGISTRY)
+        with self.assertRaises(ValueError):
+            registry.resolve("governance.arbiter")
+
+    def test_upstream_role_contract_is_inherited_deterministically(self):
+        registry = RoleRegistry(REGISTRY)
+        paw = registry.resolve("sector.paw")
+        self.assertEqual(paw.upstream_roles, ["sector.weaver"])
+        self.assertIn("specification_closure", paw.must_obey)
+        self.assertIn("capability_boundary", paw.must_obey)
+        self.assertIn("receipts_over_claims", paw.must_obey)
+        self.assertIn("architecture_decision", paw.outputs)
+        self.assertIn("execution_receipt", paw.outputs)
+
+    def test_spec_steward_capability_is_hydrated(self):
+        registry = RoleRegistry(REGISTRY)
+        steward = registry.resolve("governance.spec_steward")
+        self.assertEqual(steward.kind, "governance")
+        self.assertIn("governance.spec.audit", steward.capabilities)
+        self.assertIn("closure_gap", steward.outputs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Supersedes draft PR #183

This PR reopens the **exact same source head** `d37c0a40725bcba8642f8b53c4b98a435c87d2e9` against the same `core/integration` base because the connected GitHub draft→ready mutation failed at the connector GraphQL schema layer. No source change was made to bypass review/branch authority.

## Verified static slice
- durable AgentInstance identity independent of executor/model/session;
- durable assignment state + thread head;
- employee-scoped memory namespace;
- local durable inbox/outbox;
- executor rebinding without replacing employee identity;
- machine-hydrated active role contracts from `.agent/roles/registry.yaml`;
- deterministic upstream-role inheritance;
- proposed roles fail closed;
- hosted regression guard only, `contents: read`.

Existing exact-head evidence: Employee Runtime Guard run `33584132926` succeeded on hosted `ubuntu-latest`; employee runtime and role hydration regression steps both passed.

## Explicit non-claims
This integration does not close #151. Scheduler/lifecycle, cross-node Realm messaging, role-scoped memory authorization, skill execution hydration, Cognitive Thread return stack, and a live persistent Spec Steward assignment/receipt remain operating acceptance work.

Target: `core/integration` only. No protected-main publication authority implied.