### PR TITLE
Core #197: add ONE-resident Realm Employee mailbox

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -12,6 +12,7 @@ on:
       - 'agent_core/employee_memory.py'
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
+      - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -21,12 +22,13 @@ on:
       - 'tests/test_employee_memory.py'
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
+      - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-151-cognitive-thread-return
+      - core/issue-197-realm-mailbox
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -35,6 +37,7 @@ on:
       - 'agent_core/employee_memory.py'
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
+      - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -44,6 +47,7 @@ on:
       - 'tests/test_employee_memory.py'
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
+      - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -75,5 +79,7 @@ jobs:
         run: python -m unittest tests.test_employee_skills -v
       - name: Run Cognitive Thread return regressions
         run: python -m unittest tests.test_employee_threads -v
+      - name: Run Realm Employee mailbox regressions
+        run: python -m unittest tests.test_employee_realm_mailbox -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/employee_realm_mailbox.py
+++ b/agent_core/employee_realm_mailbox.py
@@ -132,6 +132,7 @@ class RealmEmployeeMessage:
     state: str = "queued"
     delivery_generation: int = 0
     active_claim_id: str | None = None
+    active_claimed_at: str | None = None
     active_claim_expires_at: str | None = None
     acknowledged_at: str | None = None
     receipt_id: str | None = None
@@ -173,15 +174,15 @@ class RealmEmployeeMessageReceipt:
 class EmployeeRealmMailbox:
     """ONE/Core-resident durable mailbox addressed by Employee identity.
 
-    The mailbox is deliberately independent of Node/model/session location.  A
+    The mailbox is deliberately independent of Node/model/session location. A
     message remains in ONE until a worker that currently owns an assignment for
-    the recipient Employee claims and acknowledges it.  This module chooses no
+    the recipient Employee claims and acknowledges it. This module chooses no
     Node, executor, external transport or capability carrier.
     """
 
     def __init__(self, lifecycle: EmployeeLifecycle) -> None:
         self.lifecycle = lifecycle
-        self.root = lifecycle.root / "realm" / "employee-mailbox"
+        self.root = lifecycle.runtime.root / "realm" / "employee-mailbox"
         self.messages_dir = self.root / "messages"
         self.receipts_dir = self.root / "receipts"
 
@@ -344,7 +345,7 @@ class EmployeeRealmMailbox:
                         recipient_employee_id=recipient_employee_id,
                         recipient_assignment_id=recipient_assignment_id,
                         delivery_generation=message.delivery_generation,
-                        claimed_at=payload.get("active_claimed_at") or _iso(current),
+                        claimed_at=message.active_claimed_at or _iso(current),
                         expires_at=message.active_claim_expires_at or _iso(current),
                         redelivery_required=message.delivery_generation > 1,
                         prior_delivery_state="unknown" if message.delivery_generation > 1 else "known",
@@ -410,11 +411,7 @@ class EmployeeRealmMailbox:
         payload = _read(path)
         if payload is None:
             raise FileNotFoundError(message_id)
-        message = RealmEmployeeMessage(**{
-            key: value
-            for key, value in payload.items()
-            if key in RealmEmployeeMessage.__dataclass_fields__
-        })
+        message = RealmEmployeeMessage(**payload)
         if message.recipient_employee_id != recipient_employee_id:
             raise PermissionError("employee_message_recipient_mismatch")
         if message.state == "acknowledged":

