### PR TITLE
Core #200: add deterministic Supervisor reconcile kernel

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -13,6 +13,7 @@ on:
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
+      - 'agent_core/core_supervisor.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -23,12 +24,13 @@ on:
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
+      - 'tests/test_core_supervisor.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-197-realm-mailbox
+      - core/issue-200-supervisor-reconcile-kernel
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -38,6 +40,7 @@ on:
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
+      - 'agent_core/core_supervisor.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -48,6 +51,7 @@ on:
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
+      - 'tests/test_core_supervisor.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -81,5 +85,7 @@ jobs:
         run: python -m unittest tests.test_employee_threads -v
       - name: Run Realm Employee mailbox regressions
         run: python -m unittest tests.test_employee_realm_mailbox -v
+      - name: Run Core Supervisor reconciliation regressions
+        run: python -m unittest tests.test_core_supervisor -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/core_supervisor.py
+++ b/agent_core/core_supervisor.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Iterable
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_wake import EmployeeWakeIntent, EmployeeWakePlanner
+
+
+RECONCILE_INTENT_SCHEMA = "agentos.core-reconcile-intent/v1"
+RECONCILE_PLAN_SCHEMA = "agentos.core-reconcile-plan/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileIntent:
+    """Authority-neutral durable-work progression intent.
+
+    A reconcile intent says which durable Employee assignment needs attention. It
+    deliberately does not choose a Node, executor/model/session, transport,
+    capability carrier, executable, argv, URL, or credential. A later governed
+    delivery layer may resolve those authorities.
+    """
+
+    schema: str
+    reconcile_id: str
+    kind: str
+    employee_id: str
+    assignment_id: str
+    reason: str
+    wake_intent: EmployeeWakeIntent
+    authority_boundary: str = "observe_and_select_only"
+    node_selection: str = "unbound"
+    executor_selection: str = "unbound"
+    transport_selection: str = "unbound"
+    capability_authority: str = "unbound"
+    credential_exposed: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["wake_intent"] = self.wake_intent.as_dict()
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileSuppression:
+    employee_id: str
+    assignment_id: str | None
+    reason: str
+
+
+@dataclass(slots=True)
+class ReconcilePlan:
+    schema: str = RECONCILE_PLAN_SCHEMA
+    intents: list[ReconcileIntent] = field(default_factory=list)
+    suppressed: list[ReconcileSuppression] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "intents": [intent.as_dict() for intent in self.intents],
+            "suppressed": [asdict(item) for item in self.suppressed],
+            "errors": [dict(item) for item in self.errors],
+        }
+
+
+class CoreSupervisorReconciler:
+    """Pure/bounded reconciliation kernel for persistent Core supervision.
+
+    This class performs observation and selection only. It does not dispatch a
+    wake, claim an Employee assignment, execute a capability, interpret GitHub
+    Issue prose, or select any carrier. The future persistent service can call
+    this kernel repeatedly and persist/dispatch returned intents through separate
+    governed components.
+    """
+
+    def __init__(self, lifecycle: EmployeeLifecycle) -> None:
+        self.lifecycle = lifecycle
+        self.wake_planner = EmployeeWakePlanner(lifecycle)
+
+    @staticmethod
+    def _reconcile_id(wake: EmployeeWakeIntent) -> str:
+        source = (
+            f"{wake.wake_id}\0{wake.employee_id}\0{wake.assignment_id}\0"
+            f"{wake.mode}\0{wake.expected_lease_generation}"
+        ).encode("utf-8")
+        return "reconcile_" + hashlib.sha256(source).hexdigest()[:24]
+
+    def discover_employee_ids(self) -> list[str]:
+        directory = self.lifecycle.runtime.employees_dir
+        if not directory.exists():
+            return []
+        return sorted(path.stem for path in directory.glob("*.json") if path.is_file())
+
+    def reconcile(
+        self,
+        *,
+        employee_ids: Iterable[str] | None = None,
+        blocked_assignment_ids: Iterable[str] = (),
+        persisted_reconcile_ids: Iterable[str] = (),
+        now: datetime | None = None,
+    ) -> ReconcilePlan:
+        blocked = {str(value) for value in blocked_assignment_ids}
+        persisted = {str(value) for value in persisted_reconcile_ids}
+        selected_employees = sorted(set(employee_ids or self.discover_employee_ids()))
+        plan = ReconcilePlan()
+
+        for employee_id in selected_employees:
+            try:
+                wake = self.wake_planner.plan_next(employee_id, now=now)
+            except Exception as exc:  # malformed/unknown state must not create work
+                plan.errors.append(
+                    {
+                        "employee_id": str(employee_id),
+                        "error": type(exc).__name__,
+                        "disposition": "fail_closed_no_intent",
+                    }
+                )
+                continue
+
+            if wake is None:
+                plan.suppressed.append(
+                    ReconcileSuppression(
+                        employee_id=str(employee_id),
+                        assignment_id=None,
+                        reason="no_runnable_assignment",
+                    )
+                )
+                continue
+
+            if wake.assignment_id in blocked:
+                plan.suppressed.append(
+                    ReconcileSuppression(
+                        employee_id=wake.employee_id,
+                        assignment_id=wake.assignment_id,
+                        reason="dependencies_blocked",
+                    )
+                )
+                continue
+
+            reconcile_id = self._reconcile_id(wake)
+            if reconcile_id in persisted:
+                plan.suppressed.append(
+                    ReconcileSuppression(
+                        employee_id=wake.employee_id,
+                        assignment_id=wake.assignment_id,
+                        reason="reconcile_intent_already_persisted",
+                    )
+                )
+                continue
+
+            reason = "assignment_resume_required" if wake.resume_required else "assignment_pending"
+            plan.intents.append(
+                ReconcileIntent(
+                    schema=RECONCILE_INTENT_SCHEMA,
+                    reconcile_id=reconcile_id,
+                    kind="employee_wake",
+                    employee_id=wake.employee_id,
+                    assignment_id=wake.assignment_id,
+                    reason=reason,
+                    wake_intent=wake,
+                )
+            )
+
+        plan.intents.sort(key=lambda item: (item.employee_id, item.assignment_id, item.reconcile_id))
+        plan.suppressed.sort(key=lambda item: (item.employee_id, item.assignment_id or "", item.reason))
+        plan.errors.sort(key=lambda item: (item.get("employee_id", ""), item.get("error", "")))
+        return plan

