### PR TITLE
Core #197: bootstrap first live Spec Steward Employee acceptance

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -20,12 +20,15 @@ on:
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/core_supervisor_delivery.py'
+      - 'agent_core/spec_steward_bootstrap.py'
+      - 'agent_core/spec_steward_acceptance.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
       - 'governance/core-supervisor-delivery.json'
+      - 'governance/spec-steward-employee.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
@@ -42,6 +45,8 @@ on:
       - 'tests/test_core_supervisor_delivery.py'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
+      - 'tests/test_spec_steward_bootstrap.py'
+      - 'tests/test_spec_steward_acceptance.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -51,6 +56,7 @@ on:
   push:
     branches:
       - core/issue-197-governed-wake-delivery-v2
+      - core/issue-197-spec-steward-bootstrap
       - core/issue-200-persistent-supervisor-loop
       - core/issue-200-governed-supervisor-delivery
       - core/integration
@@ -69,12 +75,15 @@ on:
       - 'agent_core/core_supervisor_service.py'
       - 'agent_core/core_supervisor_daemon.py'
       - 'agent_core/core_supervisor_delivery.py'
+      - 'agent_core/spec_steward_bootstrap.py'
+      - 'agent_core/spec_steward_acceptance.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
       - 'governance/core-supervisor-delivery.json'
+      - 'governance/spec-steward-employee.json'
       - 'tests/test_employee_runtime.py'
       - 'tests/test_employee_lifecycle.py'
       - 'tests/test_employee_wake.py'
@@ -91,6 +100,8 @@ on:
       - 'tests/test_core_supervisor_delivery.py'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_role_runtime.py'
+      - 'tests/test_spec_steward_bootstrap.py'
+      - 'tests/test_spec_steward_acceptance.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -145,3 +156,8 @@ jobs:
         run: python -m unittest tests.test_core_supervisor_assets -v
       - name: Run role hydration regressions
         run: python -m unittest tests.test_role_runtime -v
+      - name: Run Spec Steward bootstrap regressions
+        run: python -m unittest tests.test_spec_steward_bootstrap -v
+      - name: Run Spec Steward O3 acceptance regressions
+        if: ${{ hashFiles('tests/test_spec_steward_acceptance.py') != '' }}
+        run: python -m unittest tests.test_spec_steward_acceptance -v

--- a/agent_core/spec_steward_acceptance.py
+++ b/agent_core/spec_steward_acceptance.py
@@ -5,13 +5,15 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
 from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
 from agent_core.core_work_items import WorkItemStore
 from agent_core.employee_lifecycle import EmployeeLifecycle, RECEIPT_SCHEMA
 from agent_core.employee_memory import EmployeeMemoryPolicy, EmployeeMemoryService
+from agent_core.employee_presence import WAKE_CAPABILITY
 from agent_core.employee_runtime import EmployeeRuntime
 from agent_core.employee_skills import EmployeeSkillRegistry, EmployeeSkillService
