### PR TITLE
Core #182: integrate hardened Control Inbox → ONE bridge

### DIFF
--- a/.agent/scripts/agentos-control-inbox-bridge.service
+++ b/.agent/scripts/agentos-control-inbox-bridge.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=AgentOS ChatGPT Control Inbox to ONE Bridge
+Documentation=https://github.com/alston-personal/agentmanager/blob/core/integration/docs/CONTROL_INBOX_BRIDGE.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu/agentmanager
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=/home/ubuntu/.config/agentos/control-inbox.env
+ExecStart=/usr/bin/python3 -m agent_core.control_inbox_bridge
+Restart=on-failure
+RestartSec=5
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+
+# The bridge source/config is read-only at runtime; only its durable claim/result
+# state belongs under agent-data. Secrets stay in the external EnvironmentFile.
+ReadWritePaths=/home/ubuntu/agent-data/runtime/control-inbox
+
+[Install]
+WantedBy=default.target

--- a/.github/workflows/control-inbox-bridge-guard.yml
+++ b/.github/workflows/control-inbox-bridge-guard.yml
@@ -37,8 +37,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install test dependency
+        run: python -m pip install --disable-pip-version-check pytest
       - name: Run Control Inbox bridge regressions
-        run: python -m unittest tests.test_control_inbox_bridge -v
+        run: python -m pytest tests/test_control_inbox_bridge.py -q
       - name: Verify service is secret-free and bounded
         shell: bash
         run: |

--- a/.github/workflows/control-inbox-bridge-guard.yml
+++ b/.github/workflows/control-inbox-bridge-guard.yml
@@ -1,0 +1,54 @@
+name: Control Inbox Bridge Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agent_core/control_inbox_bridge.py'
+      - 'tests/test_control_inbox_bridge.py'
+      - '.agent/scripts/agentos-control-inbox-bridge.service'
+      - 'config/control-inbox.env.example'
+      - 'docs/CONTROL_INBOX_BRIDGE.md'
+      - 'docs/CHATGPT_ONE_TRANSPORT.md'
+      - '.github/workflows/control-inbox-bridge-guard.yml'
+  push:
+    branches:
+      - core/integration
+    paths:
+      - 'agent_core/control_inbox_bridge.py'
+      - 'tests/test_control_inbox_bridge.py'
+      - '.agent/scripts/agentos-control-inbox-bridge.service'
+      - 'config/control-inbox.env.example'
+      - 'docs/CONTROL_INBOX_BRIDGE.md'
+      - 'docs/CHATGPT_ONE_TRANSPORT.md'
+      - '.github/workflows/control-inbox-bridge-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bridge-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run Control Inbox bridge regressions
+        run: python -m unittest tests.test_control_inbox_bridge -v
+      - name: Verify service is secret-free and bounded
+        shell: bash
+        run: |
+          set -euo pipefail
+          unit=.agent/scripts/agentos-control-inbox-bridge.service
+          env_example=config/control-inbox.env.example
+          grep -F 'ExecStart=/usr/bin/python3 -m agent_core.control_inbox_bridge' "$unit"
+          grep -F 'EnvironmentFile=/home/ubuntu/.config/agentos/control-inbox.env' "$unit"
+          grep -F 'AGENTOS_CONTROL_ALLOWED_ACTIONS=' "$env_example"
+          if grep -Eiq '(github_pat_[A-Za-z0-9_]+|ghp_[A-Za-z0-9]+|Bearer[[:space:]]+[A-Za-z0-9._-]+)' "$unit" "$env_example"; then
+            echo 'secret-like literal found in source-controlled runtime contract' >&2
+            exit 1
+          fi

--- a/agent_core/control_inbox_bridge.py
+++ b/agent_core/control_inbox_bridge.py
@@ -8,17 +8,31 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 
 COMMAND_SCHEMA = 'agentos.control-command/v0.1'
 RESULT_SCHEMA = 'agentos.control-result/v0.1'
+STATE_SCHEMA = 'agentos.control-inbox-state/v0.2'
+LEGACY_STATE_SCHEMA = 'agentos.control-inbox-state/v0.1'
 DEFAULT_REPOSITORY = 'alston-personal/agentmanager'
 DEFAULT_ISSUE_NUMBER = 50
 DEFAULT_ALLOWED_LOGIN = 'alstonhuang'
 DEFAULT_ONE_URL = 'http://127.0.0.1:8780'
 MAX_COMMAND_LIFETIME_SECONDS = 600
+FORBIDDEN_ACTION_PREFIXES = (
+    'shell.', 'filesystem.', 'fs.', 'keyboard.', 'mouse.',
+    'gui.input', 'desktop.input',
+)
+COMMON_RECEIPT_FIELDS = (
+    'schema', 'node_id', 'task_id', 'action', 'ok', 'realm_id',
+    'received_at', 'started_at', 'completed_at', 'status', 'state',
+)
+
+
+class OneControllerError(RuntimeError):
+    """Safe ONE error containing only a stable classification code."""
 
 
 def _utc_now() -> datetime:
@@ -51,11 +65,93 @@ def _task_id(command_id: str) -> str:
     return 'ctl_' + digest
 
 
