### PR TITLE
Core #175: reconcile legacy product integration carrier noise

### DIFF
--- a/.github/workflows/product-deployment-carrier-guard.yml
+++ b/.github/workflows/product-deployment-carrier-guard.yml
@@ -1,0 +1,36 @@
+name: Product Deployment Carrier Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'governance/product-deployment-carriers.json'
+      - 'tests/test_product_deployment_carriers.py'
+      - '.github/workflows/product-deployment-carrier-guard.yml'
+  push:
+    branches:
+      - core/issue-175-legacy-carrier-reconciliation
+      - core/integration
+    paths:
+      - 'governance/product-deployment-carriers.json'
+      - 'tests/test_product_deployment_carriers.py'
+      - '.github/workflows/product-deployment-carrier-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  carrier-registry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate registry JSON
+        run: python -m json.tool governance/product-deployment-carriers.json >/dev/null
+      - name: Run carrier governance regressions
+        run: python -m unittest tests.test_product_deployment_carriers -v

--- a/.github/workflows/transport-routing-guard.yml
+++ b/.github/workflows/transport-routing-guard.yml
@@ -9,6 +9,8 @@ on:
       - agent_core/transport_routing.py
       - governance/transport-routing.json
       - tests/test_transport_routing.py
+      - governance/product-deployment-carriers.json
+      - tests/test_product_deployment_carriers.py
       - docs/CHATGPT_ONE_TRANSPORT.md
       - AGENTS.md
       - docs/CURRENT_STATE.md
@@ -20,6 +22,8 @@ on:
       - agent_core/transport_routing.py
       - governance/transport-routing.json
       - tests/test_transport_routing.py
+      - governance/product-deployment-carriers.json
+      - tests/test_product_deployment_carriers.py
       - docs/CHATGPT_ONE_TRANSPORT.md
       - AGENTS.md
       - docs/CURRENT_STATE.md
@@ -71,3 +75,13 @@ jobs:
           assert policy['failure_semantics']['control_plane_transport_unavailable'] == 'fail_closed'
           assert policy['failure_semantics']['control_plane_transport_error'] == 'surface_error_no_workflow_fallback'
           PY
+
+  deployment-carrier-classification:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate product deployment carrier JSON
+        run: python3 -m json.tool governance/product-deployment-carriers.json >/dev/null
+      - name: Assert no-job legacy Actions noise is not transport evidence
+        run: python3 -m unittest tests.test_product_deployment_carriers -v

