### PR TITLE
Core #197: add governed Employee wake delivery through ONE

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -13,11 +13,15 @@ on:
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
+      - 'agent_core/employee_presence.py'
+      - 'agent_core/employee_wake_delivery.py'
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/role_runtime.py'
+      - 'agentos_node/employee_wake_inbox.py'
+      - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
       - 'tests/test_employee_runtime.py'
@@ -27,6 +31,7 @@ on:
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
+      - 'tests/test_employee_wake_delivery.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
@@ -40,6 +45,7 @@ on:
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
+      - core/issue-197-governed-wake-delivery-v2
       - core/issue-200-persistent-supervisor-loop
       - core/integration
     paths:
@@ -50,11 +56,15 @@ on:
       - 'agent_core/employee_skills.py'
       - 'agent_core/employee_threads.py'
       - 'agent_core/employee_realm_mailbox.py'
+      - 'agent_core/employee_presence.py'
+      - 'agent_core/employee_wake_delivery.py'
       - 'agent_core/core_supervisor.py'
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/role_runtime.py'
+      - 'agentos_node/employee_wake_inbox.py'
+      - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
       - 'tests/test_employee_runtime.py'
@@ -64,6 +74,7 @@ on:
       - 'tests/test_employee_skills.py'
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
+      - 'tests/test_employee_wake_delivery.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
@@ -105,6 +116,8 @@ jobs:
         run: python -m unittest tests.test_employee_threads -v
       - name: Run Realm Employee mailbox regressions
         run: python -m unittest tests.test_employee_realm_mailbox -v
+      - name: Run governed Employee wake-delivery regressions
+        run: python -m unittest tests.test_employee_wake_delivery -v
       - name: Run Core Supervisor reconciliation regressions
         run: python -m unittest tests.test_core_supervisor -v
       - name: Run Core WorkItem intake regressions

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -32,6 +32,7 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_employee_wake_delivery.py'
+      - 'tests/test_employee_wake_inbox_security.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
@@ -75,6 +76,7 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_employee_wake_delivery.py'
+      - 'tests/test_employee_wake_inbox_security.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
@@ -118,6 +120,8 @@ jobs:
         run: python -m unittest tests.test_employee_realm_mailbox -v
       - name: Run governed Employee wake-delivery regressions
         run: python -m unittest tests.test_employee_wake_delivery -v
+      - name: Run Employee wake-inbox privacy regressions
+        run: python -m unittest tests.test_employee_wake_inbox_security -v
       - name: Run Core Supervisor reconciliation regressions
         run: python -m unittest tests.test_core_supervisor -v
       - name: Run Core WorkItem intake regressions

