### PR TITLE
Core #151: add authority-neutral Employee wake planner

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -8,22 +8,26 @@ on:
     paths:
       - 'agent_core/employee_runtime.py'
       - 'agent_core/employee_lifecycle.py'
+      - 'agent_core/employee_wake.py'
       - 'agent_core/role_runtime.py'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
+      - 'tests/test_employee_wake.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-151-employee-lifecycle
+      - core/issue-151-employee-wake-planner
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
       - 'agent_core/employee_lifecycle.py'
+      - 'agent_core/employee_wake.py'
       - 'agent_core/role_runtime.py'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
+      - 'tests/test_employee_wake.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -47,5 +51,7 @@ jobs:
         run: python -m unittest tests.test_employee_runtime -v
       - name: Run Employee lifecycle regressions
         run: python -m unittest tests.test_employee_lifecycle -v
+      - name: Run Employee wake-planner regressions
+        run: python -m unittest tests.test_employee_wake -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_wake.py
+++ b/agent_core/employee_wake.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+
+
+WAKE_INTENT_SCHEMA = "agentos.employee-wake-intent/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class EmployeeWakeIntent:
+    """A deterministic request to *consider* waking one employee assignment.
+
+    This is deliberately not an execution request.  It carries no transport,
+    Node, provider/model, capability invocation, argv, URL, or credential.  A
+    separate governed dispatcher must resolve those authorities after this
+    planner has selected the durable Employee assignment that needs attention.
+    """
+
+    schema: str
+    wake_id: str
+    employee_id: str
+    assignment_id: str
+    mode: str
+    expected_lease_generation: int
+    goal: str
+    thread_head: str
+    constraints: tuple[str, ...]
+    role_ids: tuple[str, ...]
+    skill_ids: tuple[str, ...]
+    resume_required: bool
+    prior_execution_state: str
+    authority_boundary: str = "selection_only_no_execution"
+    executor_selection: str = "unbound"
+    transport_selection: str = "unbound"
+    credential_exposed: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["constraints"] = list(self.constraints)
+        value["role_ids"] = list(self.role_ids)
+        value["skill_ids"] = list(self.skill_ids)
+        return value
+
+
+class EmployeeWakePlanner:
+    """Read-only planner for durable Employee work that needs a wakeup.
+
+    Selection authority stops at the assignment boundary.  The planner never
+    claims a lease and never chooses an executor, Node, transport, or capability.
+    Repeated planning before a claim is intentionally idempotent: the same
+    assignment/generation produces the same wake_id.
+    """
+
+    def __init__(self, lifecycle: EmployeeLifecycle) -> None:
+        self.lifecycle = lifecycle
+
+    @staticmethod
+    def _wake_id(
+        employee_id: str,
+        assignment_id: str,
+        expected_generation: int,
+        mode: str,
+    ) -> str:
+        source = (
+            f"{employee_id}\0{assignment_id}\0{expected_generation}\0{mode}"
+        ).encode("utf-8")
+        return "wake_" + hashlib.sha256(source).hexdigest()[:24]
+
+    def plan_next(
+        self,
+        employee_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> EmployeeWakeIntent | None:
+        selected = self.lifecycle.next_assignment(employee_id, now=now)
+        if selected is None:
+            return None
+
+        assignment, resume_required = selected
+        employee = self.lifecycle.runtime.get_employee(employee_id)
+        lease = self.lifecycle.get_lease(assignment.assignment_id)
+
+        if resume_required:
+            # next_assignment() only returns active work as resumable when the
+            # previous ownership is absent/terminal/expired.  Any previous live
+            # external execution is therefore UNKNOWN until independently
+            # verified; the wake planner must not silently downgrade that state.
+            mode = "resume"
+            prior_execution_state = "unknown"
+            expected_generation = (lease.generation + 1) if lease else 1
+        else:
+            mode = "fresh"
+            prior_execution_state = "known"
+            expected_generation = (lease.generation + 1) if lease else 1
+
+        return EmployeeWakeIntent(
+            schema=WAKE_INTENT_SCHEMA,
+            wake_id=self._wake_id(
+                employee.agent_id,
+                assignment.assignment_id,
+                expected_generation,
+                mode,
+            ),
+            employee_id=employee.agent_id,
+            assignment_id=assignment.assignment_id,
+            mode=mode,
+            expected_lease_generation=expected_generation,
+            goal=assignment.goal,
+            thread_head=assignment.thread_head,
+            constraints=tuple(assignment.constraints),
+            role_ids=tuple(employee.role_ids),
+            skill_ids=tuple(employee.skill_ids),
+            resume_required=resume_required,
+            prior_execution_state=prior_execution_state,
+        )

--- a/tests/test_employee_wake.py
+++ b/tests/test_employee_wake.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import WAKE_INTENT_SCHEMA, EmployeeWakePlanner
+
+
+T0 = datetime(2026, 9, 2, 5, 0, 0, tzinfo=timezone.utc)
+
+
+class EmployeeWakePlannerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="openai-codex-local",
+            model="codex",
+            session_id="private-session-must-not-leak",
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit open specification closure gaps",
+            thread_head="ir-audit-start",
+            constraints=["read-only", "receipts-over-claims"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.planner = EmployeeWakePlanner(self.lifecycle)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_pending_assignment_produces_fresh_bounded_wake_intent(self):
+        intent = self.planner.plan_next("spec-steward", now=T0)
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent.schema, WAKE_INTENT_SCHEMA)
+        self.assertEqual(intent.employee_id, "spec-steward")
+        self.assertEqual(intent.assignment_id, "audit-001")
+        self.assertEqual(intent.mode, "fresh")
+        self.assertEqual(intent.expected_lease_generation, 1)
+        self.assertFalse(intent.resume_required)
+        self.assertEqual(intent.prior_execution_state, "known")
+        self.assertEqual(intent.thread_head, "ir-audit-start")
+        self.assertEqual(intent.role_ids, ("governance.spec_steward",))
+        self.assertEqual(intent.skill_ids, ("spec.audit",))
+        self.assertEqual(intent.authority_boundary, "selection_only_no_execution")
+        self.assertEqual(intent.executor_selection, "unbound")
+        self.assertEqual(intent.transport_selection, "unbound")
+        self.assertFalse(intent.credential_exposed)
+
+        serialized = json.dumps(intent.as_dict(), ensure_ascii=False).casefold()
+        self.assertNotIn("private-session-must-not-leak", serialized)
+        for forbidden in (
+            "node_id",
+            "one_url",
+            "github_actions",
+            "workflow_dispatch",
+            "argv",
+            "executable",
+            "authorization",
+            "bearer ",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_repeated_planning_before_claim_is_idempotent(self):
+        first = self.planner.plan_next("spec-steward", now=T0)
+        second = self.planner.plan_next(
+            "spec-steward", now=T0 + timedelta(seconds=20)
+        )
+        self.assertEqual(first.wake_id, second.wake_id)
+        self.assertEqual(first.expected_lease_generation, 1)
+        self.assertEqual(second.expected_lease_generation, 1)
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "pending")
+        self.assertIsNone(self.lifecycle.get_lease("audit-001"))
+
+    def test_live_lease_suppresses_duplicate_wake(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-live",
+            lease_seconds=120,
+            now=T0,
+        )
+        self.assertIsNone(
+            self.planner.plan_next(
+                "spec-steward", now=T0 + timedelta(seconds=30)
+            )
+        )
+
+    def test_expired_assignment_produces_resume_with_unknown_prior_execution(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-old",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.lifecycle.checkpoint(
+            "audit-001",
+            "lease-old",
+            "ir-audit-checkpoint",
+            now=T0 + timedelta(seconds=20),
+        )
+        intent = self.planner.plan_next(
+            "spec-steward", now=T0 + timedelta(seconds=61)
+        )
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent.mode, "resume")
+        self.assertTrue(intent.resume_required)
+        self.assertEqual(intent.prior_execution_state, "unknown")
+        self.assertEqual(intent.expected_lease_generation, 2)
+        self.assertEqual(intent.thread_head, "ir-audit-checkpoint")
+
+        # Planning is still read-only: the old lease remains until a separately
+        # authorized claimant actually takes generation 2.
+        old = self.lifecycle.get_lease("audit-001")
+        self.assertEqual(old.lease_id, "lease-old")
+        self.assertEqual(old.generation, 1)
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "active")
+
+    def test_resume_wake_id_is_stable_until_reclaim(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-old",
+            lease_seconds=60,
+            now=T0,
+        )
+        first = self.planner.plan_next(
+            "spec-steward", now=T0 + timedelta(seconds=61)
+        )
+        second = self.planner.plan_next(
+            "spec-steward", now=T0 + timedelta(seconds=90)
+        )
+        self.assertEqual(first.wake_id, second.wake_id)
+        self.assertEqual(first.expected_lease_generation, 2)
+
+    def test_completed_work_is_not_woken(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-a",
+            now=T0,
+        )
+        self.lifecycle.finish(
+            "audit-001",
+            "lease-a",
+            now=T0 + timedelta(seconds=10),
+        )
+        self.assertIsNone(
+            self.planner.plan_next(
+                "spec-steward", now=T0 + timedelta(seconds=20)
+            )
+        )
+
+    def test_interrupted_active_work_is_selected_before_new_pending_work(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-old",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.runtime.create_assignment(
+            "audit-002",
+            "spec-steward",
+            "New audit",
+            thread_head="ir-new",
+        )
+        intent = self.planner.plan_next(
+            "spec-steward", now=T0 + timedelta(seconds=61)
+        )
+        self.assertEqual(intent.assignment_id, "audit-001")
+        self.assertEqual(intent.mode, "resume")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Advance #151 from resumable assignment lifecycle to deterministic wake planning without introducing a scheduler that owns executor, transport, Node, or capability authority.

## Adds
- read-only `EmployeeWakePlanner`;
- deterministic idempotent wake IDs per employee/assignment/expected lease generation/mode;
- fresh vs resume wake semantics;
- expired active work carries `prior_execution_state=unknown` and preserves thread head;
- live leases suppress duplicate wakes;
- interrupted active work remains preferred over newer pending work;
- wake intent contains durable Employee/role/skill/assignment references only;
- explicit `selection_only_no_execution`, executor=`unbound`, transport=`unbound` boundary;
- regression coverage proving planning does not claim a lease, mutate assignment state, expose executor session identity, or embed Node/Actions/argv/authorization routing detail.

## Architecture invariant
`Employee assignment selection != executor selection != transport selection != capability execution`.

The planner selects which durable Employee assignment needs attention. A separately governed ONE/dispatcher path must resolve all execution authority later.

## Remaining #151 work
Actual wake delivery/scheduler policy, role-scoped memory authorization, skill execution hydration, Cognitive Thread return semantics, Realm employee messaging, and live persistent Spec Steward evidence remain open.

Target: `core/integration` only; no protected-main publication authority implied.