--- a/governance/product-deployment-carriers.json
+++ b/governance/product-deployment-carriers.json
@@ -1,6 +1,6 @@
 {
   "schema": "agentos.product-deployment-carriers/v0",
-  "generated_at": "2026-08-31T06:36:00Z",
+  "generated_at": "2026-09-02T03:23:00Z",
   "umbrella_issue": 118,
   "worker_issue": 175,
   "invariants": [
@@ -67,6 +67,23 @@
     },
     {
       "project_id": "layoutlib",
+      "workflow": ".github/workflows/oracle-integrate-layoutlab-official-site.yml",
+      "classification": "legacy_product_integration_carrier_validation_noise_observed",
+      "runtime_effect": "intended product integration/deployment carrier; no job started in observed run",
+      "trigger": "workflow_dispatch + push paths including workflow and Layout Lab integration script",
+      "generic_core_trigger_risk": false,
+      "observed_run": 33456886112,
+      "observed_conclusion": "failure",
+      "observed_jobs": 0,
+      "observed_runner_claim": false,
+      "observed_privileged_execution": false,
+      "observed_runtime_side_effect": "none_from_this_run",
+      "transport_routing_evidence": false,
+      "safe_immediate_action": "classify/fence under #175 without treating jobs=0 validation noise as a deploy or as ChatGPT control-plane carrier selection; preserve unique product semantics until replacement parity",
+      "retire_owner": "agentos-core#175 + agentos-core#96 + alston-personal/layoutlib#2"
+    },
+    {
+      "project_id": "layoutlib",
       "workflow": ".github/workflows/oracle-release-layoutlab-v07.yml",
       "classification": "retired_positive_pattern",
       "runtime_effect": "none; canonical-source notice only",
@@ -103,6 +120,23 @@
       "contents_permission": "write",
       "evidence": "direct git push",
       "safe_immediate_action": "preserve pinned working carrier; replace evidence write and migrate toward product request + Core #165 execution boundary",
+      "retire_owner": "agentos-core#175 + agentos-core#165 + alston-personal/vendor-reputation-service#27"
+    },
+    {
+      "project_id": "vendor-reputation",
+      "workflow": ".github/workflows/oracle-integrate-vendor-reputation.yml",
+      "classification": "legacy_product_integration_carrier_validation_noise_observed",
+      "runtime_effect": "intended product integration/deployment carrier; no job started in observed run",
+      "trigger": "workflow_dispatch + push paths on legacy vendor integration carrier",
+      "generic_core_trigger_risk": false,
+      "observed_run": 33456886833,
+      "observed_conclusion": "failure",
+      "observed_jobs": 0,
+      "observed_runner_claim": false,
+      "observed_privileged_execution": false,
+      "observed_runtime_side_effect": "none_from_this_run",
+      "transport_routing_evidence": false,
+      "safe_immediate_action": "classify/fence under #175 without treating jobs=0 validation noise as a deploy or as ChatGPT control-plane carrier selection; preserve unique product semantics until #165/product-owned replacement parity",
       "retire_owner": "agentos-core#175 + agentos-core#165 + alston-personal/vendor-reputation-service#27"
     },
     {

--- a/tests/test_product_deployment_carriers.py
+++ b/tests/test_product_deployment_carriers.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REGISTRY = Path(__file__).resolve().parents[1] / "governance" / "product-deployment-carriers.json"
+NO_JOB_CLASS = "legacy_product_integration_carrier_validation_noise_observed"
+
+
+class ProductDeploymentCarrierRegistryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        cls.carriers = cls.data["carriers"]
+
+    def test_schema_and_worker_are_canonical(self):
+        self.assertEqual(
+            self.data["schema"],
+            "agentos.product-deployment-carriers/v0",
+        )
+        self.assertEqual(self.data["worker_issue"], 175)
+
+    def test_workflow_paths_are_unique(self):
+        workflows = [item["workflow"] for item in self.carriers]
+        self.assertEqual(len(workflows), len(set(workflows)))
+
+    def test_observed_no_job_runs_cannot_be_transport_or_runtime_evidence(self):
+        observed = [
+            item for item in self.carriers
+            if item.get("classification") == NO_JOB_CLASS
+        ]
+        self.assertGreaterEqual(len(observed), 2)
+        for item in observed:
+            self.assertEqual(item.get("observed_jobs"), 0)
+            self.assertFalse(item.get("observed_runner_claim"))
+            self.assertFalse(item.get("observed_privileged_execution"))
+            self.assertEqual(
+                item.get("observed_runtime_side_effect"),
+                "none_from_this_run",
+            )
+            self.assertFalse(item.get("transport_routing_evidence"))
+
+    def test_known_no_job_noise_is_persisted(self):
+        by_workflow = {item["workflow"]: item for item in self.carriers}
+        layout = by_workflow[
+            ".github/workflows/oracle-integrate-layoutlab-official-site.yml"
+        ]
+        vendor = by_workflow[
+            ".github/workflows/oracle-integrate-vendor-reputation.yml"
+        ]
+        self.assertEqual(layout["observed_run"], 33456886112)
+        self.assertEqual(vendor["observed_run"], 33456886833)
+        self.assertEqual(layout["observed_jobs"], 0)
+        self.assertEqual(vendor["observed_jobs"], 0)
+
+    def test_registry_preserves_working_carrier_invariant(self):
+        self.assertIn(
+            "working_carriers_are_preserved_until_verified_replacements_exist",
+            self.data["invariants"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Reconcile two observed legacy product integration workflow failures into the canonical product deployment-carrier registry without treating validation/no-job noise as runtime execution or ChatGPT transport evidence.

## Adds
- explicit carrier entries for `.github/workflows/oracle-integrate-layoutlab-official-site.yml` and `.github/workflows/oracle-integrate-vendor-reputation.yml`;
- observed run IDs, `jobs=0`, no runner claim, no privileged execution, no runtime side effect from those runs, and `transport_routing_evidence=false`;
- regression tests enforcing unique workflow registration and no-job classification semantics;
- hosted read-only Product Deployment Carrier Guard.

## Preserved invariant
Working product carriers are not blanket-disabled or deleted before product-owned replacement/parity. This PR classifies evidence only; it performs no product deployment and grants no release/runtime authority.

Target: `core/integration` only. #175 remains open for remaining carrier audits/fences/migrations.