--- a/agent_core/employee_presence.py
+++ b/agent_core/employee_presence.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_runtime import EmployeeRuntime
+
+
+PRESENCE_SCHEMA = "agentos.employee-presence/v1"
+WAKE_CAPABILITY = "agent.employee.wake.deliver"
+MIN_TTL_SECONDS = 30
+MAX_TTL_SECONDS = 900
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "").strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError("unsafe_employee_presence_id")
+    return value
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+@dataclass(frozen=True, slots=True)
+class EmployeePresence:
+    schema: str
+    employee_id: str
+    node_id: str
+    presence_id: str
+    generation: int
+    bound_at: str
+    heartbeat_at: str
+    expires_at: str
+    required_capability: str = WAKE_CAPABILITY
+    executor_identity_bound: bool = False
+    credential_exposed: bool = False
+
+
+class EmployeePresenceRegistry:
+    """ONE-side ephemeral Employee -> Node location, never Employee identity.
+
+    Presence says where a bounded Employee wake inbox currently exists. It does
+    not grant assignment ownership or bind Employee identity to a model/session.
+    The caller that writes presence remains responsible for the surrounding ONE
+    authority/authentication boundary.
+    """
+
+    def __init__(self, runtime: EmployeeRuntime, node_registry: Any) -> None:
+        self.runtime = runtime
+        self.node_registry = node_registry
+        self.root = runtime.root / "realm" / "employee-presence"
+
+    def _path(self, employee_id: str) -> Path:
+        return self.root / f"{_safe_id(employee_id)}.json"
+
+    def get(self, employee_id: str) -> EmployeePresence | None:
+        path = self._path(employee_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema") != PRESENCE_SCHEMA:
+            raise ValueError("employee_presence_state_invalid")
+        return EmployeePresence(**payload)
+
+    def _eligible_node(self, node_id: str) -> dict[str, Any]:
+        node_id = _safe_id(node_id)
+        node_map = self.node_registry.node_map()
+        node = next((item for item in node_map.get("nodes", []) if item.get("node_id") == node_id), None)
+        if node is None:
+            raise KeyError(node_id)
+        if node.get("status") != "online":
+            raise RuntimeError("employee_presence_node_not_online")
+        if WAKE_CAPABILITY not in set(node.get("capabilities") or []):
+            raise PermissionError("employee_presence_node_lacks_wake_capability")
+        return node
+
+    def bind(
+        self,
+        employee_id: str,
+        node_id: str,
+        presence_id: str,
+        *,
+        ttl_seconds: int = 120,
+        supersede_presence_id: str | None = None,
+        now: datetime | None = None,
+    ) -> EmployeePresence:
+        employee_id = _safe_id(employee_id)
+        node_id = _safe_id(node_id)
+        presence_id = _safe_id(presence_id)
+        self.runtime.get_employee(employee_id)
+        self._eligible_node(node_id)
+        ttl = int(ttl_seconds)
+        if ttl < MIN_TTL_SECONDS or ttl > MAX_TTL_SECONDS:
+            raise ValueError("employee_presence_ttl_out_of_range")
+        current = now or _utcnow()
+        existing = self.get(employee_id)
+
+        if existing and existing.presence_id == presence_id:
+            if existing.node_id != node_id:
+                raise RuntimeError("employee_presence_id_node_mismatch")
+            return self.heartbeat(employee_id, presence_id, ttl_seconds=ttl, now=current)
+
+        generation = 1
+        if existing:
+            generation = existing.generation + 1
+            live = _parse(existing.expires_at) > current
+            if live and supersede_presence_id != existing.presence_id:
+                raise RuntimeError("employee_presence_already_live")
+
+        presence = EmployeePresence(
+            schema=PRESENCE_SCHEMA,
+            employee_id=employee_id,
+            node_id=node_id,
+            presence_id=presence_id,
+            generation=generation,
+            bound_at=_iso(current),
+            heartbeat_at=_iso(current),
+            expires_at=_iso(current + timedelta(seconds=ttl)),
+        )
+        _atomic_write(self._path(employee_id), asdict(presence))
+        return presence
+
+    def heartbeat(
+        self,
+        employee_id: str,
+        presence_id: str,
+        *,
+        ttl_seconds: int = 120,
+        now: datetime | None = None,
+    ) -> EmployeePresence:
+        employee_id = _safe_id(employee_id)
+        presence_id = _safe_id(presence_id)
+        current = now or _utcnow()
+        ttl = int(ttl_seconds)
+        if ttl < MIN_TTL_SECONDS or ttl > MAX_TTL_SECONDS:
+            raise ValueError("employee_presence_ttl_out_of_range")
+        existing = self.get(employee_id)
+        if existing is None or existing.presence_id != presence_id:
+            raise PermissionError("employee_presence_not_owned")
+        self._eligible_node(existing.node_id)
+        if _parse(existing.expires_at) <= current:
+            raise RuntimeError("employee_presence_expired")
+        updated = EmployeePresence(
+            **{
+                **asdict(existing),
+                "heartbeat_at": _iso(current),
+                "expires_at": _iso(current + timedelta(seconds=ttl)),
+            }
+        )
+        _atomic_write(self._path(employee_id), asdict(updated))
+        return updated
+
+    def resolve(self, employee_id: str, *, now: datetime | None = None) -> EmployeePresence:
+        employee_id = _safe_id(employee_id)
+        self.runtime.get_employee(employee_id)
+        current = now or _utcnow()
+        presence = self.get(employee_id)
+        if presence is None:
+            raise RuntimeError("employee_presence_unavailable")
+        if _parse(presence.expires_at) <= current:
+            raise RuntimeError("employee_presence_expired")
+        self._eligible_node(presence.node_id)
+        return presence

--- a/agent_core/employee_wake_delivery.py
+++ b/agent_core/employee_wake_delivery.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.controller_service import ControllerService
+from agent_core.employee_presence import EmployeePresenceRegistry, WAKE_CAPABILITY
+from agent_core.employee_wake import EmployeeWakeIntent
+
+
+DELIVERY_SCHEMA = "agentos.employee-wake-delivery-state/v1"
+PRESENCE_ROUTE_SCHEMA = "agentos.employee-wake-route/v1"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return (value or _utcnow()).astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "").strip()
+    if not value or any(ch in value for ch in "/\\\0") or value in {".", ".."}:
+        raise ValueError("unsafe_employee_wake_delivery_id")
+    return value
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != DELIVERY_SCHEMA:
+        raise ValueError("employee_wake_delivery_state_invalid")
+    return payload
+
+
+def _attempt_id(wake_id: str, presence_generation: int, node_id: str) -> str:
+    digest = hashlib.sha256(f"{wake_id}\0{presence_generation}\0{node_id}".encode("utf-8")).hexdigest()[:24]
+    return "wakedelivery_" + digest
+
+
+def _task_id(wake_id: str, presence_generation: int) -> str:
+    digest = hashlib.sha256(f"{wake_id}\0{presence_generation}".encode("utf-8")).hexdigest()[:24]
+    return "empwake_" + digest
+
+
+@dataclass(slots=True)
+class EmployeeWakeDeliveryState:
+    schema: str
+    attempt_id: str
+    wake_id: str
+    employee_id: str
+    assignment_id: str
+    presence_id: str
+    presence_generation: int
+    node_id: str
+    task_id: str
+    status: str
+    attempted_at: str
+    updated_at: str
+    queued_at: str | None = None
+    completed_at: str | None = None
+    node_ok: bool | None = None
+    node_wake_accepted: bool | None = None
+    error_code: str | None = None
+    controller_entered: bool | None = None
+    credential_exposed: bool = False
+
+
+class EmployeeWakeDelivery:
+    """Deliver one exact durable Employee wake intent through existing ONE Node queue.
+
+    This layer does not re-plan work. Its input is the exact wake intent already
+    selected/journaled by Core. Delivery is scoped by Employee presence generation.
+    A crash after persisting `dispatching` is UNKNOWN and is not blindly retried to
+    that same presence generation.
+    """
+
+    def __init__(self, presence: EmployeePresenceRegistry, controller: ControllerService) -> None:
+        self.presence = presence
+        self.controller = controller
+        self.root = presence.runtime.root / "realm" / "employee-wake-delivery"
+
+    def _path(self, wake_id: str, presence_generation: int) -> Path:
+        return self.root / _safe_id(wake_id) / f"{int(presence_generation):06d}.json"
+
+    def get(self, wake_id: str, presence_generation: int) -> EmployeeWakeDeliveryState | None:
+        payload = _read(self._path(wake_id, presence_generation))
+        return EmployeeWakeDeliveryState(**payload) if payload else None
+
+    def deliver_intent(
+        self,
+        intent: EmployeeWakeIntent,
+        *,
+        now: datetime | None = None,
+    ) -> EmployeeWakeDeliveryState:
+        if not isinstance(intent, EmployeeWakeIntent):
+            raise TypeError("employee_wake_intent_type_required")
+        current = now or _utcnow()
+        route = self.presence.resolve(intent.employee_id, now=current)
+        path = self._path(intent.wake_id, route.generation)
+        existing = _read(path)
+        if existing is not None:
+            state = EmployeeWakeDeliveryState(**existing)
+            if state.status == "dispatching":
+                state.status = "unknown"
+                state.error_code = "dispatch_interrupted_after_claim"
+                state.updated_at = _iso(current)
+                _atomic_write(path, asdict(state))
+            return state
+
+        state = EmployeeWakeDeliveryState(
+            schema=DELIVERY_SCHEMA,
+            attempt_id=_attempt_id(intent.wake_id, route.generation, route.node_id),
+            wake_id=intent.wake_id,
+            employee_id=intent.employee_id,
+            assignment_id=intent.assignment_id,
+            presence_id=route.presence_id,
+            presence_generation=route.generation,
+            node_id=route.node_id,
+            task_id=_task_id(intent.wake_id, route.generation),
+            status="dispatching",
+            attempted_at=_iso(current),
+            updated_at=_iso(current),
+        )
+        _atomic_write(path, asdict(state))
+
+        wake_route = {
+            "schema": PRESENCE_ROUTE_SCHEMA,
+            "employee_id": route.employee_id,
+            "node_id": route.node_id,
+            "presence_id": route.presence_id,
+            "presence_generation": route.generation,
+        }
+        request = {
+            "schema": ControllerService.REQUEST_SCHEMA,
+            "node_id": route.node_id,
+            "action": WAKE_CAPABILITY,
+            "task_id": state.task_id,
+            "payload": {
+                "wake_intent": intent.as_dict(),
+                "employee_wake_route": wake_route,
+            },
+        }
+        try:
+            result = self.controller.dispatch(request)
+        except Exception:
+            # Crossing the durable ONE queue boundary can be ambiguous. Do not
+            # serialize exception text and do not blindly retry the same route.
+            state.status = "unknown"
+            state.error_code = "controller_dispatch_uncertain"
+            state.updated_at = _iso(current)
+            _atomic_write(path, asdict(state))
+            return state
+
+        state.status = "queued"
+        state.queued_at = str(result.get("queued_at") or _iso(current))
+        state.controller_entered = bool(result.get("controller_entered"))
+        state.updated_at = _iso(current)
+        _atomic_write(path, asdict(state))
+        return state
+
+    def reconcile(
+        self,
+        wake_id: str,
+        presence_generation: int,
+        *,
+        now: datetime | None = None,
+    ) -> EmployeeWakeDeliveryState:
+        state = self.get(wake_id, presence_generation)
+        if state is None:
+            raise FileNotFoundError(wake_id)
+        receipt = self.controller.fabric.get_receipt(state.task_id)
+        if receipt is None:
+            return state
+
+        current = now or _utcnow()
+        valid_identity = (
+            receipt.get("schema") == "agentos.node-receipt/v0.1"
+            and receipt.get("task_id") == state.task_id
+            and receipt.get("node_id") == state.node_id
+            and receipt.get("action") == WAKE_CAPABILITY
+        )
+        if not valid_identity:
+            state.status = "unknown"
+            state.error_code = "node_receipt_identity_mismatch"
+        else:
+            wake_receipt = receipt.get("wake_delivery")
+            accepted = bool(
+                isinstance(wake_receipt, dict)
+                and wake_receipt.get("wake_id") == state.wake_id
+                and wake_receipt.get("employee_id") == state.employee_id
+                and wake_receipt.get("assignment_id") == state.assignment_id
+                and wake_receipt.get("node_id") == state.node_id
+                and wake_receipt.get("presence_id") == state.presence_id
+                and wake_receipt.get("presence_generation") == state.presence_generation
+                and wake_receipt.get("accepted") is True
+                and wake_receipt.get("executor_invoked") is False
+                and wake_receipt.get("credential_exposed") is False
+            )
+            state.node_ok = receipt.get("ok") is True
+            state.node_wake_accepted = accepted
+            if state.node_ok and accepted:
+                state.status = "delivered"
+                state.error_code = None
+            else:
+                state.status = "failed"
+                state.error_code = "node_wake_delivery_failed"
+        state.completed_at = _iso(current)
+        state.updated_at = _iso(current)
+        _atomic_write(self._path(wake_id, presence_generation), asdict(state))
+        return state