+def _is_forbidden_action(action: str) -> bool:
+    value = str(action or '').strip().lower()
+    return any(value.startswith(prefix) for prefix in FORBIDDEN_ACTION_PREFIXES)
+
+
+def _safe_scalar(value: Any) -> Any:
+    if isinstance(value, (bool, int, float)) or value is None:
+        return value
+    if isinstance(value, str):
+        # Receipts are evidence, not a secret-bearing debug channel.  Keep bounded
+        # scalar protocol data only; never echo authorization/token-like strings.
+        lowered = value.lower()
+        if any(marker in lowered for marker in ('bearer ', 'github_pat_', 'ghp_', 'token=', 'secret=')):
+            return '<redacted>'
+        return value[:256]
+    return None
+
+
+def _project_surface_inventory(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    projected: dict[str, Any] = {}
+    for key in ('schema', 'surface_count', 'capabilities', 'providers'):
+        item = value.get(key)
+        if isinstance(item, list):
+            projected[key] = [str(v)[:128] for v in item[:64] if isinstance(v, (str, int, float, bool))]
+        elif isinstance(item, (str, int, float, bool)):
+            projected[key] = _safe_scalar(item)
+    surfaces = []
+    for surface in value.get('surfaces') or []:
+        if not isinstance(surface, dict):
+            continue
+        safe = {}
+        for key in ('surface_id', 'provider', 'kind', 'running', 'attachable', 'capabilities'):
+            item = surface.get(key)
+            if isinstance(item, list):
+                safe[key] = [str(v)[:128] for v in item[:32] if isinstance(v, (str, int, float, bool))]
+            elif isinstance(item, (str, int, float, bool)) or item is None:
+                safe[key] = _safe_scalar(item)
+        surfaces.append(safe)
+    if surfaces:
+        projected['surfaces'] = surfaces[:64]
+    return projected
+
+
+def _project_receipt(receipt: Any, action: str) -> dict[str, Any] | None:
+    """Return bounded evidence; drop paths, usernames, titles and raw payloads."""
+    if not isinstance(receipt, dict):
+        return None
+    projected: dict[str, Any] = {}
+    for key in COMMON_RECEIPT_FIELDS:
+        if key in receipt:
+            safe = _safe_scalar(receipt.get(key))
+            if safe is not None or receipt.get(key) is None:
+                projected[key] = safe
+
+    if action == 'agent.surface.inspect':
+        inventory = _project_surface_inventory(receipt.get('surface_inventory'))
+        if inventory is not None:
+            projected['surface_inventory'] = inventory
+    elif action == 'desktop.session.inspect':
+        desktop = receipt.get('desktop')
+        if isinstance(desktop, dict):
+            projected['desktop'] = {
+                key: _safe_scalar(desktop.get(key))
+                for key in ('interactive', 'active_console_session_id', 'process_session_id')
+                if key in desktop
+            }
+    elif action == 'desktop.windows.inspect':
+        if isinstance(receipt.get('window_count'), int):
+            projected['window_count'] = receipt['window_count']
+        # Window titles and usernames are intentionally not published to GitHub.
+        processes = []
+        for window in receipt.get('windows') or []:
+            if isinstance(window, dict) and isinstance(window.get('process_name'), str):
+                processes.append(window['process_name'][:128])
+        if processes:
+            projected['processes'] = sorted(set(processes))[:64]
+    return projected
+
+
 @dataclass(frozen=True)
 class BridgeConfig:
     repository: str
     issue_number: int
     allowed_login: str
+    allowed_actions: frozenset[str]
     github_token: str
     controller_token: str
     one_url: str
@@ -63,19 +159,35 @@ class BridgeConfig:
     poll_seconds: float
     receipt_wait_seconds: int
 
+    def __post_init__(self) -> None:
+        if not self.allowed_login:
+            raise ValueError('allowed login is required')
+        if not self.allowed_actions:
+            raise ValueError('explicit control action allowlist is required')
+        if any(_is_forbidden_action(action) for action in self.allowed_actions):
+            raise ValueError('generic shell/filesystem/input action cannot be allowlisted')
+
     @classmethod
     def from_env(cls) -> 'BridgeConfig':
         github_token = str(os.environ.get('AGENTOS_GITHUB_TOKEN') or os.environ.get('GH_TOKEN') or '').strip()
         controller_token = str(os.environ.get('AGENTOS_CONTROLLER_TOKEN') or '').strip()
+        allowed_actions = frozenset(
+            value.strip()
+            for value in str(os.environ.get('AGENTOS_CONTROL_ALLOWED_ACTIONS') or '').split(',')
+            if value.strip()
+        )
         if not github_token:
             raise RuntimeError('AGENTOS_GITHUB_TOKEN or GH_TOKEN is required')
         if not controller_token:
             raise RuntimeError('AGENTOS_CONTROLLER_TOKEN is required')
+        if not allowed_actions:
+            raise RuntimeError('AGENTOS_CONTROL_ALLOWED_ACTIONS is required')
         data_root = Path(os.environ.get('AGENT_DATA_ROOT', '/home/ubuntu/agent-data'))
         return cls(
             repository=str(os.environ.get('AGENTOS_CONTROL_REPOSITORY') or DEFAULT_REPOSITORY),
             issue_number=int(os.environ.get('AGENTOS_CONTROL_ISSUE') or DEFAULT_ISSUE_NUMBER),
             allowed_login=str(os.environ.get('AGENTOS_CONTROL_ALLOWED_LOGIN') or DEFAULT_ALLOWED_LOGIN),
+            allowed_actions=allowed_actions,
             github_token=github_token,
             controller_token=controller_token,
             one_url=str(os.environ.get('AGENTOS_ONE_URL') or DEFAULT_ONE_URL).rstrip('/'),
@@ -101,7 +213,7 @@ class GitHubIssueClient:
                 'Accept': 'application/vnd.github+json',
                 'Authorization': f'Bearer {self.token}',
                 'X-GitHub-Api-Version': '2022-11-28',
-                'User-Agent': 'AgentOS-Control-Inbox/0.1',
+                'User-Agent': 'AgentOS-Control-Inbox/0.2',
                 'Content-Type': 'application/json',
             },
         )