--- a/agent_core/employee_realm_mailbox.py
+++ b/agent_core/employee_realm_mailbox.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+
+
+MESSAGE_SCHEMA = "agentos.employee-realm-message/v1"
+CLAIM_SCHEMA = "agentos.employee-realm-message-claim/v1"
+RECEIPT_SCHEMA = "agentos.employee-realm-message-receipt/v1"
+MESSAGE_KINDS = {"handoff", "finding", "question", "answer", "notification"}
+RECEIPT_DISPOSITIONS = {"processed", "deferred", "rejected"}
+MAX_SUBJECT_CHARS = 160
+MAX_SUMMARY_CHARS = 4000
+MAX_REFS = 32
+MAX_REF_CHARS = 256
+MAX_CLAIM_SECONDS = 600
+SECRET_MARKERS = (
+    "bearer ",
+    "github_pat_",
+    "ghp_",
+    "token=",
+    "secret=",
+    "authorization:",
+)
+FORBIDDEN_REF_MARKERS = ("://", "\\", "../", "..\\")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return (value or _now()).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "").strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError("unsafe_employee_message_id")
+    return value
+
+
+def _safe_text(value: str, *, limit: int, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field}_required")
+    if len(text) > limit:
+        raise ValueError(f"{field}_too_long")
+    lowered = text.casefold()
+    if any(marker in lowered for marker in SECRET_MARKERS):
+        raise ValueError(f"{field}_contains_secret_like_value")
+    return text
+
+
+def _safe_ref(value: str) -> str:
+    ref = str(value or "").strip()
+    if not ref or len(ref) > MAX_REF_CHARS:
+        raise ValueError("invalid_employee_message_ref")
+    lowered = ref.casefold()
+    if any(marker in lowered for marker in SECRET_MARKERS):
+        raise ValueError("employee_message_ref_contains_secret_like_value")
+    if ref.startswith(("/", "~")) or any(marker in ref for marker in FORBIDDEN_REF_MARKERS):
+        raise ValueError("employee_message_ref_must_be_logical")
+    if ":" not in ref:
+        raise ValueError("employee_message_ref_must_be_typed")
+    return ref
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("employee_message_state_invalid")
+    return payload
+
+
+def _message_digest(payload: dict[str, Any]) -> str:
+    canonical = {
+        key: payload.get(key)
+        for key in (
+            "sender_employee_id",
+            "recipient_employee_id",
+            "kind",
+            "subject",
+            "summary",
+            "assignment_ref",
+            "thread_ref",
+            "artifact_refs",
+        )
+    }
+    raw = json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass(slots=True)
+class RealmEmployeeMessage:
+    schema: str
+    message_id: str
+    digest: str
+    sender_employee_id: str
+    recipient_employee_id: str
+    kind: str
+    subject: str
+    summary: str
+    assignment_ref: str | None
+    thread_ref: str | None
+    artifact_refs: list[str]
+    created_at: str
+    state: str = "queued"
+    delivery_generation: int = 0
+    active_claim_id: str | None = None
+    active_claim_expires_at: str | None = None
+    acknowledged_at: str | None = None
+    receipt_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RealmEmployeeMessageClaim:
+    schema: str
+    message_id: str
+    claim_id: str
+    recipient_employee_id: str
+    recipient_assignment_id: str
+    delivery_generation: int
+    claimed_at: str
+    expires_at: str
+    redelivery_required: bool
+    prior_delivery_state: str
+    transport: str = "one_resident_mailbox"
+    node_selection: str = "unbound"
+    executor_selection: str = "unbound"
+    credential_exposed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RealmEmployeeMessageReceipt:
+    schema: str
+    receipt_id: str
+    message_id: str
+    claim_id: str
+    recipient_employee_id: str
+    recipient_assignment_id: str
+    delivery_generation: int
+    disposition: str
+    acknowledged_at: str
+    transport: str = "one_resident_mailbox"
+    credential_exposed: bool = False
+
+
+class EmployeeRealmMailbox:
+    """ONE/Core-resident durable mailbox addressed by Employee identity.
+
+    The mailbox is deliberately independent of Node/model/session location.  A
+    message remains in ONE until a worker that currently owns an assignment for
+    the recipient Employee claims and acknowledges it.  This module chooses no
+    Node, executor, external transport or capability carrier.
+    """
+
+    def __init__(self, lifecycle: EmployeeLifecycle) -> None:
+        self.lifecycle = lifecycle
+        self.root = lifecycle.root / "realm" / "employee-mailbox"
+        self.messages_dir = self.root / "messages"
+        self.receipts_dir = self.root / "receipts"
+
+    def _message_path(self, recipient_employee_id: str, message_id: str) -> Path:
+        return self.messages_dir / _safe_id(recipient_employee_id) / f"{_safe_id(message_id)}.json"
+
+    def _receipt_path(self, message_id: str, generation: int) -> Path:
+        return self.receipts_dir / _safe_id(message_id) / f"{int(generation)}.json"
+
+    def _find_message_path(self, message_id: str) -> Path:
+        message_id = _safe_id(message_id)
+        matches = list(self.messages_dir.glob(f"*/{message_id}.json"))
+        if not matches:
+            raise FileNotFoundError(message_id)
+        if len(matches) > 1:
+            raise RuntimeError("duplicate_employee_message_id")
+        return matches[0]
+
+    def get(self, message_id: str) -> RealmEmployeeMessage:
+        payload = _read(self._find_message_path(message_id))
+        if payload is None:
+            raise FileNotFoundError(message_id)
+        if payload.get("schema") != MESSAGE_SCHEMA:
+            raise ValueError("employee_message_schema_invalid")
+        return RealmEmployeeMessage(**payload)
+
+    def send(
+        self,
+        sender_employee_id: str,
+        sender_assignment_id: str,
+        sender_lease_id: str,
+        recipient_employee_id: str,
+        message_id: str,
+        *,
+        kind: str,
+        subject: str,
+        summary: str,
+        assignment_ref: str | None = None,
+        thread_ref: str | None = None,
+        artifact_refs: list[str] | None = None,
+        now: datetime | None = None,
+    ) -> RealmEmployeeMessage:
+        sender_employee_id = _safe_id(sender_employee_id)
+        recipient_employee_id = _safe_id(recipient_employee_id)
+        message_id = _safe_id(message_id)
+        kind = str(kind or "").strip()
+        if kind not in MESSAGE_KINDS:
+            raise ValueError("employee_message_kind_not_allowed")
+
+        self.lifecycle.runtime.get_employee(sender_employee_id)
+        self.lifecycle.runtime.get_employee(recipient_employee_id)
+        self.lifecycle._require_current_active(  # noqa: SLF001
+            sender_assignment_id,
+            sender_lease_id,
+            now=now,
+        )
+        sender_assignment = self.lifecycle.runtime.get_assignment(sender_assignment_id)
+        if sender_assignment.employee_id != sender_employee_id:
+            raise PermissionError("sender_assignment_employee_mismatch")
+
+        refs = list(artifact_refs or [])
+        if len(refs) > MAX_REFS:
+            raise ValueError("employee_message_too_many_refs")
+        normalized_refs = [_safe_ref(value) for value in refs]
+        normalized_assignment_ref = _safe_ref(assignment_ref) if assignment_ref else None
+        normalized_thread_ref = _safe_ref(thread_ref) if thread_ref else None
+
+        candidate = RealmEmployeeMessage(
+            schema=MESSAGE_SCHEMA,
+            message_id=message_id,
+            digest="",
+            sender_employee_id=sender_employee_id,
+            recipient_employee_id=recipient_employee_id,
+            kind=kind,
+            subject=_safe_text(subject, limit=MAX_SUBJECT_CHARS, field="subject"),
+            summary=_safe_text(summary, limit=MAX_SUMMARY_CHARS, field="summary"),
+            assignment_ref=normalized_assignment_ref,
+            thread_ref=normalized_thread_ref,
+            artifact_refs=normalized_refs,
+            created_at=_iso(now),
+        )
+        raw = asdict(candidate)
+        raw["digest"] = _message_digest(raw)
+        candidate.digest = raw["digest"]
+        path = self._message_path(recipient_employee_id, message_id)
+        existing = _read(path)
+        if existing is not None:
+            if existing.get("digest") != candidate.digest:
+                raise RuntimeError("employee_message_idempotency_conflict")
+            return RealmEmployeeMessage(**existing)
+        _atomic_write(path, raw)
+        return candidate
+
+    def pending(self, recipient_employee_id: str, *, now: datetime | None = None) -> list[RealmEmployeeMessage]:
+        recipient_employee_id = _safe_id(recipient_employee_id)
+        self.lifecycle.runtime.get_employee(recipient_employee_id)
+        current = now or _now()
+        inbox = self.messages_dir / recipient_employee_id
+        if not inbox.exists():
+            return []
+        result: list[RealmEmployeeMessage] = []
+        for path in sorted(inbox.glob("*.json")):
+            payload = _read(path)
+            if not payload or payload.get("schema") != MESSAGE_SCHEMA:
+                continue
+            message = RealmEmployeeMessage(**payload)
+            if message.state == "acknowledged":
+                continue
+            if message.state == "claimed" and message.active_claim_expires_at:
+                if _parse(message.active_claim_expires_at) > current:
+                    continue
+            result.append(message)
+        return result
+
+    def claim(
+        self,
+        message_id: str,
+        recipient_employee_id: str,
+        recipient_assignment_id: str,
+        recipient_lease_id: str,
+        claim_id: str,
+        *,
+        claim_seconds: int = 120,
+        now: datetime | None = None,
+    ) -> RealmEmployeeMessageClaim:
+        message_id = _safe_id(message_id)
+        recipient_employee_id = _safe_id(recipient_employee_id)
+        claim_id = _safe_id(claim_id)
+        current = now or _now()
+        claim_seconds = max(15, min(int(claim_seconds), MAX_CLAIM_SECONDS))
+
+        self.lifecycle._require_current_active(  # noqa: SLF001
+            recipient_assignment_id,
+            recipient_lease_id,
+            now=current,
+        )
+        assignment = self.lifecycle.runtime.get_assignment(recipient_assignment_id)
+        if assignment.employee_id != recipient_employee_id:
+            raise PermissionError("recipient_assignment_employee_mismatch")
+
+        path = self._find_message_path(message_id)
+        payload = _read(path)
+        if payload is None:
+            raise FileNotFoundError(message_id)
+        message = RealmEmployeeMessage(**payload)
+        if message.recipient_employee_id != recipient_employee_id:
+            raise PermissionError("employee_message_recipient_mismatch")
+        if message.state == "acknowledged":
+            raise RuntimeError("employee_message_already_acknowledged")
+
+        prior_unknown = False
+        if message.state == "claimed" and message.active_claim_id:
+            expires = _parse(message.active_claim_expires_at or "1970-01-01T00:00:00Z")
+            if expires > current:
+                if message.active_claim_id == claim_id:
+                    return RealmEmployeeMessageClaim(
+                        schema=CLAIM_SCHEMA,
+                        message_id=message_id,
+                        claim_id=claim_id,
+                        recipient_employee_id=recipient_employee_id,
+                        recipient_assignment_id=recipient_assignment_id,
+                        delivery_generation=message.delivery_generation,
+                        claimed_at=payload.get("active_claimed_at") or _iso(current),
+                        expires_at=message.active_claim_expires_at or _iso(current),
+                        redelivery_required=message.delivery_generation > 1,
+                        prior_delivery_state="unknown" if message.delivery_generation > 1 else "known",
+                    )
+                raise RuntimeError("employee_message_already_claimed")
+            prior_unknown = True
+
+        generation = message.delivery_generation + 1
+        claimed_at = _iso(current)
+        expires_at = _iso(current + timedelta(seconds=claim_seconds))
+        payload.update(
+            {
+                "state": "claimed",
+                "delivery_generation": generation,
+                "active_claim_id": claim_id,
+                "active_claimed_at": claimed_at,
+                "active_claim_expires_at": expires_at,
+            }
+        )
+        _atomic_write(path, payload)
+        return RealmEmployeeMessageClaim(
+            schema=CLAIM_SCHEMA,
+            message_id=message_id,
+            claim_id=claim_id,
+            recipient_employee_id=recipient_employee_id,
+            recipient_assignment_id=recipient_assignment_id,
+            delivery_generation=generation,
+            claimed_at=claimed_at,
+            expires_at=expires_at,
+            redelivery_required=prior_unknown,
+            prior_delivery_state="unknown" if prior_unknown else "known",
+        )
+
+    def acknowledge(
+        self,
+        message_id: str,
+        recipient_employee_id: str,
+        recipient_assignment_id: str,
+        recipient_lease_id: str,
+        claim_id: str,
+        *,
+        disposition: str = "processed",
+        now: datetime | None = None,
+    ) -> RealmEmployeeMessageReceipt:
+        message_id = _safe_id(message_id)
+        recipient_employee_id = _safe_id(recipient_employee_id)
+        claim_id = _safe_id(claim_id)
+        disposition = str(disposition or "").strip()
+        if disposition not in RECEIPT_DISPOSITIONS:
+            raise ValueError("employee_message_disposition_not_allowed")
+        current = now or _now()
+
+        self.lifecycle._require_current_active(  # noqa: SLF001
+            recipient_assignment_id,
+            recipient_lease_id,
+            now=current,
+        )
+        assignment = self.lifecycle.runtime.get_assignment(recipient_assignment_id)
+        if assignment.employee_id != recipient_employee_id:
+            raise PermissionError("recipient_assignment_employee_mismatch")
+
+        path = self._find_message_path(message_id)
+        payload = _read(path)
+        if payload is None:
+            raise FileNotFoundError(message_id)
+        message = RealmEmployeeMessage(**{
+            key: value
+            for key, value in payload.items()
+            if key in RealmEmployeeMessage.__dataclass_fields__
+        })
+        if message.recipient_employee_id != recipient_employee_id:
+            raise PermissionError("employee_message_recipient_mismatch")
+        if message.state == "acknowledged":
+            receipt_payload = _read(self._receipt_path(message_id, message.delivery_generation))
+            if receipt_payload is None:
+                raise RuntimeError("employee_message_receipt_missing")
+            return RealmEmployeeMessageReceipt(**receipt_payload)
+        if message.state != "claimed" or message.active_claim_id != claim_id:
+            raise PermissionError("employee_message_claim_not_owned")
+        if not message.active_claim_expires_at or _parse(message.active_claim_expires_at) <= current:
+            raise RuntimeError("employee_message_claim_expired")
+
+        receipt_id = "msgreceipt_" + hashlib.sha256(
+            f"{message_id}\0{message.delivery_generation}\0{claim_id}\0{disposition}".encode("utf-8")
+        ).hexdigest()[:24]
+        receipt = RealmEmployeeMessageReceipt(
+            schema=RECEIPT_SCHEMA,
+            receipt_id=receipt_id,
+            message_id=message_id,
+            claim_id=claim_id,
+            recipient_employee_id=recipient_employee_id,
+            recipient_assignment_id=recipient_assignment_id,
+            delivery_generation=message.delivery_generation,
+            disposition=disposition,
+            acknowledged_at=_iso(current),
+        )
+        # Receipt is persisted before message terminal state so an interrupted
+        # acknowledgement can be recovered without inventing a successful ack.
+        _atomic_write(self._receipt_path(message_id, message.delivery_generation), asdict(receipt))
+        payload.update(
+            {
+                "state": "acknowledged",
+                "acknowledged_at": receipt.acknowledged_at,
+                "receipt_id": receipt.receipt_id,
+            }
+        )
+        _atomic_write(path, payload)
+        return receipt