-from agent_core.employee_presence import WAKE_CAPABILITY
 from agent_core.role_runtime import RoleRegistry
 from agent_core.spec_steward_bootstrap import (
     DEFAULT_ROLE_REGISTRY_PATH,
@@ -88,6 +90,7 @@ class SpecStewardAcceptanceReport:
     checks: dict[str, bool]
     blocking_reasons: tuple[str, ...]
     qualifying_delivery_count: int
+    qualifying_wake_generations: tuple[int, ...]
     observed_lease_generation: int | None
     terminal_receipt_generation: int | None
     ready_for_live_marker: bool
@@ -99,6 +102,7 @@ class SpecStewardAcceptanceReport:
     def as_dict(self) -> dict[str, Any]:
         value = asdict(self)
         value["blocking_reasons"] = list(self.blocking_reasons)
+        value["qualifying_wake_generations"] = list(self.qualifying_wake_generations)
         return value
 
 
@@ -225,6 +229,51 @@ def _qualifying_deliveries(runtime: EmployeeRuntime, contract: SpecStewardBootst
             continue
         result.append(payload)
     return result
+
+
+def _qualifying_wake_generations(
+    runtime: EmployeeRuntime,
+    contract: SpecStewardBootstrapContract,
+    deliveries: list[dict[str, Any]],
+) -> tuple[int, ...]:
+    generations: set[int] = set()
+    intents_root = runtime.root / "supervisor" / "intents"
+    for delivery in deliveries:
+        reconcile_id = str(delivery.get("reconcile_id") or "").strip()
+        if not reconcile_id:
+            continue
+        try:
+            record = _read_json(intents_root / f"{reconcile_id}.json")
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not record or record.get("schema") != INTENT_RECORD_SCHEMA:
+            continue
+        if record.get("reconcile_id") != reconcile_id or record.get("state") != "planned":
+            continue
+        if record.get("dispatch_performed") is not False:
+            continue
+        intent = record.get("intent")
+        if not isinstance(intent, dict) or intent.get("schema") != RECONCILE_INTENT_SCHEMA:
+            continue
+        if intent.get("employee_id") != contract.employee.employee_id:
+            continue
+        if intent.get("assignment_id") != contract.initial_work_item.assignment_id:
+            continue
+        wake = intent.get("wake_intent")
+        if not isinstance(wake, dict):
+            continue
+        if wake.get("wake_id") != delivery.get("wake_id"):
+            continue
+        if wake.get("employee_id") != contract.employee.employee_id:
+            continue
+        if wake.get("assignment_id") != contract.initial_work_item.assignment_id:
+            continue
+        if wake.get("credential_exposed") is not False:
+            continue
+        generation = int(wake.get("expected_lease_generation") or 0)
+        if generation >= 1:
+            generations.add(generation)
+    return tuple(sorted(generations))
 
 
 def _memory_continuity_ok(
@@ -366,6 +415,7 @@ def inspect_spec_steward_acceptance(
     )
 
     deliveries = _qualifying_deliveries(runtime, contract)
+    wake_generations = _qualifying_wake_generations(runtime, contract, deliveries)
     checks["governed_one_wake_delivery"] = bool(deliveries)
 
     try:
@@ -381,6 +431,11 @@ def inspect_spec_steward_acceptance(
         and lease.resumed_from_lease_id != lease.lease_id
         and lease.thread_head == assignment_thread_head
         and assignment_thread_head != contract.initial_thread_head
+    )
+    checks["initial_and_resume_wakes_governed"] = bool(
+        lease
+        and 1 in wake_generations
+        and int(lease.generation) in wake_generations
     )
     checks["fresh_executor_or_session_live_witness"] = _live_witness_ok(
         runtime, contract, current_lease=lease
@@ -426,6 +481,7 @@ def inspect_spec_steward_acceptance(
         checks=checks,
         blocking_reasons=blocking,
         qualifying_delivery_count=len(deliveries),
+        qualifying_wake_generations=wake_generations,
         observed_lease_generation=lease.generation if lease else None,
         terminal_receipt_generation=receipt_generation,
         ready_for_live_marker=not blocking,

--- a/agent_core/spec_steward_acceptance.py
+++ b/agent_core/spec_steward_acceptance.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_work_items import WorkItemStore
+from agent_core.employee_lifecycle import EmployeeLifecycle, RECEIPT_SCHEMA
+from agent_core.employee_memory import EmployeeMemoryPolicy, EmployeeMemoryService
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_skills import EmployeeSkillRegistry, EmployeeSkillService
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.role_runtime import RoleRegistry
+from agent_core.spec_steward_bootstrap import (
+    DEFAULT_ROLE_REGISTRY_PATH,
+    DEFAULT_SKILL_REGISTRY_PATH,
+    SpecStewardBootstrapContract,
+    load_spec_steward_contract,
+)
+
+
+REPORT_SCHEMA = "agentos.spec-steward-o3-acceptance-report/v1"
+LIVE_WITNESS_SCHEMA = "agentos.spec-steward-o3-live-witness/v1"
+MEMORY_EVIDENCE_SCHEMA = "agentos.spec-steward-o3-memory-evidence/v1"
+DEFAULT_MEMORY_POLICY_PATH = (
+    Path(__file__).resolve().parent.parent / "governance" / "employee-memory-policy.json"
+)
+MEMORY_CLASS = "governance_evidence"
+MEMORY_KEY = "spec-steward-o3-continuity"
+EXPECTED_AUTHORITY_POLICY = "core-supervisor-employee-wake-v1"
+EXPECTED_TRANSPORT = "one_direct"
+LIVE_WITNESS_FIELDS = {
+    "schema",
+    "employee_id",
+    "assignment_id",
+    "witness_kind",
+    "from_lease_id",
+    "to_lease_id",
+    "from_generation",
+    "to_generation",
+    "fresh_executor_or_session",
+    "process_boundary_observed",
+    "session_identity_exposed",
+    "credential_exposed",
+    "observed_at",
+}
+MEMORY_EVIDENCE_FIELDS = {
+    "schema",
+    "employee_id",
+    "assignment_id",
+    "thread_head",
+    "observed_after_resume",
+    "session_identity_exposed",
+    "credential_exposed",
+}
+RECEIPT_FORBIDDEN_KEYS = {
+    "session",
+    "session_id",
+    "credential",
+    "credentials",
+    "token",
+    "secret",
+    "authorization",
+    "password",
+    "cookie",
+    "api_key",
+    "apikey",
+    "private_key",
+}
+SECRET_MARKERS = (
+    "bearer ",
+    "github_pat_",
+    "ghp_",
+    "token=",
+    "secret=",
+    "authorization:",
+    "session_id=",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SpecStewardAcceptanceReport:
+    schema: str
+    employee_id: str
+    assignment_id: str
+    checks: dict[str, bool]
+    blocking_reasons: tuple[str, ...]
+    qualifying_delivery_count: int
+    observed_lease_generation: int | None
+    terminal_receipt_generation: int | None
+    ready_for_live_marker: bool
+    live_attestation_required: bool = True
+    verified_marker_emitted: bool = False
+    credential_exposed: bool = False
+    session_identity_exposed: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["blocking_reasons"] = list(self.blocking_reasons)
+        return value
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("spec_steward_acceptance_evidence_invalid")
+    return payload
+
+
+def _exact_fields(payload: dict[str, Any], expected: set[str]) -> bool:
+    return set(payload) == expected
+
+
+def _safe_receipt_value(value: Any) -> bool:
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    if isinstance(value, str):
+        lowered = value.casefold()
+        return not any(marker in lowered for marker in SECRET_MARKERS)
+    if isinstance(value, list):
+        return all(_safe_receipt_value(item) for item in value)
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key).strip().casefold()
+            if key in RECEIPT_FORBIDDEN_KEYS:
+                return False
+            if not _safe_receipt_value(item):
+                return False
+        return True
+    return False
+
+
+def _employee_contract_ok(runtime: EmployeeRuntime, contract: SpecStewardBootstrapContract) -> bool:
+    try:
+        employee = runtime.get_employee(contract.employee.employee_id)
+    except (FileNotFoundError, ValueError):
+        return False
+    return bool(
+        employee.agent_id == contract.employee.employee_id
+        and employee.display_name == contract.employee.display_name
+        and tuple(employee.role_ids) == contract.employee.role_ids
+        and tuple(employee.skill_ids) == contract.employee.skill_ids
+        and employee.memory_namespace == f"employee:{contract.employee.employee_id}"
+    )
+
+
+def _machine_contracts_ok(
+    runtime: EmployeeRuntime,
+    contract: SpecStewardBootstrapContract,
+    role_registry: RoleRegistry,
+    skill_registry: EmployeeSkillRegistry,
+) -> bool:
+    try:
+        employee = runtime.get_employee(contract.employee.employee_id)
+        roles = role_registry.hydrate_employee_roles(list(employee.role_ids))
+        skills = EmployeeSkillService(runtime, role_registry, skill_registry).hydrate_employee_skills(
+            employee.agent_id
+        )
+    except (FileNotFoundError, KeyError, PermissionError, ValueError):
+        return False
+    role_capabilities = {
+        capability
+        for role in roles
+        for capability in role.capabilities
+    }
+    return bool(
+        tuple(skill.skill_id for skill in skills) == contract.employee.skill_ids
+        and set(contract.initial_work_item.required_capabilities).issubset(role_capabilities)
+    )
+
+
+def _work_item_ok(runtime: EmployeeRuntime, contract: SpecStewardBootstrapContract) -> bool:
+    try:
+        persisted = WorkItemStore(runtime).get(contract.initial_work_item.work_item_id)
+    except (FileNotFoundError, ValueError):
+        return False
+    return persisted == contract.initial_work_item
+
+
+def _assignment_ok(runtime: EmployeeRuntime, contract: SpecStewardBootstrapContract) -> bool:
+    try:
+        assignment = runtime.get_assignment(contract.initial_work_item.assignment_id)
+    except (FileNotFoundError, ValueError):
+        return False
+    return bool(
+        assignment.employee_id == contract.employee.employee_id
+        and assignment.goal == contract.initial_work_item.goal
+        and tuple(assignment.constraints) == contract.initial_work_item.constraints
+    )
+
+
+def _qualifying_deliveries(runtime: EmployeeRuntime, contract: SpecStewardBootstrapContract) -> list[dict[str, Any]]:
+    root = runtime.root / "supervisor" / "deliveries"
+    if not root.is_dir():
+        return []
+    result: list[dict[str, Any]] = []
+    for path in sorted(root.glob("*.json")):
+        try:
+            payload = _read_json(path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not payload or payload.get("schema") != DELIVERY_STATE_SCHEMA:
+            continue
+        if payload.get("employee_id") != contract.employee.employee_id:
+            continue
+        if payload.get("assignment_id") != contract.initial_work_item.assignment_id:
+            continue
+        if payload.get("transport") != EXPECTED_TRANSPORT:
+            continue
+        if payload.get("authority_policy_id") != EXPECTED_AUTHORITY_POLICY:
+            continue
+        if payload.get("capability") != WAKE_CAPABILITY:
+            continue
+        if payload.get("dispatch_performed") is not True:
+            continue
+        if payload.get("status") not in {"claimed", "terminal_observed"}:
+            continue
+        if not payload.get("task_id") or not payload.get("node_id") or not payload.get("presence_id"):
+            continue
+        if int(payload.get("presence_generation") or 0) < 1:
+            continue
+        result.append(payload)
+    return result
+
+
+def _memory_continuity_ok(
+    runtime: EmployeeRuntime,
+    contract: SpecStewardBootstrapContract,
+    assignment_thread_head: str,
+    *,
+    role_registry: RoleRegistry,
+    memory_policy_path: str | Path,
+) -> bool:
+    service = EmployeeMemoryService(
+        runtime,
+        role_registry,
+        EmployeeMemoryPolicy(memory_policy_path),
+    )
+    try:
+        payload = service.read(contract.employee.employee_id, MEMORY_CLASS, MEMORY_KEY)
+    except (FileNotFoundError, PermissionError, ValueError):
+        return False
+    if not isinstance(payload, dict) or not _exact_fields(payload, MEMORY_EVIDENCE_FIELDS):
+        return False
+    return bool(
+        payload.get("schema") == MEMORY_EVIDENCE_SCHEMA
+        and payload.get("employee_id") == contract.employee.employee_id
+        and payload.get("assignment_id") == contract.initial_work_item.assignment_id
+        and payload.get("thread_head") == assignment_thread_head
+        and payload.get("observed_after_resume") is True
+        and payload.get("session_identity_exposed") is False
+        and payload.get("credential_exposed") is False
+    )
+
+
+def _live_witness_ok(
+    runtime: EmployeeRuntime,
+    contract: SpecStewardBootstrapContract,
+    *,
+    current_lease: Any,
+) -> bool:
+    path = runtime.root / "acceptance" / "spec-steward-o3-live-witness.json"
+    try:
+        payload = _read_json(path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    if not payload or not _exact_fields(payload, LIVE_WITNESS_FIELDS):
+        return False
+    if current_lease is None:
+        return False
+    return bool(
+        payload.get("schema") == LIVE_WITNESS_SCHEMA
+        and payload.get("employee_id") == contract.employee.employee_id
+        and payload.get("assignment_id") == contract.initial_work_item.assignment_id
+        and payload.get("witness_kind") == "fresh_executor_or_session_transition"
+        and payload.get("from_lease_id") == current_lease.resumed_from_lease_id
+        and payload.get("to_lease_id") == current_lease.lease_id
+        and int(payload.get("from_generation") or 0) == current_lease.generation - 1
+        and int(payload.get("to_generation") or 0) == current_lease.generation
+        and payload.get("fresh_executor_or_session") is True
+        and payload.get("process_boundary_observed") is True
+        and payload.get("session_identity_exposed") is False
+        and payload.get("credential_exposed") is False
+        and bool(str(payload.get("observed_at") or "").strip())
+    )
+
+
+def _terminal_receipt(
+    runtime: EmployeeRuntime,
+    contract: SpecStewardBootstrapContract,
+    *,
+    current_lease: Any,
+    assignment_thread_head: str,
+) -> tuple[bool, int | None]:
+    if current_lease is None:
+        return False, None
+    path = (
+        runtime.root
+        / "lifecycle"
+        / "receipts"
+        / contract.initial_work_item.assignment_id
+        / f"{int(current_lease.generation):06d}.json"
+    )
+    try:
+        payload = _read_json(path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False, None
+    if not payload:
+        return False, None
+    result_summary = payload.get("result_summary")
+    ok = bool(
+        payload.get("schema") == RECEIPT_SCHEMA
+        and payload.get("employee_id") == contract.employee.employee_id
+        and payload.get("assignment_id") == contract.initial_work_item.assignment_id
+        and payload.get("lease_id") == current_lease.lease_id
+        and int(payload.get("generation") or 0) == current_lease.generation
+        and payload.get("outcome") == "completed"
+        and payload.get("thread_head") == assignment_thread_head
+        and payload.get("credential_exposed") is False
+        and isinstance(result_summary, dict)
+        and _safe_receipt_value(result_summary)
+    )
+    return ok, int(payload.get("generation") or 0) if ok else None
+
+
+def inspect_spec_steward_acceptance(
+    runtime: EmployeeRuntime,
+    *,
+    contract_path: str | Path | None = None,
+    role_registry_path: str | Path = DEFAULT_ROLE_REGISTRY_PATH,
+    skill_registry_path: str | Path = DEFAULT_SKILL_REGISTRY_PATH,
+    memory_policy_path: str | Path = DEFAULT_MEMORY_POLICY_PATH,
+) -> SpecStewardAcceptanceReport:
+    """Read O3 evidence without mutating Employee, Supervisor, ONE, or acceptance state.
+
+    A complete report only means persisted evidence is ready for a separate live
+    attestation step. This inspector never emits the O3 VERIFIED marker, including
+    when exercised by static CI.
+    """
+    contract = load_spec_steward_contract(contract_path) if contract_path else load_spec_steward_contract()
+    role_registry = RoleRegistry(role_registry_path)
+    skill_registry = EmployeeSkillRegistry(skill_registry_path)
+    lifecycle = EmployeeLifecycle(runtime)
+
+    checks: dict[str, bool] = {}
+    checks["employee_contract"] = _employee_contract_ok(runtime, contract)
+    checks["active_role_and_skill_hydrated"] = _machine_contracts_ok(
+        runtime, contract, role_registry, skill_registry
+    )
+    checks["canonical_work_item"] = _work_item_ok(runtime, contract)
+    checks["assignment_contract"] = _assignment_ok(runtime, contract)
+
+    try:
+        assignment = runtime.get_assignment(contract.initial_work_item.assignment_id)
+    except (FileNotFoundError, ValueError):
+        assignment = None
+    assignment_thread_head = assignment.thread_head if assignment else ""
+    checks["checkpoint_thread_head"] = bool(
+        assignment
+        and assignment_thread_head
+        and assignment_thread_head != contract.initial_thread_head
+    )
+
+    deliveries = _qualifying_deliveries(runtime, contract)
+    checks["governed_one_wake_delivery"] = bool(deliveries)
+
+    try:
+        lease = lifecycle.get_lease(contract.initial_work_item.assignment_id)
+    except (ValueError, TypeError):
+        lease = None
+    checks["resumed_assignment_lease"] = bool(
+        lease
+        and lease.generation >= 2
+        and lease.resume_required is True
+        and lease.prior_execution_state == "unknown"
+        and bool(lease.resumed_from_lease_id)
+        and lease.resumed_from_lease_id != lease.lease_id
+        and lease.thread_head == assignment_thread_head
+        and assignment_thread_head != contract.initial_thread_head
+    )
+    checks["fresh_executor_or_session_live_witness"] = _live_witness_ok(
+        runtime, contract, current_lease=lease
+    )
+    checks["private_memory_continuity"] = bool(
+        assignment_thread_head
+        and _memory_continuity_ok(
+            runtime,
+            contract,
+            assignment_thread_head,
+            role_registry=role_registry,
+            memory_policy_path=memory_policy_path,
+        )
+    )
+    receipt_ok, receipt_generation = _terminal_receipt(
+        runtime,
+        contract,
+        current_lease=lease,
+        assignment_thread_head=assignment_thread_head,
+    )
+    checks["terminal_sanitized_employee_receipt"] = receipt_ok
+    checks["assignment_completed"] = bool(assignment and assignment.state == "completed")
+    checks["credential_and_session_identity_not_exposed"] = bool(
+        checks["fresh_executor_or_session_live_witness"]
+        and checks["private_memory_continuity"]
+        and checks["terminal_sanitized_employee_receipt"]
+    )
+    checks["carrier_and_authority_evidence"] = bool(
+        deliveries
+        and all(
+            item.get("transport") == EXPECTED_TRANSPORT
+            and item.get("authority_policy_id") == EXPECTED_AUTHORITY_POLICY
+            and item.get("capability") == WAKE_CAPABILITY
+            for item in deliveries
+        )
+    )
+
+    blocking = tuple(name for name, ok in checks.items() if not ok)
+    return SpecStewardAcceptanceReport(
+        schema=REPORT_SCHEMA,
+        employee_id=contract.employee.employee_id,
+        assignment_id=contract.initial_work_item.assignment_id,
+        checks=checks,
+        blocking_reasons=blocking,
+        qualifying_delivery_count=len(deliveries),
+        observed_lease_generation=lease.generation if lease else None,
+        terminal_receipt_generation=receipt_generation,
+        ready_for_live_marker=not blocking,
+        verified_marker_emitted=False,
+        credential_exposed=False,
+        session_identity_exposed=False,
+    )

--- a/agent_core/spec_steward_bootstrap.py
+++ b/agent_core/spec_steward_bootstrap.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_core.core_work_items import WorkItem, WorkItemStore, normalize_work_item
+from agent_core.employee_runtime import AgentInstance, EmployeeRuntime
+from agent_core.employee_skills import EmployeeSkillRegistry, EmployeeSkillService
+from agent_core.role_runtime import EffectiveRoleContract, RoleRegistry
+
+
+BOOTSTRAP_SCHEMA = "agentos.employee-bootstrap/v1"
+BOOTSTRAP_RESULT_SCHEMA = "agentos.spec-steward-bootstrap-result/v1"
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONTRACT_PATH = ROOT / "governance" / "spec-steward-employee.json"
+DEFAULT_ROLE_REGISTRY_PATH = ROOT / ".agent" / "roles" / "registry.yaml"
+DEFAULT_SKILL_REGISTRY_PATH = ROOT / "governance" / "employee-skills.json"
+
+EMPLOYEE_FIELDS = {"employee_id", "display_name", "role_ids", "skill_ids"}
+CONTRACT_FIELDS = {
+    "schema",
+    "bootstrap_id",
+    "employee",
+    "initial_work_item",
+    "initial_thread_head",
+    "acceptance_marker",
+    "acceptance_requires",
+    "invariants",
+}
+
+
+def _nonempty(value: Any, name: str, limit: int = 512) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > limit:
+        raise ValueError(f"invalid_spec_steward_{name}")
+    return text
+
+
+def _strings(value: Any, name: str, *, max_items: int = 64) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or len(value) > max_items:
+        raise ValueError(f"invalid_spec_steward_{name}")
+    result = tuple(_nonempty(item, name, 512) for item in value)
+    if len(set(result)) != len(result):
+        raise ValueError(f"duplicate_spec_steward_{name}")
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class DesiredEmployee:
+    employee_id: str
+    display_name: str
+    role_ids: tuple[str, ...]
+    skill_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SpecStewardBootstrapContract:
+    schema: str
+    bootstrap_id: str
+    employee: DesiredEmployee
+    initial_work_item: WorkItem
+    initial_thread_head: str
+    acceptance_marker: str
+    acceptance_requires: tuple[str, ...]
+    invariants: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SpecStewardBootstrapResult:
+    schema: str
+    bootstrap_id: str
+    employee_id: str
+    assignment_id: str
+    work_item_id: str
+    employee_created: bool
+    work_item_created: bool
+    assignment_created: bool
+    initial_thread_seeded: bool
+    assignment_state: str
+    thread_head: str
+    role_ids: tuple[str, ...]
+    skill_ids: tuple[str, ...]
+    role_capabilities: tuple[str, ...]
+    hydrated_skill_ids: tuple[str, ...]
+    execution_authority: str = "not_granted_by_bootstrap"
+    transport_selection: str = "unbound"
+    executor_selection: str = "unbound"
+    credential_exposed: bool = False
+    verified_marker_emitted: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        for key in ("role_ids", "skill_ids", "role_capabilities", "hydrated_skill_ids"):
+            value[key] = list(value[key])
+        return value
+
+
+def load_spec_steward_contract(path: str | Path = DEFAULT_CONTRACT_PATH) -> SpecStewardBootstrapContract:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or raw.get("schema") != BOOTSTRAP_SCHEMA:
+        raise ValueError("invalid_spec_steward_bootstrap_schema")
+    extra = sorted(set(raw) - CONTRACT_FIELDS)
+    if extra:
+        raise ValueError("unexpected_spec_steward_bootstrap_fields:" + ",".join(extra))
+
+    employee_raw = raw.get("employee")
+    if not isinstance(employee_raw, dict):
+        raise ValueError("spec_steward_employee_contract_required")
+    extra_employee = sorted(set(employee_raw) - EMPLOYEE_FIELDS)
+    if extra_employee:
+        raise ValueError("unexpected_spec_steward_employee_fields:" + ",".join(extra_employee))
+    employee = DesiredEmployee(
+        employee_id=_nonempty(employee_raw.get("employee_id"), "employee_id", 180),
+        display_name=_nonempty(employee_raw.get("display_name"), "display_name", 180),
+        role_ids=_strings(employee_raw.get("role_ids"), "role_ids"),
+        skill_ids=_strings(employee_raw.get("skill_ids"), "skill_ids"),
+    )
+    work_item = normalize_work_item(raw.get("initial_work_item") or {})
+    contract = SpecStewardBootstrapContract(
+        schema=BOOTSTRAP_SCHEMA,
+        bootstrap_id=_nonempty(raw.get("bootstrap_id"), "bootstrap_id", 180),
+        employee=employee,
+        initial_work_item=work_item,
+        initial_thread_head=_nonempty(raw.get("initial_thread_head"), "initial_thread_head", 512),
+        acceptance_marker=_nonempty(raw.get("acceptance_marker"), "acceptance_marker", 180),
+        acceptance_requires=_strings(raw.get("acceptance_requires"), "acceptance_requires"),
+        invariants=_strings(raw.get("invariants"), "invariants"),
+    )
+    if contract.employee.role_ids != ("governance.spec_steward",):
+        raise ValueError("spec_steward_role_contract_must_be_exact")
+    if contract.employee.skill_ids != ("spec.audit",):
+        raise ValueError("spec_steward_skill_contract_must_be_exact")
+    if contract.initial_work_item.employee_id != contract.employee.employee_id:
+        raise ValueError("spec_steward_work_item_employee_mismatch")
+    if contract.initial_work_item.project_id != "agentos-core":
+        raise ValueError("spec_steward_project_scope_mismatch")
+    if contract.initial_work_item.source_ref != "core:issue-197-o3":
+        raise ValueError("spec_steward_source_scope_mismatch")
+    if contract.acceptance_marker != "SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED":
+        raise ValueError("spec_steward_acceptance_marker_mismatch")
+    return contract
+
+
+def _validate_machine_contracts(
+    contract: SpecStewardBootstrapContract,
+    role_registry: RoleRegistry,
+    skill_registry: EmployeeSkillRegistry,
+) -> tuple[list[EffectiveRoleContract], tuple[str, ...]]:
+    roles = [role_registry.resolve(role_id) for role_id in contract.employee.role_ids]
+    role_capabilities = tuple(sorted({cap for role in roles for cap in role.capabilities}))
+    missing_work = sorted(
+        set(contract.initial_work_item.required_capabilities) - set(role_capabilities)
+    )
+    if missing_work:
+        raise PermissionError(
+            "spec_steward_work_item_missing_role_capability:" + ",".join(missing_work)
+        )
+
+    for skill_id in contract.employee.skill_ids:
+        skill = skill_registry.resolve(skill_id)
+        missing_skill = sorted(set(skill.required_capabilities) - set(role_capabilities))
+        if missing_skill:
+            raise PermissionError(
+                "spec_steward_skill_missing_role_capability:" + ",".join(missing_skill)
+            )
+        if skill.mutation_authority is not False:
+            raise PermissionError("spec_steward_skill_mutation_authority_forbidden")
+    return roles, role_capabilities
+
+
+def _assert_existing_employee_matches(employee: AgentInstance, desired: DesiredEmployee) -> None:
+    if (
+        employee.agent_id != desired.employee_id
+        or employee.display_name != desired.display_name
+        or tuple(employee.role_ids) != desired.role_ids
+        or tuple(employee.skill_ids) != desired.skill_ids
+        or employee.memory_namespace != f"employee:{desired.employee_id}"
+    ):
+        raise RuntimeError("spec_steward_employee_contract_conflict")
+
+
+def ensure_spec_steward(
+    runtime: EmployeeRuntime,
+    *,
+    contract_path: str | Path = DEFAULT_CONTRACT_PATH,
+    role_registry_path: str | Path = DEFAULT_ROLE_REGISTRY_PATH,
+    skill_registry_path: str | Path = DEFAULT_SKILL_REGISTRY_PATH,
+) -> SpecStewardBootstrapResult:
+    """Idempotently materialize the declared Spec Steward Employee and bounded O3 assignment.
+
+    This writes only the supplied EmployeeRuntime. It does not bind an executor,
+    create Employee presence, choose transport, enable the Supervisor, dispatch ONE
+    work, or emit the O3 VERIFIED marker.
+    """
+    contract = load_spec_steward_contract(contract_path)
+    role_registry = RoleRegistry(role_registry_path)
+    skill_registry = EmployeeSkillRegistry(skill_registry_path)
+    _roles, role_capabilities = _validate_machine_contracts(
+        contract, role_registry, skill_registry
+    )
+
+    employee_created = False
+    try:
+        employee = runtime.get_employee(contract.employee.employee_id)
+        _assert_existing_employee_matches(employee, contract.employee)
+    except FileNotFoundError:
+        employee = runtime.create_employee(
+            contract.employee.employee_id,
+            contract.employee.display_name,
+            role_ids=list(contract.employee.role_ids),
+            skill_ids=list(contract.employee.skill_ids),
+        )
+        employee_created = True
+
+    skill_service = EmployeeSkillService(runtime, role_registry, skill_registry)
+    hydrated_skills = skill_service.hydrate_employee_skills(employee.agent_id)
+
+    store = WorkItemStore(runtime)
+    work_item_path = store.root / f"{contract.initial_work_item.work_item_id}.json"
+    work_item_created = not work_item_path.exists()
+    store.persist(contract.initial_work_item.as_dict())
+
+    assignment_path = runtime.assignments_dir / f"{contract.initial_work_item.assignment_id}.json"
+    assignment_created = not assignment_path.exists()
+    assignment = store.project_pending_assignment(contract.initial_work_item.work_item_id)
+
+    initial_thread_seeded = False
+    if not assignment.thread_head and assignment.state == "pending":
+        assignment = runtime.update_assignment(
+            assignment.assignment_id,
+            thread_head=contract.initial_thread_head,
+        )
+        initial_thread_seeded = True
+    # Never reset a progressed/terminal assignment or overwrite a checkpoint.
+
+    return SpecStewardBootstrapResult(
+        schema=BOOTSTRAP_RESULT_SCHEMA,
+        bootstrap_id=contract.bootstrap_id,
+        employee_id=employee.agent_id,
+        assignment_id=assignment.assignment_id,
+        work_item_id=contract.initial_work_item.work_item_id,
+        employee_created=employee_created,
+        work_item_created=work_item_created,
+        assignment_created=assignment_created,
+        initial_thread_seeded=initial_thread_seeded,
+        assignment_state=assignment.state,
+        thread_head=assignment.thread_head,
+        role_ids=tuple(employee.role_ids),
+        skill_ids=tuple(employee.skill_ids),
+        role_capabilities=role_capabilities,
+        hydrated_skill_ids=tuple(skill.skill_id for skill in hydrated_skills),
+    )
+
+
+def build_spec_steward_audit_request(
+    runtime: EmployeeRuntime,
+    *,
+    contract_path: str | Path = DEFAULT_CONTRACT_PATH,
+    role_registry_path: str | Path = DEFAULT_ROLE_REGISTRY_PATH,
+    skill_registry_path: str | Path = DEFAULT_SKILL_REGISTRY_PATH,
+) -> dict[str, Any]:
+    """Build a bounded skill intent only; downstream capability authority is still required."""
+    contract = load_spec_steward_contract(contract_path)
+    service = EmployeeSkillService(
+        runtime,
+        RoleRegistry(role_registry_path),
+        EmployeeSkillRegistry(skill_registry_path),
+    )
+    return service.build_request(
+        contract.employee.employee_id,
+        "spec.audit",
+        "audit",
+        {
+            "scope": "core-issue-197-o3",
+            "target_refs": ["core:issue-197", "core:employee-runtime"],
+        },
+    )

--- a/docs/SPEC_STEWARD_O3_ACCEPTANCE.md
+++ b/docs/SPEC_STEWARD_O3_ACCEPTANCE.md
@@ -1,0 +1,50 @@
+# Spec Steward O3 persistent Employee acceptance
+
+Issue: #197
+
+This slice source-controls the first durable `governance.spec_steward` Employee bootstrap and a read-only O3 evidence inspector.
+
+## What bootstrap does
+
+`ensure_spec_steward()` idempotently materializes:
+
+- Employee `agentos-spec-steward`
+- role `governance.spec_steward`
+- skill `spec.audit`
+- bounded WorkItem / assignment `spec-steward-o3-acceptance-v1`
+- initial Cognitive Thread head
+
+It does **not** bind an executor, create Employee presence, enable Supervisor delivery, dispatch through ONE, mutate Oracle service state, publish protected main, or emit the O3 VERIFIED marker.
+
+## What the inspector proves
+
+`inspect_spec_steward_acceptance()` is read-only. It cross-checks persisted evidence for:
+
+- exact Employee / WorkItem / assignment contract
+- active machine-hydrated role and skill
+- governed `one_direct` wake delivery under `core-supervisor-employee-wake-v1`
+- immutable Supervisor reconcile records covering initial lease generation and resumed lease generation
+- resumed lifecycle lease with prior execution state `unknown`
+- progressed thread head
+- privacy-safe live executor/session transition witness
+- role-authorized private `governance_evidence` continuity record
+- completed sanitized Employee receipt
+- carrier / authority evidence
+
+The inspector may report `ready_for_live_marker=true` when persisted evidence is complete, but it always reports `verified_marker_emitted=false`.
+
+## Live acceptance remains separate
+
+`SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED` requires a real fresh executor/session transition against a live governed ONE path. Static CI, synthetic fixtures, source-controlled role status, bootstrap success, or a merely reachable Node are not operating evidence.
+
+The live witness must not contain raw session identity or credentials. Presence generation is Node-location evidence only and is not treated as executor/session identity proof.
+
+## Governance invariants
+
+- Employee identity != executor/model/session/Node identity.
+- Active role declaration != operating Employee evidence.
+- Skill != capability authority.
+- Wake selection != execution authority.
+- GitHub Actions is not a control-plane fallback.
+- Verification must not mutate the state being verified.
+- Static CI cannot emit the O3 VERIFIED marker.

--- a/governance/spec-steward-employee.json
+++ b/governance/spec-steward-employee.json
@@ -1,0 +1,66 @@
+{
+  "schema": "agentos.employee-bootstrap/v1",
+  "bootstrap_id": "spec-steward-o3-v1",
+  "employee": {
+    "employee_id": "agentos-spec-steward",
+    "display_name": "AgentOS Spec Steward",
+    "role_ids": [
+      "governance.spec_steward"
+    ],
+    "skill_ids": [
+      "spec.audit"
+    ]
+  },
+  "initial_work_item": {
+    "schema": "agentos.core-work-item/v1",
+    "work_item_id": "spec-steward-o3-acceptance-v1",
+    "source_kind": "canonical_state",
+    "source_ref": "core:issue-197-o3",
+    "project_id": "agentos-core",
+    "employee_id": "agentos-spec-steward",
+    "assignment_id": "spec-steward-o3-acceptance-v1",
+    "goal": "Audit only the AgentOS Core #197 O3 persistent-Employee acceptance scope and emit closure-gap evidence needed to prove or block operating acceptance.",
+    "constraints": [
+      "scope-is-core-issue-197-o3-only",
+      "read-only-governance-audit",
+      "no-protected-main-publication",
+      "no-runtime-mutation-without-separate-authority",
+      "no-credential-or-session-identity-output",
+      "receipt-and-provenance-required"
+    ],
+    "dependency_refs": [],
+    "required_capabilities": [
+      "governance.spec.audit"
+    ],
+    "authority_requirements": [
+      "role-contract-must-cover-required-capability",
+      "skill-does-not-grant-capability-authority",
+      "runtime-mutation-requires-separate-authority"
+    ],
+    "source_revision": "spec-steward-o3-v1",
+    "state": "open"
+  },
+  "initial_thread_head": "o3:spec-steward-acceptance:start",
+  "acceptance_marker": "SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED",
+  "acceptance_requires": [
+    "active_role_hydrated",
+    "active_skill_hydrated",
+    "governed_one_wake_delivered",
+    "executor_claim_observed",
+    "checkpoint_thread_head_observed",
+    "fresh_executor_or_session_resume_observed",
+    "private_memory_continuity_observed",
+    "credential_and_session_identity_not_exposed",
+    "terminal_sanitized_employee_receipt_persisted",
+    "carrier_and_authority_evidence_persisted"
+  ],
+  "invariants": [
+    "bootstrap_is_idempotent",
+    "bootstrap_never_reopens_terminal_assignment",
+    "bootstrap_never_overwrites_progressed_thread_head",
+    "employee_identity_is_not_executor_node_model_or_session_identity",
+    "role_status_active_is_not_operating_evidence",
+    "static_ci_cannot_emit_verified_marker",
+    "github_actions_is_not_control_plane_fallback"
+  ]
+}

--- a/tests/test_spec_steward_acceptance.py
+++ b/tests/test_spec_steward_acceptance.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_memory import EmployeeMemoryPolicy, EmployeeMemoryService
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.role_runtime import RoleRegistry
+from agent_core.spec_steward_acceptance import (
+    DEFAULT_MEMORY_POLICY_PATH,
+    EXPECTED_AUTHORITY_POLICY,
+    LIVE_WITNESS_SCHEMA,
+    MEMORY_CLASS,
+    MEMORY_EVIDENCE_SCHEMA,
+    MEMORY_KEY,
+    inspect_spec_steward_acceptance,
+)
+from agent_core.spec_steward_bootstrap import (
+    DEFAULT_ROLE_REGISTRY_PATH,
+    ensure_spec_steward,
+)
+
+
+T0 = datetime(2026, 9, 2, 6, 40, 0, tzinfo=timezone.utc)
+EMPLOYEE_ID = "agentos-spec-steward"
+ASSIGNMENT_ID = "spec-steward-o3-acceptance-v1"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+class SpecStewardAcceptanceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name) / "runtime"
+        self.runtime = EmployeeRuntime(self.root)
+        ensure_spec_steward(self.runtime)
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _record_governed_wake(self, generation: int, suffix: str) -> None:
+        reconcile_id = f"reconcile_o3_{suffix}"
+        wake_id = f"wake_o3_{suffix}"
+        thread_head = self.runtime.get_assignment(ASSIGNMENT_ID).thread_head
+        _write_json(
+            self.root / "supervisor" / "intents" / f"{reconcile_id}.json",
+            {
+                "schema": INTENT_RECORD_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "state": "planned",
+                "planned_at": T0.isoformat(),
+                "planned_by_cycle": generation,
+                "intent": {
+                    "schema": RECONCILE_INTENT_SCHEMA,
+                    "reconcile_id": reconcile_id,
+                    "kind": "employee_wake",
+                    "employee_id": EMPLOYEE_ID,
+                    "assignment_id": ASSIGNMENT_ID,
+                    "reason": "assignment_pending" if generation == 1 else "assignment_resume_required",
+                    "wake_intent": {
+                        "schema": "agentos.employee-wake-intent/v1",
+                        "wake_id": wake_id,
+                        "employee_id": EMPLOYEE_ID,
+                        "assignment_id": ASSIGNMENT_ID,
+                        "mode": "start" if generation == 1 else "resume",
+                        "expected_lease_generation": generation,
+                        "goal": self.runtime.get_assignment(ASSIGNMENT_ID).goal,
+                        "thread_head": thread_head,
+                        "constraints": list(self.runtime.get_assignment(ASSIGNMENT_ID).constraints),
+                        "role_ids": ["governance.spec_steward"],
+                        "skill_ids": ["spec.audit"],
+                        "resume_required": generation > 1,
+                        "prior_execution_state": "known" if generation == 1 else "unknown",
+                        "authority_boundary": "selection_only_no_execution_authority",
+                        "executor_selection": "unbound",
+                        "transport_selection": "unbound",
+                        "credential_exposed": False,
+                    },
+                    "authority_boundary": "observe_and_select_only",
+                    "node_selection": "unbound",
+                    "executor_selection": "unbound",
+                    "transport_selection": "unbound",
+                    "capability_authority": "unbound",
+                    "credential_exposed": False,
+                },
+                "dispatch_performed": False,
+            },
+        )
+        _write_json(
+            self.root / "supervisor" / "deliveries" / f"{reconcile_id}.json",
+            {
+                "schema": DELIVERY_STATE_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "wake_id": wake_id,
+                "status": "claimed",
+                "created_at": T0.isoformat(),
+                "updated_at": T0.isoformat(),
+                "authority_policy_id": EXPECTED_AUTHORITY_POLICY,
+                "transport_policy_id": "transport-routing-v1",
+                "transport": "one_direct",
+                "transport_authority": "core_policy",
+                "capability": WAKE_CAPABILITY,
+                "supervisor_leader_generation": 1,
+                "dispatch_performed": True,
+                "presence_id": f"presence-{suffix}",
+                "presence_generation": generation,
+                "node_id": "node-o3",
+                "wake_attempt_id": f"attempt-{suffix}",
+                "task_id": f"task-{suffix}",
+                "error_code": None,
+            },
+        )
+
+    def _write_memory_evidence(self, thread_head: str) -> None:
+        service = EmployeeMemoryService(
+            self.runtime,
+            RoleRegistry(DEFAULT_ROLE_REGISTRY_PATH),
+            EmployeeMemoryPolicy(DEFAULT_MEMORY_POLICY_PATH),
+        )
+        service.write(
+            EMPLOYEE_ID,
+            MEMORY_CLASS,
+            MEMORY_KEY,
+            {
+                "schema": MEMORY_EVIDENCE_SCHEMA,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "thread_head": thread_head,
+                "observed_after_resume": True,
+                "session_identity_exposed": False,
+                "credential_exposed": False,
+            },
+        )
+
+    def _write_live_witness(self, *, extra: dict | None = None) -> None:
+        lease = self.lifecycle.get_lease(ASSIGNMENT_ID)
+        self.assertIsNotNone(lease)
+        payload = {
+            "schema": LIVE_WITNESS_SCHEMA,
+            "employee_id": EMPLOYEE_ID,
+            "assignment_id": ASSIGNMENT_ID,
+            "witness_kind": "fresh_executor_or_session_transition",
+            "from_lease_id": lease.resumed_from_lease_id,
+            "to_lease_id": lease.lease_id,
+            "from_generation": lease.generation - 1,
+            "to_generation": lease.generation,
+            "fresh_executor_or_session": True,
+            "process_boundary_observed": True,
+            "session_identity_exposed": False,
+            "credential_exposed": False,
+            "observed_at": (T0 + timedelta(seconds=70)).isoformat(),
+        }
+        payload.update(extra or {})
+        _write_json(self.root / "acceptance" / "spec-steward-o3-live-witness.json", payload)
+
+    def _build_complete_evidence(self) -> None:
+        self._record_governed_wake(1, "initial")
+        self.runtime.bind_executor(
+            EMPLOYEE_ID,
+            provider="test-executor",
+            model="model-a",
+            session_id="private-session-a",
+        )
+        self.lifecycle.claim(
+            ASSIGNMENT_ID,
+            EMPLOYEE_ID,
+            "lease-a",
+            lease_seconds=60,
+            now=T0,
+        )
+        self.lifecycle.checkpoint(
+            ASSIGNMENT_ID,
+            "lease-a",
+            "o3:checkpoint:first-executor",
+            now=T0 + timedelta(seconds=20),
+        )
+
+        self._record_governed_wake(2, "resume")
+        self.runtime.bind_executor(
+            EMPLOYEE_ID,
+            provider="test-executor",
+            model="model-b",
+            session_id="private-session-b",
+        )
+        resumed = self.lifecycle.claim(
+            ASSIGNMENT_ID,
+            EMPLOYEE_ID,
+            "lease-b",
+            lease_seconds=60,
+            now=T0 + timedelta(seconds=61),
+        )
+        self.assertTrue(resumed.resume_required)
+        self.lifecycle.checkpoint(
+            ASSIGNMENT_ID,
+            "lease-b",
+            "o3:checkpoint:resumed-executor",
+            now=T0 + timedelta(seconds=65),
+        )
+        final_head = self.runtime.get_assignment(ASSIGNMENT_ID).thread_head
+        self._write_memory_evidence(final_head)
+        self._write_live_witness()
+        self.lifecycle.finish(
+            ASSIGNMENT_ID,
+            "lease-b",
+            result_summary={
+                "closure_gap_count": 0,
+                "acceptance_scope": "core-issue-197-o3",
+            },
+            now=T0 + timedelta(seconds=75),
+        )
+
+    def test_bootstrap_only_is_blocked_and_inspector_is_read_only(self):
+        before = {
+            str(path.relative_to(self.root)): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        report = inspect_spec_steward_acceptance(self.runtime)
+        after = {
+            str(path.relative_to(self.root)): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+        self.assertFalse(report.ready_for_live_marker)
+        self.assertFalse(report.verified_marker_emitted)
+        self.assertFalse(report.checks["governed_one_wake_delivery"])
+        self.assertFalse(report.checks["resumed_assignment_lease"])
+        self.assertFalse(report.checks["fresh_executor_or_session_live_witness"])
+        self.assertIn("terminal_sanitized_employee_receipt", report.blocking_reasons)
+        self.assertEqual(report.qualifying_wake_generations, ())
+
+    def test_complete_persisted_evidence_is_ready_but_never_emits_verified_marker(self):
+        self._build_complete_evidence()
+        report = inspect_spec_steward_acceptance(self.runtime)
+        self.assertTrue(report.ready_for_live_marker)
+        self.assertFalse(report.verified_marker_emitted)
+        self.assertTrue(all(report.checks.values()))
+        self.assertEqual(report.qualifying_delivery_count, 2)
+        self.assertEqual(report.qualifying_wake_generations, (1, 2))
+        self.assertEqual(report.observed_lease_generation, 2)
+        self.assertEqual(report.terminal_receipt_generation, 2)
+        serialized = json.dumps(report.as_dict(), ensure_ascii=False)
+        self.assertNotIn("private-session-a", serialized)
+        self.assertNotIn("private-session-b", serialized)
+
+    def test_resume_without_initial_governed_wake_is_not_ready(self):
+        self._build_complete_evidence()
+        (self.root / "supervisor" / "deliveries" / "reconcile_o3_initial.json").unlink()
+        report = inspect_spec_steward_acceptance(self.runtime)
+        self.assertFalse(report.ready_for_live_marker)
+        self.assertFalse(report.checks["initial_and_resume_wakes_governed"])
+        self.assertEqual(report.qualifying_wake_generations, (2,))
+
+    def test_live_witness_rejects_raw_session_identity_field(self):
+        self._build_complete_evidence()
+        self._write_live_witness(extra={"session_id": "must-not-persist"})
+        report = inspect_spec_steward_acceptance(self.runtime)
+        self.assertFalse(report.ready_for_live_marker)
+        self.assertFalse(report.checks["fresh_executor_or_session_live_witness"])
+        serialized = json.dumps(report.as_dict(), ensure_ascii=False)
+        self.assertNotIn("must-not-persist", serialized)
+
+    def test_terminal_receipt_with_secret_shaped_summary_is_rejected(self):
+        self._build_complete_evidence()
+        receipt_path = self.root / "lifecycle" / "receipts" / ASSIGNMENT_ID / "000002.json"
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        receipt["result_summary"]["token"] = "ghp_should-never-be-evidence"
+        _write_json(receipt_path, receipt)
+        report = inspect_spec_steward_acceptance(self.runtime)
+        self.assertFalse(report.ready_for_live_marker)
+        self.assertFalse(report.checks["terminal_sanitized_employee_receipt"])
+        self.assertFalse(report.checks["credential_and_session_identity_not_exposed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_steward_bootstrap.py
+++ b/tests/test_spec_steward_bootstrap.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.spec_steward_bootstrap import (
+    DEFAULT_CONTRACT_PATH,
+    build_spec_steward_audit_request,
+    ensure_spec_steward,
+    load_spec_steward_contract,
+)
+
+
+class SpecStewardBootstrapTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runtime = EmployeeRuntime(self.root / "employee-runtime")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_contract_is_bounded_to_issue_197_o3(self):
+        contract = load_spec_steward_contract()
+        self.assertEqual(contract.employee.employee_id, "agentos-spec-steward")
+        self.assertEqual(contract.employee.role_ids, ("governance.spec_steward",))
+        self.assertEqual(contract.employee.skill_ids, ("spec.audit",))
+        self.assertEqual(contract.initial_work_item.project_id, "agentos-core")
+        self.assertEqual(contract.initial_work_item.source_ref, "core:issue-197-o3")
+        self.assertEqual(contract.initial_work_item.required_capabilities, ("governance.spec.audit",))
+        self.assertIn("read-only-governance-audit", contract.initial_work_item.constraints)
+        self.assertIn("static_ci_cannot_emit_verified_marker", contract.invariants)
+
+    def test_first_ensure_materializes_exact_employee_work_item_assignment_and_thread(self):
+        result = ensure_spec_steward(self.runtime)
+        self.assertTrue(result.employee_created)
+        self.assertTrue(result.work_item_created)
+        self.assertTrue(result.assignment_created)
+        self.assertTrue(result.initial_thread_seeded)
+        self.assertFalse(result.verified_marker_emitted)
+        self.assertEqual(result.execution_authority, "not_granted_by_bootstrap")
+        self.assertEqual(result.transport_selection, "unbound")
+        self.assertEqual(result.executor_selection, "unbound")
+        self.assertFalse(result.credential_exposed)
+        self.assertEqual(result.hydrated_skill_ids, ("spec.audit",))
+        self.assertIn("governance.spec.audit", result.role_capabilities)
+
+        employee = self.runtime.get_employee("agentos-spec-steward")
+        self.assertEqual(employee.role_ids, ["governance.spec_steward"])
+        self.assertEqual(employee.skill_ids, ["spec.audit"])
+        self.assertEqual(employee.memory_namespace, "employee:agentos-spec-steward")
+        self.assertEqual(employee.executor.provider, "unbound")
+        self.assertEqual(employee.executor.session_id, "")
+
+        assignment = self.runtime.get_assignment("spec-steward-o3-acceptance-v1")
+        self.assertEqual(assignment.state, "pending")
+        self.assertEqual(assignment.thread_head, "o3:spec-steward-acceptance:start")
+        self.assertIn("scope-is-core-issue-197-o3-only", assignment.constraints)
+        self.assertFalse((self.runtime.root / "realm" / "employee-presence").exists())
+        self.assertFalse((self.runtime.root / "supervisor" / "deliveries").exists())
+
+    def test_second_ensure_is_idempotent_and_does_not_reset_runtime_state(self):
+        first = ensure_spec_steward(self.runtime)
+        employee_before = self.runtime.get_employee(first.employee_id)
+        assignment_before = self.runtime.get_assignment(first.assignment_id)
+
+        second = ensure_spec_steward(self.runtime)
+        self.assertFalse(second.employee_created)
+        self.assertFalse(second.work_item_created)
+        self.assertFalse(second.assignment_created)
+        self.assertFalse(second.initial_thread_seeded)
+        employee_after = self.runtime.get_employee(first.employee_id)
+        assignment_after = self.runtime.get_assignment(first.assignment_id)
+        self.assertEqual(employee_after.created_at, employee_before.created_at)
+        self.assertEqual(assignment_after.created_at, assignment_before.created_at)
+        self.assertEqual(assignment_after.thread_head, assignment_before.thread_head)
+
+    def test_ensure_preserves_progressed_thread_and_terminal_assignment(self):
+        result = ensure_spec_steward(self.runtime)
+        self.runtime.update_assignment(
+            result.assignment_id,
+            state="completed",
+            thread_head="o3:checkpoint:terminal",
+            result={"schema": "test-terminal-evidence", "ok": True},
+        )
+        again = ensure_spec_steward(self.runtime)
+        self.assertEqual(again.assignment_state, "completed")
+        self.assertEqual(again.thread_head, "o3:checkpoint:terminal")
+        self.assertFalse(again.initial_thread_seeded)
+        assignment = self.runtime.get_assignment(result.assignment_id)
+        self.assertEqual(assignment.state, "completed")
+        self.assertEqual(assignment.thread_head, "o3:checkpoint:terminal")
+        self.assertEqual(assignment.result["schema"], "test-terminal-evidence")
+
+    def test_existing_employee_identity_contract_drift_fails_closed(self):
+        self.runtime.create_employee(
+            "agentos-spec-steward",
+            "Wrong Name",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        with self.assertRaisesRegex(RuntimeError, "spec_steward_employee_contract_conflict"):
+            ensure_spec_steward(self.runtime)
+        self.assertFalse((self.runtime.root / "supervisor" / "work-items").exists())
+
+    def test_audit_request_is_intent_only_and_requires_downstream_authority(self):
+        ensure_spec_steward(self.runtime)
+        request = build_spec_steward_audit_request(self.runtime)
+        self.assertEqual(request["skill"]["skill_id"], "spec.audit")
+        self.assertEqual(request["intent"], "audit")
+        self.assertEqual(request["args"]["scope"], "core-issue-197-o3")
+        self.assertEqual(request["capability_authorization"], "required_downstream")
+        self.assertEqual(request["execution_authority"], "external_governed_dispatcher")
+        self.assertEqual(request["executor_selection"], "unbound")
+        self.assertEqual(request["transport_selection"], "unbound")
+        self.assertFalse(request["credential_exposed"])
+        encoded = json.dumps(request, sort_keys=True).casefold()
+        for forbidden in ("shell.exec", "workflow_dispatch", "github_actions", "bearer ", "token="):
+            self.assertNotIn(forbidden, encoded)
+
+    def test_unknown_bootstrap_field_is_rejected(self):
+        raw = json.loads(DEFAULT_CONTRACT_PATH.read_text(encoding="utf-8"))
+        raw["executor"] = {"provider": "anything"}
+        path = self.root / "bad-bootstrap.json"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unexpected_spec_steward_bootstrap_fields"):
+            load_spec_steward_contract(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Source-control the first durable `governance.spec_steward` Employee desired state and a read-only O3 acceptance inspector.

## Included
- declarative Spec Steward Employee + bounded #197 O3 WorkItem
- idempotent bootstrap that hydrates active role/skill contracts without granting executor/transport/runtime authority
- read-only acceptance inspector that cross-checks Supervisor delivery + immutable reconcile intent generations, lifecycle resume, thread continuity, private governance-evidence memory, privacy-safe live transition witness, and sanitized terminal Employee receipt
- regression coverage for bootstrap idempotency, static-CI non-verification, missing initial governed wake, raw session-field rejection, and secret-shaped receipt rejection
- O3 acceptance documentation

## Explicit non-claims
- does not deploy or enable Oracle runtime services
- does not create live Employee presence
- does not perform the real fresh executor/session transition
- does not use GitHub Actions as control-plane carrier
- does not emit `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`
- no protected-main publication authority is implied

Closes no issue by itself; #197 remains open until real live O3 evidence is obtained.