@@ -154,14 +266,16 @@ class OneControllerClient:
         try:
             with urlopen(request, timeout=10) as response:
                 raw = response.read().decode('utf-8')
-                return int(response.status), json.loads(raw) if raw else None
+                try:
+                    body = json.loads(raw) if raw else None
+                except json.JSONDecodeError as exc:
+                    raise OneControllerError('one_protocol_invalid_json') from exc
+                return int(response.status), body
         except HTTPError as exc:
-            raw = exc.read().decode('utf-8')
-            try:
-                body = json.loads(raw) if raw else None
-            except json.JSONDecodeError:
-                body = {'error': raw}
-            return int(exc.code), body
+            # Never read or echo ONE's error body. It can contain internal details.
+            return int(exc.code), None
+        except (URLError, TimeoutError, OSError) as exc:
+            raise OneControllerError('one_unavailable') from exc
 
     def dispatch(self, node_id: str, command: dict[str, Any]) -> dict[str, Any]:
         args = command.get('args') or {}
@@ -174,16 +288,20 @@ class OneControllerClient:
             **args,
         }
         status, payload = self._request('POST', '/v1/controller/dispatch', body)
-        if status != 202 or not isinstance(payload, dict) or not payload.get('ok'):
-            raise RuntimeError(f'ONE dispatch failed: HTTP {status}: {payload}')
+        if not 200 <= status < 300:
+            raise OneControllerError(f'one_dispatch_http_{status}')
+        if not isinstance(payload, dict) or payload.get('ok') is not True:
+            raise OneControllerError('one_dispatch_protocol_error')
         return payload
 
     def receipt(self, task_id: str) -> dict[str, Any] | None:
         status, payload = self._request('GET', f'/v1/controller/receipts/{task_id}')
         if status == 404:
             return None
-        if status != 200 or not isinstance(payload, dict) or not payload.get('ok'):
-            raise RuntimeError(f'ONE receipt failed: HTTP {status}: {payload}')
+        if not 200 <= status < 300:
+            raise OneControllerError(f'one_receipt_http_{status}')
+        if not isinstance(payload, dict) or payload.get('ok') is not True:
+            raise OneControllerError('one_receipt_protocol_error')
         receipt = payload.get('receipt')
         return receipt if isinstance(receipt, dict) else None
 
@@ -196,11 +314,14 @@ class ControlInboxBridge:
 
     def _load_state(self) -> dict[str, Any]:
         if not self.config.state_path.exists():
-            return {'schema': 'agentos.control-inbox-state/v0.1', 'processed_comment_ids': []}
+            return {'schema': STATE_SCHEMA, 'processed_comment_ids': [], 'commands': {}}
         data = json.loads(self.config.state_path.read_text(encoding='utf-8'))
-        if data.get('schema') != 'agentos.control-inbox-state/v0.1':
+        schema = data.get('schema')
+        if schema not in {STATE_SCHEMA, LEGACY_STATE_SCHEMA}:
             raise ValueError('invalid control inbox state')
+        data['schema'] = STATE_SCHEMA
         data.setdefault('processed_comment_ids', [])
+        data.setdefault('commands', {})
         return data
 
     def _save_state(self, state: dict[str, Any]) -> None:
@@ -211,26 +332,31 @@ class ControlInboxBridge:
 
     def _validate_command(self, payload: dict[str, Any]) -> dict[str, Any]:
         if payload.get('schema') != COMMAND_SCHEMA:
-            raise ValueError('invalid command schema')
+            raise ValueError('invalid_command_schema')
         command_id = str(payload.get('command_id') or '').strip()
         node_id = str(payload.get('node_id') or '').strip()
         action = str(payload.get('action') or '').strip()
-        issued_at = _parse_utc(str(payload.get('issued_at') or ''))
-        expires_at = _parse_utc(str(payload.get('expires_at') or ''))
+        try:
+            issued_at = _parse_utc(str(payload.get('issued_at') or ''))
+            expires_at = _parse_utc(str(payload.get('expires_at') or ''))
+        except (TypeError, ValueError) as exc:
+            raise ValueError('invalid_command_time') from exc
         now = _utc_now()
         if not command_id or not node_id or not action:
-            raise ValueError('command_id, node_id and action are required')
+            raise ValueError('missing_command_identity')
+        if action not in self.config.allowed_actions or _is_forbidden_action(action):
+            raise ValueError('unauthorized_action')
         if issued_at > now + timedelta(seconds=60):
-            raise ValueError('issued_at is in the future')
+            raise ValueError('issued_at_in_future')
         if expires_at <= now:
