### PR TITLE
Core #151: add durable Employee assignment lifecycle

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -7,18 +7,23 @@ on:
       - main
     paths:
       - 'agent_core/employee_runtime.py'
+      - 'agent_core/employee_lifecycle.py'
       - 'agent_core/role_runtime.py'
       - 'tests/test_employee_runtime.py'
+      - 'tests/test_employee_lifecycle.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
+      - core/issue-151-employee-lifecycle
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
+      - 'agent_core/employee_lifecycle.py'
       - 'agent_core/role_runtime.py'
       - 'tests/test_employee_runtime.py'
+      - 'tests/test_employee_lifecycle.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -40,5 +45,7 @@ jobs:
         run: python -m pip install PyYAML
       - name: Run employee runtime regressions
         run: python -m unittest tests.test_employee_runtime -v
+      - name: Run Employee lifecycle regressions
+        run: python -m unittest tests.test_employee_lifecycle -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_lifecycle.py
+++ b/agent_core/employee_lifecycle.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_runtime import Assignment, EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+
+LEASE_SCHEMA = "agentos.employee-assignment-lease/v1"
+RECEIPT_SCHEMA = "agentos.employee-assignment-receipt/v1"
+WORK_PACKET_SCHEMA = "agentos.employee-work-packet/v1"
+VALID_FINISH_STATES = {"completed", "blocked", "handoff", "cancelled"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "").strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError("unsafe_lifecycle_id")
+    return value
+
+
+def _atomic_json_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("lifecycle_state_invalid")
+    return value
+
+
+@dataclass(slots=True)
+class AssignmentLease:
+    schema: str
+    assignment_id: str
+    employee_id: str
+    lease_id: str
+    generation: int
+    status: str
+    claimed_at: str
+    heartbeat_at: str
+    expires_at: str
+    thread_head: str = ""
+    resume_required: bool = False
+    prior_execution_state: str = "known"
+    resumed_from_lease_id: str | None = None
+    last_checkpoint_at: str | None = None
+
+
+@dataclass(slots=True)
+class AssignmentReceipt:
+    schema: str
+    assignment_id: str
+    employee_id: str
+    lease_id: str
+    generation: int
+    outcome: str
+    recorded_at: str
+    thread_head: str
+    role_ids: list[str] = field(default_factory=list)
+    executor_provider: str = "unbound"
+    executor_model: str = ""
+    result_summary: dict[str, Any] = field(default_factory=dict)
+    credential_exposed: bool = False
+
+
+class EmployeeLifecycle:
+    """Durable claim/lease/checkpoint/receipt layer for AgentOS employees.
+
+    This module does not invoke a model or choose a privileged execution carrier. It
+    only arbitrates which executor session currently owns an Employee assignment and
+    preserves enough durable state for another executor to resume safely.
+
+    If a lease expires without a terminal receipt, the next claimant inherits the
+    assignment/thread head but `prior_execution_state` is `unknown`. This prevents a
+    crashed executor from being silently interpreted as having performed no side
+    effects.
+    """
+
+    def __init__(self, runtime: EmployeeRuntime) -> None:
+        self.runtime = runtime
+        self.root = runtime.root / "lifecycle"
+        self.leases_dir = self.root / "leases"
+        self.receipts_dir = self.root / "receipts"
+
+    def _lease_path(self, assignment_id: str) -> Path:
+        return self.leases_dir / f"{_safe_id(assignment_id)}.json"
+
+    def _receipt_path(self, assignment_id: str, generation: int) -> Path:
+        return self.receipts_dir / _safe_id(assignment_id) / f"{generation:06d}.json"
+
+    def get_lease(self, assignment_id: str) -> AssignmentLease | None:
+        data = _read_json(self._lease_path(assignment_id))
+        if data is None:
+            return None
+        return AssignmentLease(**data)
+
+    @staticmethod
+    def lease_expired(lease: AssignmentLease, *, now: datetime | None = None) -> bool:
+        current = now or _utcnow()
+        return current >= _parse(lease.expires_at)
+
+    def claim(
+        self,
+        assignment_id: str,
+        employee_id: str,
+        lease_id: str,
+        *,
+        lease_seconds: int = 300,
+        now: datetime | None = None,
+    ) -> AssignmentLease:
+        if lease_seconds < 30 or lease_seconds > 3600:
+            raise ValueError("lease_seconds_out_of_range")
+        assignment_id = _safe_id(assignment_id)
+        employee_id = _safe_id(employee_id)
+        lease_id = _safe_id(lease_id)
+        assignment = self.runtime.get_assignment(assignment_id)
+        if assignment.employee_id != employee_id:
+            raise PermissionError("assignment_employee_mismatch")
+        if assignment.state not in {"pending", "active"}:
+            raise RuntimeError("assignment_not_claimable")
+
+        current = now or _utcnow()
+        existing = self.get_lease(assignment_id)
+        if existing and existing.status == "active" and not self.lease_expired(existing, now=current):
+            if existing.employee_id == employee_id and existing.lease_id == lease_id:
+                return existing
+            raise RuntimeError("assignment_already_leased")
+
+        generation = 1
+        resume_required = False
+        prior_execution_state = "known"
+        resumed_from: str | None = None
+        if existing is not None:
+            generation = existing.generation + 1
+            if existing.status == "active" and self.lease_expired(existing, now=current):
+                resume_required = True
+                prior_execution_state = "unknown"
+                resumed_from = existing.lease_id
+
+        expires = current + timedelta(seconds=lease_seconds)
+        lease = AssignmentLease(
+            schema=LEASE_SCHEMA,
+            assignment_id=assignment_id,
+            employee_id=employee_id,
+            lease_id=lease_id,
+            generation=generation,
+            status="active",
+            claimed_at=_iso(current),
+            heartbeat_at=_iso(current),
+            expires_at=_iso(expires),
+            thread_head=assignment.thread_head,
+            resume_required=resume_required,
+            prior_execution_state=prior_execution_state,
+            resumed_from_lease_id=resumed_from,
+        )
+        _atomic_json_write(self._lease_path(assignment_id), asdict(lease))
+        if assignment.state == "pending":
+            self.runtime.update_assignment(assignment_id, state="active")
+        return lease
+
+    def heartbeat(
+        self,
+        assignment_id: str,
+        lease_id: str,
+        *,
+        lease_seconds: int = 300,
+        now: datetime | None = None,
+    ) -> AssignmentLease:
+        if lease_seconds < 30 or lease_seconds > 3600:
+            raise ValueError("lease_seconds_out_of_range")
+        lease = self._require_current_active(assignment_id, lease_id, now=now)
+        current = now or _utcnow()
+        lease.heartbeat_at = _iso(current)
+        lease.expires_at = _iso(current + timedelta(seconds=lease_seconds))
+        _atomic_json_write(self._lease_path(assignment_id), asdict(lease))
+        return lease
+
+    def checkpoint(
+        self,
+        assignment_id: str,
+        lease_id: str,
+        thread_head: str,
+        *,
+        now: datetime | None = None,
+    ) -> AssignmentLease:
+        lease = self._require_current_active(assignment_id, lease_id, now=now)
+        current = now or _utcnow()
+        head = str(thread_head or "").strip()
+        if not head:
+            raise ValueError("thread_head_required")
+        self.runtime.update_assignment(assignment_id, thread_head=head)
+        lease.thread_head = head
+        lease.last_checkpoint_at = _iso(current)
+        _atomic_json_write(self._lease_path(assignment_id), asdict(lease))
+        return lease
+
+    def finish(
+        self,
+        assignment_id: str,
+        lease_id: str,
+        *,
+        state: str = "completed",
+        result_summary: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> AssignmentReceipt:
+        if state not in VALID_FINISH_STATES:
+            raise ValueError("invalid_finish_state")
+        lease = self._require_current_active(assignment_id, lease_id, now=now)
+        current = now or _utcnow()
+        assignment = self.runtime.get_assignment(assignment_id)
+        employee = self.runtime.get_employee(assignment.employee_id)
+        summary = dict(result_summary or {})
+        receipt = AssignmentReceipt(
+            schema=RECEIPT_SCHEMA,
+            assignment_id=assignment.assignment_id,
+            employee_id=assignment.employee_id,
+            lease_id=lease.lease_id,
+            generation=lease.generation,
+            outcome=state,
+            recorded_at=_iso(current),
+            thread_head=assignment.thread_head,
+            role_ids=list(employee.role_ids),
+            executor_provider=employee.executor.provider,
+            executor_model=employee.executor.model,
+            result_summary=summary,
+            credential_exposed=False,
+        )
+        receipt_path = self._receipt_path(assignment_id, lease.generation)
+        if receipt_path.exists():
+            existing = AssignmentReceipt(**(_read_json(receipt_path) or {}))
+            if existing.lease_id == lease_id and existing.outcome == state:
+                return existing
+            raise RuntimeError("terminal_receipt_conflict")
+
+        # Persist terminal evidence before releasing assignment ownership.
+        _atomic_json_write(receipt_path, asdict(receipt))
+        self.runtime.update_assignment(
+            assignment_id,
+            state=state,
+            result={
+                "schema": RECEIPT_SCHEMA,
+                "generation": lease.generation,
+                "outcome": state,
+                "receipt": str(receipt_path.relative_to(self.runtime.root)),
+            },
+        )
+        lease.status = state
+        lease.expires_at = _iso(current)
+        _atomic_json_write(self._lease_path(assignment_id), asdict(lease))
+        return receipt
+
+    def next_assignment(
+        self,
+        employee_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> tuple[Assignment, bool] | None:
+        employee_id = _safe_id(employee_id)
+        self.runtime.get_employee(employee_id)
+        current = now or _utcnow()
+        active_resumable: list[Assignment] = []
+        pending: list[Assignment] = []
+        if not self.runtime.assignments_dir.exists():
+            return None
+        for path in sorted(self.runtime.assignments_dir.glob("*.json")):
+            assignment = self.runtime.get_assignment(path.stem)
+            if assignment.employee_id != employee_id:
+                continue
+            if assignment.state == "active":
+                lease = self.get_lease(assignment.assignment_id)
+                if lease is None or lease.status != "active" or self.lease_expired(lease, now=current):
+                    active_resumable.append(assignment)
+            elif assignment.state == "pending":
+                pending.append(assignment)
+        if active_resumable:
+            active_resumable.sort(key=lambda value: (value.created_at, value.assignment_id))
+            return active_resumable[0], True
+        if pending:
+            pending.sort(key=lambda value: (value.created_at, value.assignment_id))
+            return pending[0], False
+        return None
+
+    def build_work_packet(
+        self,
+        assignment_id: str,
+        lease_id: str,
+        role_registry: RoleRegistry,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        lease = self._require_current_active(assignment_id, lease_id, now=now)
+        assignment = self.runtime.get_assignment(assignment_id)
+        employee = self.runtime.get_employee(assignment.employee_id)
+        roles = role_registry.hydrate_employee_roles(employee.role_ids)
+        return {
+            "schema": WORK_PACKET_SCHEMA,
+            "employee": {
+                "agent_id": employee.agent_id,
+                "display_name": employee.display_name,
+                "memory_namespace": employee.memory_namespace,
+                "role_ids": list(employee.role_ids),
+                "skill_ids": list(employee.skill_ids),
+                "executor": {
+                    "provider": employee.executor.provider,
+                    "model": employee.executor.model,
+                },
+            },
+            "assignment": {
+                "assignment_id": assignment.assignment_id,
+                "goal": assignment.goal,
+                "state": assignment.state,
+                "parent_assignment_id": assignment.parent_assignment_id,
+                "thread_head": assignment.thread_head,
+                "constraints": list(assignment.constraints),
+            },
+            "lease": {
+                "lease_id": lease.lease_id,
+                "generation": lease.generation,
+                "expires_at": lease.expires_at,
+                "resume_required": lease.resume_required,
+                "prior_execution_state": lease.prior_execution_state,
+            },
+            "roles": [asdict(role) for role in roles],
+            "credential_exposed": False,
+        }
+
+    def _require_current_active(
+        self,
+        assignment_id: str,
+        lease_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> AssignmentLease:
+        lease = self.get_lease(assignment_id)
+        if lease is None or lease.status != "active":
+            raise RuntimeError("active_lease_required")
+        if lease.lease_id != _safe_id(lease_id):
+            raise PermissionError("lease_mismatch")
+        if self.lease_expired(lease, now=now):
+            raise RuntimeError("lease_expired")
+        return lease

--- a/tests/test_employee_lifecycle.py
+++ b/tests/test_employee_lifecycle.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.employee_lifecycle import (
+    LEASE_SCHEMA,
+    RECEIPT_SCHEMA,
+    WORK_PACKET_SCHEMA,
+    EmployeeLifecycle,
+)
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+
+
+T0 = datetime(2026, 9, 2, 4, 0, 0, tzinfo=timezone.utc)
+
+
+class EmployeeLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit open specification closure gaps",
+            thread_head="ir-before-claim",
+            constraints=["read-only", "receipts-over-claims"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_claim_activates_pending_assignment_and_is_idempotent_for_same_lease(self):
+        lease = self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            now=T0,
+        )
+        self.assertEqual(lease.schema, LEASE_SCHEMA)
+        self.assertEqual(lease.generation, 1)
+        self.assertFalse(lease.resume_required)
+        self.assertEqual(lease.prior_execution_state, "known")
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "active")
+        same = self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            now=T0 + timedelta(seconds=10),
+        )
+        self.assertEqual(same.generation, 1)
+        self.assertEqual(same.lease_id, "lease-a")
+
+    def test_competing_claim_is_rejected_while_lease_is_live(self):
+        self.lifecycle.claim("audit-001", "spec-steward", "lease-a", now=T0)
+        with self.assertRaisesRegex(RuntimeError, "assignment_already_leased"):
+            self.lifecycle.claim(
+                "audit-001",
+                "spec-steward",
+                "lease-b",
+                now=T0 + timedelta(seconds=30),
+            )
+
+    def test_expired_lease_reclaim_marks_prior_execution_unknown_and_preserves_thread_head(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.lifecycle.checkpoint(
+            "audit-001",
+            "lease-a",
+            "ir-checkpoint-1",
+            now=T0 + timedelta(seconds=20),
+        )
+        resumed = self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-b",
+            lease_seconds=60,
+            now=T0 + timedelta(seconds=61),
+        )
+        self.assertEqual(resumed.generation, 2)
+        self.assertTrue(resumed.resume_required)
+        self.assertEqual(resumed.prior_execution_state, "unknown")
+        self.assertEqual(resumed.resumed_from_lease_id, "lease-a")
+        self.assertEqual(resumed.thread_head, "ir-checkpoint-1")
+        self.assertEqual(
+            self.runtime.get_assignment("audit-001").thread_head,
+            "ir-checkpoint-1",
+        )
+
+    def test_heartbeat_extends_current_lease(self):
+        lease = self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            lease_seconds=60,
+            now=T0,
+        )
+        renewed = self.lifecycle.heartbeat(
+            "audit-001",
+            "lease-a",
+            lease_seconds=120,
+            now=T0 + timedelta(seconds=30),
+        )
+        self.assertNotEqual(lease.expires_at, renewed.expires_at)
+        self.assertFalse(
+            self.lifecycle.lease_expired(
+                renewed,
+                now=T0 + timedelta(seconds=100),
+            )
+        )
+
+    def test_expired_owner_cannot_checkpoint(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            lease_seconds=60,
+            now=T0,
+        )
+        with self.assertRaisesRegex(RuntimeError, "lease_expired"):
+            self.lifecycle.checkpoint(
+                "audit-001",
+                "lease-a",
+                "late-head",
+                now=T0 + timedelta(seconds=61),
+            )
+        self.assertEqual(
+            self.runtime.get_assignment("audit-001").thread_head,
+            "ir-before-claim",
+        )
+
+    def test_finish_persists_receipt_before_releasing_lease(self):
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="openai-codex-local",
+            model="codex",
+            session_id="private-session-id",
+        )
+        self.lifecycle.claim("audit-001", "spec-steward", "lease-a", now=T0)
+        self.lifecycle.checkpoint(
+            "audit-001",
+            "lease-a",
+            "ir-complete",
+            now=T0 + timedelta(seconds=10),
+        )
+        receipt = self.lifecycle.finish(
+            "audit-001",
+            "lease-a",
+            result_summary={"closure_gaps": 3},
+            now=T0 + timedelta(seconds=20),
+        )
+        self.assertEqual(receipt.schema, RECEIPT_SCHEMA)
+        self.assertEqual(receipt.outcome, "completed")
+        self.assertEqual(receipt.thread_head, "ir-complete")
+        self.assertEqual(receipt.result_summary, {"closure_gaps": 3})
+        self.assertFalse(receipt.credential_exposed)
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "completed")
+        self.assertEqual(self.lifecycle.get_lease("audit-001").status, "completed")
+        serialized = json.dumps(receipt.__dict__ if hasattr(receipt, "__dict__") else {
+            "executor_provider": receipt.executor_provider,
+            "executor_model": receipt.executor_model,
+            "result_summary": receipt.result_summary,
+        })
+        self.assertNotIn("private-session-id", serialized)
+
+    def test_next_assignment_prefers_expired_active_work_over_new_pending(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.runtime.create_assignment(
+            "audit-002",
+            "spec-steward",
+            "Newer audit",
+        )
+        selected = self.lifecycle.next_assignment(
+            "spec-steward",
+            now=T0 + timedelta(seconds=61),
+        )
+        self.assertIsNotNone(selected)
+        assignment, resume_required = selected
+        self.assertEqual(assignment.assignment_id, "audit-001")
+        self.assertTrue(resume_required)
+
+    def test_work_packet_hydrates_roles_without_executor_session_identity(self):
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="openai-codex-local",
+            model="codex",
+            session_id="must-not-leak",
+        )
+        self.lifecycle.claim("audit-001", "spec-steward", "lease-a", now=T0)
+        registry = RoleRegistry(
+            Path(__file__).resolve().parents[1] / ".agent" / "roles" / "registry.yaml"
+        )
+        packet = self.lifecycle.build_work_packet(
+            "audit-001",
+            "lease-a",
+            registry,
+            now=T0 + timedelta(seconds=5),
+        )
+        self.assertEqual(packet["schema"], WORK_PACKET_SCHEMA)
+        self.assertEqual(packet["employee"]["agent_id"], "spec-steward")
+        self.assertEqual(packet["roles"][0]["role_id"], "governance.spec_steward")
+        self.assertIn("governance.spec.audit", packet["roles"][0]["capabilities"])
+        self.assertFalse(packet["credential_exposed"])
+        serialized = json.dumps(packet, ensure_ascii=False)
+        self.assertNotIn("must-not-leak", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Advance the already-integrated Employee/Role runtime from durable identity/state into a safe resumable assignment lifecycle without introducing a second control plane or auto-invoking executors.

## Adds
- durable assignment claim/lease generation;
- bounded heartbeat renewal;
- durable thread-head checkpoint;
- competing live lease rejection;
- expired lease recovery with `resume_required=true` and `prior_execution_state=unknown`;
- deterministic preference for interrupted active work before newer pending work;
- terminal assignment receipt persisted before lease release;
- executor-safe work packet with machine-hydrated roles, assignment constraints and lease generation; executor session identity is not exposed;
- hosted Employee Runtime Guard coverage.

## Governance boundary
This module does not invoke a model, choose a transport, execute a capability, or grant mutation authority. An expired executor lease does not prove that its external side effects were absent; resumed work explicitly carries UNKNOWN prior execution state.

## Remaining #151 operating work
This slice still does not create a daemon/scheduler or a live Spec Steward run. After integration, #151 still needs scheduler/wakeup policy, role-scoped memory authorization, skills, Cognitive Thread return semantics, Realm employee messaging, and live persistent Spec Steward operating evidence.

Target: `core/integration` only; no protected-main publication authority implied.