--- a/tests/test_employee_realm_mailbox.py
+++ b/tests/test_employee_realm_mailbox.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_realm_mailbox import (
+    CLAIM_SCHEMA,
+    MESSAGE_SCHEMA,
+    RECEIPT_SCHEMA,
+    EmployeeRealmMailbox,
+)
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+T0 = datetime(2026, 9, 2, 7, 0, 0, tzinfo=timezone.utc)
+
+
+class EmployeeRealmMailboxTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee("weaver", "Weaver")
+        self.runtime.create_employee("spec-steward", "Spec Steward")
+        self.runtime.create_assignment(
+            "sender-a",
+            "weaver",
+            "Prepare bounded handoff",
+            thread_head="thread:sender",
+        )
+        self.runtime.create_assignment(
+            "recipient-a",
+            "spec-steward",
+            "Review handoff",
+            thread_head="thread:recipient",
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.lifecycle.claim(
+            "sender-a", "weaver", "lease-sender", lease_seconds=600, now=T0
+        )
+        self.lifecycle.claim(
+            "recipient-a",
+            "spec-steward",
+            "lease-recipient",
+            lease_seconds=600,
+            now=T0,
+        )
+        self.mailbox = EmployeeRealmMailbox(self.lifecycle)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _send(self, message_id="msg-1"):
+        return self.mailbox.send(
+            "weaver",
+            "sender-a",
+            "lease-sender",
+            "spec-steward",
+            message_id,
+            kind="handoff",
+            subject="Specification handoff",
+            summary="Review the bounded closure finding.",
+            assignment_ref="assignment:sender-a",
+            thread_ref="thread:sender",
+            artifact_refs=["issue:197", "spec:employee-operating-plane"],
+            now=T0 + timedelta(seconds=10),
+        )
+
+    def test_send_persists_employee_addressed_message_in_one_mailbox(self):
+        message = self._send()
+        self.assertEqual(message.schema, MESSAGE_SCHEMA)
+        self.assertEqual(message.sender_employee_id, "weaver")
+        self.assertEqual(message.recipient_employee_id, "spec-steward")
+        self.assertEqual(message.state, "queued")
+        self.assertEqual(message.delivery_generation, 0)
+        path = (
+            self.root
+            / "realm"
+            / "employee-mailbox"
+            / "messages"
+            / "spec-steward"
+            / "msg-1.json"
+        )
+        self.assertTrue(path.is_file())
+        serialized = path.read_text(encoding="utf-8").casefold()
+        for forbidden in (
+            "node_id",
+            "provider",
+            "session_id",
+            "github_actions",
+            "workflow_dispatch",
+            "executable",
+            "argv",
+            "authorization",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_same_message_id_and_content_is_idempotent_but_conflict_fails(self):
+        first = self._send()
+        second = self._send()
+        self.assertEqual(first.digest, second.digest)
+        with self.assertRaisesRegex(
+            RuntimeError, "employee_message_idempotency_conflict"
+        ):
+            self.mailbox.send(
+                "weaver",
+                "sender-a",
+                "lease-sender",
+                "spec-steward",
+                "msg-1",
+                kind="handoff",
+                subject="Changed subject",
+                summary="Different body",
+                now=T0 + timedelta(seconds=20),
+            )
+
+    def test_sender_must_own_live_assignment(self):
+        with self.assertRaisesRegex(
+            PermissionError, "sender_assignment_employee_mismatch"
+        ):
+            self.mailbox.send(
+                "weaver",
+                "recipient-a",
+                "lease-recipient",
+                "spec-steward",
+                "msg-wrong-owner",
+                kind="finding",
+                subject="No",
+                summary="This sender does not own the assignment.",
+                now=T0 + timedelta(seconds=10),
+            )
+        with self.assertRaisesRegex(RuntimeError, "lease_expired"):
+            self.mailbox.send(
+                "weaver",
+                "sender-a",
+                "lease-sender",
+                "spec-steward",
+                "msg-expired",
+                kind="finding",
+                subject="Expired",
+                summary="Lease is no longer current.",
+                now=T0 + timedelta(seconds=601),
+            )
+
+    def test_payload_surface_is_bounded_and_rejects_urls_paths_and_secrets(self):
+        unsafe = (
+            {"artifact_refs": ["https://example.invalid/a"]},
+            {"artifact_refs": ["/tmp/private"]},
+            {"artifact_refs": ["file:../private"]},
+            {"artifact_refs": ["token=TOPSECRET"]},
+            {"summary": "Bearer TOPSECRET"},
+        )
+        for index, override in enumerate(unsafe):
+            kwargs = {
+                "kind": "finding",
+                "subject": "Bounded",
+                "summary": "Safe summary",
+                "artifact_refs": ["issue:197"],
+            }
+            kwargs.update(override)
+            with self.assertRaises(ValueError):
+                self.mailbox.send(
+                    "weaver",
+                    "sender-a",
+                    "lease-sender",
+                    "spec-steward",
+                    f"unsafe-{index}",
+                    now=T0 + timedelta(seconds=10),
+                    **kwargs,
+                )
+
+    def test_recipient_claim_requires_recipient_assignment_lease(self):
+        self._send()
+        with self.assertRaisesRegex(
+            PermissionError, "recipient_assignment_employee_mismatch"
+        ):
+            self.mailbox.claim(
+                "msg-1",
+                "spec-steward",
+                "sender-a",
+                "lease-sender",
+                "claim-wrong",
+                now=T0 + timedelta(seconds=20),
+            )
+        claim = self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            now=T0 + timedelta(seconds=20),
+        )
+        self.assertEqual(claim.schema, CLAIM_SCHEMA)
+        self.assertEqual(claim.delivery_generation, 1)
+        self.assertFalse(claim.redelivery_required)
+        self.assertEqual(claim.prior_delivery_state, "known")
+        self.assertEqual(claim.transport, "one_resident_mailbox")
+        self.assertEqual(claim.node_selection, "unbound")
+        self.assertEqual(claim.executor_selection, "unbound")
+        self.assertFalse(claim.credential_exposed)
+
+    def test_live_claim_suppresses_other_claim_and_same_claim_is_idempotent(self):
+        self._send()
+        first = self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            now=T0 + timedelta(seconds=20),
+        )
+        same = self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            now=T0 + timedelta(seconds=30),
+        )
+        self.assertEqual(first.delivery_generation, same.delivery_generation)
+        with self.assertRaisesRegex(RuntimeError, "employee_message_already_claimed"):
+            self.mailbox.claim(
+                "msg-1",
+                "spec-steward",
+                "recipient-a",
+                "lease-recipient",
+                "claim-2",
+                now=T0 + timedelta(seconds=30),
+            )
+
+    def test_expired_claim_redelivery_marks_prior_delivery_unknown(self):
+        self._send()
+        self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            claim_seconds=30,
+            now=T0 + timedelta(seconds=20),
+        )
+        claim = self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-2",
+            now=T0 + timedelta(seconds=51),
+        )
+        self.assertEqual(claim.delivery_generation, 2)
+        self.assertTrue(claim.redelivery_required)
+        self.assertEqual(claim.prior_delivery_state, "unknown")
+
+    def test_ack_receipt_is_persisted_before_terminal_message_and_idempotent(self):
+        self._send()
+        self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            now=T0 + timedelta(seconds=20),
+        )
+        receipt = self.mailbox.acknowledge(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            disposition="processed",
+            now=T0 + timedelta(seconds=30),
+        )
+        self.assertEqual(receipt.schema, RECEIPT_SCHEMA)
+        self.assertEqual(receipt.delivery_generation, 1)
+        self.assertEqual(receipt.disposition, "processed")
+        self.assertFalse(receipt.credential_exposed)
+        self.assertEqual(self.mailbox.get("msg-1").state, "acknowledged")
+        repeated = self.mailbox.acknowledge(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            disposition="processed",
+            now=T0 + timedelta(seconds=40),
+        )
+        self.assertEqual(repeated.receipt_id, receipt.receipt_id)
+        self.assertEqual(self.mailbox.pending("spec-steward"), [])
+
+    def test_ack_requires_current_claim_and_live_employee_assignment(self):
+        self._send()
+        self.mailbox.claim(
+            "msg-1",
+            "spec-steward",
+            "recipient-a",
+            "lease-recipient",
+            "claim-1",
+            claim_seconds=30,
+            now=T0 + timedelta(seconds=20),
+        )
+        with self.assertRaisesRegex(PermissionError, "employee_message_claim_not_owned"):
+            self.mailbox.acknowledge(
+                "msg-1",
+                "spec-steward",
+                "recipient-a",
+                "lease-recipient",
+                "claim-other",
+                now=T0 + timedelta(seconds=25),
+            )
+        with self.assertRaisesRegex(RuntimeError, "employee_message_claim_expired"):
+            self.mailbox.acknowledge(
+                "msg-1",
+                "spec-steward",
+                "recipient-a",
+                "lease-recipient",
+                "claim-1",
+                now=T0 + timedelta(seconds=51),
+            )
+
+    def test_mailbox_survives_runtime_restart_without_node_binding(self):
+        self._send()
+        restarted_runtime = EmployeeRuntime(self.root)
+        restarted_lifecycle = EmployeeLifecycle(restarted_runtime)
+        restarted = EmployeeRealmMailbox(restarted_lifecycle)
+        pending = restarted.pending("spec-steward", now=T0 + timedelta(seconds=20))
+        self.assertEqual([item.message_id for item in pending], ["msg-1"])
+        serialized = json.dumps(
+            [
+                {
+                    "message_id": item.message_id,
+                    "sender_employee_id": item.sender_employee_id,
+                    "recipient_employee_id": item.recipient_employee_id,
+                }
+                for item in pending
+            ],
+            ensure_ascii=False,
+        )
+        self.assertNotIn("node", serialized.casefold())
+        self.assertNotIn("session", serialized.casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Implement #197 O1 as a durable ONE/Core-resident Employee mailbox without binding Employee identity or message durability to a Node, executor, model, session, GitHub issue, or Actions workflow.

## Adds
- typed `agentos.employee-realm-message/v1` envelope;
- Employee addressing by durable `employee_id`;
- sender must own a live Employee assignment lease;
- bounded message kinds / subject / summary / logical typed refs only;
- rejects URL/path/secret-like carrier payloads;
- deterministic message digest + message-id idempotency conflict fence;
- ONE-resident queued/claimed/acknowledged state under Employee runtime `realm/employee-mailbox`;
- recipient claim requires a live assignment lease belonging to the recipient Employee;
- live claim suppresses competing delivery;
- expired claim redelivery increments generation and marks `prior_delivery_state=unknown`;
- sanitized delivery receipt persisted before terminal message state;
- mailbox survives Employee runtime restart and does not encode Node/provider/session selection;
- Employee Runtime Guard coverage.

## Architecture invariant
`Employee address != Node address != executor/session identity`.

This mailbox stores Realm communication in ONE first. It deliberately does not choose an external wake/delivery carrier. O2 will separately convert durable Employee wake intent into governed ONE delivery; `github_actions` is not a control-plane fallback.

## Evidence
Branch Employee Runtime Guard run `33588699904` completed SUCCESS after the mailbox state-schema/root fixes. The dedicated Realm Employee mailbox regression step and all prior Employee/Role regressions passed.

An unrelated legacy Layout integration workflow also emitted its known validation failure on branch pushes, but its run had `jobs=0`; no runner was claimed and no privileged/product runtime execution occurred. That remains #175 carrier noise, not #197 transport evidence.

## Remaining #197
O2 governed wake delivery and O3 live persistent Spec Steward fresh-executor acceptance remain open.

Target: `core/integration` only; no protected-main publication authority implied.