--- a/tests/test_core_supervisor.py
+++ b/tests/test_core_supervisor.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.core_supervisor import (
+    RECONCILE_INTENT_SCHEMA,
+    CoreSupervisorReconciler,
+)
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+T0 = datetime(2026, 9, 2, 5, 20, 0, tzinfo=timezone.utc)
+
+
+class CoreSupervisorReconcilerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.bind_executor(
+            "spec-steward",
+            provider="executor-must-not-authorize-supervisor",
+            model="private-model",
+            session_id="private-session",
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit open specification closure gaps",
+            thread_head="ir:start",
+            constraints=["read-only"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.supervisor = CoreSupervisorReconciler(self.lifecycle)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_pending_assignment_emits_authority_neutral_intent(self):
+        plan = self.supervisor.reconcile(now=T0)
+        self.assertEqual(len(plan.intents), 1)
+        intent = plan.intents[0]
+        self.assertEqual(intent.schema, RECONCILE_INTENT_SCHEMA)
+        self.assertEqual(intent.kind, "employee_wake")
+        self.assertEqual(intent.reason, "assignment_pending")
+        self.assertEqual(intent.employee_id, "spec-steward")
+        self.assertEqual(intent.assignment_id, "audit-001")
+        self.assertEqual(intent.node_selection, "unbound")
+        self.assertEqual(intent.executor_selection, "unbound")
+        self.assertEqual(intent.transport_selection, "unbound")
+        self.assertEqual(intent.capability_authority, "unbound")
+        self.assertFalse(intent.credential_exposed)
+
+        serialized = json.dumps(plan.as_dict(), ensure_ascii=False).casefold()
+        self.assertNotIn("private-session", serialized)
+        self.assertNotIn("private-model", serialized)
+        self.assertNotIn("executor-must-not-authorize-supervisor", serialized)
+        for forbidden in (
+            "github_actions",
+            "workflow_dispatch",
+            "one_url",
+            "executable",
+            "argv",
+            "bearer ",
+            "authorization",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_same_state_produces_same_reconcile_id(self):
+        first = self.supervisor.reconcile(now=T0).intents[0]
+        second = self.supervisor.reconcile(now=T0 + timedelta(seconds=10)).intents[0]
+        self.assertEqual(first.reconcile_id, second.reconcile_id)
+        self.assertEqual(first.wake_intent.wake_id, second.wake_intent.wake_id)
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "pending")
+        self.assertIsNone(self.lifecycle.get_lease("audit-001"))
+
+    def test_persisted_same_intent_suppresses_duplicate_dispatch_candidate(self):
+        first = self.supervisor.reconcile(now=T0).intents[0]
+        plan = self.supervisor.reconcile(
+            now=T0 + timedelta(seconds=5),
+            persisted_reconcile_ids=[first.reconcile_id],
+        )
+        self.assertEqual(plan.intents, [])
+        self.assertEqual(len(plan.suppressed), 1)
+        self.assertEqual(plan.suppressed[0].reason, "reconcile_intent_already_persisted")
+
+    def test_live_assignment_lease_suppresses_duplicate_wake(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-live",
+            lease_seconds=120,
+            now=T0,
+        )
+        plan = self.supervisor.reconcile(now=T0 + timedelta(seconds=30))
+        self.assertEqual(plan.intents, [])
+        self.assertEqual(plan.suppressed[0].reason, "no_runnable_assignment")
+
+    def test_expired_lease_emits_resume_unknown(self):
+        self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "lease-old",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.lifecycle.checkpoint(
+            "audit-001",
+            "lease-old",
+            "ir:checkpoint",
+            now=T0 + timedelta(seconds=20),
+        )
+        intent = self.supervisor.reconcile(now=T0 + timedelta(seconds=61)).intents[0]
+        self.assertEqual(intent.reason, "assignment_resume_required")
+        self.assertTrue(intent.wake_intent.resume_required)
+        self.assertEqual(intent.wake_intent.prior_execution_state, "unknown")
+        self.assertEqual(intent.wake_intent.thread_head, "ir:checkpoint")
+        self.assertEqual(intent.wake_intent.expected_lease_generation, 2)
+
+    def test_blocked_dependency_suppresses_without_mutating_assignment(self):
+        plan = self.supervisor.reconcile(
+            now=T0,
+            blocked_assignment_ids=["audit-001"],
+        )
+        self.assertEqual(plan.intents, [])
+        self.assertEqual(plan.suppressed[0].reason, "dependencies_blocked")
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "pending")
+
+    def test_terminal_assignment_is_not_woken(self):
+        self.lifecycle.claim("audit-001", "spec-steward", "lease-a", now=T0)
+        self.lifecycle.finish(
+            "audit-001",
+            "lease-a",
+            now=T0 + timedelta(seconds=10),
+        )
+        plan = self.supervisor.reconcile(now=T0 + timedelta(seconds=20))
+        self.assertEqual(plan.intents, [])
+        self.assertEqual(plan.suppressed[0].reason, "no_runnable_assignment")
+
+    def test_missing_or_malformed_employee_fails_closed(self):
+        missing = self.supervisor.reconcile(employee_ids=["missing-employee"], now=T0)
+        self.assertEqual(missing.intents, [])
+        self.assertEqual(missing.errors[0]["disposition"], "fail_closed_no_intent")
+
+        (self.runtime.employees_dir / "broken.json").parent.mkdir(parents=True, exist_ok=True)
+        (self.runtime.employees_dir / "broken.json").write_text("[]", encoding="utf-8")
+        malformed = self.supervisor.reconcile(employee_ids=["broken"], now=T0)
+        self.assertEqual(malformed.intents, [])
+        self.assertEqual(malformed.errors[0]["disposition"], "fail_closed_no_intent")
+
+    def test_discovery_is_deterministic_and_does_not_treat_issue_text_as_work(self):
+        self.runtime.create_employee("writer", "Writer", role_ids=["sector.weaver"])
+        ids = self.supervisor.discover_employee_ids()
+        self.assertEqual(ids, ["spec-steward", "writer"])
+
+        # The kernel has no Issue/body/prompt input surface at all. Free-form event
+        # text cannot become execution authority in S1.
+        plan = self.supervisor.reconcile(employee_ids=["writer"], now=T0)
+        self.assertEqual(plan.intents, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Implement #200 S1: a bounded, deterministic Core Supervisor reconciliation kernel over the already-canonical Employee assignment/lifecycle/wake state.

## Adds
- `CoreSupervisorReconciler` over durable Employee state;
- deterministic `agentos.core-reconcile-intent/v1`;
- pending assignment -> wake candidate;
- expired lease -> resume candidate preserving `prior_execution_state=unknown`;
- live lease / terminal work -> no duplicate wake;
- explicit dependency-blocked suppression;
- already-persisted reconcile-id suppression;
- malformed/missing Employee state fails closed with zero work intent;
- deterministic Employee discovery/order;
- supervisor intent remains authority-neutral and carries no Node/provider/model/session/carrier/capability authority;
- no GitHub Issue body/prompt execution surface exists in this kernel;
- Employee Runtime Guard covers Supervisor regressions together with existing Employee/Role contracts.

## Evidence
Hosted Employee Runtime Guard run `33593980170` completed SUCCESS on branch head. Core Supervisor reconciliation regressions and all existing Employee runtime/lifecycle/wake/memory/skill/thread/mailbox/role regressions passed.

## Non-claims
This does not yet create the long-lived daemon/process or GitHub Issue intake. S2 must normalize explicit machine-actionable WorkItems separately from free-form issue/event payloads. S3 will add singleton persistent-loop/cursor/backoff/health. S4 will use governed #197/ONE wake delivery; GitHub Actions is not a control-plane fallback.

Target: `core/integration` only; no protected-main publication authority implied.