### PR TITLE
Core #200: add persistent Supervisor daemon and service contract

### DIFF
--- a/.agent/scripts/agentos-core-supervisor.env.example
+++ b/.agent/scripts/agentos-core-supervisor.env.example
@@ -1,0 +1,9 @@
+# AgentOS Core Supervisor S3 environment example.
+# This file contains no credentials. Copy values into the host-local EnvironmentFile.
+# S3 observes durable Employee state and journals reconcile intents only; it does not dispatch them.
+
+AGENTOS_EMPLOYEE_RUNTIME_ROOT=/home/ubuntu/agent-data/employee-runtime
+AGENTOS_SUPERVISOR_SERVICE_ID=agentos-core-supervisor
+AGENTOS_SUPERVISOR_BASE_POLL_SECONDS=5
+AGENTOS_SUPERVISOR_MAX_POLL_SECONDS=60
+AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS=30

--- a/.agent/scripts/agentos-core-supervisor.service
+++ b/.agent/scripts/agentos-core-supervisor.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=AgentOS Core Supervisor (observe and plan only)
+After=local-fs.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/agentmanager
+EnvironmentFile=/home/ubuntu/.config/agentos/core-supervisor.env
+ExecStart=/usr/bin/python3 -m agent_core.core_supervisor_daemon
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateNetwork=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/ubuntu/agent-data/employee-runtime
+
+[Install]
+WantedBy=multi-user.target

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -16,6 +16,7 @@ on:
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
+      - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -29,8 +30,13 @@ on:
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
+      - 'tests/test_core_supervisor_daemon.py'
+      - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
+      - '.agent/scripts/agentos-core-supervisor.service'
+      - '.agent/scripts/agentos-core-supervisor.env.example'
+      - 'docs/CORE_SUPERVISOR.md'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
@@ -47,6 +53,7 @@ on:
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
+      - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -60,8 +67,13 @@ on:
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
+      - 'tests/test_core_supervisor_daemon.py'
+      - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
+      - '.agent/scripts/agentos-core-supervisor.service'
+      - '.agent/scripts/agentos-core-supervisor.env.example'
+      - 'docs/CORE_SUPERVISOR.md'
       - '.github/workflows/employee-runtime-guard.yml'
   workflow_dispatch:
 
@@ -99,5 +111,9 @@ jobs:
         run: python -m unittest tests.test_core_work_items -v
       - name: Run persistent Core Supervisor service regressions
         run: python -m unittest tests.test_core_supervisor_service -v
+      - name: Run Core Supervisor daemon regressions
+        run: python -m unittest tests.test_core_supervisor_daemon -v
+      - name: Run Core Supervisor service asset regressions
+        run: python -m unittest tests.test_core_supervisor_assets -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -15,6 +15,7 @@ on:
       - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
+      - 'agent_core/core_supervisor_service.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -27,12 +28,13 @@ on:
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
+      - 'tests/test_core_supervisor_service.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
-      - core/issue-200-work-item-intake
+      - core/issue-200-persistent-supervisor-loop
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -44,6 +46,7 @@ on:
       - 'agent_core/employee_realm_mailbox.py'
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
+      - 'agent_core/core_supervisor_service.py'
       - 'agent_core/role_runtime.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -56,6 +59,7 @@ on:
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
+      - 'tests/test_core_supervisor_service.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.github/workflows/employee-runtime-guard.yml'
@@ -93,5 +97,7 @@ jobs:
         run: python -m unittest tests.test_core_supervisor -v
       - name: Run Core WorkItem intake regressions
         run: python -m unittest tests.test_core_work_items -v
+      - name: Run persistent Core Supervisor service regressions
+        run: python -m unittest tests.test_core_supervisor_service -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v

