### PR TITLE
Core #200: connect persistent Supervisor to governed ONE wake delivery

### DIFF
--- a/.agent/scripts/agentos-core-supervisor-delivery.conf.example
+++ b/.agent/scripts/agentos-core-supervisor-delivery.conf.example
@@ -1,0 +1,11 @@
+# Optional systemd drop-in for AgentOS Core Supervisor S4 one_direct delivery.
+# Install only after the existing ONE Realm paths are verified on the target host.
+# Keep PrivateNetwork=true in the base unit: current one_direct uses the local ONE
+# fabric/Node Registry state and does not require a generic outbound network path.
+
+[Service]
+# The base service already grants write access to employee-runtime, where the
+# immutable reconcile journal and S4 delivery ledger live. S4 additionally needs
+# the existing ONE realm directory so ControllerService can enqueue the bounded
+# agent.employee.wake.deliver task into fabric.json.
+ReadWritePaths=/home/ubuntu/agent-data/realm

--- a/.agent/scripts/agentos-core-supervisor.env.example
+++ b/.agent/scripts/agentos-core-supervisor.env.example
@@ -1,9 +1,19 @@
-# AgentOS Core Supervisor S3 environment example.
+# AgentOS Core Supervisor environment example.
 # This file contains no credentials. Copy values into the host-local EnvironmentFile.
-# S3 observes durable Employee state and journals reconcile intents only; it does not dispatch them.
+# S3 observe/plan is the default. S4 governed wake delivery must be explicitly enabled.
 
 AGENTOS_EMPLOYEE_RUNTIME_ROOT=/home/ubuntu/agent-data/employee-runtime
 AGENTOS_SUPERVISOR_SERVICE_ID=agentos-core-supervisor
 AGENTOS_SUPERVISOR_BASE_POLL_SECONDS=5
 AGENTOS_SUPERVISOR_MAX_POLL_SECONDS=60
 AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS=30
+
+# Default: no delivery authority is attached.
+AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled
+
+# To enable S4 after the systemd delivery sandbox/drop-in is installed:
+# AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct
+# AGENTOS_SUPERVISOR_ONE_DATA_ROOT=/home/ubuntu/agent-data
+#
+# one_direct reuses the existing ONE realm/fabric and Node Registry. The daemon
+# refuses to initialize a missing Realm and does not use GitHub Actions fallback.

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -19,11 +19,13 @@ on:
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
+      - 'agent_core/core_supervisor_delivery.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
+      - 'governance/core-supervisor-delivery.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
@@ -37,17 +39,20 @@ on:
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
       - 'tests/test_core_supervisor_daemon.py'
+      - 'tests/test_core_supervisor_delivery.py'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
+      - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'docs/CORE_SUPERVISOR.md'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
       - core/issue-197-governed-wake-delivery-v2
       - core/issue-200-persistent-supervisor-loop
+      - core/issue-200-governed-supervisor-delivery
       - core/integration
     paths:
       - 'agent_core/employee_runtime.py'
@@ -63,11 +68,13 @@ on:
       - 'agent_core/core_work_items.py'
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
+      - 'agent_core/core_supervisor_delivery.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
+      - 'governance/core-supervisor-delivery.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
@@ -81,11 +88,13 @@ on:
       - 'tests/test_core_work_items.py'
       - 'tests/test_core_supervisor_service.py'
       - 'tests/test_core_supervisor_daemon.py'
+      - 'tests/test_core_supervisor_delivery.py'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
+      - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'docs/CORE_SUPERVISOR.md'
       - '.github/workflows/employee-runtime-guard.yml'
   workflow_dispatch:
@@ -130,6 +139,8 @@ jobs:
         run: python -m unittest tests.test_core_supervisor_service -v
       - name: Run Core Supervisor daemon regressions
         run: python -m unittest tests.test_core_supervisor_daemon -v
+      - name: Run governed Core Supervisor delivery regressions
+        run: python -m unittest tests.test_core_supervisor_delivery -v
       - name: Run Core Supervisor service asset regressions
         run: python -m unittest tests.test_core_supervisor_assets -v
       - name: Run role hydration regressions

--- a/agent_core/core_supervisor_daemon.py
+++ b/agent_core/core_supervisor_daemon.py
@@ -10,9 +10,18 @@ from pathlib import Path
 from threading import Event
 from typing import Iterator
 
+from agent_core.controller_service import ControllerService
+from agent_core.core_supervisor_delivery import (
+    SupervisorWakeAuthorityResolver,
+    SupervisorWakeCoordinator,
+)
 from agent_core.core_supervisor_service import CoreSupervisorService
 from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import EmployeePresenceRegistry
 from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake_delivery import EmployeeWakeDelivery
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
 
 
 def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
@@ -45,6 +54,29 @@ def _service_id(value: str | None = None) -> str:
     if not text or len(text) > 120 or any(ch in text for ch in "/\\\0"):
         raise ValueError("invalid_supervisor_service_id")
     return text
+
+
+def _delivery_mode(value: str | None = None) -> str:
+    mode = str(value or os.environ.get("AGENTOS_SUPERVISOR_DELIVERY_MODE") or "disabled").strip().lower()
+    if mode not in {"disabled", "one_direct"}:
+        raise ValueError("invalid_supervisor_delivery_mode")
+    return mode
+
+
+def _one_data_root(value: str | None = None) -> Path:
+    raw = str(
+        value
+        or os.environ.get("AGENTOS_SUPERVISOR_ONE_DATA_ROOT")
+        or os.environ.get("AGENTOS_DATA_ROOT")
+        or os.environ.get("AGENT_DATA_ROOT")
+        or ""
+    ).strip()
+    if not raw:
+        raise ValueError("supervisor_one_data_root_required")
+    root = Path(raw).expanduser()
+    if not root.is_absolute():
+        raise ValueError("supervisor_one_data_root_must_be_absolute")
+    return root.resolve()
 
 
 def _instance_owner(service_id: str) -> str:
@@ -81,15 +113,36 @@ def build_service(
     service_id: str,
     base_poll_seconds: int,
     max_poll_seconds: int,
+    delivery_mode: str = "disabled",
+    one_data_root: Path | None = None,
 ) -> CoreSupervisorService:
     runtime = EmployeeRuntime(runtime_root)
     lifecycle = EmployeeLifecycle(runtime)
