### PR TITLE
Core #151: enforce role-scoped Employee memory policy

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -9,25 +9,31 @@ on:
       - 'agent_core/employee_runtime.py'
       - 'agent_core/employee_lifecycle.py'
       - 'agent_core/employee_wake.py'
+      - 'agent_core/employee_memory.py'
       - 'agent_core/role_runtime.py'
+      - 'governance/employee-memory-policy.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
+      - 'tests/test_employee_memory.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-151-employee-wake-planner
+      - core/issue-151-role-memory-policy
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
       - 'agent_core/employee_lifecycle.py'
       - 'agent_core/employee_wake.py'
+      - 'agent_core/employee_memory.py'
       - 'agent_core/role_runtime.py'
+      - 'governance/employee-memory-policy.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
+      - 'tests/test_employee_memory.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -53,5 +59,7 @@ jobs:
         run: python -m unittest tests.test_employee_lifecycle -v
       - name: Run Employee wake-planner regressions
         run: python -m unittest tests.test_employee_wake -v
+      - name: Run Employee memory-policy regressions
+        run: python -m unittest tests.test_employee_memory -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_memory.py
+++ b/agent_core/employee_memory.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+
+
+MEMORY_POLICY_SCHEMA = "agentos.employee-memory-policy/v1"
+MEMORY_DECISION_SCHEMA = "agentos.employee-memory-decision/v1"
+VALID_OPERATIONS = {"read", "write"}
+
+
+@dataclass(frozen=True, slots=True)
+class EmployeeMemoryDecision:
+    schema: str
+    employee_id: str
+    memory_class: str
+    operation: str
+    allowed: bool
+    authorizing_roles: tuple[str, ...]
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["authorizing_roles"] = list(self.authorizing_roles)
+        return value
+
+
+class EmployeeMemoryPolicy:
+    """Explicit deny-by-default role -> private-memory-class policy."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("employee_memory_policy_must_be_object")
+        if raw.get("schema") != MEMORY_POLICY_SCHEMA:
+            raise ValueError("unsupported_employee_memory_policy_schema")
+        if raw.get("default_effect") != "deny":
+            raise ValueError("employee_memory_policy_must_default_deny")
+        if raw.get("cross_employee_access") != "deny":
+            raise ValueError("cross_employee_memory_must_default_deny")
+
+        classes = raw.get("memory_classes")
+        rules = raw.get("role_rules")
+        if not isinstance(classes, list) or not classes:
+            raise ValueError("memory_classes_required")
+        if not isinstance(rules, dict):
+            raise ValueError("role_rules_required")
+
+        self.memory_classes = frozenset(str(value) for value in classes)
+        if "*" in self.memory_classes or any(not value.strip() for value in self.memory_classes):
+            raise ValueError("memory_class_wildcards_not_allowed")
+
+        normalized: dict[str, dict[str, frozenset[str]]] = {}
+        for role_id, rule in rules.items():
+            role_id = str(role_id).strip()
+            if not role_id or role_id == "*" or not isinstance(rule, dict):
+                raise ValueError("invalid_memory_role_rule")
+            normalized[role_id] = {}
+            for operation in VALID_OPERATIONS:
+                values = rule.get(operation, [])
+                if not isinstance(values, list):
+                    raise ValueError("memory_role_rule_must_be_list")
+                allowed = frozenset(str(value) for value in values)
+                if "*" in allowed or not allowed.issubset(self.memory_classes):
+                    raise ValueError("invalid_memory_class_grant")
+                normalized[role_id][operation] = allowed
+        self.role_rules = normalized
+
+    def grants(self, role_id: str, operation: str) -> frozenset[str]:
+        if operation not in VALID_OPERATIONS:
+            raise ValueError("invalid_memory_operation")
+        return self.role_rules.get(role_id, {}).get(operation, frozenset())
+
+
+class EmployeeMemoryService:
+    """Policy-enforced private Employee memory.
+
+    Memory is currently self-only.  Cross-Employee knowledge transfer must use a
+    governed message/handoff/public knowledge surface rather than reading another
+    Employee's private memory directory.  Executor identity never participates in
+    authorization.
+    """
+
+    def __init__(
+        self,
+        runtime: EmployeeRuntime,
+        role_registry: RoleRegistry,
+        policy: EmployeeMemoryPolicy,
+    ) -> None:
+        self.runtime = runtime
+        self.role_registry = role_registry
+        self.policy = policy
+
+    def authorize(
+        self,
+        caller_employee_id: str,
+        target_employee_id: str,
+        memory_class: str,
+        operation: str,
+    ) -> EmployeeMemoryDecision:
+        operation = str(operation).strip().lower()
+        memory_class = str(memory_class).strip()
+        if operation not in VALID_OPERATIONS:
+            raise ValueError("invalid_memory_operation")
+
+        caller = self.runtime.get_employee(caller_employee_id)
+        self.runtime.get_employee(target_employee_id)
+        if caller.agent_id != target_employee_id:
+            return EmployeeMemoryDecision(
+                schema=MEMORY_DECISION_SCHEMA,
+                employee_id=caller.agent_id,
+                memory_class=memory_class,
+                operation=operation,
+                allowed=False,
+                authorizing_roles=(),
+                reason="cross_employee_private_memory_denied",
+            )
+        if memory_class not in self.policy.memory_classes:
+            return EmployeeMemoryDecision(
+                schema=MEMORY_DECISION_SCHEMA,
+                employee_id=caller.agent_id,
+                memory_class=memory_class,
+                operation=operation,
+                allowed=False,
+                authorizing_roles=(),
+                reason="unknown_memory_class",
+            )
+        if not caller.role_ids:
+            return EmployeeMemoryDecision(
+                schema=MEMORY_DECISION_SCHEMA,
+                employee_id=caller.agent_id,
+                memory_class=memory_class,
+                operation=operation,
+                allowed=False,
+                authorizing_roles=(),
+                reason="active_role_required",
+            )
+
+        # Fail the entire request if any role reference cannot be machine-hydrated
+        # as active.  A proposed/stale role must never accidentally coexist with an
+        # active role and inherit that role's memory authority.
+        self.role_registry.hydrate_employee_roles(list(caller.role_ids))
+        granting = tuple(
+            sorted(
+                role_id
+                for role_id in caller.role_ids
+                if memory_class in self.policy.grants(role_id, operation)
+            )
+        )
+        return EmployeeMemoryDecision(
+            schema=MEMORY_DECISION_SCHEMA,
+            employee_id=caller.agent_id,
+            memory_class=memory_class,
+            operation=operation,
+            allowed=bool(granting),
+            authorizing_roles=granting,
+            reason="explicit_role_grant" if granting else "no_explicit_role_grant",
+        )
+
+    def write(
+        self,
+        employee_id: str,
+        memory_class: str,
+        key: str,
+        value: Any,
+    ) -> EmployeeMemoryDecision:
+        decision = self.authorize(
+            employee_id, employee_id, memory_class, "write"
+        )
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        self.runtime._write_memory_record(  # noqa: SLF001 - policy boundary primitive
+            employee_id, memory_class, key, value
+        )
+        return decision
+
+    def read(self, employee_id: str, memory_class: str, key: str) -> Any:
+        decision = self.authorize(
+            employee_id, employee_id, memory_class, "read"
+        )
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        return self.runtime._read_memory_record(  # noqa: SLF001 - policy boundary primitive
+            employee_id, memory_class, key
+        )
+
+    def read_other(
+        self,
+        caller_employee_id: str,
+        target_employee_id: str,
+        memory_class: str,
+        key: str,
+    ) -> Any:
+        decision = self.authorize(
+            caller_employee_id, target_employee_id, memory_class, "read"
+        )
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        # cross_employee_access is policy-fixed deny in v1, so this line is not
+        # reachable today.  It exists to keep authorization and storage semantics
+        # explicit if a future policy version introduces a governed shared scope.
+        return self.runtime._read_memory_record(  # noqa: SLF001
+            target_employee_id, memory_class, key
+        )

--- a/agent_core/employee_runtime.py
+++ b/agent_core/employee_runtime.py
@@ -91,6 +91,10 @@ class EmployeeRuntime:
     This runtime deliberately stores *references* to roles and skills. Hydrating those
     references into an effective role contract is handled by the role runtime so that
     employee identity stays independent from role-file representation and executor.
+
+    Private Employee memory is a governed resource.  Public callers must use
+    ``EmployeeMemoryService``; the storage primitives here are intentionally private
+    so role authorization cannot be bypassed by a convenient legacy helper.
     """
 
     def __init__(self, root: str | os.PathLike[str]) -> None:
@@ -204,18 +208,54 @@ class EmployeeRuntime:
         return assignment
 
     def write_memory(self, agent_id: str, key: str, value: Any) -> None:
-        agent_id = _safe_id(agent_id)
-        self.get_employee(agent_id)
-        key = _safe_id(key)
-        path = self.memory_dir / agent_id / f"{key}.json"
-        _atomic_json_write(path, {"value": value, "updated_at": _now()})
+        """Deprecated unscoped entrypoint; intentionally fails closed."""
+        raise PermissionError("employee_memory_policy_required")
 
     def read_memory(self, agent_id: str, key: str) -> Any:
+        """Deprecated unscoped entrypoint; intentionally fails closed."""
+        raise PermissionError("employee_memory_policy_required")
+
+    def _write_memory_record(
+        self,
+        agent_id: str,
+        memory_class: str,
+        key: str,
+        value: Any,
+    ) -> None:
+        """Storage primitive for EmployeeMemoryService after policy authorization."""
         agent_id = _safe_id(agent_id)
+        self.get_employee(agent_id)
+        memory_class = _safe_id(memory_class)
         key = _safe_id(key)
-        data = _read_json(self.memory_dir / agent_id / f"{key}.json", {})
+        path = self.memory_dir / agent_id / memory_class / f"{key}.json"
+        _atomic_json_write(
+            path,
+            {
+                "memory_class": memory_class,
+                "value": value,
+                "updated_at": _now(),
+            },
+        )
+
+    def _read_memory_record(
+        self,
+        agent_id: str,
+        memory_class: str,
+        key: str,
+    ) -> Any:
+        """Storage primitive for EmployeeMemoryService after policy authorization."""
+        agent_id = _safe_id(agent_id)
+        self.get_employee(agent_id)
+        memory_class = _safe_id(memory_class)
+        key = _safe_id(key)
+        data = _read_json(
+            self.memory_dir / agent_id / memory_class / f"{key}.json",
+            {},
+        )
         if not data:
             raise FileNotFoundError(key)