-            raise ValueError('command expired')
+            raise ValueError('command_expired')
         if expires_at <= issued_at:
-            raise ValueError('expires_at must be after issued_at')
+            raise ValueError('invalid_expiry_window')
         if (expires_at - issued_at).total_seconds() > MAX_COMMAND_LIFETIME_SECONDS:
-            raise ValueError('command lifetime exceeds bootstrap limit')
+            raise ValueError('command_lifetime_exceeds_limit')
         args = payload.get('args') or {}
         if not isinstance(args, dict):
-            raise ValueError('args must be an object')
+            raise ValueError('invalid_args')
         return {
             'schema': COMMAND_SCHEMA,
             'command_id': command_id,
@@ -241,25 +367,58 @@ class ControlInboxBridge:
             'args': args,
         }
 
-    def _result(self, command: dict[str, Any], *, status: str, task_id: str | None = None, receipt: dict[str, Any] | None = None, error: str | None = None) -> dict[str, Any]:
+    def _result(self, command: dict[str, Any], *, status: str,
+                task_id: str | None = None, receipt: dict[str, Any] | None = None,
+                error: str | None = None) -> dict[str, Any]:
         result: dict[str, Any] = {
             'schema': RESULT_SCHEMA,
-            'command_id': command.get('command_id'),
-            'node_id': command.get('node_id'),
-            'action': command.get('action'),
+            'command_id': str(command.get('command_id') or 'unknown')[:160],
+            'node_id': str(command.get('node_id') or 'unknown')[:160],
+            'action': str(command.get('action') or 'unknown')[:160],
             'status': status,
             'observed_at': _iso(),
         }
         if task_id:
-            result['task_id'] = task_id
+            result['task_id'] = task_id[:160]
         if receipt is not None:
-            result['receipt'] = receipt
+            projected = _project_receipt(receipt, result['action'])
+            if projected is not None:
+                result['receipt'] = projected
         if error:
-            result['error'] = error
+            result['error'] = str(error)[:160]
         return result
+
+    def _terminal(self, state: dict[str, Any], command_id: str,
+                  result: dict[str, Any], *, posted: bool = False) -> None:
+        state['commands'][command_id] = {
+            'phase': 'terminal', 'result': result, 'posted': posted, 'updated_at': _iso(),
+        }
+        self._save_state(state)
+
+    def _flush_pending(self, state: dict[str, Any]) -> int:
+        posted = 0
+        for command_id, entry in list(state.get('commands', {}).items()):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get('phase') == 'claimed':
+                # We cannot know whether ONE executed after a crash. Never redispatch.
+                command = entry.get('command') if isinstance(entry.get('command'), dict) else {'command_id': command_id}
+                result = self._result(command, status='unknown', error='bridge_interrupted_after_claim')
+                self._terminal(state, command_id, result, posted=False)
+                entry = state['commands'][command_id]
+            if entry.get('phase') == 'terminal' and not entry.get('posted'):
+                result = entry.get('result')
+                if isinstance(result, dict):
+                    self.github.post_result(result)
+                    entry['posted'] = True
+                    entry['updated_at'] = _iso()
+                    self._save_state(state)
+                    posted += 1
+        return posted
 
     def process_once(self) -> int:
         state = self._load_state()
+        self._flush_pending(state)
         processed = {int(value) for value in state.get('processed_comment_ids') or []}
         handled = 0
         for comment in self.github.comments():
@@ -270,13 +429,42 @@ class ControlInboxBridge:
             payload = _json_from_comment(str(comment.get('body') or ''))
             if author != self.config.allowed_login or payload is None or payload.get('schema') != COMMAND_SCHEMA:
                 processed.add(comment_id)
+                state['processed_comment_ids'] = sorted(processed)[-2000:]
+                self._save_state(state)
                 continue
 
-            command: dict[str, Any] = payload
+            command_id = str(payload.get('command_id') or f'comment:{comment_id}')
+            if command_id in state['commands']:
+                processed.add(comment_id)
+                state['processed_comment_ids'] = sorted(processed)[-2000:]
+                self._save_state(state)
+                continue
+
             try:
                 command = self._validate_command(payload)
+            except ValueError as exc:
+                result = self._result(payload, status='rejected', error=str(exc))
+                processed.add(comment_id)
+                state['processed_comment_ids'] = sorted(processed)[-2000:]
+                self._terminal(state, command_id, result, posted=False)
+                self.github.post_result(result)
+                state['commands'][command_id]['posted'] = True
+                self._save_state(state)
+                handled += 1
+                continue
+
+            # Persist the privileged boundary before dispatch. A restart after this
+            # point becomes `unknown`; it never silently replays the command.
+            processed.add(comment_id)
+            state['processed_comment_ids'] = sorted(processed)[-2000:]
+            state['commands'][command_id] = {
+                'phase': 'claimed', 'command': command, 'claimed_at': _iso(),
+            }
+            self._save_state(state)
+
+            try:
                 dispatch = self.one.dispatch(command['node_id'], command)
-                task_id = str(dispatch.get('task_id') or '')
+                task_id = str(dispatch.get('task_id') or _task_id(command_id))
                 deadline = time.monotonic() + self.config.receipt_wait_seconds
                 receipt = None
                 while time.monotonic() < deadline:
@@ -285,23 +473,28 @@ class ControlInboxBridge:
                         break
                     time.sleep(1)
                 status = 'completed' if receipt is not None else 'queued'