-    return CoreSupervisorService(
+    service = CoreSupervisorService(
         lifecycle,
         owner_id=_instance_owner(service_id),
         base_poll_seconds=base_poll_seconds,
         max_poll_seconds=max_poll_seconds,
     )
+    mode = _delivery_mode(delivery_mode)
+    if mode == "disabled":
+        return service
+
+    root = _one_data_root(str(one_data_root) if one_data_root is not None else None)
+    node_registry = NodeRegistry(path=root / "realm" / "nodes.json")
+    fabric = RealmFabricStore(path=root / "realm" / "fabric.json", node_registry=node_registry)
+    controller = ControllerService(fabric)
+    presence = EmployeePresenceRegistry(runtime, node_registry)
+    wake_delivery = EmployeeWakeDelivery(presence, controller)
+    authority = SupervisorWakeAuthorityResolver(requested_transport="one_direct")
+    coordinator = SupervisorWakeCoordinator(
+        service,
+        wake_delivery,
+        authority,
+        available_transports={"one_direct": True},
+    )
+    service.attach_delivery_driver(coordinator)
+    return service
 
 
 def run_persistent(
@@ -98,10 +151,7 @@ def run_persistent(
     stop_event: Event | None = None,
     leader_lease_seconds: int = 30,
 ) -> None:
-    """Run observe/plan cycles forever while heartbeating through long idle backoff.
-
-    This daemon never dispatches a reconcile intent. S4 owns governed ONE delivery.
-    """
+    """Run persistent reconcile cycles and any explicitly attached governed S4 driver."""
     stopper = stop_event or Event()
     retry_seconds = max(1, min(5, leader_lease_seconds // 2))
 
@@ -131,7 +181,7 @@ def run_persistent(
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="AgentOS Core Supervisor (observe/plan only)")
+    parser = argparse.ArgumentParser(description="AgentOS Core Supervisor (S3 observe/plan; S4 governed delivery opt-in)")
     parser.add_argument("--runtime-root")
     parser.add_argument("--service-id")
     parser.add_argument("--once", action="store_true", help="Run one reconcile cycle and exit")
@@ -149,16 +199,23 @@ def main(argv: list[str] | None = None) -> int:
     base_poll = _env_int("AGENTOS_SUPERVISOR_BASE_POLL_SECONDS", 5, minimum=1, maximum=300)
     max_poll = _env_int("AGENTOS_SUPERVISOR_MAX_POLL_SECONDS", 60, minimum=base_poll, maximum=3600)
     leader_lease = _env_int("AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS", 30, minimum=5, maximum=300)
+    delivery_mode = _delivery_mode()
+    one_root = _one_data_root() if delivery_mode == "one_direct" else None
 
     service = build_service(
         runtime_root=root,
         service_id=service_id,
         base_poll_seconds=base_poll,
         max_poll_seconds=max_poll,
+        delivery_mode=delivery_mode,
+        one_data_root=one_root,
     )
 
     if args.health:
-        print(json.dumps(service.health(), ensure_ascii=False, sort_keys=True))
+        payload = service.health()
+        if service.delivery_driver is not None:
+            payload["delivery"] = service.delivery_driver.health()
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
         return 0
 
     with _process_singleton_lock(root):

--- a/agent_core/core_supervisor_daemon.py
+++ b/agent_core/core_supervisor_daemon.py
@@ -79,6 +79,28 @@ def _one_data_root(value: str | None = None) -> Path:
     return root.resolve()
 
 
+def _require_existing_one_root(root: Path) -> str:
+    """Fail closed unless root already contains one coherent ONE Realm."""
+    fabric_path = root / "realm" / "fabric.json"
+    nodes_path = root / "realm" / "nodes.json"
+    if not fabric_path.is_file() or not nodes_path.is_file():
+        raise RuntimeError("supervisor_one_control_plane_state_missing")
+    try:
+        fabric = json.loads(fabric_path.read_text(encoding="utf-8"))
+        nodes = json.loads(nodes_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("supervisor_one_control_plane_state_invalid") from exc
+    if not isinstance(fabric, dict) or fabric.get("schema") != "agentos.realm-fabric/v0.1":
+        raise RuntimeError("supervisor_one_fabric_schema_invalid")
+    if not isinstance(nodes, dict) or nodes.get("schema") != "agentos.node-registry/v0.1":
+        raise RuntimeError("supervisor_one_node_registry_schema_invalid")
+    fabric_realm = str(fabric.get("realm_id") or "").strip()
+    node_realm = str(nodes.get("realm_id") or "").strip()
+    if not fabric_realm or not node_realm or fabric_realm != node_realm:
+        raise RuntimeError("supervisor_one_control_plane_realm_mismatch")
+    return fabric_realm
+
+
 def _instance_owner(service_id: str) -> str:
     return f"{service_id}.{uuid.uuid4().hex[:12]}"
 
@@ -129,6 +151,7 @@ def build_service(
         return service
 
     root = _one_data_root(str(one_data_root) if one_data_root is not None else None)
+    _require_existing_one_root(root)
     node_registry = NodeRegistry(path=root / "realm" / "nodes.json")
     fabric = RealmFabricStore(path=root / "realm" / "fabric.json", node_registry=node_registry)
     controller = ControllerService(fabric)

--- a/agent_core/core_supervisor_delivery.py
+++ b/agent_core/core_supervisor_delivery.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA, CoreSupervisorService
+from agent_core.employee_wake import EmployeeWakeIntent, WAKE_INTENT_SCHEMA
+from agent_core.employee_wake_delivery import EmployeeWakeDelivery
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.transport_routing import RouteDecision, resolve_transport
+
+
+DELIVERY_POLICY_SCHEMA = "agentos.core-supervisor-delivery-policy/v1"
+DELIVERY_STATE_SCHEMA = "agentos.core-supervisor-delivery-state/v1"
+DELIVERY_SUMMARY_SCHEMA = "agentos.core-supervisor-delivery-summary/v1"
+DEFAULT_POLICY_PATH = Path(__file__).resolve().parent.parent / "governance" / "core-supervisor-delivery.json"
+TERMINAL_ASSIGNMENT_STATES = {"completed", "cancelled", "blocked", "handoff"}
+TERMINAL_DELIVERY_STATES = {"claimed", "terminal_observed", "superseded"}
+RETRYABLE_DELIVERY_STATES = {"blocked", "unknown", "failed", "awaiting_claim"}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _safe_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 256 or any(ch in text for ch in "/\\\0") or text in {".", ".."}:
+        raise ValueError("unsafe_supervisor_delivery_id")
+    return text
+
+
+def _atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("supervisor_delivery_state_invalid")
+    return payload
+
+
+def _string_tuple(value: Any, *, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"invalid_persisted_wake_{field}")
+    return tuple(value)
+
+
+def _wake_from_dict(payload: Any) -> EmployeeWakeIntent:
+    if not isinstance(payload, dict) or payload.get("schema") != WAKE_INTENT_SCHEMA:
+        raise ValueError("invalid_persisted_wake_intent")
+    if payload.get("credential_exposed") is not False:
+        raise ValueError("invalid_persisted_wake_credential_boundary")
+    return EmployeeWakeIntent(
+        schema=WAKE_INTENT_SCHEMA,
+        wake_id=_safe_id(payload.get("wake_id")),
+        employee_id=_safe_id(payload.get("employee_id")),
+        assignment_id=_safe_id(payload.get("assignment_id")),
+        mode=str(payload.get("mode") or ""),
+        expected_lease_generation=int(payload.get("expected_lease_generation") or 0),
+        goal=str(payload.get("goal") or ""),
+        thread_head=str(payload.get("thread_head") or ""),
+        constraints=_string_tuple(payload.get("constraints"), field="constraints"),
+        role_ids=_string_tuple(payload.get("role_ids"), field="role_ids"),
+        skill_ids=_string_tuple(payload.get("skill_ids"), field="skill_ids"),
+        resume_required=payload.get("resume_required") is True,
+        prior_execution_state=str(payload.get("prior_execution_state") or ""),
+        authority_boundary=str(payload.get("authority_boundary") or ""),
+        executor_selection=str(payload.get("executor_selection") or ""),
+        transport_selection=str(payload.get("transport_selection") or ""),
+        credential_exposed=False,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class WakeAuthorityDecision:
+    policy_id: str
+    reconcile_kind: str
+    capability: str
+    intent_class: str
+    transport: str
+    transport_authority: str
+    transport_policy_id: str
+
+
+class SupervisorWakeAuthorityResolver:
+    """Resolve authority before looking at Node capability availability.
+
+    The supervisor policy authorizes one bounded capability and delegates carrier
+    choice to the existing authority-driven transport-routing policy. A reachable
+    Node or workflow runner can never expand this policy.
+    """
+
+    def __init__(self, policy_path: str | Path = DEFAULT_POLICY_PATH, *, requested_transport: str = "one_direct") -> None:
+        self.policy_path = Path(policy_path)
+        self.requested_transport = str(requested_transport or "").strip()
+        payload = json.loads(self.policy_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema") != DELIVERY_POLICY_SCHEMA:
+            raise ValueError("invalid_supervisor_delivery_policy")
+        self.policy = payload
+
+    def resolve(self, reconcile_intent: Mapping[str, Any], available_transports: Iterable[str] | Mapping[str, bool]) -> WakeAuthorityDecision:
+        if reconcile_intent.get("schema") != RECONCILE_INTENT_SCHEMA:
+            raise PermissionError("supervisor_delivery_reconcile_schema_rejected")
+        kind = str(reconcile_intent.get("kind") or "")
+        rule = self.policy.get("reconcile_kinds", {}).get(kind)
+        if not isinstance(rule, dict):
+            raise PermissionError("supervisor_delivery_kind_not_authorized")
+        if reconcile_intent.get("authority_boundary") != "observe_and_select_only":
+            raise PermissionError("supervisor_delivery_authority_boundary_rejected")
+        for key in ("node_selection", "executor_selection", "transport_selection", "capability_authority"):
+            if reconcile_intent.get(key) != "unbound":
+                raise PermissionError("supervisor_delivery_prebound_authority_rejected")
+        if reconcile_intent.get("credential_exposed") is not False:
+            raise PermissionError("supervisor_delivery_credential_boundary_rejected")
+
+        capability = str(rule.get("capability") or "")
+        if capability != WAKE_CAPABILITY:
+            raise PermissionError("supervisor_delivery_capability_not_authorized")
+        intent_class = str(rule.get("intent_class") or "")
+        route: RouteDecision = resolve_transport(
+            intent_class,
+            available_transports,
+            requested_transport=self.requested_transport,
+        )
+        allowed = {str(item) for item in (rule.get("allowed_transports") or [])}
+        if route.transport not in allowed:
+            raise PermissionError("supervisor_delivery_transport_not_authorized")
+        return WakeAuthorityDecision(
+            policy_id=str(self.policy.get("policy_id") or "unknown"),
+            reconcile_kind=kind,
+            capability=capability,
+            intent_class=intent_class,
+            transport=route.transport,
+            transport_authority=route.authority,
+            transport_policy_id=route.policy_id,
+        )
+
+
+@dataclass(slots=True)
+class SupervisorDeliveryState:
+    schema: str
+    reconcile_id: str
+    employee_id: str
+    assignment_id: str
+    wake_id: str
+    status: str
+    created_at: str
+    updated_at: str
+    authority_policy_id: str
+    transport_policy_id: str
+    transport: str
+    transport_authority: str
+    capability: str
+    supervisor_leader_generation: int
+    dispatch_performed: bool = False
+    presence_id: str | None = None
+    presence_generation: int | None = None
+    node_id: str | None = None
+    wake_attempt_id: str | None = None
+    task_id: str | None = None
+    error_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorDeliverySummary:
+    schema: str
+    examined_count: int
+    dispatch_count: int
+    queued_count: int
+    awaiting_claim_count: int
+    claimed_count: int
+    blocked_count: int
+    unknown_count: int
+    failed_count: int
+    superseded_count: int
+    error_count: int
+
+    @property
+    def dispatch_performed(self) -> bool:
+        return self.dispatch_count > 0
+
+
+class SupervisorWakeCoordinator:
+    """Advance immutable Supervisor reconcile intents across governed ONE wake delivery.
+
+    S3 reconcile records remain immutable evidence. S4 writes a separate delivery
+    ledger. A Node accepting a wake capsule is not treated as assignment ownership:
+    the coordinator continues in `awaiting_claim` until an Employee lease with the
+    expected generation is observed.
+    """
+
+    def __init__(
+        self,
+        service: CoreSupervisorService,
+        delivery: EmployeeWakeDelivery,
+        authority: SupervisorWakeAuthorityResolver,
+        *,
+        available_transports: Iterable[str] | Mapping[str, bool],
+        max_intents_per_cycle: int = 16,
+    ) -> None:
+        if max_intents_per_cycle < 1 or max_intents_per_cycle > 256:
+            raise ValueError("invalid_supervisor_delivery_cycle_limit")
+        self.service = service
+        self.delivery = delivery
+        self.authority = authority
+        self.available_transports = available_transports
+        self.max_intents_per_cycle = int(max_intents_per_cycle)
+        self.root = service.root / "deliveries"
+
+    def _path(self, reconcile_id: str) -> Path:
+        return self.root / f"{_safe_id(reconcile_id)}.json"
+
+    def get(self, reconcile_id: str) -> SupervisorDeliveryState | None:
+        payload = _read(self._path(reconcile_id))
+        if payload is None:
+            return None
+        if payload.get("schema") != DELIVERY_STATE_SCHEMA or payload.get("reconcile_id") != reconcile_id:
+            raise ValueError("supervisor_delivery_state_invalid")
+        return SupervisorDeliveryState(**payload)
+
+    def _persist(self, state: SupervisorDeliveryState) -> SupervisorDeliveryState:
+        _atomic(self._path(state.reconcile_id), asdict(state))
+        return state
+
+    def _load_reconcile(self, reconcile_id: str) -> tuple[dict[str, Any], EmployeeWakeIntent]:
+        path = self.service.intents_dir / f"{_safe_id(reconcile_id)}.json"
+        payload = _read(path)
+        if payload is None:
+            raise FileNotFoundError(reconcile_id)
+        if payload.get("schema") != INTENT_RECORD_SCHEMA or payload.get("reconcile_id") != reconcile_id:
+            raise ValueError("supervisor_reconcile_record_invalid")
+        if payload.get("state") != "planned" or payload.get("dispatch_performed") is not False:
+            raise PermissionError("supervisor_reconcile_record_not_delivery_eligible")
+        intent = payload.get("intent")
+        if not isinstance(intent, dict):
+            raise ValueError("supervisor_reconcile_intent_missing")
+        wake = _wake_from_dict(intent.get("wake_intent"))
+        if intent.get("employee_id") != wake.employee_id or intent.get("assignment_id") != wake.assignment_id:
+            raise ValueError("supervisor_reconcile_wake_identity_mismatch")
+        return intent, wake
+
+    def _current_exact_wake(self, wake: EmployeeWakeIntent, *, now: datetime) -> bool:
+        current = self.service.reconciler.wake_planner.plan_next(wake.employee_id, now=now)
+        return current is not None and current.as_dict() == wake.as_dict()
+
+    def _claimed_or_terminal(self, state: SupervisorDeliveryState, wake: EmployeeWakeIntent, *, now: datetime) -> SupervisorDeliveryState | None:
+        assignment = self.service.runtime.get_assignment(wake.assignment_id)
+        if assignment.state in TERMINAL_ASSIGNMENT_STATES:
+            state.status = "terminal_observed"
+            state.error_code = None
+            state.updated_at = _iso(now)
+            return self._persist(state)
+        lease = self.service.lifecycle.get_lease(wake.assignment_id)
+        if (
+            lease is not None
+            and lease.status == "active"
+            and lease.generation >= wake.expected_lease_generation
+            and not self.service.lifecycle.lease_expired(lease, now=now)
+        ):
+            state.status = "claimed"
+            state.error_code = None
+            state.updated_at = _iso(now)
+            return self._persist(state)
+        return None
+
+    def _new_state(self, reconcile_id: str, wake: EmployeeWakeIntent, decision: WakeAuthorityDecision, leader_generation: int, *, now: datetime, status: str, error_code: str | None = None) -> SupervisorDeliveryState:
+        timestamp = _iso(now)
+        return SupervisorDeliveryState(
+            schema=DELIVERY_STATE_SCHEMA,
+            reconcile_id=reconcile_id,
+            employee_id=wake.employee_id,
+            assignment_id=wake.assignment_id,
+            wake_id=wake.wake_id,
+            status=status,
+            created_at=timestamp,
+            updated_at=timestamp,
+            authority_policy_id=decision.policy_id,
+            transport_policy_id=decision.transport_policy_id,
+            transport=decision.transport,
+            transport_authority=decision.transport_authority,
+            capability=decision.capability,
+            supervisor_leader_generation=int(leader_generation),
+            error_code=error_code,
+        )
+
+    @staticmethod
+    def _copy_delivery(state: SupervisorDeliveryState, delivered: Any, *, now: datetime, status: str) -> SupervisorDeliveryState:
+        state.status = status
+        state.updated_at = _iso(now)
+        state.dispatch_performed = state.dispatch_performed or bool(delivered.controller_entered) or delivered.status == "unknown"
+        state.presence_id = delivered.presence_id
+        state.presence_generation = delivered.presence_generation
+        state.node_id = delivered.node_id
+        state.wake_attempt_id = delivered.attempt_id
+        state.task_id = delivered.task_id
+        state.error_code = delivered.error_code
+        return state
+
+    def advance_one(self, reconcile_id: str, leader_generation: int, *, now: datetime | None = None) -> SupervisorDeliveryState:
+        current_time = now or _now()
+        self.service.require_leader(leader_generation, now=current_time)
+        intent, wake = self._load_reconcile(reconcile_id)
+
+        try:
+            decision = self.authority.resolve(intent, self.available_transports)
+        except Exception:
+            existing = self.get(reconcile_id)
+            if existing is not None:
+                existing.status = "blocked"
+                existing.error_code = "wake_authority_unavailable"
+                existing.updated_at = _iso(current_time)
+                return self._persist(existing)
+            # Keep the authority rejection in a separate ledger without inventing
+            # transport/capability data that was not successfully resolved.
+            timestamp = _iso(current_time)
+            return self._persist(SupervisorDeliveryState(
+                schema=DELIVERY_STATE_SCHEMA,
+                reconcile_id=reconcile_id,
+                employee_id=wake.employee_id,
+                assignment_id=wake.assignment_id,
+                wake_id=wake.wake_id,
+                status="blocked",
+                created_at=timestamp,
+                updated_at=timestamp,
+                authority_policy_id="unresolved",
+                transport_policy_id="unresolved",
+                transport="unresolved",
+                transport_authority="unresolved",
+                capability=WAKE_CAPABILITY,
+                supervisor_leader_generation=int(leader_generation),
+                error_code="wake_authority_unavailable",
+            ))
+
+        state = self.get(reconcile_id)
+        if state is None:
+            state = self._new_state(reconcile_id, wake, decision, leader_generation, now=current_time, status="ready")
+        if state.status in TERMINAL_DELIVERY_STATES:
+            return state
+
+        progressed = self._claimed_or_terminal(state, wake, now=current_time)
+        if progressed is not None:
+            return progressed
+
+        if state.status == "queued":
+            delivered = self.delivery.reconcile(wake.wake_id, int(state.presence_generation or 0), now=current_time)
+            if delivered.status == "delivered":
+                return self._persist(self._copy_delivery(state, delivered, now=current_time, status="awaiting_claim"))
+            if delivered.status in {"unknown", "failed"}:
+                return self._persist(self._copy_delivery(state, delivered, now=current_time, status=delivered.status))
+            return state
+
+        if state.status == "awaiting_claim":
+            try:
+                route = self.delivery.presence.resolve(wake.employee_id, now=current_time)
+            except Exception:
+                return state
+            if state.presence_generation is None or route.generation <= state.presence_generation:
+                return state
+            # Employee moved after the previous Node accepted the wake but before
+            # any assignment claim. The exact same wake may follow the new presence.
+
+        if state.status in {"unknown", "failed"}:
+            try:
+                route = self.delivery.presence.resolve(wake.employee_id, now=current_time)
+            except Exception:
+                return state
+            if state.presence_generation is not None and route.generation <= state.presence_generation:
+                return state
+
+        try:
+            current_exact = self._current_exact_wake(wake, now=current_time)
+        except Exception:
+            state.status = "blocked"
+            state.error_code = "current_wake_validation_failed"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+        if not current_exact:
+            state.status = "superseded"
+            state.error_code = "persisted_wake_no_longer_current"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+
+        try:
+            delivered = self.delivery.deliver_intent(wake, now=current_time)
+        except (KeyError, PermissionError, RuntimeError):
+            state.status = "blocked"
+            state.error_code = "employee_presence_unavailable"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+        except Exception:
+            state.status = "blocked"
+            state.error_code = "wake_delivery_pre_dispatch_failed"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+
+        mapped = delivered.status if delivered.status in {"queued", "unknown", "failed"} else "blocked"
+        state = self._copy_delivery(state, delivered, now=current_time, status=mapped)
+        if mapped == "blocked" and state.error_code is None:
+            state.error_code = "wake_delivery_state_unexpected"
+        return self._persist(state)
+
+    def advance_all(self, leader_generation: int, *, now: datetime | None = None) -> SupervisorDeliverySummary:
+        current_time = now or _now()
+        self.service.require_leader(leader_generation, now=current_time)
+        candidates: list[str] = []
+        if self.service.intents_dir.exists():
+            for path in sorted(self.service.intents_dir.glob("reconcile_*.json")):
+                reconcile_id = path.stem
+                existing = self.get(reconcile_id)
+                if existing is not None and existing.status in TERMINAL_DELIVERY_STATES:
+                    continue
+                candidates.append(reconcile_id)
+                if len(candidates) >= self.max_intents_per_cycle:
+                    break
+
+        counts = {
+            "dispatch": 0,
+            "queued": 0,
+            "awaiting_claim": 0,
+            "claimed": 0,
+            "blocked": 0,
+            "unknown": 0,
+            "failed": 0,
+            "superseded": 0,
+            "error": 0,
+        }
+        for reconcile_id in candidates:
+            before = self.get(reconcile_id)
+            before_attempt = before.wake_attempt_id if before else None
+            try:
+                state = self.advance_one(reconcile_id, leader_generation, now=current_time)
+            except Exception:
+                counts["error"] += 1
+                continue
+            if state.dispatch_performed and state.wake_attempt_id and state.wake_attempt_id != before_attempt:
+                counts["dispatch"] += 1
+            if state.status in counts:
+                counts[state.status] += 1
+
+        return SupervisorDeliverySummary(
+            schema=DELIVERY_SUMMARY_SCHEMA,
+            examined_count=len(candidates),
+            dispatch_count=counts["dispatch"],
+            queued_count=counts["queued"],
+            awaiting_claim_count=counts["awaiting_claim"],
+            claimed_count=counts["claimed"],
+            blocked_count=counts["blocked"],
+            unknown_count=counts["unknown"],
+            failed_count=counts["failed"],
+            superseded_count=counts["superseded"],
+            error_count=counts["error"],
+        )
+
+    def health(self) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        if self.root.exists():
+            for path in self.root.glob("reconcile_*.json"):
+                payload = _read(path) or {}
+                status = str(payload.get("status") or "invalid")
+                counts[status] = counts.get(status, 0) + 1
+        return {
+            "schema": "agentos.core-supervisor-delivery-health/v1",
+            "policy_id": str(self.authority.policy.get("policy_id") or "unknown"),
+            "requested_transport": self.authority.requested_transport,
+            "states": dict(sorted(counts.items())),
+        }

--- a/agent_core/core_supervisor_service.py
+++ b/agent_core/core_supervisor_service.py
@@ -4,7 +4,6 @@ import fcntl
 import hashlib
 import json
 import os
-import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -81,15 +80,25 @@ class SupervisorCycleReceipt:
     next_poll_seconds: int
     dispatch_performed: bool = False
     authority_boundary: str = "persistent_observe_plan_only"
+    delivery_examined_count: int = 0
+    delivery_dispatch_count: int = 0
+    delivery_queued_count: int = 0
+    delivery_awaiting_claim_count: int = 0
+    delivery_claimed_count: int = 0
+    delivery_blocked_count: int = 0
+    delivery_unknown_count: int = 0
+    delivery_failed_count: int = 0
+    delivery_superseded_count: int = 0
+    delivery_error_count: int = 0
 
 
 class CoreSupervisorService:
-    """Persistent Core loop that observes and journals work, but does not dispatch it.
+    """Persistent Core loop for durable reconciliation and optional governed wake delivery.
 
-    S3 deliberately stops before execution authority. It owns singleton process
-    coordination, repeated reconciliation, durable intent journaling, cycle receipts,
-    crash-safe restart state, and adaptive polling. S4 is responsible for handing a
-    planned intent to governed ONE delivery.
+    S3 observe/plan behavior remains the default. S4 is enabled only when a
+    governed delivery driver is explicitly attached. Planning never itself grants
+    delivery authority, and the immutable reconcile-intent journal remains the
+    source evidence for what Core selected before any delivery decision.
     """
 
     def __init__(
@@ -118,6 +127,17 @@ class CoreSupervisorService:
         self.state_path = self.root / "state.json"
         self.intents_dir = self.root / "intents"
         self.cycles_dir = self.root / "cycles"
+        self.delivery_driver: Any | None = None
+
+    def attach_delivery_driver(self, driver: Any) -> None:
+        """Explicitly enable the S4 boundary for this service instance."""
+        if driver is None:
+            raise ValueError("supervisor_delivery_driver_required")
+        if self.delivery_driver is not None:
+            raise RuntimeError("supervisor_delivery_driver_already_attached")
+        if getattr(driver, "service", None) is not self:
+            raise ValueError("supervisor_delivery_driver_service_mismatch")
+        self.delivery_driver = driver
 
     def _lock(self):
         self.leader_lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -204,6 +224,10 @@ class CoreSupervisorService:
             raise RuntimeError("supervisor_leader_expired")
         return lease
 
+    def require_leader(self, generation: int, *, now: datetime | None = None) -> SupervisorLeaderLease:
+        """Public read/guard used by governed S4 components before crossing authority."""
+        return self._require_leader(generation, now=now or _now())
+
     def _persisted_reconcile_ids(self) -> set[str]:
         if not self.intents_dir.exists():
             return set()
@@ -265,13 +289,35 @@ class CoreSupervisorService:
         plan_digest = hashlib.sha256(
             json.dumps(plan_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
         ).hexdigest()
+
+        delivery_summary = None
+        delivery_top_error = 0
+        if self.delivery_driver is not None:
+            try:
+                delivery_summary = self.delivery_driver.advance_all(leader.generation, now=current)
+            except Exception:
+                # Never serialize exception text from an authority boundary. A
+                # later cycle may retry after the durable cause is corrected.
+                delivery_top_error = 1
+
+        dispatch_performed = bool(delivery_summary and delivery_summary.dispatch_performed)
         previous_digest = str(previous.get("last_plan_digest") or "")
         previous_poll = int(previous.get("next_poll_seconds") or self.base_poll_seconds)
-        if new_count > 0 or plan_digest != previous_digest:
+        delivery_needs_fast_poll = bool(
+            delivery_summary
+            and (delivery_summary.dispatch_count > 0 or delivery_summary.queued_count > 0)
+        )
+        if new_count > 0 or plan_digest != previous_digest or delivery_needs_fast_poll:
             next_poll = self.base_poll_seconds
         else:
             next_poll = min(self.max_poll_seconds, max(self.base_poll_seconds, previous_poll * 2))
         total_planned = len(self._persisted_reconcile_ids())
+
+        boundary = (
+            "persistent_observe_plan_plus_governed_wake_delivery"
+            if self.delivery_driver is not None
+            else "persistent_observe_plan_only"
+        )
         receipt = SupervisorCycleReceipt(
             schema=CYCLE_SCHEMA,
             cycle_generation=cycle_generation,
@@ -285,6 +331,18 @@ class CoreSupervisorService:
             error_count=len(plan.errors),
             blocked_assignment_count=len(blocked),
             next_poll_seconds=next_poll,
+            dispatch_performed=dispatch_performed,
+            authority_boundary=boundary,
+            delivery_examined_count=int(getattr(delivery_summary, "examined_count", 0)),
+            delivery_dispatch_count=int(getattr(delivery_summary, "dispatch_count", 0)),
+            delivery_queued_count=int(getattr(delivery_summary, "queued_count", 0)),
+            delivery_awaiting_claim_count=int(getattr(delivery_summary, "awaiting_claim_count", 0)),
+            delivery_claimed_count=int(getattr(delivery_summary, "claimed_count", 0)),
+            delivery_blocked_count=int(getattr(delivery_summary, "blocked_count", 0)),
+            delivery_unknown_count=int(getattr(delivery_summary, "unknown_count", 0)),
+            delivery_failed_count=int(getattr(delivery_summary, "failed_count", 0)),
+            delivery_superseded_count=int(getattr(delivery_summary, "superseded_count", 0)),
+            delivery_error_count=int(getattr(delivery_summary, "error_count", 0)) + delivery_top_error,
         )
         _atomic(self.cycles_dir / f"{cycle_generation:08d}.json", asdict(receipt))
         _atomic(
@@ -300,7 +358,18 @@ class CoreSupervisorService:
                 "next_poll_seconds": next_poll,
                 "planned_intent_count": total_planned,
                 "last_cycle_receipt": f"cycles/{cycle_generation:08d}.json",
-                "dispatch_performed": False,
+                "dispatch_performed": dispatch_performed,
+                "authority_boundary": boundary,
+                "delivery_examined_count": receipt.delivery_examined_count,
+                "delivery_dispatch_count": receipt.delivery_dispatch_count,
+                "delivery_queued_count": receipt.delivery_queued_count,
+                "delivery_awaiting_claim_count": receipt.delivery_awaiting_claim_count,
+                "delivery_claimed_count": receipt.delivery_claimed_count,
+                "delivery_blocked_count": receipt.delivery_blocked_count,
+                "delivery_unknown_count": receipt.delivery_unknown_count,
+                "delivery_failed_count": receipt.delivery_failed_count,
+                "delivery_superseded_count": receipt.delivery_superseded_count,
+                "delivery_error_count": receipt.delivery_error_count,
             },
         )
         return receipt
@@ -322,7 +391,18 @@ class CoreSupervisorService:
             "last_cycle_at": state.get("last_cycle_at"),
             "next_poll_seconds": state.get("next_poll_seconds"),
             "planned_intent_count": int(state.get("planned_intent_count") or 0),
-            "dispatch_performed": False,
+            "dispatch_performed": bool(state.get("dispatch_performed", False)),
+            "authority_boundary": state.get("authority_boundary", "persistent_observe_plan_only"),
+            "delivery_examined_count": int(state.get("delivery_examined_count") or 0),
+            "delivery_dispatch_count": int(state.get("delivery_dispatch_count") or 0),
+            "delivery_queued_count": int(state.get("delivery_queued_count") or 0),
+            "delivery_awaiting_claim_count": int(state.get("delivery_awaiting_claim_count") or 0),
+            "delivery_claimed_count": int(state.get("delivery_claimed_count") or 0),
+            "delivery_blocked_count": int(state.get("delivery_blocked_count") or 0),
+            "delivery_unknown_count": int(state.get("delivery_unknown_count") or 0),
+            "delivery_failed_count": int(state.get("delivery_failed_count") or 0),
+            "delivery_superseded_count": int(state.get("delivery_superseded_count") or 0),
+            "delivery_error_count": int(state.get("delivery_error_count") or 0),
         }
 
     def run_forever(

--- a/agent_core/employee_wake_delivery.py
+++ b/agent_core/employee_wake_delivery.py
@@ -91,7 +91,8 @@ class EmployeeWakeDelivery:
     This layer does not re-plan work. Its input is the exact wake intent already
     selected/journaled by Core. Delivery is scoped by Employee presence generation.
     A crash after persisting `dispatching` is UNKNOWN and is not blindly retried to
-    that same presence generation.
+    that same presence generation. Delivery also refuses to initialize missing ONE
+    state: fabric and Node Registry must already exist and identify the same Realm.
     """
 
     def __init__(self, presence: EmployeePresenceRegistry, controller: ControllerService) -> None:
@@ -106,6 +107,20 @@ class EmployeeWakeDelivery:
         payload = _read(self._path(wake_id, presence_generation))
         return EmployeeWakeDeliveryState(**payload) if payload else None
 
+    def _require_existing_one_control_plane(self) -> None:
+        fabric = self.controller.fabric
+        registry = fabric.node_registry
+        fabric_path = Path(fabric.path)
+        registry_path = Path(registry.path)
+        if not fabric_path.is_file() or not registry_path.is_file():
+            raise RuntimeError("one_control_plane_state_missing")
+        fabric_state = fabric.load()
+        registry_state = registry.load()
+        fabric_realm = str(fabric_state.get("realm_id") or "")
+        registry_realm = str(registry_state.get("realm_id") or "")
+        if not fabric_realm or not registry_realm or fabric_realm != registry_realm:
+            raise RuntimeError("one_control_plane_realm_mismatch")
+
     def deliver_intent(
         self,
         intent: EmployeeWakeIntent,
@@ -115,6 +130,7 @@ class EmployeeWakeDelivery:
         if not isinstance(intent, EmployeeWakeIntent):
             raise TypeError("employee_wake_intent_type_required")
         current = now or _utcnow()
+        self._require_existing_one_control_plane()
         route = self.presence.resolve(intent.employee_id, now=current)
         path = self._path(intent.wake_id, route.generation)
         existing = _read(path)

--- a/docs/CORE_SUPERVISOR.md
+++ b/docs/CORE_SUPERVISOR.md
@@ -1,8 +1,8 @@
 # AgentOS Core Supervisor
 
-Status: **S3 integration candidate — persistent observe/plan loop, no execution dispatch**.
+Status: **S4 source integration candidate — persistent reconciliation with explicit governed ONE wake delivery; live Oracle operating acceptance is still pending**.
 
-The Core Supervisor is the always-running reconciliation process for AgentOS. Employees remain durable organizational identities; they are not independent daemons. The Supervisor observes durable state and decides which assignment needs attention next.
+The Core Supervisor is the long-running reconciliation process for AgentOS. Employees remain durable organizational identities; they are not independent daemons. The Supervisor observes durable state, journals which Employee assignment needs attention, and may cross the S4 wake boundary only when an explicit machine policy authorizes the exact persisted wake through the existing ONE control plane.
 
 ## Core model
 
@@ -23,17 +23,35 @@ Issue event / Realm message / timer / dependency / user goal
              observe -> reconcile -> journal
                          |
                          v
-                planned ReconcileIntent
-                         |
-                    S4 boundary
+          immutable planned ReconcileIntent
                          |
                          v
-               governed ONE delivery
+                 S4 authority policy
+                         |
+                 exact-current-wake fence
+                         |
+                         v
+           existing Employee presence in ONE
+                         |
+                         v
+        ControllerService -> existing ONE queue
+                         |
+                         v
+               fixed Node wake inbox
+                         |
+                         v
+              authenticated Node receipt
+                         |
+                         v
+                    awaiting_claim
+                         |
+                         v
+          Employee lifecycle lease / receipt
 ```
 
-The invariant is **event != authority**. A GitHub Issue can trigger re-evaluation, but Issue prose is not an executable command and does not grant Node, executor, transport, capability, credential, or publication authority.
+The invariant is **event != authority**. A GitHub Issue can trigger re-evaluation, but Issue prose is not an executable command and does not grant Node, executor, transport, capability, credential, publication, or protected-branch authority.
 
-## What S3 does
+## S1-S3 persistent reconciliation
 
 The persistent service:
 
@@ -42,7 +60,7 @@ The persistent service:
 - scans durable Employee assignments;
 - respects live Employee leases and blocked WorkItem dependencies;
 - converts pending/resumable assignments into deterministic reconcile intents;
-- journals a reconcile intent before any future delivery attempt;
+- journals a reconcile intent before any delivery attempt;
 - preserves `prior_execution_state=unknown` when an Employee execution lease expired without a terminal receipt;
 - suppresses duplicate intents after restart;
 - writes durable cycle receipts and a read-only health projection;
@@ -50,23 +68,71 @@ The persistent service:
 - continues leader heartbeats during long idle backoff;
 - survives process restart without deleting pending work.
 
-## What S3 explicitly does not do
+The S3 reconcile record is immutable evidence. S4 does not rewrite it to claim that delivery happened.
 
-S3 does **not**:
+## S4 governed wake delivery
 
-- select a Node, executor, model, session, transport, or capability carrier;
-- execute Issue text, shell commands, argv, scripts, or filesystem mutations;
-- send a wake to a Node;
-- claim an Employee assignment on behalf of an executor;
-- invoke GitHub Actions as a control-plane fallback;
-- publish to protected `main`;
-- prove that the service is already installed or running on Oracle.
+S4 is opt-in and uses `governance/core-supervisor-delivery.json` plus the existing authority-driven `governance/transport-routing.json`.
 
-The source-controlled systemd unit uses `PrivateNetwork=true` intentionally. S3 has no network authority. S4 must cross a separate governed ONE delivery boundary.
+For the current `employee_wake` reconcile kind, S4 authorizes only:
 
-## CLI
+- capability: `agent.employee.wake.deliver`;
+- intent class: `control_plane`;
+- transport: explicit `one_direct`;
+- an exact already-persisted `EmployeeWakeIntent`.
 
-The production entrypoint is:
+It explicitly does **not** grant:
+
+- Employee assignment claim authority;
+- executor/model/provider/session selection authority;
+- generic shell, argv, filesystem, desktop, URL, or credential authority;
+- GitHub Actions fallback authority.
+
+Capability availability is checked only after authority is resolved. An online Node or an available runner never grants authority by itself.
+
+### Exact-current-wake fence
+
+A persisted wake can become stale after planning. For example, another executor may claim the assignment or the assignment goal/thread/role/skill state may change before delivery.
+
+Before a new delivery attempt, S4 recomputes the planner only as a validation read and requires the complete current wake projection to match the exact persisted wake. It does not replace or re-plan the delivery input. A mismatch becomes `superseded` and does not cross ONE.
+
+### Delivery ledger
+
+S4 writes a separate ledger:
+
+```text
+supervisor/
+  intents/                  # immutable S3 selection evidence
+  deliveries/               # S4 authority/delivery progression
+  cycles/
+  leader.json
+  state.json
+```
+
+Important delivery states include:
+
+- `blocked`: authority, presence, or pre-dispatch prerequisite unavailable;
+- `queued`: exact wake entered the existing ONE Node queue;
+- `awaiting_claim`: Node accepted the fixed wake capsule, but no executor owns the assignment yet;
+- `claimed`: a live Employee lifecycle lease at the expected generation is observed;
+- `unknown`: delivery crossed an ambiguous external boundary and is not blindly retried to the same presence;
+- `failed`: terminal Node wake failure for that presence generation;
+- `superseded`: the persisted wake is no longer the exact current wake;
+- `terminal_observed`: the underlying assignment is already terminal.
+
+A Node receipt is **not** treated as execution success. `wake_delivery.accepted=true` proves only that the Node wake inbox accepted the bounded capsule; it must also prove `executor_invoked=false` and `credential_exposed=false`. The Supervisor remains in `awaiting_claim` until a real Employee lifecycle lease is observed.
+
+If an Employee moves to a strictly newer presence generation before any assignment claim, the same exact wake may follow that new presence. The same presence is not blindly re-sent. If an execution lease later expires, S1 produces a new deterministic resume wake with `prior_execution_state=unknown`.
+
+## No shadow ONE
+
+S4 reuses the existing ONE control plane. `EmployeeWakeDelivery` refuses to dispatch unless both the existing Realm fabric and Node Registry already exist, carry non-empty Realm identities, and identify the same Realm.
+
+The Supervisor must never initialize a missing `fabric.json` or `nodes.json` as a side effect of enabling delivery. A missing or mismatched control-plane store is a fail-closed configuration error, not permission to create a second Realm.
+
+## CLI and opt-in configuration
+
+The production entrypoint remains:
 
 ```text
 python3 -m agent_core.core_supervisor_daemon
@@ -78,46 +144,50 @@ Read-only health:
 python3 -m agent_core.core_supervisor_daemon --health
 ```
 
-One reconciliation cycle, useful for bounded local validation:
+One bounded cycle:
 
 ```text
 python3 -m agent_core.core_supervisor_daemon --once
 ```
 
-`AGENTOS_EMPLOYEE_RUNTIME_ROOT` must resolve to an absolute durable runtime path. `AGENTOS_DATA_ROOT` may be used as a parent fallback, in which case the Employee runtime is `<data-root>/employee-runtime`.
+`AGENTOS_EMPLOYEE_RUNTIME_ROOT` must be an absolute durable runtime path. Non-secret configuration is documented in `.agent/scripts/agentos-core-supervisor.env.example`.
 
-Non-secret configuration is documented in `.agent/scripts/agentos-core-supervisor.env.example`.
+The default is deliberately:
+
+```text
+AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled
+```
+
+S4 is enabled only by an explicit host-local configuration such as:
+
+```text
+AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct
+AGENTOS_SUPERVISOR_ONE_DATA_ROOT=/home/ubuntu/agent-data
+```
+
+Enabling `one_direct` attaches the S4 coordinator to that process; repository merge by itself does not enable it.
 
 ## Persistent-process safety
 
-Two independent fences are used:
+Two independent fences remain active:
 
 1. A long-held OS file lock at the runtime root prevents two local Supervisor daemon processes from operating concurrently.
 2. A durable leader lease/generation protects restart/takeover semantics. A new process instance uses a new owner identity; takeover after an expired leader is recorded with prior owner state `unknown`.
 
-The daemon never sleeps longer than half of the current leader lease without heartbeating, even when reconciliation backoff is longer than the lease.
+Every S4 advance requires the current Supervisor leader generation before crossing authority. The daemon never sleeps longer than half of the current leader lease without heartbeating, even when reconciliation backoff is longer than the lease.
 
-## Durable state
+## systemd sandbox
 
-Under the Employee runtime root:
+`.agent/scripts/agentos-core-supervisor.service` remains the safe S3 base template:
 
-```text
-supervisor/
-  process.lock
-  leader.json
-  state.json
-  work-items/
-  intents/
-  cycles/
-```
+- `PrivateNetwork=true`;
+- `NoNewPrivileges=true`;
+- `ProtectSystem=strict`;
+- write access limited to the Employee runtime root.
 
-`intents/*.json` are S3 planned records with `dispatch_performed=false`. A merge of S3 therefore must never be interpreted as evidence that a Node was awakened or that an executor ran.
+S4 does not silently widen the base unit. The optional `.agent/scripts/agentos-core-supervisor-delivery.conf.example` is a separate systemd drop-in that adds write access only to the existing ONE `realm/` directory needed by the local file-backed `one_direct` queue. `PrivateNetwork=true` remains in force; current S4 does not need generic outbound networking.
 
-## systemd template
-
-`.agent/scripts/agentos-core-supervisor.service` is a reference deployment template. Its write sandbox is intentionally limited to the configured Employee runtime area and its network namespace is private.
-
-Before installation, the host-specific paths in the service and env file must be checked against the actual runtime layout. Installing/enabling/restarting the service is a separate governed runtime mutation and requires its own receipt/evidence.
+Before installation, host-specific paths must be checked against the actual canonical runtime. Installing a drop-in, changing host-local env, enabling/restarting the service, creating a persistent Employee presence, or running a live Spec Steward assignment are governed runtime mutations and need independent receipts/evidence.
 
 **Repository merge != Oracle deployment != operating acceptance.**
 
@@ -125,8 +195,18 @@ Before installation, the host-specific paths in the service and env file must be
 
 - S1 deterministic reconcile kernel: integrated.
 - S2 event/WorkItem intake: integrated.
-- S3 persistent singleton loop: this slice.
-- S4 governed ONE wake delivery: separate authority boundary.
-- #197 Spec Steward: first end-to-end live Employee acceptance.
+- S3 persistent singleton loop: integrated.
+- #197 O2 exact governed Employee wake carrier: integrated.
+- S4 Supervisor -> exact persisted wake -> ONE delivery coordinator: this source slice.
+- #197 O3 Spec Steward: first real persistent Employee operating acceptance.
 
-The final acceptance is not static CI. A real persistent Supervisor must notice a pending Spec Steward assignment without a user saying `繼續`, cause a governed wake through ONE, observe executor/session turnover, resume the same Employee/assignment/thread safely, and stop waking after a terminal receipt.
+Static hosted CI can prove deterministic state transitions and the local ONE queue/Node receipt contract, but it cannot prove that Oracle is currently running the service or that a real executor/session transition occurred.
+
+The final acceptance requires a live persistent Supervisor to notice a pending Spec Steward assignment without a user saying `繼續`, deliver the exact wake through the authorized ONE path, observe a real executor claim/checkpoint, survive executor/session turnover or lease expiry, resume the same Employee/assignment/thread safely, persist a terminal sanitized Employee receipt, and stop waking terminal work.
+
+Success markers remain:
+
+- `CORE_SUPERVISOR_PERSISTENT_RECONCILIATION=VERIFIED`
+- `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`
+
+Neither marker may be claimed from source merge or static CI alone.

--- a/governance/core-supervisor-delivery.json
+++ b/governance/core-supervisor-delivery.json
@@ -1,0 +1,41 @@
+{
+  "schema": "agentos.core-supervisor-delivery-policy/v1",
+  "policy_id": "core-supervisor-employee-wake-v1",
+  "description": "Explicit authority for the persistent Core Supervisor to deliver only already-persisted Employee wake intents through the governed ONE control plane. Capability availability never grants authority.",
+  "reconcile_kinds": {
+    "employee_wake": {
+      "capability": "agent.employee.wake.deliver",
+      "intent_class": "control_plane",
+      "allowed_transports": [
+        "one_direct"
+      ],
+      "requires_live_supervisor_leader": true,
+      "requires_exact_persisted_wake": true,
+      "requires_current_wake_match": true,
+      "assignment_claim_authority": false,
+      "executor_selection_authority": false,
+      "provider_selection_authority": false,
+      "session_selection_authority": false,
+      "credential_authority": false
+    }
+  },
+  "failure_semantics": {
+    "authority_unavailable": "fail_closed_no_dispatch",
+    "presence_unavailable": "remain_retryable_without_authority_expansion",
+    "stale_wake": "supersede_without_dispatch",
+    "dispatch_ambiguous": "unknown_no_same_presence_retry",
+    "delivery_failed": "no_same_presence_retry",
+    "one_unavailable": "fail_closed_no_actions_fallback"
+  },
+  "invariants": [
+    "event_does_not_grant_authority",
+    "capability_availability_does_not_grant_authority",
+    "persisted_reconcile_intent_is_immutable_evidence",
+    "delivery_must_use_exact_persisted_wake_intent",
+    "delivery_does_not_claim_employee_assignment",
+    "delivery_does_not_select_executor_model_provider_or_session",
+    "github_actions_is_not_control_plane_fallback",
+    "one_failure_does_not_expand_authority",
+    "ambiguous_external_side_effect_is_unknown"
+  ]
+}

--- a/tests/test_core_supervisor_assets.py
+++ b/tests/test_core_supervisor_assets.py
@@ -7,37 +7,68 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SERVICE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.service"
+DELIVERY_DROPIN = ROOT / ".agent" / "scripts" / "agentos-core-supervisor-delivery.conf.example"
 ENV_EXAMPLE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.env.example"
+DELIVERY_POLICY = ROOT / "governance" / "core-supervisor-delivery.json"
 DOC = ROOT / "docs" / "CORE_SUPERVISOR.md"
 
 
 class CoreSupervisorAssetTests(unittest.TestCase):
-    def test_service_runs_observe_plan_daemon_with_network_disabled(self):
+    def test_base_service_remains_s3_sandbox_with_network_disabled(self):
         text = SERVICE.read_text(encoding="utf-8")
         self.assertIn("ExecStart=/usr/bin/python3 -m agent_core.core_supervisor_daemon", text)
         self.assertIn("PrivateNetwork=true", text)
         self.assertIn("NoNewPrivileges=true", text)
         self.assertIn("ProtectSystem=strict", text)
         self.assertIn("ReadWritePaths=/home/ubuntu/agent-data/employee-runtime", text)
+        self.assertNotIn("ReadWritePaths=/home/ubuntu/agent-data/realm", text)
         lowered = text.casefold()
         self.assertNotIn("workflow_dispatch", lowered)
         self.assertNotIn("github actions", lowered)
         self.assertNotIn("shell.exec", lowered)
 
-    def test_environment_example_is_non_secret_configuration_only(self):
+    def test_environment_example_defaults_delivery_to_disabled_and_contains_no_secret(self):
         text = ENV_EXAMPLE.read_text(encoding="utf-8")
         self.assertIn("AGENTOS_EMPLOYEE_RUNTIME_ROOT=", text)
         self.assertIn("AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS=", text)
+        self.assertRegex(text, re.compile(r"^AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled$", re.MULTILINE))
+        self.assertIn("# AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct", text)
+        self.assertIn("# AGENTOS_SUPERVISOR_ONE_DATA_ROOT=", text)
         lowered = text.casefold()
         for forbidden in ("password=", "token=", "secret=", "authorization=", "bearer "):
             self.assertNotIn(forbidden, lowered)
+
+    def test_s4_dropin_is_explicit_narrow_filesystem_extension_only(self):
+        text = DELIVERY_DROPIN.read_text(encoding="utf-8")
+        self.assertIn("[Service]", text)
+        self.assertIn("ReadWritePaths=/home/ubuntu/agent-data/realm", text)
+        lowered = text.casefold()
+        self.assertNotIn("privatenetwork=false", lowered)
+        self.assertNotIn("execstart=", lowered)
+        self.assertNotIn("environment=", lowered)
+        self.assertNotIn("shell.exec", lowered)
+        self.assertNotIn("github actions", lowered)
+
+    def test_s4_policy_allows_only_exact_wake_through_one_direct(self):
+        text = DELIVERY_POLICY.read_text(encoding="utf-8")
+        self.assertIn('"capability": "agent.employee.wake.deliver"', text)
+        self.assertIn('"allowed_transports": [', text)
+        self.assertIn('"one_direct"', text)
+        self.assertNotIn('"github_actions"', text)
+        self.assertIn('"assignment_claim_authority": false', text)
+        self.assertIn('"executor_selection_authority": false', text)
+        self.assertIn('"credential_authority": false', text)
 
     def test_docs_keep_source_merge_separate_from_live_deployment(self):
         text = DOC.read_text(encoding="utf-8")
         self.assertIn("Repository merge != Oracle deployment != operating acceptance", text)
         self.assertIn("event != authority", text)
         self.assertIn("PrivateNetwork=true", text)
-        self.assertRegex(text, re.compile(r"S4.*governed ONE wake delivery", re.IGNORECASE))
+        self.assertIn("AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled", text)
+        self.assertIn("No shadow ONE", text)
+        self.assertIn("awaiting_claim", text)
+        self.assertRegex(text, re.compile(r"S4.*governed", re.IGNORECASE))
+        self.assertIn("Neither marker may be claimed from source merge or static CI alone", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_core_supervisor_daemon.py
+++ b/tests/test_core_supervisor_daemon.py
@@ -8,8 +8,11 @@ from contextlib import redirect_stdout
 from pathlib import Path
 
 from agent_core.core_supervisor_daemon import (
+    _delivery_mode,
     _heartbeat_step,
     _process_singleton_lock,
+    _require_existing_one_root,
+    build_service,
     main,
     run_persistent,
 )
@@ -56,6 +59,30 @@ class _StopAfterWaits:
 
 
 class CoreSupervisorDaemonTests(unittest.TestCase):
+    def _write_one_root(self, root: Path, *, fabric_realm="realm-test", node_realm="realm-test"):
+        realm = root / "realm"
+        realm.mkdir(parents=True, exist_ok=True)
+        (realm / "fabric.json").write_text(
+            json.dumps({
+                "schema": "agentos.realm-fabric/v0.1",
+                "realm_id": fabric_realm,
+                "invites": {},
+                "join_requests": {},
+                "nodes": {},
+                "tasks": {},
+                "receipts": {},
+            }),
+            encoding="utf-8",
+        )
+        (realm / "nodes.json").write_text(
+            json.dumps({
+                "schema": "agentos.node-registry/v0.1",
+                "realm_id": node_realm,
+                "nodes": {},
+            }),
+            encoding="utf-8",
+        )
+
     def test_heartbeat_step_never_sleeps_past_half_leader_lease(self):
         self.assertEqual(_heartbeat_step(60, 30), 15)
         self.assertEqual(_heartbeat_step(10, 30), 10)
@@ -92,7 +119,7 @@ class CoreSupervisorDaemonTests(unittest.TestCase):
             self.assertFalse(payload["dispatch_performed"])
             self.assertFalse((root / "supervisor" / "leader.json").exists())
 
-    def test_once_cli_journals_pending_work_without_dispatch(self):
+    def test_once_cli_journals_pending_work_without_dispatch_by_default(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp).resolve()
             runtime = EmployeeRuntime(root)
@@ -106,12 +133,71 @@ class CoreSupervisorDaemonTests(unittest.TestCase):
             payload = json.loads(out.getvalue())
             self.assertEqual(payload["new_intent_count"], 1)
             self.assertFalse(payload["dispatch_performed"])
+            self.assertEqual(payload["authority_boundary"], "persistent_observe_plan_only")
             intent_files = list((root / "supervisor" / "intents").glob("reconcile_*.json"))
             self.assertEqual(len(intent_files), 1)
 
     def test_runtime_root_must_be_explicit_absolute_path(self):
         with self.assertRaisesRegex(ValueError, "employee_runtime_root_must_be_absolute"):
             main(["--runtime-root", "relative/path", "--health"])
+
+    def test_delivery_mode_is_explicit_and_fail_closed(self):
+        self.assertEqual(_delivery_mode("disabled"), "disabled")
+        self.assertEqual(_delivery_mode("one_direct"), "one_direct")
+        with self.assertRaisesRegex(ValueError, "invalid_supervisor_delivery_mode"):
+            _delivery_mode("github_actions")
+        with self.assertRaisesRegex(ValueError, "invalid_supervisor_delivery_mode"):
+            _delivery_mode("auto")
+
+    def test_default_builder_does_not_attach_delivery_authority(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            service = build_service(
+                runtime_root=root / "employee-runtime",
+                service_id="test-supervisor",
+                base_poll_seconds=2,
+                max_poll_seconds=16,
+            )
+            self.assertIsNone(service.delivery_driver)
+
+    def test_one_direct_builder_requires_existing_matching_one_realm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            runtime_root = root / "employee-runtime"
+            one_root = root / "one"
+            with self.assertRaisesRegex(RuntimeError, "supervisor_one_control_plane_state_missing"):
+                build_service(
+                    runtime_root=runtime_root,
+                    service_id="test-supervisor",
+                    base_poll_seconds=2,
+                    max_poll_seconds=16,
+                    delivery_mode="one_direct",
+                    one_data_root=one_root,
+                )
+            self.assertFalse((one_root / "realm" / "fabric.json").exists())
+            self.assertFalse((one_root / "realm" / "nodes.json").exists())
+
+            self._write_one_root(one_root, fabric_realm="realm-a", node_realm="realm-b")
+            with self.assertRaisesRegex(RuntimeError, "supervisor_one_control_plane_realm_mismatch"):
+                _require_existing_one_root(one_root)
+
+    def test_one_direct_builder_attaches_only_to_existing_matching_realm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            runtime_root = root / "employee-runtime"
+            one_root = root / "one"
+            self._write_one_root(one_root)
+            service = build_service(
+                runtime_root=runtime_root,
+                service_id="test-supervisor",
+                base_poll_seconds=2,
+                max_poll_seconds=16,
+                delivery_mode="one_direct",
+                one_data_root=one_root,
+            )
+            self.assertIsNotNone(service.delivery_driver)
+            self.assertEqual(service.delivery_driver.authority.requested_transport, "one_direct")
+            self.assertEqual(_require_existing_one_root(one_root), "realm-test")
 
 
 if __name__ == "__main__":

--- a/tests/test_core_supervisor_delivery.py
+++ b/tests/test_core_supervisor_delivery.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.controller_service import ControllerService
+from agent_core.core_supervisor_delivery import (
+    SupervisorWakeAuthorityResolver,
+    SupervisorWakeCoordinator,
+)
+from agent_core.core_supervisor_service import CoreSupervisorService
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import EmployeePresenceRegistry
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake_delivery import EmployeeWakeDelivery
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+T0 = datetime(2026, 9, 2, 6, 0, 0, tzinfo=timezone.utc)
+
+
+class CoreSupervisorDeliveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root / "employee-runtime")
+        self.runtime.create_employee(
+            "spec-steward",
+            "Spec Steward",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.create_assignment(
+            "audit-001",
+            "spec-steward",
+            "Audit closure gaps",
+            thread_head="ir:start",
+            constraints=["read-only-first"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+
+        self.node_registry = NodeRegistry(path=self.root / "one" / "realm" / "nodes.json")
+        self.fabric = RealmFabricStore(
+            path=self.root / "one" / "realm" / "fabric.json",
+            node_registry=self.node_registry,
+        )
+        self.fabric.initialize_realm("realm-test")
+        self.wake_root = self.root / "node-wakes"
+        self.client = ThinClient(
+            NodeIdentity("realm-test", "node-a"),
+            ThinClientPolicy(employee_wake_root=self.wake_root),
+        )
+        manifest = self.client.capability_manifest()
+        invite = self.fabric.create_invite(expires_minutes=5, label="supervisor-s4-test")
+        enrolled = self.fabric.enroll(
+            invite_id=invite["invite_id"],
+            code=invite["code"],
+            manifest=manifest,
+        )
+        self.node_token = enrolled["node_token"]
+        self.fabric.record_heartbeat(
+            {
+                "schema": "agentos.node-heartbeat/v0.1",
+                "realm_id": "realm-test",
+                "node_id": "node-a",
+                "status": "online",
+                "observed_at": None,
+                "uptime_seconds": 10,
+                "surface_count": 0,
+                "manifest": manifest,
+            },
+            self.node_token,
+        )
+        self.presence = EmployeePresenceRegistry(self.runtime, self.node_registry)
+        self.controller = ControllerService(self.fabric)
+        self.wake_delivery = EmployeeWakeDelivery(self.presence, self.controller)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _service(self, *, available_transports=None, bind_presence=True):
+        if bind_presence:
+            self.presence.bind(
+                "spec-steward",
+                "node-a",
+                "presence-a",
+                ttl_seconds=120,
+                now=T0,
+            )
+        service = CoreSupervisorService(
+            self.lifecycle,
+            owner_id="supervisor-test",
+            base_poll_seconds=2,
+            max_poll_seconds=16,
+        )
+        authority = SupervisorWakeAuthorityResolver(requested_transport="one_direct")
+        coordinator = SupervisorWakeCoordinator(
+            service,
+            self.wake_delivery,
+            authority,
+            available_transports=available_transports or {"one_direct": True},
+        )
+        service.attach_delivery_driver(coordinator)
+        return service, coordinator
+
+    def _execute_all(self):
+        tasks = self.fabric.pull_tasks("node-a", self.node_token, limit=10)
+        receipts = []
+        for task in tasks:
+            receipt = self.client.execute(task)
+            self.fabric.record_receipt(receipt, self.node_token)
+            receipts.append(receipt)
+        return tasks, receipts
+
+    def _only_reconcile_id(self, service):
+        files = list(service.intents_dir.glob("reconcile_*.json"))
+        self.assertEqual(len(files), 1)
+        return files[0].stem
+
+    def test_cycle_progresses_plan_queue_receipt_and_real_assignment_claim(self):
+        service, coordinator = self._service()
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+
+        first = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self.assertEqual(first.new_intent_count, 1)
+        self.assertTrue(first.dispatch_performed)
+        self.assertEqual(first.delivery_dispatch_count, 1)
+        self.assertEqual(first.delivery_queued_count, 1)
+        self.assertEqual(first.authority_boundary, "persistent_observe_plan_plus_governed_wake_delivery")
+        self.assertEqual(self.runtime.get_assignment("audit-001").state, "pending")
+        self.assertIsNone(self.lifecycle.get_lease("audit-001"))
+
+        tasks, receipts = self._execute_all()
+        self.assertEqual(len(tasks), 1)
+        self.assertTrue(receipts[0]["wake_delivery"]["accepted"])
+        self.assertFalse(receipts[0]["wake_delivery"]["executor_invoked"])
+
+        second = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=2))
+        self.assertFalse(second.dispatch_performed)
+        self.assertEqual(second.delivery_awaiting_claim_count, 1)
+        reconcile_id = self._only_reconcile_id(service)
+        self.assertEqual(coordinator.get(reconcile_id).status, "awaiting_claim")
+
+        lease = self.lifecycle.claim(
+            "audit-001",
+            "spec-steward",
+            "executor-lease-1",
+            lease_seconds=60,
+            now=T0 + timedelta(seconds=3),
+        )
+        self.assertEqual(lease.generation, 1)
+        third = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=4))
+        self.assertEqual(third.delivery_claimed_count, 1)
+        self.assertEqual(coordinator.get(reconcile_id).status, "claimed")
+
+    def test_stale_exact_wake_is_superseded_without_delivery(self):
+        service = CoreSupervisorService(
+            self.lifecycle,
+            owner_id="supervisor-test",
+            base_poll_seconds=2,
+            max_poll_seconds=16,
+        )
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+        planned = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self.assertEqual(planned.new_intent_count, 1)
+
+        self.runtime.update_assignment("audit-001", goal="Audit a different exact scope")
+        authority = SupervisorWakeAuthorityResolver(requested_transport="one_direct")
+        coordinator = SupervisorWakeCoordinator(
+            service,
+            self.wake_delivery,
+            authority,
+            available_transports={"one_direct": True},
+        )
+        service.attach_delivery_driver(coordinator)
+        receipt = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=2))
+        self.assertFalse(receipt.dispatch_performed)
+        self.assertEqual(receipt.delivery_superseded_count, 1)
+        self.assertEqual(self.fabric.load()["tasks"]["node-a"], [])
+
+    def test_missing_presence_blocks_then_retries_when_presence_appears(self):
+        service, coordinator = self._service(bind_presence=False)
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+        first = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self.assertFalse(first.dispatch_performed)
+        self.assertEqual(first.delivery_blocked_count, 1)
+        reconcile_id = self._only_reconcile_id(service)
+        self.assertEqual(coordinator.get(reconcile_id).error_code, "employee_presence_unavailable")
+
+        self.presence.bind(
+            "spec-steward",
+            "node-a",
+            "presence-a",
+            ttl_seconds=120,
+            now=T0 + timedelta(seconds=2),
+        )
+        second = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=3))
+        self.assertTrue(second.dispatch_performed)
+        self.assertEqual(second.delivery_queued_count, 1)
+        self.assertEqual(len(self.fabric.load()["tasks"]["node-a"]), 1)
+
+    def test_actions_availability_never_expands_control_plane_authority(self):
+        service, coordinator = self._service(available_transports={"github_actions": True})
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+        receipt = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self.assertFalse(receipt.dispatch_performed)
+        self.assertEqual(receipt.delivery_blocked_count, 1)
+        reconcile_id = self._only_reconcile_id(service)
+        state = coordinator.get(reconcile_id)
+        self.assertEqual(state.status, "blocked")
+        self.assertEqual(state.error_code, "wake_authority_unavailable")
+        self.assertEqual(self.fabric.load()["tasks"]["node-a"], [])
+
+    def test_awaiting_claim_is_not_resent_to_same_presence(self):
+        service, coordinator = self._service()
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+        service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self._execute_all()
+        service.run_cycle(leader.generation, now=T0 + timedelta(seconds=2))
+        reconcile_id = self._only_reconcile_id(service)
+        self.assertEqual(coordinator.get(reconcile_id).status, "awaiting_claim")
+
+        third = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=3))
+        self.assertFalse(third.dispatch_performed)
+        self.assertEqual(self.fabric.pull_tasks("node-a", self.node_token, limit=10), [])
+        self.assertEqual(coordinator.get(reconcile_id).status, "awaiting_claim")
+
+    def test_unclaimed_wake_can_follow_new_presence_generation(self):
+        service, coordinator = self._service()
+        leader = service.claim_leader(lease_seconds=60, now=T0)
+        service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
+        self._execute_all()
+        service.run_cycle(leader.generation, now=T0 + timedelta(seconds=2))
+        reconcile_id = self._only_reconcile_id(service)
+        self.assertEqual(coordinator.get(reconcile_id).status, "awaiting_claim")
+
+        second_presence = self.presence.bind(
+            "spec-steward",
+            "node-a",
+            "presence-b",
+            ttl_seconds=120,
+            supersede_presence_id="presence-a",
+            now=T0 + timedelta(seconds=3),
+        )
+        self.assertEqual(second_presence.generation, 2)
+        fourth = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=4))
+        self.assertTrue(fourth.dispatch_performed)
+        state = coordinator.get(reconcile_id)
+        self.assertEqual(state.status, "queued")
+        self.assertEqual(state.presence_generation, 2)
+        tasks = self.fabric.pull_tasks("node-a", self.node_token, limit=10)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["employee_wake_route"]["presence_generation"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_supervisor_delivery.py
+++ b/tests/test_core_supervisor_delivery.py
@@ -168,7 +168,7 @@ class CoreSupervisorDeliveryTests(unittest.TestCase):
         planned = service.run_cycle(leader.generation, now=T0 + timedelta(seconds=1))
         self.assertEqual(planned.new_intent_count, 1)
 
-        self.runtime.update_assignment("audit-001", goal="Audit a different exact scope")
+        self.runtime.update_assignment("audit-001", thread_head="ir:changed-after-plan")
         authority = SupervisorWakeAuthorityResolver(requested_transport="one_direct")
         coordinator = SupervisorWakeCoordinator(
             service,

--- a/tests/test_employee_wake_delivery.py
+++ b/tests/test_employee_wake_delivery.py
@@ -116,7 +116,6 @@ class EmployeeWakeDeliveryTests(unittest.TestCase):
         self.assertTrue(delivered.node_ok)
         self.assertTrue(delivered.node_wake_accepted)
 
-        # Wake delivery does not own execution authority.
         assignment = self.runtime.get_assignment("audit-001")
         self.assertEqual(assignment.state, "pending")
         self.assertIsNone(self.lifecycle.get_lease("audit-001"))
@@ -219,7 +218,7 @@ class EmployeeWakeDeliveryTests(unittest.TestCase):
 
     def test_interrupted_dispatch_record_becomes_unknown_and_is_not_redispatched(self):
         intent = self._intent()
-        path = self.delivery._path(intent.wake_id, 1)  # focused crash-state fixture
+        path = self.delivery._path(intent.wake_id, 1)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             json.dumps(
@@ -263,6 +262,29 @@ class EmployeeWakeDeliveryTests(unittest.TestCase):
         state = self.delivery.reconcile(intent.wake_id, queued.presence_generation)
         self.assertEqual(state.status, "failed")
         self.assertFalse(state.node_wake_accepted)
+
+    def test_missing_one_state_fails_before_dispatch_and_creates_no_shadow_store(self):
+        intent = self._intent()
+        missing_root = self.root / "missing-one"
+        registry = NodeRegistry(path=missing_root / "realm" / "nodes.json")
+        fabric = RealmFabricStore(path=missing_root / "realm" / "fabric.json", node_registry=registry)
+        presence = EmployeePresenceRegistry(self.runtime, registry)
+        delivery = EmployeeWakeDelivery(presence, ControllerService(fabric))
+        with self.assertRaisesRegex(RuntimeError, "one_control_plane_state_missing"):
+            delivery.deliver_intent(intent, now=self.now)
+        self.assertFalse(fabric.path.exists())
+        self.assertFalse(registry.path.exists())
+        self.assertEqual(list(delivery.root.rglob("*.json")), [])
+
+    def test_mismatched_one_realm_fails_before_dispatch(self):
+        intent = self._intent()
+        self.node_registry.path.write_text(
+            json.dumps({"schema": "agentos.node-registry/v0.1", "realm_id": "other-realm", "nodes": {}}),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(RuntimeError, "one_control_plane_realm_mismatch"):
+            self.delivery.deliver_intent(intent, now=self.now)
+        self.assertEqual(self.fabric.load()["tasks"].get("node-a", []), [])
 
     def test_presence_expiry_and_capability_freshness_fail_closed(self):
         with self.assertRaisesRegex(RuntimeError, "employee_presence_expired"):


### PR DESCRIPTION
## Scope
Implement #200 S4 on top of integrated S1-S3 and #197 O2: allow the persistent Core Supervisor to advance an exact immutable planned Employee wake into the governed ONE wake carrier, without turning planning, Node availability, or GitHub events into authority.

## Adds
- explicit `governance/core-supervisor-delivery.json` authority policy;
- `SupervisorWakeAuthorityResolver` layered on the existing authority-driven transport router;
- separate durable S4 delivery ledger under `supervisor/deliveries/`; S3 reconcile records remain immutable evidence;
- exact-current-wake validation before every new dispatch attempt;
- lifecycle progression `queued -> awaiting_claim -> claimed` so Node inbox acceptance is never misreported as executor ownership;
- stale exact wake -> `superseded` without ONE dispatch;
- same-presence no-blind-retry semantics for awaiting/unknown/failed delivery;
- exact wake may follow a strictly newer Employee presence generation while still unclaimed;
- cycle/health projections for S4 delivery counts and authority boundary;
- explicit daemon opt-in: default delivery mode remains `disabled`, only `one_direct` can attach S4;
- startup and carrier preflight requiring pre-existing, schema-valid, Realm-consistent ONE `fabric.json` and `nodes.json`; no shadow ONE creation;
- optional systemd S4 drop-in granting only existing ONE realm directory write access while base `PrivateNetwork=true` remains;
- hosted end-to-end Supervisor regressions covering plan -> ONE queue -> Node receipt -> awaiting claim -> real Employee lifecycle claim;
- fail-closed regressions for Actions-only availability, missing presence, stale wake, duplicate same-presence delivery, presence migration, shadow ONE, daemon opt-in, and deployment assets.

## Authority boundary
S4 authorizes only the fixed `agent.employee.wake.deliver` capability for an exact persisted `EmployeeWakeIntent`, classified as `control_plane`, using explicit `one_direct`. It grants no assignment claim, executor/model/provider/session selection, credential, generic shell/filesystem/desktop, publication, or protected-main authority. GitHub Actions remains forbidden as an implicit control-plane fallback.

## Important semantics
A Node receipt with `wake_delivery.accepted=true` proves only that the bounded capsule reached the fixed inbox and must also prove `executor_invoked=false` and `credential_exposed=false`. The Supervisor remains `awaiting_claim` until a real Employee lifecycle lease at the expected generation is observed.

## Evidence
Final branch Employee Runtime Guard run `33596875858` completed SUCCESS on head `2387a17981b2b5b4ed4df4885f963e6e555c72a4`. Employee runtime/lifecycle/wake/memory/skills/thread/mailbox, O2 wake carrier, privacy, S1-S3 Supervisor/WorkItem/daemon, S4 governed delivery, deployment assets, and role hydration all passed.

## Non-claims
This PR does not install the systemd service/drop-in, change host-local Supervisor env, create a live Employee presence, wake Oracle, or prove Spec Steward O3 operating acceptance. Repository merge != Oracle deployment != operating acceptance.

Target: `core/integration` only; no protected-main publication authority implied.