--- a/agentos_node/employee_wake_inbox.py
+++ b/agentos_node/employee_wake_inbox.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+WAKE_INTENT_SCHEMA = "agentos.employee-wake-intent/v1"
+WAKE_ROUTE_SCHEMA = "agentos.employee-wake-route/v1"
+WAKE_RECEIPT_SCHEMA = "agentos.employee-wake-delivery/v1"
+ALLOWED_INTENT_KEYS = {
+    "schema",
+    "wake_id",
+    "employee_id",
+    "assignment_id",
+    "mode",
+    "expected_lease_generation",
+    "goal",
+    "thread_head",
+    "constraints",
+    "role_ids",
+    "skill_ids",
+    "resume_required",
+    "prior_execution_state",
+    "authority_boundary",
+    "executor_selection",
+    "transport_selection",
+    "credential_exposed",
+}
+ROUTE_KEYS = {"schema", "employee_id", "node_id", "presence_id", "presence_generation"}
+FORBIDDEN_INTENT_KEYS = {
+    "argv", "executable", "command", "shell", "url", "endpoint", "credential",
+    "credentials", "token", "secret", "authorization", "headers", "env",
+    "environment", "node_id", "provider", "model", "session_id",
+}
+SECRET_MARKERS = ("bearer ", "github_pat_", "ghp_", "token=", "secret=", "authorization:")
+
+
+def _safe_id(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 256 or any(ch in text for ch in "/\\\0") or text in {".", ".."}:
+        raise ValueError(f"invalid_{field}")
+    return text
+
+
+def _walk_safe(value: Any, *, path: str = "wake_intent") -> None:
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key).strip().casefold()
+            if key in FORBIDDEN_INTENT_KEYS:
+                raise ValueError(f"forbidden_employee_wake_field:{path}.{key}")
+            _walk_safe(item, path=f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        if len(value) > 128:
+            raise ValueError("employee_wake_list_too_large")
+        for index, item in enumerate(value):
+            _walk_safe(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        if len(value) > 4096:
+            raise ValueError("employee_wake_string_too_large")
+        lowered = value.casefold()
+        if any(marker in lowered for marker in SECRET_MARKERS):
+            raise ValueError(f"employee_wake_secret_like_value:{path}")
+        return
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+    raise ValueError(f"unsupported_employee_wake_value:{path}")
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _digest(intent: dict[str, Any], route: dict[str, Any]) -> str:
+    raw = json.dumps(
+        {"wake_intent": intent, "employee_wake_route": route},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def deliver_employee_wake(task: dict[str, Any], root: Path, *, expected_node_id: str) -> dict[str, Any]:
+    """Persist one bounded wake capsule; never start or select an executor."""
+    intent = task.get("wake_intent")
+    route = task.get("employee_wake_route")
+    if not isinstance(intent, dict):
+        raise ValueError("employee_wake_intent_required")
+    if not isinstance(route, dict):
+        raise ValueError("employee_wake_route_required")
+    if intent.get("schema") != WAKE_INTENT_SCHEMA:
+        raise ValueError("invalid_employee_wake_intent_schema")
+    if route.get("schema") != WAKE_ROUTE_SCHEMA:
+        raise ValueError("invalid_employee_wake_route_schema")
+
+    unexpected_intent = sorted(set(intent) - ALLOWED_INTENT_KEYS)
+    if unexpected_intent:
+        raise ValueError("unexpected_employee_wake_fields:" + ",".join(unexpected_intent))
+    unexpected_route = sorted(set(route) - ROUTE_KEYS)
+    if unexpected_route:
+        raise ValueError("unexpected_employee_wake_route_fields:" + ",".join(unexpected_route))
+    _walk_safe(intent)
+
+    wake_id = _safe_id(intent.get("wake_id"), field="wake_id")
+    employee_id = _safe_id(intent.get("employee_id"), field="employee_id")
+    assignment_id = _safe_id(intent.get("assignment_id"), field="assignment_id")
+    route_employee_id = _safe_id(route.get("employee_id"), field="route_employee_id")
+    route_node_id = _safe_id(route.get("node_id"), field="route_node_id")
+    presence_id = _safe_id(route.get("presence_id"), field="presence_id")
+    local_node_id = _safe_id(expected_node_id, field="expected_node_id")
+    if route_employee_id != employee_id:
+        raise PermissionError("employee_wake_route_employee_mismatch")
+    if route_node_id != local_node_id:
+        raise PermissionError("employee_wake_route_node_mismatch")
+    generation_raw = route.get("presence_generation")
+    if isinstance(generation_raw, bool) or not isinstance(generation_raw, int) or generation_raw < 1:
+        raise ValueError("employee_wake_presence_generation_invalid")
+    presence_generation = generation_raw
+
+    if intent.get("authority_boundary") != "selection_only_no_execution":
+        raise ValueError("employee_wake_authority_boundary_invalid")
+    if intent.get("executor_selection") != "unbound":
+        raise ValueError("employee_wake_executor_must_be_unbound")
+    if intent.get("transport_selection") != "unbound":
+        raise ValueError("employee_wake_transport_must_be_unbound")
+    if intent.get("credential_exposed") is not False:
+        raise ValueError("employee_wake_credential_boundary_invalid")
+    if intent.get("mode") not in {"fresh", "resume"}:
+        raise ValueError("employee_wake_mode_invalid")
+    lease_generation = intent.get("expected_lease_generation")
+    if isinstance(lease_generation, bool) or not isinstance(lease_generation, int) or lease_generation < 1:
+        raise ValueError("employee_wake_generation_invalid")
+
+    digest = _digest(intent, route)
+    path = Path(root) / employee_id / f"{wake_id}.{presence_generation:06d}.json"
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(existing, dict) or existing.get("digest") != digest:
+            raise RuntimeError("employee_wake_idempotency_conflict")
+    else:
+        _atomic_write(
+            path,
+            {
+                "schema": WAKE_RECEIPT_SCHEMA,
+                "wake_id": wake_id,
+                "employee_id": employee_id,
+                "assignment_id": assignment_id,
+                "node_id": route_node_id,
+                "presence_id": presence_id,
+                "presence_generation": presence_generation,
+                "expected_lease_generation": lease_generation,
+                "digest": digest,
+                "wake_intent": intent,
+                "employee_wake_route": route,
+            },
+        )
+
+    return {
+        "wake_delivery": {
+            "schema": WAKE_RECEIPT_SCHEMA,
+            "wake_id": wake_id,
+            "employee_id": employee_id,
+            "assignment_id": assignment_id,
+            "node_id": route_node_id,
+            "presence_id": presence_id,
+            "presence_generation": presence_generation,
+            "expected_lease_generation": lease_generation,
+            "accepted": True,
+            "digest": digest,
+            "executor_invoked": False,
+            "credential_exposed": False,
+        }
+    }

--- a/agentos_node/employee_wake_inbox.py
+++ b/agentos_node/employee_wake_inbox.py
@@ -45,30 +45,30 @@ def _safe_id(value: Any, *, field: str) -> str:
     return text
 
 
-def _walk_safe(value: Any, *, path: str = "wake_intent") -> None:
+def _walk_safe(value: Any) -> None:
     if isinstance(value, dict):
         for raw_key, item in value.items():
             key = str(raw_key).strip().casefold()
             if key in FORBIDDEN_INTENT_KEYS:
-                raise ValueError(f"forbidden_employee_wake_field:{path}.{key}")
-            _walk_safe(item, path=f"{path}.{key}")
+                raise ValueError("forbidden_employee_wake_field")
+            _walk_safe(item)
         return
     if isinstance(value, list):
         if len(value) > 128:
             raise ValueError("employee_wake_list_too_large")
-        for index, item in enumerate(value):
-            _walk_safe(item, path=f"{path}[{index}]")
+        for item in value:
+            _walk_safe(item)
         return
     if isinstance(value, str):
         if len(value) > 4096:
             raise ValueError("employee_wake_string_too_large")
         lowered = value.casefold()
         if any(marker in lowered for marker in SECRET_MARKERS):
-            raise ValueError(f"employee_wake_secret_like_value:{path}")
+            raise ValueError("employee_wake_secret_like_value")
         return
     if value is None or isinstance(value, (bool, int, float)):
         return
-    raise ValueError(f"unsupported_employee_wake_value:{path}")
+    raise ValueError("unsupported_employee_wake_value")
 
 
 def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
@@ -105,12 +105,10 @@ def deliver_employee_wake(task: dict[str, Any], root: Path, *, expected_node_id:
     if route.get("schema") != WAKE_ROUTE_SCHEMA:
         raise ValueError("invalid_employee_wake_route_schema")
 
-    unexpected_intent = sorted(set(intent) - ALLOWED_INTENT_KEYS)
-    if unexpected_intent:
-        raise ValueError("unexpected_employee_wake_fields:" + ",".join(unexpected_intent))
-    unexpected_route = sorted(set(route) - ROUTE_KEYS)
-    if unexpected_route:
-        raise ValueError("unexpected_employee_wake_route_fields:" + ",".join(unexpected_route))
+    if set(intent) - ALLOWED_INTENT_KEYS:
+        raise ValueError("unexpected_employee_wake_fields")
+    if set(route) - ROUTE_KEYS:
+        raise ValueError("unexpected_employee_wake_route_fields")
     _walk_safe(intent)
 
     wake_id = _safe_id(intent.get("wake_id"), field="wake_id")

--- a/agentos_node/thin_client.py
+++ b/agentos_node/thin_client.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agentos_node import interactive_desktop
 from agentos_node.agent_surfaces import discover_surfaces
+from agentos_node.employee_wake_inbox import deliver_employee_wake
 from agentos_node.runtime_provenance import observe_runtime
 from agentos_node.session_bridge import FileSessionBridge
 
@@ -40,6 +41,7 @@ class ThinClientPolicy:
     allowed_executables: set[str] = field(default_factory=set)
     readable_roots: tuple[Path, ...] = field(default_factory=tuple)
     writable_roots: tuple[Path, ...] = field(default_factory=tuple)
+    employee_wake_root: Path | None = None
     max_timeout_seconds: int = 300
 
     @staticmethod
@@ -100,6 +102,8 @@ class ThinClient:
             caps.append('filesystem.read')
         if self.policy.writable_roots:
             caps.append('filesystem.write')
+        if self.policy.employee_wake_root is not None:
+            caps.append('agent.employee.wake.deliver')
         if platform.system() == 'Windows':
             caps.extend([
                 'desktop.session.inspect', 'desktop.windows.inspect', 'desktop.screenshot',
@@ -169,6 +173,14 @@ class ThinClient:
                 result = self._read_file(task)
             elif action == 'filesystem.write':
                 result = self._write_file(task)
+            elif action == 'agent.employee.wake.deliver':
+                if self.policy.employee_wake_root is None:
+                    raise PermissionError('employee_wake_inbox_not_configured')
+                result = deliver_employee_wake(
+                    task,
+                    self.policy.employee_wake_root,
+                    expected_node_id=self.identity.node_id,
+                )
             elif action == 'agent.surface.inspect':
                 result = {'surface_inventory': self.surface_inventory()}
             elif action == 'agent.session.discover':

--- a/tests/test_employee_wake_delivery.py
+++ b/tests/test_employee_wake_delivery.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.controller_service import ControllerService
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import EmployeePresenceRegistry, WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import EmployeeWakePlanner
+from agent_core.employee_wake_delivery import DELIVERY_SCHEMA, EmployeeWakeDelivery
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+class EmployeeWakeDeliveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root / "employee-runtime")
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit open closure gaps",
+            thread_head="ir:start",
+            constraints=["read-only-first"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.planner = EmployeeWakePlanner(self.lifecycle)
+
+        self.node_registry = NodeRegistry(path=self.root / "nodes.json")
+        self.fabric = RealmFabricStore(path=self.root / "fabric.json", node_registry=self.node_registry)
+        self.fabric.initialize_realm("realm-test")
+        self.wake_root = self.root / "node-wakes"
+        self.client = ThinClient(
+            NodeIdentity("realm-test", "node-a"),
+            ThinClientPolicy(employee_wake_root=self.wake_root),
+        )
+        manifest = self.client.capability_manifest()
+        invite = self.fabric.create_invite(expires_minutes=5, label="wake-delivery-test")
+        enrolled = self.fabric.enroll(
+            invite_id=invite["invite_id"],
+            code=invite["code"],
+            manifest=manifest,
+        )
+        self.node_token = enrolled["node_token"]
+        self.fabric.record_heartbeat(
+            {
+                "schema": "agentos.node-heartbeat/v0.1",
+                "realm_id": "realm-test",
+                "node_id": "node-a",
+                "status": "online",
+                "observed_at": None,
+                "uptime_seconds": 10,
+                "surface_count": 0,
+                "manifest": manifest,
+            },
+            self.node_token,
+        )
+
+        self.presence = EmployeePresenceRegistry(self.runtime, self.node_registry)
+        self.now = datetime.now(timezone.utc).replace(microsecond=0)
+        self.presence.bind(
+            "spec-steward",
+            "node-a",
+            "presence-a",
+            ttl_seconds=120,
+            now=self.now,
+        )
+        self.controller = ControllerService(self.fabric)
+        self.delivery = EmployeeWakeDelivery(self.presence, self.controller)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _intent(self):
+        intent = self.planner.plan_next("spec-steward", now=self.now)
+        self.assertIsNotNone(intent)
+        return intent
+
+    def _execute_one_task(self):
+        tasks = self.fabric.pull_tasks("node-a", self.node_token, limit=10)
+        self.assertEqual(len(tasks), 1)
+        receipt = self.client.execute(tasks[0])
+        self.fabric.record_receipt(receipt, self.node_token)
+        return tasks[0], receipt
+
+    def test_full_one_queue_node_receipt_reconcile_path(self):
+        intent = self._intent()
+        queued = self.delivery.deliver_intent(intent, now=self.now)
+        self.assertEqual(queued.schema, DELIVERY_SCHEMA)
+        self.assertEqual(queued.status, "queued")
+        self.assertEqual(queued.presence_generation, 1)
+        self.assertTrue(queued.controller_entered)
+
+        task, node_receipt = self._execute_one_task()
+        self.assertEqual(task["action"], WAKE_CAPABILITY)
+        self.assertTrue(node_receipt["ok"])
+        self.assertTrue(node_receipt["wake_delivery"]["accepted"])
+        self.assertFalse(node_receipt["wake_delivery"]["executor_invoked"])
+        self.assertEqual(node_receipt["wake_delivery"]["presence_id"], "presence-a")
+        self.assertEqual(node_receipt["wake_delivery"]["presence_generation"], 1)
+
+        delivered = self.delivery.reconcile(intent.wake_id, 1, now=self.now + timedelta(seconds=1))
+        self.assertEqual(delivered.status, "delivered")
+        self.assertTrue(delivered.node_ok)
+        self.assertTrue(delivered.node_wake_accepted)
+
+        # Wake delivery does not own execution authority.
+        assignment = self.runtime.get_assignment("audit-001")
+        self.assertEqual(assignment.state, "pending")
+        self.assertIsNone(self.lifecycle.get_lease("audit-001"))
+
+    def test_node_without_explicit_wake_root_does_not_advertise_or_accept(self):
+        client = ThinClient(NodeIdentity("realm-test", "node-b"), ThinClientPolicy())
+        self.assertNotIn(WAKE_CAPABILITY, client.capability_manifest()["capabilities"])
+        intent = self._intent()
+        receipt = client.execute(
+            {
+                "schema": "agentos.node-task/v0.1",
+                "task_id": "wake-node-b",
+                "action": WAKE_CAPABILITY,
+                "wake_intent": intent.as_dict(),
+                "employee_wake_route": {
+                    "schema": "agentos.employee-wake-route/v1",
+                    "employee_id": "spec-steward",
+                    "node_id": "node-b",
+                    "presence_id": "presence-b",
+                    "presence_generation": 1,
+                },
+            }
+        )
+        self.assertFalse(receipt["ok"])
+        self.assertNotIn("wake_delivery", receipt)
+
+    def test_route_target_node_mismatch_fails_closed_without_capsule(self):
+        intent = self._intent()
+        receipt = self.client.execute(
+            {
+                "schema": "agentos.node-task/v0.1",
+                "task_id": "bad-route",
+                "action": WAKE_CAPABILITY,
+                "wake_intent": intent.as_dict(),
+                "employee_wake_route": {
+                    "schema": "agentos.employee-wake-route/v1",
+                    "employee_id": "spec-steward",
+                    "node_id": "some-other-node",
+                    "presence_id": "presence-a",
+                    "presence_generation": 1,
+                },
+            }
+        )
+        self.assertFalse(receipt["ok"])
+        self.assertEqual(list(self.wake_root.rglob("*.json")), [])
+
+    def test_route_employee_mismatch_fails_closed(self):
+        intent = self._intent()
+        receipt = self.client.execute(
+            {
+                "schema": "agentos.node-task/v0.1",
+                "task_id": "wrong-employee",
+                "action": WAKE_CAPABILITY,
+                "wake_intent": intent.as_dict(),
+                "employee_wake_route": {
+                    "schema": "agentos.employee-wake-route/v1",
+                    "employee_id": "someone-else",
+                    "node_id": "node-a",
+                    "presence_id": "presence-a",
+                    "presence_generation": 1,
+                },
+            }
+        )
+        self.assertFalse(receipt["ok"])
+        self.assertEqual(list(self.wake_root.rglob("*.json")), [])
+
+    def test_same_exact_intent_and_presence_is_idempotent(self):
+        intent = self._intent()
+        first = self.delivery.deliver_intent(intent, now=self.now)
+        second = self.delivery.deliver_intent(intent, now=self.now + timedelta(seconds=1))
+        self.assertEqual(first.task_id, second.task_id)
+        self.assertEqual(second.status, "queued")
+        tasks = self.fabric.load()["tasks"]["node-a"]
+        self.assertEqual(len(tasks), 1)
+
+    def test_new_presence_generation_can_receive_same_unclaimed_wake(self):
+        intent = self._intent()
+        first = self.delivery.deliver_intent(intent, now=self.now)
+        self.assertEqual(first.presence_generation, 1)
+        self._execute_one_task()
+        self.delivery.reconcile(intent.wake_id, 1, now=self.now + timedelta(seconds=1))
+
+        second_presence = self.presence.bind(
+            "spec-steward",
+            "node-a",
+            "presence-b",
+            ttl_seconds=120,
+            supersede_presence_id="presence-a",
+            now=self.now + timedelta(seconds=2),
+        )
+        self.assertEqual(second_presence.generation, 2)
+        second = self.delivery.deliver_intent(intent, now=self.now + timedelta(seconds=3))
+        self.assertEqual(second.presence_generation, 2)
+        self.assertNotEqual(first.task_id, second.task_id)
+        task, receipt = self._execute_one_task()
+        self.assertEqual(task["employee_wake_route"]["presence_generation"], 2)
+        self.assertEqual(receipt["wake_delivery"]["presence_generation"], 2)
+        capsules = sorted(self.wake_root.rglob("*.json"))
+        self.assertEqual(len(capsules), 2)
+
+    def test_interrupted_dispatch_record_becomes_unknown_and_is_not_redispatched(self):
+        intent = self._intent()
+        path = self.delivery._path(intent.wake_id, 1)  # focused crash-state fixture
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": DELIVERY_SCHEMA,
+                    "attempt_id": "attempt-crashed",
+                    "wake_id": intent.wake_id,
+                    "employee_id": intent.employee_id,
+                    "assignment_id": intent.assignment_id,
+                    "presence_id": "presence-a",
+                    "presence_generation": 1,
+                    "node_id": "node-a",
+                    "task_id": "task-crashed",
+                    "status": "dispatching",
+                    "attempted_at": self.now.isoformat(),
+                    "updated_at": self.now.isoformat(),
+                    "queued_at": None,
+                    "completed_at": None,
+                    "node_ok": None,
+                    "node_wake_accepted": None,
+                    "error_code": None,
+                    "controller_entered": None,
+                    "credential_exposed": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = self.delivery.deliver_intent(intent, now=self.now + timedelta(seconds=1))
+        self.assertEqual(state.status, "unknown")
+        self.assertEqual(state.error_code, "dispatch_interrupted_after_claim")
+        self.assertEqual(self.fabric.load()["tasks"]["node-a"], [])
+
+    def test_receipt_route_mismatch_is_not_accepted_as_delivery(self):
+        intent = self._intent()
+        queued = self.delivery.deliver_intent(intent, now=self.now)
+        task = self.fabric.pull_tasks("node-a", self.node_token, limit=10)[0]
+        receipt = self.client.execute(task)
+        self.assertTrue(receipt["ok"])
+        receipt["wake_delivery"]["presence_generation"] = 999
+        self.fabric.record_receipt(receipt, self.node_token)
+        state = self.delivery.reconcile(intent.wake_id, queued.presence_generation)
+        self.assertEqual(state.status, "failed")
+        self.assertFalse(state.node_wake_accepted)
+
+    def test_presence_expiry_and_capability_freshness_fail_closed(self):
+        with self.assertRaisesRegex(RuntimeError, "employee_presence_expired"):
+            self.presence.resolve("spec-steward", now=self.now + timedelta(seconds=121))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_employee_wake_inbox_security.py
+++ b/tests/test_employee_wake_inbox_security.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import EmployeeWakePlanner
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+class EmployeeWakeInboxSecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        runtime = EmployeeRuntime(self.root / "runtime")
+        runtime.create_employee("steward", "Steward", role_ids=["governance.spec_steward"])
+        runtime.create_assignment("audit-1", "steward", "Audit safely")
+        intent = EmployeeWakePlanner(EmployeeLifecycle(runtime)).plan_next("steward")
+        self.assertIsNotNone(intent)
+        self.intent = intent.as_dict()
+        self.client = ThinClient(
+            NodeIdentity("realm-test", "node-a"),
+            ThinClientPolicy(employee_wake_root=self.root / "wakes"),
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _task(self, intent):
+        return {
+            "schema": "agentos.node-task/v0.1",
+            "task_id": "wake-security",
+            "action": "agent.employee.wake.deliver",
+            "wake_intent": intent,
+            "employee_wake_route": {
+                "schema": "agentos.employee-wake-route/v1",
+                "employee_id": "steward",
+                "node_id": "node-a",
+                "presence_id": "presence-a",
+                "presence_generation": 1,
+            },
+        }
+
+    def test_unexpected_secret_like_key_name_is_not_reflected_in_receipt(self):
+        intent = dict(self.intent)
+        marker = "DO_NOT_REFLECT_PRIVATE_MARKER_7f4b"
+        intent[marker] = "value"
+        receipt = self.client.execute(self._task(intent))
+        self.assertFalse(receipt["ok"])
+        self.assertNotIn(marker, receipt.get("error", ""))
+        self.assertIn("unexpected_employee_wake_fields", receipt.get("error", ""))
+
+    def test_secret_like_value_is_not_reflected_in_receipt(self):
+        intent = dict(self.intent)
+        marker = "bearer DO_NOT_REFLECT_PRIVATE_VALUE_91ab"
+        intent["goal"] = marker
+        receipt = self.client.execute(self._task(intent))
+        self.assertFalse(receipt["ok"])
+        self.assertNotIn(marker, receipt.get("error", ""))
+        self.assertIn("employee_wake_secret_like_value", receipt.get("error", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Complete #197 O2 on top of current `core/integration` and prepare the S4 boundary for persistent Supervisor delivery.

## Adds
- ONE-side durable Employee -> Node presence leases, scoped to `agent.employee.wake.deliver`;
- exact `EmployeeWakeIntent` delivery through existing `ControllerService` / Realm fabric;
- ThinClient fixed typed wake inbox enabled only when `employee_wake_root` is configured;
- strict presence route validation: Employee, Node, presence id, presence generation;
- authenticated Node receipt reconciliation back into Core delivery state;
- idempotency and crash-after-dispatch-claim = UNKNOWN semantics;
- strict wake payload allowlist and secret-like value rejection;
- stable privacy-safe validation errors so untrusted field names/values do not reflect into Node receipts;
- hosted end-to-end regression covering Core -> ONE queue -> Node -> inbox -> receipt -> Core reconcile;
- regression proving wake delivery does not claim the Employee assignment or invoke/select an executor.

## Important correction from the earlier O2 prototype
Delivery no longer calls `plan_next(employee_id)` again. S4 must deliver the exact durable wake intent that the Supervisor already planned/journaled; routing cannot silently recompute work at dispatch time.

## Authority boundary
This PR adds a fixed typed wake-delivery capability only. It does not grant shell/filesystem/desktop capability, does not select provider/model/session/executor, and does not claim assignment leases. Employee identity remains durable and separate from Node/executor presence.

## Evidence
Final branch guard run `33595479031` completed SUCCESS on head `bec9d9c6996665081e973536e8955ce443b1b974`. Employee runtime/lifecycle/wake/memory/skills/thread/mailbox, governed wake E2E, privacy regressions, S1-S3 Supervisor, WorkItem, daemon/service assets, and role hydration all passed.

## Non-claims
This does not yet connect the persistent Supervisor's planned intent journal to automatic delivery, and it does not deploy/enable a live Supervisor or Node wake inbox on Oracle. That is S4 / live acceptance work after merge.

Target: `core/integration` only; no protected-main publication authority implied.