--- a/agent_core/core_supervisor_daemon.py
+++ b/agent_core/core_supervisor_daemon.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from threading import Event
+from typing import Iterator
+
+from agent_core.core_supervisor_service import CoreSupervisorService
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = str(os.environ.get(name) or default).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid_{name.lower()}") from exc
+    if value < minimum or value > maximum:
+        raise ValueError(f"invalid_{name.lower()}")
+    return value
+
+
+def _runtime_root(value: str | None = None) -> Path:
+    raw = str(value or os.environ.get("AGENTOS_EMPLOYEE_RUNTIME_ROOT") or "").strip()
+    if not raw:
+        data_root = str(os.environ.get("AGENTOS_DATA_ROOT") or "").strip()
+        if data_root:
+            raw = str(Path(data_root) / "employee-runtime")
+    if not raw:
+        raise ValueError("employee_runtime_root_required")
+    root = Path(raw).expanduser()
+    if not root.is_absolute():
+        raise ValueError("employee_runtime_root_must_be_absolute")
+    return root.resolve()
+
+
+def _service_id(value: str | None = None) -> str:
+    text = str(value or os.environ.get("AGENTOS_SUPERVISOR_SERVICE_ID") or "agentos-core-supervisor").strip()
+    if not text or len(text) > 120 or any(ch in text for ch in "/\\\0"):
+        raise ValueError("invalid_supervisor_service_id")
+    return text
+
+
+def _instance_owner(service_id: str) -> str:
+    return f"{service_id}.{uuid.uuid4().hex[:12]}"
+
+
+def _heartbeat_step(remaining_seconds: int, leader_lease_seconds: int) -> int:
+    """Return a wait chunk short enough that idle backoff never outlives leadership."""
+    if remaining_seconds <= 0:
+        return 0
+    safe = max(1, int(leader_lease_seconds) // 2)
+    return min(int(remaining_seconds), safe)
+
+
+@contextmanager
+def _process_singleton_lock(root: Path) -> Iterator[None]:
+    """Hold an OS lock for this runtime root for the lifetime of one daemon process."""
+    path = root / "supervisor" / "process.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeError("supervisor_process_already_active") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def build_service(
+    *,
+    runtime_root: Path,
+    service_id: str,
+    base_poll_seconds: int,
+    max_poll_seconds: int,
+) -> CoreSupervisorService:
+    runtime = EmployeeRuntime(runtime_root)
+    lifecycle = EmployeeLifecycle(runtime)
+    return CoreSupervisorService(
+        lifecycle,
+        owner_id=_instance_owner(service_id),
+        base_poll_seconds=base_poll_seconds,
+        max_poll_seconds=max_poll_seconds,
+    )
+
+
+def run_persistent(
+    service: CoreSupervisorService,
+    *,
+    stop_event: Event | None = None,
+    leader_lease_seconds: int = 30,
+) -> None:
+    """Run observe/plan cycles forever while heartbeating through long idle backoff.
+
+    This daemon never dispatches a reconcile intent. S4 owns governed ONE delivery.
+    """
+    stopper = stop_event or Event()
+    retry_seconds = max(1, min(5, leader_lease_seconds // 2))
+
+    while not stopper.is_set():
+        try:
+            leader = service.claim_leader(lease_seconds=leader_lease_seconds)
+            break
+        except RuntimeError as exc:
+            if str(exc) != "supervisor_leader_already_active":
+                raise
+            stopper.wait(retry_seconds)
+    else:
+        return
+
+    while not stopper.is_set():
+        receipt = service.run_cycle(leader.generation)
+        remaining = int(receipt.next_poll_seconds)
+        while remaining > 0 and not stopper.is_set():
+            step = _heartbeat_step(remaining, leader_lease_seconds)
+            if stopper.wait(step):
+                return
+            remaining -= step
+            leader = service.heartbeat_leader(
+                leader.generation,
+                lease_seconds=leader_lease_seconds,
+            )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="AgentOS Core Supervisor (observe/plan only)")
+    parser.add_argument("--runtime-root")
+    parser.add_argument("--service-id")
+    parser.add_argument("--once", action="store_true", help="Run one reconcile cycle and exit")
+    parser.add_argument("--health", action="store_true", help="Print durable Supervisor health and exit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.once and args.health:
+        raise ValueError("choose_once_or_health")
+
+    root = _runtime_root(args.runtime_root)
+    service_id = _service_id(args.service_id)
+    base_poll = _env_int("AGENTOS_SUPERVISOR_BASE_POLL_SECONDS", 5, minimum=1, maximum=300)
+    max_poll = _env_int("AGENTOS_SUPERVISOR_MAX_POLL_SECONDS", 60, minimum=base_poll, maximum=3600)
+    leader_lease = _env_int("AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS", 30, minimum=5, maximum=300)
+
+    service = build_service(
+        runtime_root=root,
+        service_id=service_id,
+        base_poll_seconds=base_poll,
+        max_poll_seconds=max_poll,
+    )
+
+    if args.health:
+        print(json.dumps(service.health(), ensure_ascii=False, sort_keys=True))
+        return 0
+
+    with _process_singleton_lock(root):
+        if args.once:
+            leader = service.claim_leader(lease_seconds=leader_lease)
+            receipt = service.run_cycle(leader.generation)
+            print(json.dumps(receipt.__dict__ if hasattr(receipt, "__dict__") else {
+                name: getattr(receipt, name) for name in receipt.__dataclass_fields__
+            }, ensure_ascii=False, sort_keys=True))
+            return 0
+        run_persistent(service, leader_lease_seconds=leader_lease)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_core/core_supervisor_service.py
+++ b/agent_core/core_supervisor_service.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Event
+from typing import Any, Mapping
+
+from agent_core.core_supervisor import CoreSupervisorReconciler, ReconcileIntent
+from agent_core.core_work_items import WorkItemStore
+from agent_core.employee_lifecycle import EmployeeLifecycle
+
+
+LEADER_SCHEMA = "agentos.core-supervisor-leader/v1"
+STATE_SCHEMA = "agentos.core-supervisor-state/v1"
+CYCLE_SCHEMA = "agentos.core-supervisor-cycle/v1"
+INTENT_RECORD_SCHEMA = "agentos.core-reconcile-record/v1"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("supervisor_state_invalid")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorLeaderLease:
+    schema: str
+    owner_id: str
+    generation: int
+    claimed_at: str
+    heartbeat_at: str
+    expires_at: str
+    prior_owner_state: str
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorCycleReceipt:
+    schema: str
+    cycle_generation: int
+    owner_id: str
+    leader_generation: int
+    observed_at: str
+    plan_digest: str
+    new_intent_count: int
+    total_planned_intent_count: int
+    suppressed_count: int
+    error_count: int
+    blocked_assignment_count: int
+    next_poll_seconds: int
+    dispatch_performed: bool = False
+    authority_boundary: str = "persistent_observe_plan_only"
+
+
+class CoreSupervisorService:
+    """Persistent Core loop that observes and journals work, but does not dispatch it.
+
+    S3 deliberately stops before execution authority. It owns singleton process
+    coordination, repeated reconciliation, durable intent journaling, cycle receipts,
+    crash-safe restart state, and adaptive polling. S4 is responsible for handing a
+    planned intent to governed ONE delivery.
+    """
+
+    def __init__(
+        self,
+        lifecycle: EmployeeLifecycle,
+        *,
+        owner_id: str,
+        base_poll_seconds: int = 5,
+        max_poll_seconds: int = 60,
+    ) -> None:
+        owner = str(owner_id or "").strip()
+        if not owner or len(owner) > 180 or any(ch in owner for ch in "/\\\0"):
+            raise ValueError("invalid_supervisor_owner_id")
+        if base_poll_seconds < 1 or max_poll_seconds < base_poll_seconds:
+            raise ValueError("invalid_supervisor_poll_interval")
+        self.lifecycle = lifecycle
+        self.runtime = lifecycle.runtime
+        self.reconciler = CoreSupervisorReconciler(lifecycle)
+        self.work_items = WorkItemStore(self.runtime)
+        self.owner_id = owner
+        self.base_poll_seconds = int(base_poll_seconds)
+        self.max_poll_seconds = int(max_poll_seconds)
+        self.root = self.runtime.root / "supervisor"
+        self.leader_path = self.root / "leader.json"
+        self.leader_lock_path = self.root / "leader.lock"
+        self.state_path = self.root / "state.json"
+        self.intents_dir = self.root / "intents"
+        self.cycles_dir = self.root / "cycles"
+
+    def _lock(self):
+        self.leader_lock_path.parent.mkdir(parents=True, exist_ok=True)
+        return self.leader_lock_path.open("a+", encoding="utf-8")
+
+    def claim_leader(self, *, lease_seconds: int = 30, now: datetime | None = None) -> SupervisorLeaderLease:
+        if lease_seconds < 5 or lease_seconds > 300:
+            raise ValueError("supervisor_leader_lease_out_of_range")
+        current = now or _now()
+        with self._lock() as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                existing = _read(self.leader_path)
+                generation = 1
+                prior_state = "known"
+                claimed_at = _iso(current)
+                if existing:
+                    if existing.get("schema") != LEADER_SCHEMA:
+                        raise ValueError("supervisor_leader_state_invalid")
+                    expires = _parse(str(existing.get("expires_at") or "1970-01-01T00:00:00Z"))
+                    same_owner = existing.get("owner_id") == self.owner_id
+                    if expires > current and not same_owner:
+                        raise RuntimeError("supervisor_leader_already_active")
+                    if same_owner and expires > current:
+                        generation = int(existing.get("generation") or 1)
+                        claimed_at = str(existing.get("claimed_at") or claimed_at)
+                    else:
+                        generation = int(existing.get("generation") or 0) + 1
+                        prior_state = "unknown"
+                lease = SupervisorLeaderLease(
+                    schema=LEADER_SCHEMA,
+                    owner_id=self.owner_id,
+                    generation=generation,
+                    claimed_at=claimed_at,
+                    heartbeat_at=_iso(current),
+                    expires_at=_iso(current + timedelta(seconds=lease_seconds)),
+                    prior_owner_state=prior_state,
+                )
+                _atomic(self.leader_path, asdict(lease))
+                return lease
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def heartbeat_leader(
+        self,
+        generation: int,
+        *,
+        lease_seconds: int = 30,
+        now: datetime | None = None,
+    ) -> SupervisorLeaderLease:
+        current = now or _now()
+        with self._lock() as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                raw = _read(self.leader_path)
+                if not raw or raw.get("schema") != LEADER_SCHEMA:
+                    raise RuntimeError("supervisor_leader_missing")
+                if raw.get("owner_id") != self.owner_id or int(raw.get("generation") or 0) != int(generation):
+                    raise PermissionError("supervisor_leader_not_owned")
+                if _parse(str(raw.get("expires_at"))) <= current:
+                    raise RuntimeError("supervisor_leader_expired")
+                lease = SupervisorLeaderLease(
+                    schema=LEADER_SCHEMA,
+                    owner_id=self.owner_id,
+                    generation=int(generation),
+                    claimed_at=str(raw.get("claimed_at")),
+                    heartbeat_at=_iso(current),
+                    expires_at=_iso(current + timedelta(seconds=lease_seconds)),
+                    prior_owner_state=str(raw.get("prior_owner_state") or "known"),
+                )
+                _atomic(self.leader_path, asdict(lease))
+                return lease
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _require_leader(self, generation: int, *, now: datetime) -> SupervisorLeaderLease:
+        raw = _read(self.leader_path)
+        if not raw or raw.get("schema") != LEADER_SCHEMA:
+            raise RuntimeError("supervisor_leader_missing")
+        lease = SupervisorLeaderLease(**raw)
+        if lease.owner_id != self.owner_id or lease.generation != int(generation):
+            raise PermissionError("supervisor_leader_not_owned")
+        if _parse(lease.expires_at) <= now:
+            raise RuntimeError("supervisor_leader_expired")
+        return lease
+
+    def _persisted_reconcile_ids(self) -> set[str]:
+        if not self.intents_dir.exists():
+            return set()
+        return {path.stem for path in self.intents_dir.glob("reconcile_*.json") if path.is_file()}
+
+    def _persist_intent(self, intent: ReconcileIntent, *, cycle_generation: int, now: datetime) -> bool:
+        path = self.intents_dir / f"{intent.reconcile_id}.json"
+        if path.exists():
+            return False
+        _atomic(
+            path,
+            {
+                "schema": INTENT_RECORD_SCHEMA,
+                "reconcile_id": intent.reconcile_id,
+                "state": "planned",
+                "planned_at": _iso(now),
+                "planned_by_cycle": cycle_generation,
+                "intent": intent.as_dict(),
+                "dispatch_performed": False,
+            },
+        )
+        return True
+
+    def _blocked_assignments(self, dependency_states: Mapping[str, str]) -> set[str]:
+        result: set[str] = set()
+        if not self.work_items.root.exists():
+            return result
+        for path in sorted(self.work_items.root.glob("*.json")):
+            try:
+                item = self.work_items.get(path.stem)
+            except Exception:
+                continue
+            if item.state == "open" and item.dependency_refs and not self.work_items.dependencies_ready(item.work_item_id, dependency_states):
+                result.add(item.assignment_id)
+        return result
+
+    def run_cycle(
+        self,
+        leader_generation: int,
+        *,
+        dependency_states: Mapping[str, str] | None = None,
+        now: datetime | None = None,
+    ) -> SupervisorCycleReceipt:
+        current = now or _now()
+        leader = self._require_leader(leader_generation, now=current)
+        previous = _read(self.state_path) or {}
+        cycle_generation = int(previous.get("cycle_generation") or 0) + 1
+        blocked = self._blocked_assignments(dependency_states or {})
+        persisted = self._persisted_reconcile_ids()
+        plan = self.reconciler.reconcile(
+            blocked_assignment_ids=blocked,
+            persisted_reconcile_ids=persisted,
+            now=current,
+        )
+        new_count = sum(
+            1 for intent in plan.intents if self._persist_intent(intent, cycle_generation=cycle_generation, now=current)
+        )
+        plan_payload = plan.as_dict()
+        plan_digest = hashlib.sha256(
+            json.dumps(plan_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        previous_digest = str(previous.get("last_plan_digest") or "")
+        previous_poll = int(previous.get("next_poll_seconds") or self.base_poll_seconds)
+        if new_count > 0 or plan_digest != previous_digest:
+            next_poll = self.base_poll_seconds
+        else:
+            next_poll = min(self.max_poll_seconds, max(self.base_poll_seconds, previous_poll * 2))
+        total_planned = len(self._persisted_reconcile_ids())
+        receipt = SupervisorCycleReceipt(
+            schema=CYCLE_SCHEMA,
+            cycle_generation=cycle_generation,
+            owner_id=self.owner_id,
+            leader_generation=leader.generation,
+            observed_at=_iso(current),
+            plan_digest=plan_digest,
+            new_intent_count=new_count,
+            total_planned_intent_count=total_planned,
+            suppressed_count=len(plan.suppressed),
+            error_count=len(plan.errors),
+            blocked_assignment_count=len(blocked),
+            next_poll_seconds=next_poll,
+        )
+        _atomic(self.cycles_dir / f"{cycle_generation:08d}.json", asdict(receipt))
+        _atomic(
+            self.state_path,
+            {
+                "schema": STATE_SCHEMA,
+                "status": "running",
+                "owner_id": self.owner_id,
+                "leader_generation": leader.generation,
+                "cycle_generation": cycle_generation,
+                "last_cycle_at": receipt.observed_at,
+                "last_plan_digest": plan_digest,
+                "next_poll_seconds": next_poll,
+                "planned_intent_count": total_planned,
+                "last_cycle_receipt": f"cycles/{cycle_generation:08d}.json",
+                "dispatch_performed": False,
+            },
+        )
+        return receipt
+
+    def health(self, *, now: datetime | None = None) -> dict[str, Any]:
+        current = now or _now()
+        state = _read(self.state_path) or {}
+        leader = _read(self.leader_path) or {}
+        leader_live = False
+        if leader.get("schema") == LEADER_SCHEMA and leader.get("expires_at"):
+            leader_live = _parse(str(leader["expires_at"])) > current
+        return {
+            "schema": "agentos.core-supervisor-health/v1",
+            "status": "running" if leader_live and state.get("status") == "running" else "inactive",
+            "leader_live": leader_live,
+            "owner_id": state.get("owner_id"),
+            "leader_generation": state.get("leader_generation"),
+            "cycle_generation": int(state.get("cycle_generation") or 0),
+            "last_cycle_at": state.get("last_cycle_at"),
+            "next_poll_seconds": state.get("next_poll_seconds"),
+            "planned_intent_count": int(state.get("planned_intent_count") or 0),
+            "dispatch_performed": False,
+        }
+
+    def run_forever(
+        self,
+        *,
+        stop_event: Event | None = None,
+        leader_lease_seconds: int = 30,
+    ) -> None:
+        stopper = stop_event or Event()
+        lease = self.claim_leader(lease_seconds=leader_lease_seconds)
+        while not stopper.is_set():
+            receipt = self.run_cycle(lease.generation)
+            lease = self.heartbeat_leader(lease.generation, lease_seconds=leader_lease_seconds)
+            stopper.wait(receipt.next_poll_seconds)
+        # Exiting does not erase durable state or pretend pending intents are done.

--- a/docs/CORE_SUPERVISOR.md
+++ b/docs/CORE_SUPERVISOR.md
@@ -1,0 +1,132 @@
+# AgentOS Core Supervisor
+
+Status: **S3 integration candidate — persistent observe/plan loop, no execution dispatch**.
+
+The Core Supervisor is the always-running reconciliation process for AgentOS. Employees remain durable organizational identities; they are not independent daemons. The Supervisor observes durable state and decides which assignment needs attention next.
+
+## Core model
+
+```text
+Issue event / Realm message / timer / dependency / user goal
+                         |
+                         v
+                 bounded event intake
+                         |
+                         v
+                      WorkItem
+                         |
+                         v
+             Employee durable assignment
+                         |
+                         v
+                Core Supervisor S1-S3
+             observe -> reconcile -> journal
+                         |
+                         v
+                planned ReconcileIntent
+                         |
+                    S4 boundary
+                         |
+                         v
+               governed ONE delivery
+```
+
+The invariant is **event != authority**. A GitHub Issue can trigger re-evaluation, but Issue prose is not an executable command and does not grant Node, executor, transport, capability, credential, or publication authority.
+
+## What S3 does
+
+The persistent service:
+
+- holds a process singleton lock for one Employee runtime root;
+- holds and heartbeats a durable Supervisor leader lease;
+- scans durable Employee assignments;
+- respects live Employee leases and blocked WorkItem dependencies;
+- converts pending/resumable assignments into deterministic reconcile intents;
+- journals a reconcile intent before any future delivery attempt;
+- preserves `prior_execution_state=unknown` when an Employee execution lease expired without a terminal receipt;
+- suppresses duplicate intents after restart;
+- writes durable cycle receipts and a read-only health projection;
+- increases polling backoff when state is unchanged;
+- continues leader heartbeats during long idle backoff;
+- survives process restart without deleting pending work.
+
+## What S3 explicitly does not do
+
+S3 does **not**:
+
+- select a Node, executor, model, session, transport, or capability carrier;
+- execute Issue text, shell commands, argv, scripts, or filesystem mutations;
+- send a wake to a Node;
+- claim an Employee assignment on behalf of an executor;
+- invoke GitHub Actions as a control-plane fallback;
+- publish to protected `main`;
+- prove that the service is already installed or running on Oracle.
+
+The source-controlled systemd unit uses `PrivateNetwork=true` intentionally. S3 has no network authority. S4 must cross a separate governed ONE delivery boundary.
+
+## CLI
+
+The production entrypoint is:
+
+```text
+python3 -m agent_core.core_supervisor_daemon
+```
+
+Read-only health:
+
+```text
+python3 -m agent_core.core_supervisor_daemon --health
+```
+
+One reconciliation cycle, useful for bounded local validation:
+
+```text
+python3 -m agent_core.core_supervisor_daemon --once
+```
+
+`AGENTOS_EMPLOYEE_RUNTIME_ROOT` must resolve to an absolute durable runtime path. `AGENTOS_DATA_ROOT` may be used as a parent fallback, in which case the Employee runtime is `<data-root>/employee-runtime`.
+
+Non-secret configuration is documented in `.agent/scripts/agentos-core-supervisor.env.example`.
+
+## Persistent-process safety
+
+Two independent fences are used:
+
+1. A long-held OS file lock at the runtime root prevents two local Supervisor daemon processes from operating concurrently.
+2. A durable leader lease/generation protects restart/takeover semantics. A new process instance uses a new owner identity; takeover after an expired leader is recorded with prior owner state `unknown`.
+
+The daemon never sleeps longer than half of the current leader lease without heartbeating, even when reconciliation backoff is longer than the lease.
+
+## Durable state
+
+Under the Employee runtime root:
+
+```text
+supervisor/
+  process.lock
+  leader.json
+  state.json
+  work-items/
+  intents/
+  cycles/
+```
+
+`intents/*.json` are S3 planned records with `dispatch_performed=false`. A merge of S3 therefore must never be interpreted as evidence that a Node was awakened or that an executor ran.
+
+## systemd template
+
+`.agent/scripts/agentos-core-supervisor.service` is a reference deployment template. Its write sandbox is intentionally limited to the configured Employee runtime area and its network namespace is private.
+
+Before installation, the host-specific paths in the service and env file must be checked against the actual runtime layout. Installing/enabling/restarting the service is a separate governed runtime mutation and requires its own receipt/evidence.
+
+**Repository merge != Oracle deployment != operating acceptance.**
+
+## Acceptance path
+
+- S1 deterministic reconcile kernel: integrated.
+- S2 event/WorkItem intake: integrated.
+- S3 persistent singleton loop: this slice.
+- S4 governed ONE wake delivery: separate authority boundary.
+- #197 Spec Steward: first end-to-end live Employee acceptance.
+
+The final acceptance is not static CI. A real persistent Supervisor must notice a pending Spec Steward assignment without a user saying `繼續`, cause a governed wake through ONE, observe executor/session turnover, resume the same Employee/assignment/thread safely, and stop waking after a terminal receipt.

--- a/tests/test_core_supervisor_assets.py
+++ b/tests/test_core_supervisor_assets.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.service"
+ENV_EXAMPLE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.env.example"
+DOC = ROOT / "docs" / "CORE_SUPERVISOR.md"
+
+
+class CoreSupervisorAssetTests(unittest.TestCase):
+    def test_service_runs_observe_plan_daemon_with_network_disabled(self):
+        text = SERVICE.read_text(encoding="utf-8")
+        self.assertIn("ExecStart=/usr/bin/python3 -m agent_core.core_supervisor_daemon", text)
+        self.assertIn("PrivateNetwork=true", text)
+        self.assertIn("NoNewPrivileges=true", text)
+        self.assertIn("ProtectSystem=strict", text)
+        self.assertIn("ReadWritePaths=/home/ubuntu/agent-data/employee-runtime", text)
+        lowered = text.casefold()
+        self.assertNotIn("workflow_dispatch", lowered)
+        self.assertNotIn("github actions", lowered)
+        self.assertNotIn("shell.exec", lowered)
+
+    def test_environment_example_is_non_secret_configuration_only(self):
+        text = ENV_EXAMPLE.read_text(encoding="utf-8")
+        self.assertIn("AGENTOS_EMPLOYEE_RUNTIME_ROOT=", text)
+        self.assertIn("AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS=", text)
+        lowered = text.casefold()
+        for forbidden in ("password=", "token=", "secret=", "authorization=", "bearer "):
+            self.assertNotIn(forbidden, lowered)
+
+    def test_docs_keep_source_merge_separate_from_live_deployment(self):
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("Repository merge != Oracle deployment != operating acceptance", text)
+        self.assertIn("event != authority", text)
+        self.assertIn("PrivateNetwork=true", text)
+        self.assertRegex(text, re.compile(r"S4.*governed ONE wake delivery", re.IGNORECASE))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_supervisor_daemon.py
+++ b/tests/test_core_supervisor_daemon.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from agent_core.core_supervisor_daemon import (
+    _heartbeat_step,
+    _process_singleton_lock,
+    main,
+    run_persistent,
+)
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+class _Receipt:
+    next_poll_seconds = 60
+
+
+class _FakeService:
+    def __init__(self):
+        self.claims = 0
+        self.cycles = 0
+        self.heartbeats = 0
+
+    class _Leader:
+        generation = 1
+
+    def claim_leader(self, *, lease_seconds):
+        self.claims += 1
+        return self._Leader()
+
+    def run_cycle(self, generation):
+        self.cycles += 1
+        return _Receipt()
+
+    def heartbeat_leader(self, generation, *, lease_seconds):
+        self.heartbeats += 1
+        return self._Leader()
+
+
+class _StopAfterWaits:
+    def __init__(self, stop_after: int):
+        self.stop_after = stop_after
+        self.waits: list[int] = []
+
+    def is_set(self):
+        return False
+
+    def wait(self, seconds):
+        self.waits.append(int(seconds))
+        return len(self.waits) >= self.stop_after
+
+
+class CoreSupervisorDaemonTests(unittest.TestCase):
+    def test_heartbeat_step_never_sleeps_past_half_leader_lease(self):
+        self.assertEqual(_heartbeat_step(60, 30), 15)
+        self.assertEqual(_heartbeat_step(10, 30), 10)
+        self.assertEqual(_heartbeat_step(1, 5), 1)
+
+    def test_long_idle_backoff_heartbeats_before_leader_can_expire(self):
+        service = _FakeService()
+        stop = _StopAfterWaits(stop_after=3)
+        run_persistent(service, stop_event=stop, leader_lease_seconds=30)
+        self.assertEqual(service.claims, 1)
+        self.assertEqual(service.cycles, 1)
+        self.assertEqual(stop.waits, [15, 15, 15])
+        self.assertEqual(service.heartbeats, 2)
+
+    def test_process_lock_is_held_for_daemon_lifetime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with _process_singleton_lock(root):
+                with self.assertRaisesRegex(RuntimeError, "supervisor_process_already_active"):
+                    with _process_singleton_lock(root):
+                        self.fail("second daemon lock must not be acquired")
+            with _process_singleton_lock(root):
+                pass
+
+    def test_health_cli_is_read_only_and_does_not_claim_leader(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = main(["--runtime-root", str(root), "--health"])
+            self.assertEqual(rc, 0)
+            payload = json.loads(out.getvalue())
+            self.assertEqual(payload["status"], "inactive")
+            self.assertFalse(payload["dispatch_performed"])
+            self.assertFalse((root / "supervisor" / "leader.json").exists())
+
+    def test_once_cli_journals_pending_work_without_dispatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            runtime = EmployeeRuntime(root)
+            runtime.create_employee("steward", "Steward", role_ids=["governance.spec_steward"])
+            runtime.create_assignment("audit-1", "steward", "Audit one issue")
+
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = main(["--runtime-root", str(root), "--service-id", "test-supervisor", "--once"])
+            self.assertEqual(rc, 0)
+            payload = json.loads(out.getvalue())
+            self.assertEqual(payload["new_intent_count"], 1)
+            self.assertFalse(payload["dispatch_performed"])
+            intent_files = list((root / "supervisor" / "intents").glob("reconcile_*.json"))
+            self.assertEqual(len(intent_files), 1)
+
+    def test_runtime_root_must_be_explicit_absolute_path(self):
+        with self.assertRaisesRegex(ValueError, "employee_runtime_root_must_be_absolute"):
+            main(["--runtime-root", "relative/path", "--health"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_supervisor_service.py
+++ b/tests/test_core_supervisor_service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.core_supervisor_service import CoreSupervisorService
+from agent_core.core_work_items import WORK_ITEM_SCHEMA, WorkItemStore
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+T0 = datetime(2026, 9, 2, 5, 30, 0, tzinfo=timezone.utc)
+
+
+class CoreSupervisorServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root)
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit closure gaps",
+            thread_head="ir:start",
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def service(self, owner="supervisor-a"):
+        return CoreSupervisorService(
+            self.lifecycle,
+            owner_id=owner,
+            base_poll_seconds=2,
+            max_poll_seconds=16,
+        )
+
+    def test_singleton_leader_rejects_competing_live_owner(self):
+        a = self.service("supervisor-a")
+        b = self.service("supervisor-b")
+        lease = a.claim_leader(lease_seconds=30, now=T0)
+        self.assertEqual(lease.generation, 1)
+        with self.assertRaisesRegex(RuntimeError, "supervisor_leader_already_active"):
+            b.claim_leader(lease_seconds=30, now=T0 + timedelta(seconds=5))
+
+    def test_expired_leader_takeover_increments_generation_and_marks_unknown(self):
+        a = self.service("supervisor-a")
+        b = self.service("supervisor-b")
+        a.claim_leader(lease_seconds=10, now=T0)
+        takeover = b.claim_leader(lease_seconds=30, now=T0 + timedelta(seconds=11))
+        self.assertEqual(takeover.generation, 2)
+        self.assertEqual(takeover.prior_owner_state, "unknown")
+
+    def test_cycle_persists_reconcile_intent_before_any_dispatch(self):
+        service = self.service()
+        leader = service.claim_leader(now=T0)
+        receipt = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self.assertEqual(receipt.new_intent_count, 1)
+        self.assertFalse(receipt.dispatch_performed)
+        intent_files = list(service.intents_dir.glob("reconcile_*.json"))
+        self.assertEqual(len(intent_files), 1)
+        stored = json.loads(intent_files[0].read_text(encoding="utf-8"))
+        self.assertEqual(stored["state"], "planned")
+        self.assertFalse(stored["dispatch_performed"])
+        self.assertEqual(stored["intent"]["employee_id"], "spec-steward")
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "pending")
+        self.assertIsNone(self.lifecycle.get_lease("audit-001"))
+
+    def test_restart_does_not_duplicate_same_planned_intent(self):
+        first = self.service("supervisor-a")
+        lease = first.claim_leader(now=T0)
+        cycle1 = first.run_cycle(lease.generation, now=T0 + timedelta(seconds=1))
+        self.assertEqual(cycle1.new_intent_count, 1)
+
+        restarted = self.service("supervisor-a")
+        renewed = restarted.claim_leader(now=T0 + timedelta(seconds=2))
+        cycle2 = restarted.run_cycle(renewed.generation, now=T0 + timedelta(seconds=3))
+        self.assertEqual(cycle2.new_intent_count, 0)
+        self.assertEqual(cycle2.total_planned_intent_count, 1)
+
+    def test_unchanged_cycles_back_off_without_busy_loop(self):
+        service = self.service()
+        leader = service.claim_leader(now=T0)
+        first = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        second = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=2))
+        third = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=3))
+        self.assertEqual(first.next_poll_seconds, 2)
+        self.assertGreaterEqual(second.next_poll_seconds, 2)
+        self.assertGreaterEqual(third.next_poll_seconds, second.next_poll_seconds)
+        self.assertLessEqual(third.next_poll_seconds, 16)
+
+    def test_work_item_dependency_blocks_assignment_until_explicit_completion(self):
+        # Replace the ad-hoc assignment with a WorkItem-owned one so S3 can derive
+        # blocked assignment ids from durable dependency state.
+        self.runtime.update_assignment("audit-001", state="cancelled")
+        store = WorkItemStore(self.runtime)
+        store.persist({
+            "schema": WORK_ITEM_SCHEMA,
+            "work_item_id": "work-audit-002",
+            "source_kind": "github_issue",
+            "source_ref": "github:alston-personal/agentmanager#200",
+            "project_id": "agentos-core",
+            "employee_id": "spec-steward",
+            "assignment_id": "audit-002",
+            "goal": "Audit after dependency closes",
+            "dependency_refs": ["github:alston-personal/agentmanager#197"],
+            "state": "open",
+        })
+        store.project_pending_assignment("work-audit-002")
+        service = self.service()
+        leader = service.claim_leader(now=T0)
+        blocked = service.run_cycle(leader.generation, dependency_states={}, now=T0 + timedelta(seconds=1))
+        self.assertEqual(blocked.new_intent_count, 0)
+        self.assertEqual(blocked.blocked_assignment_count, 1)
+
+        ready = service.run_cycle(
+            leader.generation,
+            dependency_states={"github:alston-personal/agentmanager#197": "completed"},
+            now=T0 + timedelta(seconds=2),
+        )
+        self.assertEqual(ready.new_intent_count, 1)
+        self.assertEqual(ready.blocked_assignment_count, 0)
+
+    def test_expired_assignment_is_journaled_as_resume_unknown(self):
+        self.lifecycle.claim(
+            "audit-001", "spec-steward", "lease-old", lease_seconds=30, now=T0
+        )
+        self.lifecycle.checkpoint(
+            "audit-001", "lease-old", "ir:checkpoint", now=T0 + timedelta(seconds=10)
+        )
+        service = self.service()
+        leader = service.claim_leader(now=T0)
+        receipt = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=31))
+        self.assertEqual(receipt.new_intent_count, 1)
+        record = json.loads(next(service.intents_dir.glob("reconcile_*.json")).read_text(encoding="utf-8"))
+        wake = record["intent"]["wake_intent"]
+        self.assertTrue(wake["resume_required"])
+        self.assertEqual(wake["prior_execution_state"], "unknown")
+        self.assertEqual(wake["thread_head"], "ir:checkpoint")
+
+    def test_cycle_requires_current_leader_ownership(self):
+        service = self.service("supervisor-a")
+        service.claim_leader(lease_seconds=10, now=T0)
+        with self.assertRaisesRegex(RuntimeError, "supervisor_leader_expired"):
+            service.run_cycle(1, now=T0 + timedelta(seconds=11))
+
+    def test_health_projection_is_read_only_and_exposes_no_execution_claim(self):
+        service = self.service()
+        leader = service.claim_leader(now=T0)
+        service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        health = service.health(now=T0 + timedelta(seconds=2))
+        self.assertEqual(health["status"], "running")
+        self.assertTrue(health["leader_live"])
+        self.assertEqual(health["planned_intent_count"], 1)
+        self.assertFalse(health["dispatch_performed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_supervisor_service.py
+++ b/tests/test_core_supervisor_service.py
@@ -139,7 +139,7 @@ class CoreSupervisorServiceTests(unittest.TestCase):
             "audit-001", "lease-old", "ir:checkpoint", now=T0 + timedelta(seconds=10)
         )
         service = self.service()
-        leader = service.claim_leader(now=T0)
+        leader = service.claim_leader(lease_seconds=60, now=T0)
         receipt = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=31))
         self.assertEqual(receipt.new_intent_count, 1)
         record = json.loads(next(service.intents_dir.glob("reconcile_*.json")).read_text(encoding="utf-8"))