-                self.github.post_result(self._result(command, status=status, task_id=task_id, receipt=receipt))
-            except Exception as exc:
-                self.github.post_result(self._result(command, status='error', error=f'{type(exc).__name__}: {exc}'))
+                result = self._result(command, status=status, task_id=task_id, receipt=receipt)
+            except OneControllerError as exc:
+                result = self._result(command, status='error', error=str(exc))
+            except Exception:
+                # Deliberately do not serialize exception text: unexpected exceptions
+                # can contain headers, paths, args or backend payloads.
+                result = self._result(command, status='error', error='bridge_internal_error')
 
-            processed.add(comment_id)
-            handled += 1
-            state['processed_comment_ids'] = sorted(processed)[-1000:]
-            state['updated_at'] = _iso()
+            self._terminal(state, command_id, result, posted=False)
+            self.github.post_result(result)
+            state['commands'][command_id]['posted'] = True
             self._save_state(state)
+            handled += 1
         return handled
 
     def run_forever(self) -> None:
         while True:
             try:
                 self.process_once()
-            except Exception as exc:
-                print(f'control_inbox_bridge_error={type(exc).__name__}: {exc}', flush=True)
+            except Exception:
+                # Keep the daemon alive without echoing secret-bearing exceptions.
+                print('control_inbox_bridge_error=cycle_failed', flush=True)
             time.sleep(self.config.poll_seconds)
 
 

--- a/config/control-inbox.env.example
+++ b/config/control-inbox.env.example
@@ -1,0 +1,22 @@
+# AgentOS Control Inbox bridge runtime contract.
+# Copy to a host-local file such as:
+#   /home/ubuntu/.config/agentos/control-inbox.env
+# and chmod 600. Never commit the populated secret file.
+
+AGENTOS_GITHUB_TOKEN=
+AGENTOS_CONTROLLER_TOKEN=
+
+AGENTOS_CONTROL_REPOSITORY=alston-personal/agentmanager
+AGENTOS_CONTROL_ISSUE=50
+AGENTOS_CONTROL_ALLOWED_LOGIN=alstonhuang
+
+# Mandatory local fence. Keep this to typed bounded actions only.
+# Generic shell/filesystem/keyboard/mouse/input actions are rejected even if
+# accidentally listed here.
+AGENTOS_CONTROL_ALLOWED_ACTIONS=agent.surface.inspect,desktop.session.inspect,desktop.windows.inspect
+
+AGENTOS_ONE_URL=http://127.0.0.1:8780
+AGENT_DATA_ROOT=/home/ubuntu/agent-data
+AGENTOS_CONTROL_STATE=/home/ubuntu/agent-data/runtime/control-inbox/state.json
+AGENTOS_CONTROL_POLL_SECONDS=3
+AGENTOS_CONTROL_RECEIPT_WAIT_SECONDS=45

--- a/docs/CONTROL_INBOX_BRIDGE.md
+++ b/docs/CONTROL_INBOX_BRIDGE.md
@@ -1,0 +1,67 @@
+# Control Inbox → ONE Bridge
+
+Status: Core #182 static hardening candidate. This document describes the source-controlled bridge/runtime contract; it does **not** claim that the hardened unit is already installed or running on Oracle.
+
+## Purpose
+
+For ChatGPT plans/surfaces that do not yet expose a native authorized ONE write transport, the bootstrap path remains:
+
+```text
+ChatGPT Web -> GitHub Issue #50 mailbox -> Control Inbox bridge -> ONE ControllerService -> Node
+```
+
+GitHub is only the temporary mailbox. ONE remains the control-plane authority. GitHub Actions is not a fallback carrier for AgentOS control-plane intents.
+
+## Source of truth
+
+- bridge: `agent_core/control_inbox_bridge.py`
+- regressions: `tests/test_control_inbox_bridge.py`
+- service template: `.agent/scripts/agentos-control-inbox-bridge.service`
+- non-secret environment example: `config/control-inbox.env.example`
+
+## Security contract
+
+The bridge accepts only `agentos.control-command/v0.1` JSON comments from the configured login, for the configured repository/issue, before command expiry, and only when `action` is present in the mandatory local `AGENTOS_CONTROL_ALLOWED_ACTIONS` set.
+
+The local allowlist is an additional fence, not a replacement for ONE authorization. Generic shell, filesystem and input action prefixes are rejected even if accidentally configured. The bridge does not provide arbitrary executable/argv authority.
+
+Commands have a maximum lifetime of 600 seconds and a small positive clock-skew allowance. Expired commands never dispatch.
+
+## Delivery/idempotency contract
+
+A deterministic ONE task id is derived from `command_id`. The bridge persists a command claim **before** dispatch. If the process dies after claim but before a terminal result, restart must not blindly redispatch the privileged operation; the result becomes `unknown` / `bridge_interrupted_after_claim` until independently verified.
+
+Terminal results are persisted before GitHub publication. Unposted terminal results are retried on later cycles. This gives at-least-once result publication without pretending privileged side effects are known after an interrupted claim.
+
+## ONE protocol handling
+
+A dispatch succeeds only for HTTP 2xx plus a structured object with `ok: true`. The bridge does not hard-code HTTP 202. HTTP error bodies are not copied into exceptions/results. Transport/protocol failures use bounded stable classifications such as `one_unavailable`, `one_dispatch_http_500`, or `one_dispatch_protocol_error`.
+
+## Receipt privacy boundary
+
+GitHub results are evidence, not a debug dump. Receipts are projected to bounded action-specific fields. In particular, the public mailbox must not receive local usernames, executable/private paths, window titles, bearer tokens, raw vendor/session payloads, or arbitrary backend error bodies.
+
+## Runtime environment
+
+Populate a host-local environment file based on `config/control-inbox.env.example`; the source-controlled example intentionally contains no secrets. The service template expects `/home/ubuntu/.config/agentos/control-inbox.env` and runs the module from `/home/ubuntu/agentmanager`.
+
+Required secrets:
+- `AGENTOS_GITHUB_TOKEN` (or `GH_TOKEN`)
+- `AGENTOS_CONTROLLER_TOKEN`
+
+Required authority fence:
+- `AGENTOS_CONTROL_ALLOWED_ACTIONS`
+
+The durable bridge state defaults under `/home/ubuntu/agent-data/runtime/control-inbox/state.json` and must be writable by the service identity. The populated environment file should be mode 0600 and must never be committed.
+
+## Deployment boundary
+
+Merging the static source/service contract to `core/integration` does not install, enable, restart, or mutate the Oracle runtime. Deployment requires an independently authorized bounded runtime path and a post-deploy probe. Do not use GitHub Actions as a generic control-plane substitute to install this service.
+
+Issue #50 is a machine mailbox, not an engineering discussion thread. Source/CI work for #182 must not post probe or status comments there unless an explicitly authorized live acceptance requires it.
+
+## Verification
+
+The hosted guard runs `tests.test_control_inbox_bridge` without Oracle/self-hosted runners. Static tests cover author/schema/expiry fencing, duplicate command handling, interrupted-claim UNKNOWN semantics, 2xx protocol handling, safe HTTP failures, privacy projection, unexpected-error redaction, and generic-action rejection.
+
+Live acceptance is separate: after governed deployment, a fresh authorized control command must traverse the mailbox → hardened bridge → ONE and return a sanitized receipt, with no GitHub Actions control-plane fallback.

