### PR TITLE
Core #200: add bounded Supervisor WorkItem intake

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -14,6 +14,7 @@ on:
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/core_supervisor.py'
+      - 'agent_core/core_work_items.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -25,12 +26,13 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_core_supervisor.py'
+      - 'tests/test_core_work_items.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-200-supervisor-reconcile-kernel
+      - core/issue-200-work-item-intake
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -41,6 +43,7 @@ on:
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/core_supervisor.py'
+      - 'agent_core/core_work_items.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -52,6 +55,7 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_core_supervisor.py'
+      - 'tests/test_core_work_items.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -87,5 +91,7 @@ jobs:
         run: python -m unittest tests.test_employee_realm_mailbox -v
       - name: Run Core Supervisor reconciliation regressions
         run: python -m unittest tests.test_core_supervisor -v
+      - name: Run Core WorkItem intake regressions
+        run: python -m unittest tests.test_core_work_items -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/core_work_items.py
+++ b/agent_core/core_work_items.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from agent_core.employee_runtime import EmployeeRuntime
+
+EVENT_SCHEMA = "agentos.core-supervisor-event/v1"
+WORK_ITEM_SCHEMA = "agentos.core-work-item/v1"
+WORK_ITEM_STATES = {"open", "completed", "cancelled"}
+ISSUE_EVENT_TYPES = {"opened", "updated", "reopened", "closed", "labeled", "unlabeled", "assigned", "unassigned", "commented"}
+ALLOWED_FIELDS = {
+    "schema", "work_item_id", "source_kind", "source_ref", "project_id",
+    "employee_id", "assignment_id", "goal", "constraints", "dependency_refs",
+    "required_capabilities", "authority_requirements", "source_revision", "state",
+}
+
+
+def _id(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 180 or any(ch in text for ch in "/\\\0") or text in {".", ".."}:
+        raise ValueError(f"invalid_{name}")
+    return text
+
+
+def _text(value: Any, name: str, limit: int = 4000) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > limit:
+        raise ValueError(f"invalid_{name}")
+    return text
+
+
+def _ref(value: Any, name: str) -> str:
+    text = _text(value, name, 512)
+    if "://" in text or text.startswith(("/", "~")) or "\\" in text or ":" not in text:
+        raise ValueError(f"invalid_{name}")
+    return text
+
+
+def _strings(value: Any, name: str, max_items: int = 64) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or len(value) > max_items:
+        raise ValueError(f"invalid_{name}")
+    result = tuple(str(item or "").strip() for item in value)
+    if any(not item or len(item) > 512 for item in result):
+        raise ValueError(f"invalid_{name}")
+    return result
+
+
+def _atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorEvent:
+    schema: str
+    event_id: str
+    source_kind: str
+    source_ref: str
+    event_type: str
+    source_revision: str
+    reconcile_requested: bool = True
+    work_item_authorized: bool = False
+    authority_boundary: str = "event_reveals_work_only"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkItem:
+    schema: str
+    work_item_id: str
+    source_kind: str
+    source_ref: str
+    project_id: str
+    employee_id: str
+    assignment_id: str
+    goal: str
+    constraints: tuple[str, ...] = field(default_factory=tuple)
+    dependency_refs: tuple[str, ...] = field(default_factory=tuple)
+    required_capabilities: tuple[str, ...] = field(default_factory=tuple)
+    authority_requirements: tuple[str, ...] = field(default_factory=tuple)
+    source_revision: str = ""
+    state: str = "open"
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        for key in ("constraints", "dependency_refs", "required_capabilities", "authority_requirements"):
+            value[key] = list(value[key])
+        return value
+
+
+def observe_github_issue_event(*, repository: str, issue_number: int, event_type: str, source_revision: str) -> SupervisorEvent:
+    """Issue metadata requests reconciliation; issue prose is not an input here."""
+    repo = str(repository or "").strip()
+    if not repo or repo.count("/") != 1 or issue_number < 1:
+        raise ValueError("invalid_github_issue_ref")
+    event_type = str(event_type or "").strip()
+    if event_type not in ISSUE_EVENT_TYPES:
+        raise ValueError("unsupported_github_issue_event")
+    revision = _text(source_revision, "source_revision", 256)
+    source_ref = f"github:{repo}#{issue_number}"
+    digest = hashlib.sha256(f"{source_ref}\0{event_type}\0{revision}".encode()).hexdigest()[:24]
+    return SupervisorEvent(EVENT_SCHEMA, "event_" + digest, "github_issue", source_ref, event_type, revision)
+
+
+def normalize_work_item(payload: Mapping[str, Any]) -> WorkItem:
+    if not isinstance(payload, Mapping):
+        raise ValueError("work_item_must_be_object")
+    raw = dict(payload)
+    if raw.get("schema") != WORK_ITEM_SCHEMA:
+        raise ValueError("invalid_work_item_schema")
+    extra = sorted(set(raw) - ALLOWED_FIELDS)
+    if extra:
+        raise ValueError("unexpected_work_item_fields:" + ",".join(extra))
+    state = str(raw.get("state") or "open").strip()
+    if state not in WORK_ITEM_STATES:
+        raise ValueError("invalid_work_item_state")
+    source_kind = str(raw.get("source_kind") or "").strip()
+    if source_kind not in {"github_issue", "realm_message", "schedule", "user_goal", "canonical_state"}:
+        raise ValueError("unsupported_work_item_source")
+    deps = tuple(_ref(item, "dependency_ref") for item in _strings(raw.get("dependency_refs"), "dependency_refs"))
+    return WorkItem(
+        schema=WORK_ITEM_SCHEMA,
+        work_item_id=_id(raw.get("work_item_id"), "work_item_id"),
+        source_kind=source_kind,
+        source_ref=_ref(raw.get("source_ref"), "source_ref"),
+        project_id=_id(raw.get("project_id"), "project_id"),
+        employee_id=_id(raw.get("employee_id"), "employee_id"),
+        assignment_id=_id(raw.get("assignment_id"), "assignment_id"),
+        goal=_text(raw.get("goal"), "goal"),
+        constraints=_strings(raw.get("constraints"), "constraints"),
+        dependency_refs=deps,
+        required_capabilities=_strings(raw.get("required_capabilities"), "required_capabilities"),
+        authority_requirements=_strings(raw.get("authority_requirements"), "authority_requirements"),
+        source_revision=str(raw.get("source_revision") or "").strip(),
+        state=state,
+    )
+
+
+class WorkItemStore:
+    def __init__(self, runtime: EmployeeRuntime) -> None:
+        self.runtime = runtime
+        self.root = runtime.root / "supervisor" / "work-items"
+
+    def _path(self, work_item_id: str) -> Path:
+        return self.root / f"{_id(work_item_id, 'work_item_id')}.json"
+
+    def get(self, work_item_id: str) -> WorkItem:
+        path = self._path(work_item_id)
+        if not path.exists():
+            raise FileNotFoundError(work_item_id)
+        return normalize_work_item(json.loads(path.read_text(encoding="utf-8")))
+
+    def persist(self, payload: Mapping[str, Any]) -> WorkItem:
+        item = normalize_work_item(payload)
+        path = self._path(item.work_item_id)
+        if path.exists():
+            existing = self.get(item.work_item_id)
+            if existing == item:
+                return existing
+            raise RuntimeError("work_item_idempotency_conflict")
+        _atomic(path, item.as_dict())
+        return item
+
+    def project_pending_assignment(self, work_item_id: str):
+        item = self.get(work_item_id)
+        if item.state != "open":
+            raise RuntimeError("work_item_not_open")
+        self.runtime.get_employee(item.employee_id)
+        try:
+            existing = self.runtime.get_assignment(item.assignment_id)
+        except FileNotFoundError:
+            return self.runtime.create_assignment(
+                item.assignment_id, item.employee_id, item.goal, constraints=list(item.constraints)
+            )
+        if existing.employee_id != item.employee_id or existing.goal != item.goal or tuple(existing.constraints) != item.constraints:
+            raise RuntimeError("work_item_assignment_conflict")
+        return existing
+
+    def dependencies_ready(self, work_item_id: str, dependency_states: Mapping[str, str]) -> bool:
+        item = self.get(work_item_id)
+        return all(str(dependency_states.get(ref) or "") == "completed" for ref in item.dependency_refs)

--- a/tests/test_core_work_items.py
+++ b/tests/test_core_work_items.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.core_work_items import (
+    EVENT_SCHEMA,
+    WORK_ITEM_SCHEMA,
+    WorkItemStore,
+    normalize_work_item,
+    observe_github_issue_event,
+)
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+class CoreWorkItemTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.store = WorkItemStore(self.runtime)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def payload(self):
+        return {
+            "schema": WORK_ITEM_SCHEMA,
+            "work_item_id": "work-200-1",
+            "source_kind": "github_issue",
+            "source_ref": "github:alston-personal/agentmanager#200",
+            "project_id": "agentos-core",
+            "employee_id": "spec-steward",
+            "assignment_id": "supervisor-audit-001",
+            "goal": "Audit Core Supervisor closure requirements",
+            "constraints": ["read-only-first", "receipts-over-claims"],
+            "dependency_refs": ["github:alston-personal/agentmanager#197"],
+            "required_capabilities": ["governance.spec.audit"],
+            "authority_requirements": ["one-governed-dispatch"],
+            "source_revision": "rev-1",
+            "state": "open",
+        }
+
+    def test_issue_event_requests_reconcile_but_never_authorizes_work(self):
+        event = observe_github_issue_event(
+            repository="alston-personal/agentmanager",
+            issue_number=200,
+            event_type="updated",
+            source_revision="2026-09-02T05:20:00Z",
+        )
+        self.assertEqual(event.schema, EVENT_SCHEMA)
+        self.assertTrue(event.reconcile_requested)
+        self.assertFalse(event.work_item_authorized)
+        self.assertEqual(event.authority_boundary, "event_reveals_work_only")
+        self.assertEqual(event.source_ref, "github:alston-personal/agentmanager#200")
+
+    def test_event_id_is_deterministic_for_same_issue_revision(self):
+        args = dict(
+            repository="alston-personal/agentmanager",
+            issue_number=200,
+            event_type="updated",
+            source_revision="rev-2",
+        )
+        self.assertEqual(
+            observe_github_issue_event(**args).event_id,
+            observe_github_issue_event(**args).event_id,
+        )
+
+    def test_work_item_uses_strict_allowlist(self):
+        payload = self.payload()
+        payload["arbitrary_extra"] = "must fail"
+        with self.assertRaisesRegex(ValueError, "unexpected_work_item_fields"):
+            normalize_work_item(payload)
+
+    def test_source_and_dependencies_must_be_logical_refs(self):
+        payload = self.payload()
+        payload["source_ref"] = "https://example.invalid/issue/200"
+        with self.assertRaises(ValueError):
+            normalize_work_item(payload)
+        payload = self.payload()
+        payload["dependency_refs"] = ["/tmp/local-state"]
+        with self.assertRaises(ValueError):
+            normalize_work_item(payload)
+
+    def test_persist_and_project_only_creates_pending_assignment(self):
+        item = self.store.persist(self.payload())
+        assignment = self.store.project_pending_assignment(item.work_item_id)
+        self.assertEqual(assignment.assignment_id, "supervisor-audit-001")
+        self.assertEqual(assignment.employee_id, "spec-steward")
+        self.assertEqual(assignment.state, "pending")
+        self.assertIsNone(assignment.result)
+
+    def test_same_work_item_and_assignment_projection_are_idempotent(self):
+        first = self.store.persist(self.payload())
+        second = self.store.persist(self.payload())
+        self.assertEqual(first, second)
+        a = self.store.project_pending_assignment(first.work_item_id)
+        b = self.store.project_pending_assignment(first.work_item_id)
+        self.assertEqual(a.assignment_id, b.assignment_id)
+
+    def test_same_work_item_id_with_changed_content_conflicts(self):
+        self.store.persist(self.payload())
+        changed = self.payload()
+        changed["goal"] = "Different goal"
+        with self.assertRaisesRegex(RuntimeError, "work_item_idempotency_conflict"):
+            self.store.persist(changed)
+
+    def test_projection_conflict_does_not_overwrite_existing_assignment(self):
+        self.runtime.create_assignment(
+            "supervisor-audit-001",
+            "spec-steward",
+            "Existing different responsibility",
+        )
+        item = self.store.persist(self.payload())
+        with self.assertRaisesRegex(RuntimeError, "work_item_assignment_conflict"):
+            self.store.project_pending_assignment(item.work_item_id)
+        existing = self.runtime.get_assignment("supervisor-audit-001")
+        self.assertEqual(existing.goal, "Existing different responsibility")
+
+    def test_dependencies_require_explicit_completed_state(self):
+        item = self.store.persist(self.payload())
+        self.assertFalse(self.store.dependencies_ready(item.work_item_id, {}))
+        self.assertFalse(
+            self.store.dependencies_ready(
+                item.work_item_id,
+                {"github:alston-personal/agentmanager#197": "open"},
+            )
+        )
+        self.assertTrue(
+            self.store.dependencies_ready(
+                item.work_item_id,
+                {"github:alston-personal/agentmanager#197": "completed"},
+            )
+        )
+
+    def test_closed_work_item_cannot_project_new_assignment(self):
+        payload = self.payload()
+        payload["state"] = "completed"
+        item = self.store.persist(payload)
+        with self.assertRaisesRegex(RuntimeError, "work_item_not_open"):
+            self.store.project_pending_assignment(item.work_item_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Implement #200 S2: separate event-triggered reconciliation from machine-authorized WorkItem creation.

## Adds
- `agentos.core-supervisor-event/v1` for event observations;
- GitHub Issue metadata event -> `reconcile_requested=true`, `work_item_authorized=false`;
- Issue intake deliberately accepts no title/body/comment prose as authority;
- strict allowlisted `agentos.core-work-item/v1` schema;
- explicit Project / Employee / Assignment / dependency / capability requirement / authority requirement fields;
- logical source/dependency references only;
- durable WorkItem store under Supervisor state;
- idempotent WorkItem persistence;
- WorkItem -> pending Employee assignment projection only;
- projection conflicts fail closed instead of overwriting existing work;
- dependency readiness requires explicit completed state;
- completed/cancelled WorkItems cannot project new assignments.

## Core invariant
`event != authority`.

An Issue open/update/comment may trigger Supervisor re-evaluation, but free-form Issue prose is not parsed into commands and does not itself authorize execution. Only a separately validated bounded WorkItem can create durable pending work, and even that does not select a Node/executor/transport or bypass ONE authority.

## Evidence
Branch Employee Runtime Guard run `33594201863` completed SUCCESS. Core WorkItem intake, Supervisor reconciliation, and all existing Employee/Role regressions passed.

## Remaining #200
S3 persistent singleton loop/cursor/backoff/health and S4 governed delivery integration remain open. #197 remains the first live persistent Spec Steward end-to-end acceptance.

Target: `core/integration` only; no protected-main publication authority implied.