### PR DESCRIPTION
## Scope
Implement #200 S3 as an actual persistent Core process contract while keeping execution delivery outside the daemon.

## Adds
- durable singleton Supervisor leader lease/generation;
- repeated reconcile cycle journal + planned intent journal;
- crash/restart idempotency;
- WorkItem dependency blocking;
- adaptive polling/backoff + durable health projection;
- production `agent_core.core_supervisor_daemon` entrypoint;
- long-held runtime-root process lock so two local daemon processes cannot run concurrently;
- unique process-instance leader owner identity;
- leader heartbeat during long idle backoff so polling cannot outlive the lease;
- `--health` read-only CLI and bounded `--once` validation mode;
- non-secret environment example;
- hardened systemd reference unit with `PrivateNetwork=true`, `NoNewPrivileges=true`, strict filesystem sandbox, and write access limited to the Employee runtime root;
- `docs/CORE_SUPERVISOR.md` with explicit source/deployment/operating boundaries;
- daemon/service asset regressions in Employee Runtime Guard.

## Authority boundary
S3 is **observe/plan only**. It journals `ReconcileIntent` with `dispatch_performed=false`; it does not select a Node/executor/model/session/carrier/capability and cannot perform network delivery from the reference systemd sandbox. S4 must cross a separate governed ONE delivery boundary. GitHub Actions is not a control-plane fallback.

## Important daemon fix found during this slice
Initial service semantics allowed reconciliation backoff (up to 60s) to exceed the default Supervisor leader lease (30s). Production daemon now splits idle waits and heartbeats at most half a lease interval. Regression also guards process-level singleton behavior in addition to the durable leader lease.

## Evidence
Final branch Employee Runtime Guard run `33594958758` completed SUCCESS on head `b85fe2f8de4a9b812e07d4e6655fb24312de603f`. Employee runtime/lifecycle/wake/memory/skill/thread/mailbox, S1 Supervisor, S2 WorkItem, S3 service, daemon heartbeat/singleton, service assets, and role hydration regressions all passed.

## Non-claims
This PR does not install/enable/restart the service on Oracle and does not prove an operating persistent Supervisor. Repository merge != Oracle deployment != operating acceptance. #197/S4 remains responsible for governed wake delivery and the first live Spec Steward acceptance.

Target: `core/integration` only; no protected-main publication authority implied.