--- a/tests/test_control_inbox_bridge.py
+++ b/tests/test_control_inbox_bridge.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 
-from agent_core.control_inbox_bridge import BridgeConfig, ControlInboxBridge, _task_id
+import pytest
+
+from agent_core.control_inbox_bridge import (
+    BridgeConfig,
+    ControlInboxBridge,
+    OneControllerClient,
+    OneControllerError,
+    _project_receipt,
+    _task_id,
+)
 from agent_core.controller_api import ControllerService
 
 
@@ -17,9 +27,9 @@ class FakeRegistry:
             'nodes': [{
                 'node_id': 'node-a',
                 'status': 'online',
-                'capabilities': ['agent.surface.inspect', 'desktop.open_url'],
+                'capabilities': ['agent.surface.inspect', 'desktop.session.inspect'],
             }],
-            'realm_capabilities': ['agent.surface.inspect', 'desktop.open_url'],
+            'realm_capabilities': ['agent.surface.inspect', 'desktop.session.inspect'],
             'realm_tool_presence': [],
             'realm_surface_providers': [],
         }
@@ -55,23 +65,37 @@ class FakeGitHub:
 
 
 class FakeOne:
-    def __init__(self, receipt=None):
+    def __init__(self, receipt=None, error: Exception | None = None):
         self.dispatched = []
         self._receipt = receipt
+        self.error = error
 
     def dispatch(self, node_id, command):
         self.dispatched.append((node_id, command))
+        if self.error:
+            raise self.error
         return {'ok': True, 'task_id': _task_id(command['command_id']), 'state': 'queued'}
 
     def receipt(self, task_id):
         return self._receipt
 
 
-def _config(tmp_path: Path) -> BridgeConfig:
+class StubOneControllerClient(OneControllerClient):
+    def __init__(self, status, payload):
+        super().__init__('http://127.0.0.1:8780', 'unused')
+        self.status = status
+        self.payload = payload
+
+    def _request(self, method, path, payload=None):
+        return self.status, self.payload
+
+
+def _config(tmp_path: Path, *, actions=None) -> BridgeConfig:
     return BridgeConfig(
         repository='alston-personal/agentmanager',
         issue_number=50,
         allowed_login='alstonhuang',
+        allowed_actions=frozenset(actions or {'agent.surface.inspect', 'desktop.session.inspect'}),
         github_token='unused',
         controller_token='unused',
         one_url='http://127.0.0.1:8780',
@@ -81,76 +105,198 @@ def _config(tmp_path: Path) -> BridgeConfig:
     )
 
 
-def _command(*, expired: bool = False):
+def _command(*, command_id='cmd_test_1', action='agent.surface.inspect', expired=False, schema='agentos.control-command/v0.1'):
     now = datetime.now(timezone.utc).replace(microsecond=0)
     issued = now - timedelta(minutes=2) if expired else now - timedelta(seconds=1)
     expires = now - timedelta(seconds=1) if expired else now + timedelta(minutes=2)
     return {
-        'schema': 'agentos.control-command/v0.1',
-        'command_id': 'cmd_test_1',
+        'schema': schema,
+        'command_id': command_id,
         'issued_at': issued.isoformat().replace('+00:00', 'Z'),
         'expires_at': expires.isoformat().replace('+00:00', 'Z'),
         'node_id': 'node-a',
-        'action': 'agent.surface.inspect',
+        'action': action,
         'args': {},
     }
