### PR TITLE
Core #151: hydrate bounded Employee skill contracts

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -10,30 +10,36 @@ on:
       - 'agent_core/employee_lifecycle.py'
       - 'agent_core/employee_wake.py'
       - 'agent_core/employee_memory.py'
+      - 'agent_core/employee_skills.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
+      - 'governance/employee-skills.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
       - 'tests/test_employee_memory.py'
+      - 'tests/test_employee_skills.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-151-role-memory-policy
+      - core/issue-151-skill-hydration
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
       - 'agent_core/employee_lifecycle.py'
       - 'agent_core/employee_wake.py'
       - 'agent_core/employee_memory.py'
+      - 'agent_core/employee_skills.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
+      - 'governance/employee-skills.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
       - 'tests/test_employee_memory.py'
+      - 'tests/test_employee_skills.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -61,5 +67,7 @@ jobs:
         run: python -m unittest tests.test_employee_wake -v
       - name: Run Employee memory-policy regressions
         run: python -m unittest tests.test_employee_memory -v
+      - name: Run Employee skill-hydration regressions
+        run: python -m unittest tests.test_employee_skills -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_skills.py
+++ b/agent_core/employee_skills.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+
+
+SKILL_REGISTRY_SCHEMA = "agentos.employee-skills/v1"
+SKILL_REQUEST_SCHEMA = "agentos.employee-skill-request/v1"
+MAX_ARGS_JSON_BYTES = 8192
+FORBIDDEN_CONTRACT_KEYS = {
+    "argv",
+    "executable",
+    "command",
+    "shell",
+    "url",
+    "endpoint",
+    "credential",
+    "credentials",
+    "token",
+    "secret",
+    "authorization",
+    "headers",
+    "env",
+    "environment",
+}
+SECRET_MARKERS = (
+    "bearer ",
+    "github_pat_",
+    "ghp_",
+    "token=",
+    "secret=",
+    "authorization:",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HydratedEmployeeSkill:
+    skill_id: str
+    version: str
+    purpose: str
+    required_capabilities: tuple[str, ...]
+    allowed_intents: tuple[str, ...]
+    input_fields: tuple[str, ...]
+    output_types: tuple[str, ...]
+    mutation_authority: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        for key in (
+            "required_capabilities",
+            "allowed_intents",
+            "input_fields",
+            "output_types",
+        ):
+            value[key] = list(value[key])
+        return value
+
+
+def _assert_no_forbidden_contract_fields(value: Any, *, path: str = "root") -> None:
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key).strip().casefold()
+            if key in FORBIDDEN_CONTRACT_KEYS:
+                raise ValueError(f"forbidden_skill_contract_field:{path}.{key}")
+            _assert_no_forbidden_contract_fields(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _assert_no_forbidden_contract_fields(item, path=f"{path}[{index}]")
+
+
+def _assert_safe_request_value(value: Any, *, path: str = "args") -> None:
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key).strip().casefold()
+            if key in FORBIDDEN_CONTRACT_KEYS:
+                raise ValueError(f"forbidden_skill_request_field:{path}.{key}")
+            _assert_safe_request_value(item, path=f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _assert_safe_request_value(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        lowered = value.casefold()
+        if "://" in value or any(marker in lowered for marker in SECRET_MARKERS):
+            raise ValueError(f"unsafe_skill_request_value:{path}")
+        return
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+    raise ValueError(f"unsupported_skill_request_value:{path}")
+
+
+class EmployeeSkillRegistry:
+    """Machine-readable skill contracts with no embedded execution carrier."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("employee_skill_registry_must_be_object")
+        if raw.get("schema") != SKILL_REGISTRY_SCHEMA:
+            raise ValueError("unsupported_employee_skill_registry_schema")
+        if raw.get("default_effect") != "deny":
+            raise ValueError("employee_skill_registry_must_default_deny")
+        skills = raw.get("skills")
+        if not isinstance(skills, dict):
+            raise ValueError("employee_skill_registry_skills_required")
+        _assert_no_forbidden_contract_fields(skills, path="skills")
+        self._skills: dict[str, dict[str, Any]] = {}
+        for raw_id, raw_skill in skills.items():
+            skill_id = str(raw_id).strip()
+            if not skill_id or skill_id == "*" or not isinstance(raw_skill, dict):
+                raise ValueError("invalid_employee_skill_entry")
+            self._skills[skill_id] = raw_skill
+
+    def resolve(self, skill_id: str) -> HydratedEmployeeSkill:
+        skill_id = str(skill_id or "").strip()
+        raw = self._skills.get(skill_id)
+        if raw is None:
+            raise KeyError(f"unknown_employee_skill:{skill_id}")
+        if raw.get("status") != "active":
+            raise ValueError(f"employee_skill_not_active:{skill_id}")
+        if raw.get("mutation_authority") is not False:
+            raise ValueError(f"employee_skill_mutation_authority_forbidden:{skill_id}")
+
+        def tuple_field(name: str) -> tuple[str, ...]:
+            value = raw.get(name, [])
+            if not isinstance(value, list):
+                raise ValueError(f"employee_skill_{name}_must_be_list:{skill_id}")
+            result = tuple(str(item).strip() for item in value)
+            if any(not item or item == "*" for item in result):
+                raise ValueError(f"employee_skill_{name}_wildcard_forbidden:{skill_id}")
+            return result
+
+        return HydratedEmployeeSkill(
+            skill_id=skill_id,
+            version=str(raw.get("version") or ""),
+            purpose=str(raw.get("purpose") or ""),
+            required_capabilities=tuple_field("required_capabilities"),
+            allowed_intents=tuple_field("allowed_intents"),
+            input_fields=tuple_field("input_fields"),
+            output_types=tuple_field("output_types"),
+            mutation_authority=False,
+        )
+
+
+class EmployeeSkillService:
+    """Hydrate skill contracts only when role authority covers their requirements."""
+
+    def __init__(
+        self,
+        runtime: EmployeeRuntime,
+        role_registry: RoleRegistry,
+        skill_registry: EmployeeSkillRegistry,
+    ) -> None:
+        self.runtime = runtime
+        self.role_registry = role_registry
+        self.skill_registry = skill_registry
+
+    def hydrate_employee_skills(self, employee_id: str) -> list[HydratedEmployeeSkill]:
+        employee = self.runtime.get_employee(employee_id)
+        roles = self.role_registry.hydrate_employee_roles(list(employee.role_ids))
+        role_capabilities = {
+            capability
+            for role in roles
+            for capability in role.capabilities
+        }
+        hydrated: list[HydratedEmployeeSkill] = []
+        for skill_id in employee.skill_ids:
+            skill = self.skill_registry.resolve(skill_id)
+            missing = sorted(
+                set(skill.required_capabilities) - role_capabilities
+            )
+            if missing:
+                raise PermissionError(
+                    "employee_skill_missing_role_capability:"
+                    + skill.skill_id
+                    + ":"
+                    + ",".join(missing)
+                )
+            hydrated.append(skill)
+        return hydrated
+
+    def build_request(
+        self,
+        employee_id: str,
+        skill_id: str,
+        intent: str,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        employee = self.runtime.get_employee(employee_id)
+        hydrated = {
+            skill.skill_id: skill
+            for skill in self.hydrate_employee_skills(employee_id)
+        }
+        skill = hydrated.get(skill_id)
+        if skill is None:
+            raise PermissionError("employee_skill_not_assigned")
+        intent = str(intent or "").strip()
+        if intent not in skill.allowed_intents:
+            raise PermissionError("employee_skill_intent_not_allowed")
+        arguments = dict(args or {})
+        unexpected = sorted(set(arguments) - set(skill.input_fields))
+        if unexpected:
+            raise ValueError(
+                "employee_skill_unexpected_input:" + ",".join(unexpected)
+            )
+        _assert_safe_request_value(arguments)
+        encoded = json.dumps(arguments, ensure_ascii=False, sort_keys=True).encode(
+            "utf-8"
+        )
+        if len(encoded) > MAX_ARGS_JSON_BYTES:
+            raise ValueError("employee_skill_request_too_large")
+
+        return {
+            "schema": SKILL_REQUEST_SCHEMA,
+            "employee_id": employee.agent_id,
+            "skill": skill.as_dict(),
+            "intent": intent,
+            "args": arguments,
+            "capability_authorization": "required_downstream",
+            "execution_authority": "external_governed_dispatcher",
+            "executor_selection": "unbound",
+            "transport_selection": "unbound",
+            "credential_exposed": False,
+        }

--- a/governance/employee-skills.json
+++ b/governance/employee-skills.json
@@ -1,0 +1,34 @@
+{
+  "schema": "agentos.employee-skills/v1",
+  "default_effect": "deny",
+  "skills": {
+    "spec.audit": {
+      "status": "active",
+      "version": "1",
+      "purpose": "Audit formal specifications for owner, target, implementation evidence, drift and closure gaps.",
+      "required_capabilities": [
+        "governance.spec.audit"
+      ],
+      "allowed_intents": [
+        "audit"
+      ],
+      "input_fields": [
+        "scope",
+        "target_refs"
+      ],
+      "output_types": [
+        "spec_drift_report",
+        "stale_spec_finding",
+        "closure_gap"
+      ],
+      "mutation_authority": false
+    }
+  },
+  "invariants": [
+    "skill_id_never_grants_capability_authority",
+    "employee_role_capabilities_must_cover_all_skill_required_capabilities",
+    "skill_contract_contains_no_executable_argv_shell_url_endpoint_or_credentials",
+    "skill_request_is_intent_only_and_requires_downstream_governed_execution",
+    "unknown_or_inactive_skill_fails_closed"
+  ]
+}

--- a/tests/test_employee_skills.py
+++ b/tests/test_employee_skills.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_skills import (
+    SKILL_REQUEST_SCHEMA,
+    EmployeeSkillRegistry,
+    EmployeeSkillService,
+)
+from agent_core.role_runtime import RoleRegistry
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class EmployeeSkillTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.roles = RoleRegistry(REPO_ROOT / ".agent" / "roles" / "registry.yaml")
+        self.registry = EmployeeSkillRegistry(
+            REPO_ROOT / "governance" / "employee-skills.json"
+        )
+        self.skills = EmployeeSkillService(
+            self.runtime,
+            self.roles,
+            self.registry,
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_spec_steward_hydrates_spec_audit_from_role_capability(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        hydrated = self.skills.hydrate_employee_skills("spec-steward")
+        self.assertEqual(len(hydrated), 1)
+        self.assertEqual(hydrated[0].skill_id, "spec.audit")
+        self.assertEqual(
+            hydrated[0].required_capabilities,
+            ("governance.spec.audit",),
+        )
+        self.assertFalse(hydrated[0].mutation_authority)
+
+    def test_skill_id_does_not_grant_missing_role_capability(self):
+        self.runtime.create_employee(
+            "weaver",
+            "Weaver",
+            role_ids=["sector.weaver"],
+            skill_ids=["spec.audit"],
+        )
+        with self.assertRaisesRegex(
+            PermissionError,
+            "employee_skill_missing_role_capability:spec.audit:governance.spec.audit",
+        ):
+            self.skills.hydrate_employee_skills("weaver")
+
+    def test_build_request_is_intent_only_and_authority_unbound(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        request = self.skills.build_request(
+            "spec-steward",
+            "spec.audit",
+            "audit",
+            {
+                "scope": "agentos-core",
+                "target_refs": ["issue:151", "spec:employee-runtime"],
+            },
+        )
+        self.assertEqual(request["schema"], SKILL_REQUEST_SCHEMA)
+        self.assertEqual(request["capability_authorization"], "required_downstream")
+        self.assertEqual(
+            request["execution_authority"], "external_governed_dispatcher"
+        )
+        self.assertEqual(request["executor_selection"], "unbound")
+        self.assertEqual(request["transport_selection"], "unbound")
+        self.assertFalse(request["credential_exposed"])
+        serialized = json.dumps(request, ensure_ascii=False).casefold()
+        for forbidden in (
+            '"argv"',
+            '"executable"',
+            '"command"',
+            '"shell"',
+            '"url"',
+            '"endpoint"',
+            '"credential"',
+            '"token"',
+            '"authorization"',
+            '"node_id"',
+            "github_actions",
+            "workflow_dispatch",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_skill_must_be_assigned_even_if_role_has_capability(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=[],
+        )
+        with self.assertRaisesRegex(PermissionError, "employee_skill_not_assigned"):
+            self.skills.build_request(
+                "spec-steward",
+                "spec.audit",
+                "audit",
+                {"scope": "agentos-core", "target_refs": []},
+            )
+
+    def test_unknown_or_unexpected_intent_and_input_fail_closed(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        with self.assertRaisesRegex(
+            PermissionError, "employee_skill_intent_not_allowed"
+        ):
+            self.skills.build_request(
+                "spec-steward",
+                "spec.audit",
+                "mutate",
+                {"scope": "agentos-core", "target_refs": []},
+            )
+        with self.assertRaisesRegex(ValueError, "employee_skill_unexpected_input"):
+            self.skills.build_request(
+                "spec-steward",
+                "spec.audit",
+                "audit",
+                {"scope": "agentos-core", "target_refs": [], "extra": True},
+            )
+
+    def test_request_rejects_arbitrary_execution_and_secret_surfaces(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        unsafe_values = (
+            {"scope": {"argv": ["rm", "-rf"]}, "target_refs": []},
+            {"scope": "https://example.invalid/private", "target_refs": []},
+            {"scope": "Bearer TOPSECRET", "target_refs": []},
+            {"scope": {"token": "TOPSECRET"}, "target_refs": []},
+        )
+        for args in unsafe_values:
+            with self.assertRaises(ValueError):
+                self.skills.build_request(
+                    "spec-steward", "spec.audit", "audit", args
+                )
+
+    def test_executor_rebinding_does_not_change_skill_authority_or_leak_session(self):
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        first = self.skills.build_request(
+            "spec-steward",
+            "spec.audit",
+            "audit",
+            {"scope": "agentos-core", "target_refs": []},
+        )
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="claude-code-local",
+            model="claude",
+            session_id="private-session-id",
+        )
+        second = self.skills.build_request(
+            "spec-steward",
+            "spec.audit",
+            "audit",
+            {"scope": "agentos-core", "target_refs": []},
+        )
+        self.assertEqual(first, second)
+        serialized = json.dumps(second, ensure_ascii=False)
+        self.assertNotIn("private-session-id", serialized)
+        self.assertNotIn("claude-code-local", serialized)
+
+    def test_registry_rejects_execution_carrier_fields(self):
+        invalid_contracts = (
+            {"argv": ["tool"]},
+            {"executable": "/bin/tool"},
+            {"url": "https://example.invalid"},
+            {"token": "secret"},
+        )
+        for extra in invalid_contracts:
+            path = self.root / "invalid-skills.json"
+            skill = {
+                "status": "active",
+                "version": "1",
+                "purpose": "invalid",
+                "required_capabilities": ["governance.spec.audit"],
+                "allowed_intents": ["audit"],
+                "input_fields": ["scope"],
+                "output_types": ["closure_gap"],
+                "mutation_authority": False,
+                **extra,
+            }
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema": "agentos.employee-skills/v1",
+                        "default_effect": "deny",
+                        "skills": {"bad": skill},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                EmployeeSkillRegistry(path)
+
+    def test_inactive_and_unknown_skill_fail_closed(self):
+        path = self.root / "inactive-skills.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": "agentos.employee-skills/v1",
+                    "default_effect": "deny",
+                    "skills": {
+                        "inactive": {
+                            "status": "proposed",
+                            "version": "1",
+                            "purpose": "not active",
+                            "required_capabilities": [],
+                            "allowed_intents": ["audit"],
+                            "input_fields": [],
+                            "output_types": [],
+                            "mutation_authority": False,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        registry = EmployeeSkillRegistry(path)
+        with self.assertRaisesRegex(ValueError, "employee_skill_not_active"):
+            registry.resolve("inactive")
+        with self.assertRaisesRegex(KeyError, "unknown_employee_skill"):
+            registry.resolve("missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Advance #151 `skill_ids` from opaque strings into machine-resolved, bounded Employee skill contracts without allowing a skill to become an execution carrier or capability authority.

## Adds
- explicit deny-by-default `governance/employee-skills.json`;
- first active Employee skill `spec.audit` requiring `governance.spec.audit`;
- `EmployeeSkillRegistry` with active/unknown/wildcard/mutation-authority fences;
- skill hydration requires all declared `required_capabilities` to already exist in the Employee's machine-hydrated active role capabilities;
- skill ID alone never grants capability authority;
- bounded intent-only skill request with declared inputs/outputs;
- downstream capability authorization remains required;
- executor and transport selection remain unbound;
- skill contract/request rejects executable, argv, shell, URL/endpoint, environment and credential/token/authorization surfaces;
- executor provider/model/session rebinding does not affect skill authority;
- Employee Runtime Guard covers skill hydration regressions.

## Architecture invariant
`skill != capability authority != executor carrier`.

A skill describes a governed semantic operation. ONE / the existing dispatcher must separately authorize and execute any required capability.

## Remaining #151 work
Cognitive Thread return semantics, Realm employee messaging, actual wake delivery/scheduler policy, and live persistent Spec Steward assignment/receipt remain open.

Target: `core/integration` only; no protected-main publication authority implied.