+        if data.get("memory_class") != memory_class:
+            raise ValueError("employee_memory_class_mismatch")
         return data.get("value")
 
     def send_message(

--- a/governance/employee-memory-policy.json
+++ b/governance/employee-memory-policy.json
@@ -1,0 +1,53 @@
+{
+  "schema": "agentos.employee-memory-policy/v1",
+  "default_effect": "deny",
+  "cross_employee_access": "deny",
+  "memory_classes": [
+    "working",
+    "continuity",
+    "governance_evidence",
+    "world_model"
+  ],
+  "role_rules": {
+    "core.root": {
+      "read": ["working", "continuity"],
+      "write": ["working", "continuity"]
+    },
+    "sector.paw": {
+      "read": ["working", "continuity"],
+      "write": ["working", "continuity"]
+    },
+    "sector.claw": {
+      "read": ["working", "continuity"],
+      "write": ["working", "continuity"]
+    },
+    "sector.weaver": {
+      "read": ["working", "continuity"],
+      "write": ["working", "continuity"]
+    },
+    "sector.whisperer": {
+      "read": ["working", "continuity"],
+      "write": ["working", "continuity"]
+    },
+    "governance.spec_steward": {
+      "read": ["working", "continuity", "governance_evidence"],
+      "write": ["working", "continuity", "governance_evidence"]
+    },
+    "governance.keeper": {
+      "read": ["working", "continuity", "governance_evidence"],
+      "write": ["working", "continuity", "governance_evidence"]
+    },
+    "system.cartographer": {
+      "read": ["working", "continuity", "world_model"],
+      "write": ["working", "continuity", "world_model"]
+    }
+  },
+  "invariants": [
+    "memory_access_requires_active_machine_hydrated_role",
+    "unknown_or_unlisted_role_does_not_grant_memory_access",
+    "unknown_memory_class_is_denied",
+    "cross_employee_private_memory_access_is_denied",
+    "employee_messages_and_handoffs_are_not_private_memory_bypass_channels",
+    "executor_provider_model_or_session_identity_never_grants_memory_authority"
+  ]
+}

--- a/tests/test_employee_memory.py
+++ b/tests/test_employee_memory.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.employee_memory import (
+    MEMORY_DECISION_SCHEMA,
+    EmployeeMemoryPolicy,
+    EmployeeMemoryService,
+)
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class EmployeeMemoryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.roles = RoleRegistry(REPO_ROOT / ".agent" / "roles" / "registry.yaml")
+        self.policy = EmployeeMemoryPolicy(
+            REPO_ROOT / "governance" / "employee-memory-policy.json"
+        )
+        self.memory = EmployeeMemoryService(self.runtime, self.roles, self.policy)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_spec_steward_can_use_governance_evidence_memory(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+        )
+        decision = self.memory.write(
+            "spec-steward",
+            "governance_evidence",
+            "closure-gap",
+            {"issue": 151, "state": "open"},
+        )
+        self.assertEqual(decision.schema, MEMORY_DECISION_SCHEMA)
+        self.assertTrue(decision.allowed)
+        self.assertEqual(
+            decision.authorizing_roles, ("governance.spec_steward",)
+        )
+        self.assertEqual(
+            self.memory.read(
+                "spec-steward", "governance_evidence", "closure-gap"
+            ),
+            {"issue": 151, "state": "open"},
+        )
+
+    def test_weaver_can_use_working_memory_but_not_governance_evidence(self):
+        self.runtime.create_employee(
+            "weaver",
+            "Weaver",
+            role_ids=["sector.weaver"],
+        )
+        self.memory.write("weaver", "working", "draft", {"spec": "bounded"})
+        self.assertEqual(
+            self.memory.read("weaver", "working", "draft"),
+            {"spec": "bounded"},
+        )
+        denied = self.memory.authorize(
+            "weaver", "weaver", "governance_evidence", "write"
+        )
+        self.assertFalse(denied.allowed)
+        self.assertEqual(denied.reason, "no_explicit_role_grant")
+        with self.assertRaisesRegex(PermissionError, "no_explicit_role_grant"):
+            self.memory.write(
+                "weaver", "governance_evidence", "fake-audit", {"ok": True}
+            )
+
+    def test_cartographer_world_model_grant_is_explicit(self):
+        self.runtime.create_employee(
+            "cartographer",
+            "Cartographer",
+            role_ids=["system.cartographer"],
+        )
+        decision = self.memory.write(
+            "cartographer",
+            "world_model",
+            "node-freshness",
+            {"fresh": False},
+        )
+        self.assertTrue(decision.allowed)
+        self.assertEqual(
+            decision.authorizing_roles, ("system.cartographer",)
+        )
+
+    def test_cross_employee_private_memory_is_denied(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+        )
+        self.runtime.create_employee(
+            "keeper",
+            "Keeper",
+            role_ids=["governance.keeper"],
+        )
+        self.memory.write(
+            "keeper",
+            "governance_evidence",
+            "private-finding",
+            {"risk": "bounded"},
+        )
+        decision = self.memory.authorize(
+            "spec-steward",
+            "keeper",
+            "governance_evidence",
+            "read",
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(
+            decision.reason, "cross_employee_private_memory_denied"
+        )
+        with self.assertRaisesRegex(
+            PermissionError, "cross_employee_private_memory_denied"
+        ):
+            self.memory.read_other(
+                "spec-steward",
+                "keeper",
+                "governance_evidence",
+                "private-finding",
+            )
+
+    def test_proposed_role_cannot_coexist_with_active_role_to_gain_memory(self):
+        self.runtime.create_employee(
+            "unsafe-mixed-role",
+            "Unsafe",
+            role_ids=["sector.weaver", "governance.arbiter"],
+        )
+        with self.assertRaisesRegex(ValueError, "role is not active"):
+            self.memory.authorize(
+                "unsafe-mixed-role",
+                "unsafe-mixed-role",
+                "working",
+                "read",
+            )
+
+    def test_employee_without_active_role_is_denied(self):
+        self.runtime.create_employee("unroled", "Unroled")
+        decision = self.memory.authorize(
+            "unroled", "unroled", "working", "read"
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.reason, "active_role_required")
+
+    def test_unknown_memory_class_is_denied(self):
+        self.runtime.create_employee(
+            "weaver",
+            "Weaver",
+            role_ids=["sector.weaver"],
+        )
+        decision = self.memory.authorize(
+            "weaver", "weaver", "secret_everything", "read"
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.reason, "unknown_memory_class")
+
+    def test_active_but_unlisted_role_does_not_inherit_another_roles_grant(self):
+        policy_path = self.root / "policy.json"
+        policy_path.write_text(
+            json.dumps(
+                {
+                    "schema": "agentos.employee-memory-policy/v1",
+                    "default_effect": "deny",
+                    "cross_employee_access": "deny",
+                    "memory_classes": ["working"],
+                    "role_rules": {
+                        "governance.spec_steward": {
+                            "read": ["working"],
+                            "write": ["working"],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        service = EmployeeMemoryService(
+            self.runtime,
+            self.roles,
+            EmployeeMemoryPolicy(policy_path),
+        )
+        self.runtime.create_employee(
+            "weaver",
+            "Weaver",
+            role_ids=["sector.weaver"],
+        )
+        decision = service.authorize(
+            "weaver", "weaver", "working", "write"
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.reason, "no_explicit_role_grant")
+
+    def test_executor_rebinding_never_changes_memory_authority_or_leaks_session(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+        )
+        before = self.memory.authorize(
+            "spec-steward", "spec-steward", "governance_evidence", "read"
+        )
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="openai-codex-local",
+            model="codex",
+            session_id="private-session-id",
+        )
+        after = self.memory.authorize(
+            "spec-steward", "spec-steward", "governance_evidence", "read"
+        )
+        self.assertEqual(before.allowed, after.allowed)
+        serialized = json.dumps(after.as_dict(), ensure_ascii=False)
+        self.assertNotIn("private-session-id", serialized)
+        self.assertNotIn("openai-codex-local", serialized)
+
+    def test_policy_rejects_default_allow_and_wildcards(self):
+        for payload in (
+            {
+                "schema": "agentos.employee-memory-policy/v1",
+                "default_effect": "allow",
+                "cross_employee_access": "deny",
+                "memory_classes": ["working"],
+                "role_rules": {},
+            },
+            {
+                "schema": "agentos.employee-memory-policy/v1",
+                "default_effect": "deny",
+                "cross_employee_access": "deny",
+                "memory_classes": ["working"],
+                "role_rules": {"*": {"read": ["working"], "write": []}},
+            },
+            {
+                "schema": "agentos.employee-memory-policy/v1",
+                "default_effect": "deny",
+                "cross_employee_access": "deny",
+                "memory_classes": ["working"],
+                "role_rules": {
+                    "sector.weaver": {"read": ["*"], "write": []}
+                },
+            },
+        ):
+            path = self.root / "invalid-policy.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                EmployeeMemoryPolicy(path)
+
+    def test_memory_classes_are_storage_isolated(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+        )
+        self.memory.write("spec-steward", "working", "same-key", "work")
+        self.memory.write(
+            "spec-steward", "governance_evidence", "same-key", "evidence"
+        )
+        self.assertEqual(
+            self.memory.read("spec-steward", "working", "same-key"),
+            "work",
+        )
+        self.assertEqual(
+            self.memory.read(
+                "spec-steward", "governance_evidence", "same-key"
+            ),
+            "evidence",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_employee_runtime.py
+++ b/tests/test_employee_runtime.py
@@ -46,15 +46,22 @@ class EmployeeRuntimeTest(unittest.TestCase):
             self.assertEqual(assignment.state, "active")
             self.assertEqual(assignment.thread_head, "thread:spec-audit")
 
-    def test_employee_memory_is_namespaced(self):
+    def test_unscoped_memory_access_fails_closed(self):
         with tempfile.TemporaryDirectory() as tmp:
             runtime = EmployeeRuntime(tmp)
-            runtime.create_employee("weaver", "Weaver")
-            runtime.create_employee("claw", "Claw")
-            runtime.write_memory("weaver", "current", {"spec": "A"})
-            runtime.write_memory("claw", "current", {"risk": "B"})
-            self.assertEqual(runtime.read_memory("weaver", "current"), {"spec": "A"})
-            self.assertEqual(runtime.read_memory("claw", "current"), {"risk": "B"})
+            runtime.create_employee(
+                "weaver",
+                "Weaver",
+                role_ids=["sector.weaver"],
+            )
+            with self.assertRaisesRegex(
+                PermissionError, "employee_memory_policy_required"
+            ):
+                runtime.write_memory("weaver", "current", {"spec": "A"})
+            with self.assertRaisesRegex(
+                PermissionError, "employee_memory_policy_required"
+            ):
+                runtime.read_memory("weaver", "current")
 
     def test_local_inbox_is_durable_but_not_cross_node_claim(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Scope
Close the #151 private-memory authority gap by making Employee memory deny-by-default and role-scoped, without using executor identity as an authorization source.

## Adds
- explicit `governance/employee-memory-policy.json`;
- per-role, per-memory-class read/write grants with no wildcards;
- active Role Registry hydration required before memory authorization;
- self-private memory only in v1; cross-Employee reads are denied;
- `EmployeeMemoryService` + bounded authorization decision;
- governance-specific memory for Spec Steward / Constitution Keeper;
- world-model memory for Cartographer;
- working/continuity memory for declared active roles;
- executor provider/model/session never grants memory authority;
- unknown class, unlisted role, missing role, and proposed/stale role fail closed;
- old unscoped `EmployeeRuntime.write_memory/read_memory` entrypoints now fail closed with `employee_memory_policy_required`;
- storage is isolated by Employee + memory class + key;
- Employee Runtime Guard covers policy and enforcement regressions.

## Architecture invariant
Private memory authority comes from explicit machine policy + active role identity, not model/provider/session identity and not prose inference.

Cross-role knowledge transfer should use governed messages/handoffs or future shared knowledge scopes, not another Employee's private memory.

## Remaining #151 work
Skill execution hydration, Cognitive Thread return semantics, Realm employee messaging, actual wake delivery/scheduler policy, and live persistent Spec Steward operating evidence remain open.

Target: `core/integration` only; no protected-main publication authority implied.