+
+
+def _comment(comment_id, command, login='alstonhuang'):
+    return {'id': comment_id, 'user': {'login': login}, 'body': json.dumps(command)}
 
 
 def test_controller_dispatch_reuses_same_task_id_without_duplicate_queue():
     fabric = FakeFabric()
     controller = ControllerService(fabric)
     request = {'action': 'agent.surface.inspect', 'task_id': 'ctl_same'}
-
     first = controller.dispatch('node-a', request)
     second = controller.dispatch('node-a', request)
-
     assert first['reused'] is False
     assert second['reused'] is True
     assert second['state'] == 'queued'
     assert len(fabric.data['tasks']['node-a']) == 1
 
 
-def test_bridge_dispatches_allowed_fresh_command_and_posts_receipt(tmp_path: Path):
+def test_bridge_dispatches_fresh_command_and_posts_bounded_receipt(tmp_path: Path):
     command = _command()
-    github = FakeGitHub([{'id': 101, 'user': {'login': 'alstonhuang'}, 'body': __import__('json').dumps(command)}])
+    github = FakeGitHub([_comment(101, command)])
     receipt = {
         'schema': 'agentos.node-receipt/v0.1',
         'node_id': 'node-a',
         'task_id': _task_id(command['command_id']),
         'action': 'agent.surface.inspect',
         'ok': True,
+        'surface_inventory': {
+            'schema': 'agentos.surface-inventory/v0.1',
+            'surface_count': 1,
+            'providers': ['vscode'],
+            'capabilities': ['ide.inspect'],
+            'surfaces': [{
+                'surface_id': 'ide:vscode', 'provider': 'vscode', 'kind': 'ide',
+                'running': True, 'capabilities': ['ide.inspect'],
+                'executable': 'C:/Users/private/path/code.cmd',
+                'metadata': {'secret': 'do-not-publish'},
+            }],
+        },
     }
     one = FakeOne(receipt)
     bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
-
     assert bridge.process_once() == 1
-    assert one.dispatched[0][0] == 'node-a'
-    assert github.results[0]['status'] == 'completed'
-    assert github.results[0]['receipt']['ok'] is True
-
-    # Local state prevents replay on the next poll.
-    assert bridge.process_once() == 0
     assert len(one.dispatched) == 1
+    assert github.results[0]['status'] == 'completed'
+    rendered = json.dumps(github.results[0])
+    assert 'C:/Users/private' not in rendered
+    assert 'do-not-publish' not in rendered
+    assert github.results[0]['receipt']['surface_inventory']['providers'] == ['vscode']
 
 
 def test_bridge_ignores_untrusted_author(tmp_path: Path):
     command = _command()
-    github = FakeGitHub([{'id': 102, 'user': {'login': 'someone-else'}, 'body': __import__('json').dumps(command)}])
+    github = FakeGitHub([_comment(102, command, login='someone-else')])
     one = FakeOne()
     bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
-
     assert bridge.process_once() == 0
     assert one.dispatched == []
     assert github.results == []
 
 
-def test_bridge_rejects_expired_command_without_dispatch(tmp_path: Path):
-    command = _command(expired=True)
-    github = FakeGitHub([{'id': 103, 'user': {'login': 'alstonhuang'}, 'body': __import__('json').dumps(command)}])
+def test_invalid_schema_is_not_a_command(tmp_path: Path):
+    github = FakeGitHub([_comment(103, _command(schema='something-else'))])
     one = FakeOne()
     bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
+    assert bridge.process_once() == 0
+    assert one.dispatched == []
+    assert github.results == []
 
+
+def test_expired_command_is_rejected_before_dispatch(tmp_path: Path):
+    github = FakeGitHub([_comment(104, _command(expired=True))])
+    one = FakeOne()
+    bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
     assert bridge.process_once() == 1
     assert one.dispatched == []
