### PR TITLE
Core #151: add durable Cognitive Thread return stack

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -11,6 +11,7 @@ on:
       - 'agent_core/employee_wake.py'
       - 'agent_core/employee_memory.py'
       - 'agent_core/employee_skills.py'
+      - 'agent_core/employee_threads.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -19,12 +20,13 @@ on:
       - 'tests/test_employee_wake.py'
       - 'tests/test_employee_memory.py'
       - 'tests/test_employee_skills.py'
+      - 'tests/test_employee_threads.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-151-skill-hydration
+      - core/issue-151-cognitive-thread-return
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -32,6 +34,7 @@ on:
       - 'agent_core/employee_wake.py'
       - 'agent_core/employee_memory.py'
       - 'agent_core/employee_skills.py'
+      - 'agent_core/employee_threads.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -40,6 +43,7 @@ on:
       - 'tests/test_employee_wake.py'
       - 'tests/test_employee_memory.py'
       - 'tests/test_employee_skills.py'
+      - 'tests/test_employee_threads.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -69,5 +73,7 @@ jobs:
         run: python -m unittest tests.test_employee_memory -v
       - name: Run Employee skill-hydration regressions
         run: python -m unittest tests.test_employee_skills -v
+      - name: Run Cognitive Thread return regressions
+        run: python -m unittest tests.test_employee_threads -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_threads.py
+++ b/agent_core/employee_threads.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_lifecycle import EmployeeLifecycle, RECEIPT_SCHEMA
+
+
+THREAD_LINK_SCHEMA = "agentos.employee-thread-link/v1"
+THREAD_RETURN_SCHEMA = "agentos.employee-thread-return/v1"
+RETURNABLE_CHILD_STATES = {"completed", "blocked", "handoff", "cancelled"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return (value or _utcnow()).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "").strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError("unsafe_thread_id")
+    return value
+
+
+def _atomic_json_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("thread_state_invalid")
+    return value
+
+
+def _link_id(parent_assignment_id: str, child_assignment_id: str) -> str:
+    digest = hashlib.sha256(
+        f"{parent_assignment_id}\0{child_assignment_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    return "thread_" + digest
+
+
+def _return_id(child_assignment_id: str, generation: int) -> str:
+    digest = hashlib.sha256(
+        f"{child_assignment_id}\0{generation}".encode("utf-8")
+    ).hexdigest()[:24]
+    return "return_" + digest
+
+
+@dataclass(slots=True)
+class ThreadLink:
+    schema: str
+    link_id: str
+    parent_assignment_id: str
+    child_assignment_id: str
+    parent_employee_id: str
+    child_employee_id: str
+    parent_thread_head_at_spawn: str
+    status: str
+    created_at: str
+    return_prepared_at: str | None = None
+    applied_at: str | None = None
+    applied_parent_thread_head: str | None = None
+
+
+@dataclass(slots=True)
+class ThreadReturnEnvelope:
+    schema: str
+    return_id: str
+    link_id: str
+    parent_assignment_id: str
+    child_assignment_id: str
+    parent_employee_id: str
+    child_employee_id: str
+    child_outcome: str
+    child_thread_head: str
+    child_receipt_generation: int
+    parent_thread_head_at_spawn: str
+    parent_thread_head_current: str
+    parent_changed_since_spawn: bool
+    prepared_at: str
+    apply_authority_required: bool = True
+    credential_exposed: bool = False
+
+
+class EmployeeThreadService:
+    """Durable parent/child Cognitive Thread return stack.
+
+    Child completion never mutates the parent thread automatically.  It creates a
+    bounded return envelope.  Applying that return requires the parent Employee to
+    hold a current live lease and an optimistic thread-head fence, preventing a
+    parallel or newer parent continuation from being silently overwritten.
+    """
+
+    def __init__(self, lifecycle: EmployeeLifecycle) -> None:
+        self.lifecycle = lifecycle
+        self.root = lifecycle.root / "threads"
+        self.links_dir = self.root / "links"
+        self.returns_dir = self.root / "returns"
+
+    def _link_path(self, child_assignment_id: str) -> Path:
+        return self.links_dir / f"{_safe_id(child_assignment_id)}.json"
+
+    def _return_path(self, child_assignment_id: str) -> Path:
+        return self.returns_dir / f"{_safe_id(child_assignment_id)}.json"
+
+    def get_link(self, child_assignment_id: str) -> ThreadLink | None:
+        raw = _read_json(self._link_path(child_assignment_id))
+        return ThreadLink(**raw) if raw else None
+
+    def get_return(self, child_assignment_id: str) -> ThreadReturnEnvelope | None:
+        raw = _read_json(self._return_path(child_assignment_id))
+        return ThreadReturnEnvelope(**raw) if raw else None
+
+    def spawn_child(
+        self,
+        parent_assignment_id: str,
+        parent_lease_id: str,
+        child_assignment_id: str,
+        child_employee_id: str,
+        goal: str,
+        *,
+        constraints: list[str] | None = None,
+        thread_head: str = "",
+        now: datetime | None = None,
+    ) -> ThreadLink:
+        parent_assignment_id = _safe_id(parent_assignment_id)
+        child_assignment_id = _safe_id(child_assignment_id)
+        child_employee_id = _safe_id(child_employee_id)
+        self.lifecycle._require_current_active(  # noqa: SLF001 - same lifecycle boundary
+            parent_assignment_id,
+            parent_lease_id,
+            now=now,
+        )
+        parent = self.lifecycle.runtime.get_assignment(parent_assignment_id)
+        self.lifecycle.runtime.get_employee(child_employee_id)
+        link_path = self._link_path(child_assignment_id)
+        if link_path.exists():
+            raise FileExistsError("thread_link_already_exists")
+
+        self.lifecycle.runtime.create_assignment(
+            child_assignment_id,
+            child_employee_id,
+            goal,
+            parent_assignment_id=parent_assignment_id,
+            thread_head=str(thread_head or "").strip(),
+            constraints=list(constraints or []),
+        )
+        link = ThreadLink(
+            schema=THREAD_LINK_SCHEMA,
+            link_id=_link_id(parent_assignment_id, child_assignment_id),
+            parent_assignment_id=parent_assignment_id,
+            child_assignment_id=child_assignment_id,
+            parent_employee_id=parent.employee_id,
+            child_employee_id=child_employee_id,
+            parent_thread_head_at_spawn=parent.thread_head,
+            status="open",
+            created_at=_iso(now),
+        )
+        _atomic_json_write(link_path, asdict(link))
+        return link
+
+    def prepare_return(
+        self,
+        child_assignment_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> ThreadReturnEnvelope:
+        child_assignment_id = _safe_id(child_assignment_id)
+        link = self.get_link(child_assignment_id)
+        if link is None:
+            raise FileNotFoundError("thread_link_not_found")
+        if link.status == "applied":
+            existing = self.get_return(child_assignment_id)
+            if existing is None:
+                raise RuntimeError("applied_thread_return_missing")
+            return existing
+
+        child = self.lifecycle.runtime.get_assignment(child_assignment_id)
+        if child.state not in RETURNABLE_CHILD_STATES:
+            raise RuntimeError("child_assignment_not_returnable")
+        result = child.result if isinstance(child.result, dict) else {}
+        if result.get("schema") != RECEIPT_SCHEMA:
+            raise RuntimeError("child_terminal_receipt_required")
+        generation = int(result.get("generation") or 0)
+        if generation < 1:
+            raise RuntimeError("child_receipt_generation_invalid")
+
+        receipt_path = self.lifecycle._receipt_path(  # noqa: SLF001
+            child_assignment_id, generation
+        )
+        receipt = _read_json(receipt_path)
+        if not receipt or receipt.get("schema") != RECEIPT_SCHEMA:
+            raise RuntimeError("child_terminal_receipt_missing")
+        if receipt.get("outcome") != child.state:
+            raise RuntimeError("child_terminal_receipt_outcome_mismatch")
+
+        parent = self.lifecycle.runtime.get_assignment(link.parent_assignment_id)
+        prepared_at = _iso(now)
+        envelope = ThreadReturnEnvelope(
+            schema=THREAD_RETURN_SCHEMA,
+            return_id=_return_id(child_assignment_id, generation),
+            link_id=link.link_id,
+            parent_assignment_id=link.parent_assignment_id,
+            child_assignment_id=child_assignment_id,
+            parent_employee_id=link.parent_employee_id,
+            child_employee_id=link.child_employee_id,
+            child_outcome=child.state,
+            child_thread_head=child.thread_head,
+            child_receipt_generation=generation,
+            parent_thread_head_at_spawn=link.parent_thread_head_at_spawn,
+            parent_thread_head_current=parent.thread_head,
+            parent_changed_since_spawn=(
+                parent.thread_head != link.parent_thread_head_at_spawn
+            ),
+            prepared_at=prepared_at,
+        )
+        _atomic_json_write(self._return_path(child_assignment_id), asdict(envelope))
+        link.status = "return_ready"
+        link.return_prepared_at = prepared_at
+        _atomic_json_write(self._link_path(child_assignment_id), asdict(link))
+        return envelope
+
+    def apply_return(
+        self,
+        parent_assignment_id: str,
+        parent_lease_id: str,
+        child_assignment_id: str,
+        *,
+        expected_parent_thread_head: str,
+        new_parent_thread_head: str,
+        now: datetime | None = None,
+    ) -> ThreadLink:
+        parent_assignment_id = _safe_id(parent_assignment_id)
+        child_assignment_id = _safe_id(child_assignment_id)
+        link = self.get_link(child_assignment_id)
+        if link is None:
+            raise FileNotFoundError("thread_link_not_found")
+        if link.parent_assignment_id != parent_assignment_id:
+            raise PermissionError("thread_parent_mismatch")
+        if link.status == "applied":
+            if link.applied_parent_thread_head == str(new_parent_thread_head).strip():
+                return link
+            raise RuntimeError("thread_return_already_applied")
+        if link.status != "return_ready":
+            raise RuntimeError("thread_return_not_ready")
+
+        envelope = self.get_return(child_assignment_id)
+        if envelope is None:
+            raise RuntimeError("thread_return_envelope_missing")
+        self.lifecycle._require_current_active(  # noqa: SLF001
+            parent_assignment_id,
+            parent_lease_id,
+            now=now,
+        )
+        parent = self.lifecycle.runtime.get_assignment(parent_assignment_id)
+        expected = str(expected_parent_thread_head or "").strip()
+        if not expected:
+            raise ValueError("expected_parent_thread_head_required")
+        if expected != envelope.parent_thread_head_current:
+            raise RuntimeError("thread_return_expected_head_mismatch")
+        if parent.thread_head != envelope.parent_thread_head_current:
+            raise RuntimeError("parent_thread_advanced_after_return_preparation")
+        new_head = str(new_parent_thread_head or "").strip()
+        if not new_head:
+            raise ValueError("new_parent_thread_head_required")
+
+        self.lifecycle.checkpoint(
+            parent_assignment_id,
+            parent_lease_id,
+            new_head,
+            now=now,
+        )
+        link.status = "applied"
+        link.applied_at = _iso(now)
+        link.applied_parent_thread_head = new_head
+        _atomic_json_write(self._link_path(child_assignment_id), asdict(link))
+        return link

--- a/tests/test_employee_threads.py
+++ b/tests/test_employee_threads.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_threads import (
+    THREAD_LINK_SCHEMA,
+    THREAD_RETURN_SCHEMA,
+    EmployeeThreadService,
+)
+
+
+T0 = datetime(2026, 9, 2, 6, 0, 0, tzinfo=timezone.utc)
+
+
+class EmployeeThreadTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee("spec-steward", "Spec Steward")
+        self.runtime.create_employee("weaver", "Weaver")
+        self.runtime.create_assignment(
+            "parent-1",
+            "spec-steward",
+            "Close specification gaps",
+            thread_head="ir-parent-0",
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.lifecycle.claim(
+            "parent-1",
+            "spec-steward",
+            "parent-lease",
+            lease_seconds=300,
+            now=T0,
+        )
+        self.threads = EmployeeThreadService(self.lifecycle)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _spawn_and_finish_child(self):
+        link = self.threads.spawn_child(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            "weaver",
+            "Resolve one bounded specification question",
+            constraints=["no-parent-overwrite"],
+            thread_head="ir-child-0",
+            now=T0 + timedelta(seconds=5),
+        )
+        self.lifecycle.claim(
+            "child-1",
+            "weaver",
+            "child-lease",
+            now=T0 + timedelta(seconds=10),
+        )
+        self.lifecycle.checkpoint(
+            "child-1",
+            "child-lease",
+            "ir-child-complete",
+            now=T0 + timedelta(seconds=20),
+        )
+        receipt = self.lifecycle.finish(
+            "child-1",
+            "child-lease",
+            result_summary={
+                "answer": "bounded",
+                "private_detail": "must-not-be-in-return-envelope",
+            },
+            now=T0 + timedelta(seconds=30),
+        )
+        return link, receipt
+
+    def test_spawn_child_captures_parent_head_and_parent_relation(self):
+        link = self.threads.spawn_child(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            "weaver",
+            "Resolve one bounded specification question",
+            now=T0 + timedelta(seconds=5),
+        )
+        self.assertEqual(link.schema, THREAD_LINK_SCHEMA)
+        self.assertEqual(link.parent_thread_head_at_spawn, "ir-parent-0")
+        child = self.runtime.get_assignment("child-1")
+        self.assertEqual(child.parent_assignment_id, "parent-1")
+        self.assertEqual(child.employee_id, "weaver")
+
+    def test_child_completion_prepares_bounded_return_without_mutating_parent(self):
+        _, receipt = self._spawn_and_finish_child()
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        self.assertEqual(envelope.schema, THREAD_RETURN_SCHEMA)
+        self.assertEqual(envelope.child_outcome, "completed")
+        self.assertEqual(envelope.child_thread_head, "ir-child-complete")
+        self.assertEqual(envelope.child_receipt_generation, receipt.generation)
+        self.assertEqual(envelope.parent_thread_head_current, "ir-parent-0")
+        self.assertFalse(envelope.parent_changed_since_spawn)
+        self.assertTrue(envelope.apply_authority_required)
+        self.assertEqual(
+            self.runtime.get_assignment("parent-1").thread_head,
+            "ir-parent-0",
+        )
+        serialized = json.dumps(envelope.__dict__ if hasattr(envelope, "__dict__") else {
+            "schema": envelope.schema,
+            "child_outcome": envelope.child_outcome,
+            "child_thread_head": envelope.child_thread_head,
+            "parent_thread_head_current": envelope.parent_thread_head_current,
+        }, ensure_ascii=False)
+        self.assertNotIn("private_detail", serialized)
+        self.assertNotIn("must-not-be-in-return-envelope", serialized)
+
+    def test_parent_progress_after_spawn_is_reported_not_overwritten(self):
+        self._spawn_and_finish_child()
+        self.lifecycle.checkpoint(
+            "parent-1",
+            "parent-lease",
+            "ir-parent-parallel-progress",
+            now=T0 + timedelta(seconds=35),
+        )
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        self.assertTrue(envelope.parent_changed_since_spawn)
+        self.assertEqual(
+            envelope.parent_thread_head_at_spawn, "ir-parent-0"
+        )
+        self.assertEqual(
+            envelope.parent_thread_head_current,
+            "ir-parent-parallel-progress",
+        )
+
+    def test_apply_return_requires_live_parent_lease_and_exact_head_fence(self):
+        self._spawn_and_finish_child()
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        link = self.threads.apply_return(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            expected_parent_thread_head=envelope.parent_thread_head_current,
+            new_parent_thread_head="ir-parent-with-child",
+            now=T0 + timedelta(seconds=50),
+        )
+        self.assertEqual(link.status, "applied")
+        self.assertEqual(link.applied_parent_thread_head, "ir-parent-with-child")
+        self.assertEqual(
+            self.runtime.get_assignment("parent-1").thread_head,
+            "ir-parent-with-child",
+        )
+
+    def test_stale_prepared_return_cannot_overwrite_newer_parent_head(self):
+        self._spawn_and_finish_child()
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        self.lifecycle.checkpoint(
+            "parent-1",
+            "parent-lease",
+            "ir-parent-newer",
+            now=T0 + timedelta(seconds=45),
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "parent_thread_advanced_after_return_preparation"
+        ):
+            self.threads.apply_return(
+                "parent-1",
+                "parent-lease",
+                "child-1",
+                expected_parent_thread_head=envelope.parent_thread_head_current,
+                new_parent_thread_head="ir-unsafe-overwrite",
+                now=T0 + timedelta(seconds=50),
+            )
+        self.assertEqual(
+            self.runtime.get_assignment("parent-1").thread_head,
+            "ir-parent-newer",
+        )
+
+    def test_apply_return_rejects_expired_parent_owner(self):
+        self._spawn_and_finish_child()
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        with self.assertRaisesRegex(RuntimeError, "lease_expired"):
+            self.threads.apply_return(
+                "parent-1",
+                "parent-lease",
+                "child-1",
+                expected_parent_thread_head=envelope.parent_thread_head_current,
+                new_parent_thread_head="ir-parent-with-child",
+                now=T0 + timedelta(seconds=301),
+            )
+
+    def test_child_must_have_terminal_receipt_before_return(self):
+        self.threads.spawn_child(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            "weaver",
+            "Still working",
+            now=T0 + timedelta(seconds=5),
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "child_assignment_not_returnable"
+        ):
+            self.threads.prepare_return(
+                "child-1", now=T0 + timedelta(seconds=10)
+            )
+
+    def test_return_state_survives_runtime_restart(self):
+        self._spawn_and_finish_child()
+        prepared = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        restarted_runtime = EmployeeRuntime(self.root)
+        restarted_lifecycle = EmployeeLifecycle(restarted_runtime)
+        restarted_threads = EmployeeThreadService(restarted_lifecycle)
+        loaded = restarted_threads.get_return("child-1")
+        self.assertEqual(loaded.return_id, prepared.return_id)
+        self.assertEqual(loaded.child_thread_head, "ir-child-complete")
+        self.assertEqual(
+            restarted_threads.get_link("child-1").status,
+            "return_ready",
+        )
+
+    def test_duplicate_apply_is_idempotent_for_same_new_head(self):
+        self._spawn_and_finish_child()
+        envelope = self.threads.prepare_return(
+            "child-1", now=T0 + timedelta(seconds=40)
+        )
+        first = self.threads.apply_return(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            expected_parent_thread_head=envelope.parent_thread_head_current,
+            new_parent_thread_head="ir-parent-with-child",
+            now=T0 + timedelta(seconds=50),
+        )
+        second = self.threads.apply_return(
+            "parent-1",
+            "parent-lease",
+            "child-1",
+            expected_parent_thread_head=envelope.parent_thread_head_current,
+            new_parent_thread_head="ir-parent-with-child",
+            now=T0 + timedelta(seconds=60),
+        )
+        self.assertEqual(first.link_id, second.link_id)
+        self.assertEqual(second.status, "applied")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Advance #151 with durable parent/child Cognitive Thread return semantics so delegated work can return to the parent assignment without relying on vendor chat history or overwriting a newer parent continuation.

## Adds
- durable parent/child thread link created only by a live parent lease owner;
- parent thread head captured at child spawn;
- child terminal receipt required before return preparation;
- bounded return envelope containing child outcome/thread head/receipt generation but not arbitrary result summary or executor session identity;
- child completion never mutates parent automatically;
- parent parallel progress is detected via spawn-vs-current head comparison;
- return apply requires a live parent lease and exact optimistic parent-thread fence;
- stale prepared return cannot overwrite a newer parent head;
- applied return is persisted and duplicate same-head apply is idempotent;
- return state survives runtime restart;
- Employee Runtime Guard covers Cognitive Thread regressions.

## Architecture invariant
`child completion != parent continuation mutation`.

A child produces evidence for return. The current parent owner must deliberately integrate it into a new parent thread head. This preserves parallel worker safety and executor-independent continuation.

## Remaining #151 work
Realm employee messaging, actual wake delivery/scheduler policy, and a live persistent Spec Steward assignment/receipt remain open.

Target: `core/integration` only; no protected-main publication authority implied.