-    assert github.results[0]['status'] == 'error'
-    assert 'command expired' in github.results[0]['error']
+    assert github.results[0]['status'] == 'rejected'
+    assert github.results[0]['error'] == 'command_expired'
+
+
+def test_duplicate_command_id_dispatches_once_even_with_two_comments(tmp_path: Path):
+    first = _command(command_id='same')
+    second = _command(command_id='same')
+    github = FakeGitHub([_comment(105, first), _comment(106, second)])
+    receipt = {'schema': 'agentos.node-receipt/v0.1', 'node_id': 'node-a', 'action': 'agent.surface.inspect', 'ok': True}
+    one = FakeOne(receipt)
+    bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
+    assert bridge.process_once() == 1
+    assert len(one.dispatched) == 1
+    assert len(github.results) == 1
+
+
+def test_restart_after_claim_reports_unknown_and_never_redispatches(tmp_path: Path):
+    command = _command(command_id='interrupted')
+    github = FakeGitHub([])
+    one = FakeOne()
+    bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
+    state = bridge._load_state()
+    state['commands']['interrupted'] = {
+        'phase': 'claimed', 'command': command, 'claimed_at': command['issued_at'],
+    }
+    bridge._save_state(state)
+
+    restarted = ControlInboxBridge(_config(tmp_path), github=github, one=one)
+    assert restarted.process_once() == 0
+    assert one.dispatched == []
+    assert github.results[0]['status'] == 'unknown'
+    assert github.results[0]['error'] == 'bridge_interrupted_after_claim'
+
+
+def test_http_200_ok_dispatch_is_accepted_not_misclassified():
+    client = StubOneControllerClient(200, {
+        'ok': True, 'task_id': 'ctl_200', 'state': 'queued',
+        'schema': 'agentos.controller-dispatch-receipt/v0.1',
+    })
+    result = client.dispatch('node-a', _command())
+    assert result['ok'] is True
+    assert result['state'] == 'queued'
+
+
+@pytest.mark.parametrize('status', [400, 404, 500, 503])
+def test_http_error_classification_does_not_echo_backend_body(status):
+    secret_body = {'ok': False, 'error': 'authorization=Bearer SUPERSECRET internal path /srv/private'}
+    client = StubOneControllerClient(status, secret_body)
+    with pytest.raises(OneControllerError) as exc:
+        client.dispatch('node-a', _command())
+    text = str(exc.value)
+    assert text == f'one_dispatch_http_{status}'
+    assert 'SUPERSECRET' not in text
+    assert '/srv/private' not in text
+
+
+def test_malformed_2xx_dispatch_is_protocol_error():
+    client = StubOneControllerClient(200, {'ok': False, 'debug': 'secret'})
+    with pytest.raises(OneControllerError, match='one_dispatch_protocol_error'):
+        client.dispatch('node-a', _command())
+
+
+def test_unexpected_exception_text_is_not_published(tmp_path: Path):
+    github = FakeGitHub([_comment(107, _command())])
+    one = FakeOne(error=RuntimeError('Bearer SUPERSECRET /home/private/file'))
+    bridge = ControlInboxBridge(_config(tmp_path), github=github, one=one)
+    assert bridge.process_once() == 1
+    assert github.results[0]['error'] == 'bridge_internal_error'
+    assert 'SUPERSECRET' not in json.dumps(github.results[0])
+
+
+def test_receipt_projection_drops_username_paths_and_window_titles():
+    session = _project_receipt({
+        'schema': 'agentos.node-receipt/v0.1', 'ok': True,
+        'desktop': {'interactive': True, 'active_console_session_id': 1, 'username': 'private-user', 'pid': 99},
+    }, 'desktop.session.inspect')
+    assert session['desktop'] == {'interactive': True, 'active_console_session_id': 1}
+    assert 'private-user' not in json.dumps(session)
+
+    windows = _project_receipt({
+        'schema': 'agentos.node-receipt/v0.1', 'ok': True, 'window_count': 2,
+        'windows': [
+            {'process_name': 'chrome.exe', 'title': 'private mail subject'},
+            {'process_name': 'code.exe', 'title': 'C:/Users/private/project'},
+        ],
+    }, 'desktop.windows.inspect')
+    assert windows['window_count'] == 2
+    assert windows['processes'] == ['chrome.exe', 'code.exe']
+    rendered = json.dumps(windows)
+    assert 'private mail subject' not in rendered
+    assert 'C:/Users/private' not in rendered
+
+
+def test_generic_execution_action_cannot_be_allowlisted(tmp_path: Path):
+    with pytest.raises(ValueError, match='cannot be allowlisted'):
+        _config(tmp_path, actions={'shell.exec'})
+
+
+def test_action_not_in_local_allowlist_is_rejected(tmp_path: Path):
+    github = FakeGitHub([_comment(108, _command(action='desktop.session.inspect'))])
+    one = FakeOne()
+    bridge = ControlInboxBridge(_config(tmp_path, actions={'agent.surface.inspect'}), github=github, one=one)
+    assert bridge.process_once() == 1
+    assert one.dispatched == []
+    assert github.results[0]['status'] == 'rejected'
+    assert github.results[0]['error'] == 'unauthorized_action'


### PR DESCRIPTION
## Supersedes draft #187

Reopens the exact same source head `c126804f9125a7e9e2ffa620400dcb2780efac2a` against `core/integration` because the connected GitHub draft→ready mutation is currently broken. No source change was made to bypass review/branch authority.

## Static hardening in this slice
- HTTP 2xx + structured `ok:true` dispatch semantics; no hard-coded 202;
- raw ONE HTTP error bodies never echoed to GitHub;
- mandatory local typed-action allowlist and generic shell/filesystem/input fence;
- expiry/max-lifetime/skew validation;
- claim-before-dispatch persistence and restart → UNKNOWN/no blind redispatch;
- persisted terminal outbox retry;
- bounded action-specific receipt projection dropping usernames/private paths/window titles/raw payloads;
- stable internal error classifications;
- source-controlled secret-free systemd/env runtime contract;
- dedicated hosted CI guard and existing Control Inbox contract tests.

Exact-head evidence before reopening: Control Inbox Bridge Guard run `33586294406` SUCCESS and AgentOS Control Inbox Contract run `33586294420` SUCCESS.

## Explicit non-claims
This merge does not install/restart the Oracle service and does not prove live fresh-session #179 acceptance. Runtime deployment requires a separately authorized bounded path. This work posts no machine command/status comment to Issue #50.

Target: `core/integration` only; no protected-main publication authority implied.