### PR TITLE
Core #185: Claude Code extension ONE continuity bootstrap

### DIFF
--- a/.github/workflows/claude-one-extension-guard.yml
+++ b/.github/workflows/claude-one-extension-guard.yml
@@ -1,0 +1,39 @@
+name: Claude Extension ONE Guard
+
+on:
+  push:
+    branches:
+      - core/issue-185-claude-extension-one
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agentos_node/claude_one_mcp_stdio.py'
+      - 'scripts/install_claude_one_oracle.py'
+      - 'tests/test_claude_one_mcp_stdio.py'
+      - 'tests/test_install_claude_one_oracle.py'
+      - '.github/workflows/claude-one-extension-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Compile Claude ONE slice
+        run: |
+          python -m py_compile \
+            agentos_node/claude_one_mcp_stdio.py \
+            scripts/install_claude_one_oracle.py \
+            tests/test_claude_one_mcp_stdio.py \
+            tests/test_install_claude_one_oracle.py
+      - name: Run Claude ONE contract tests
+        run: |
+          python -m unittest -v \
+            tests.test_claude_one_mcp_stdio \
+            tests.test_install_claude_one_oracle

--- a/.github/workflows/claude-one-extension-guard.yml
+++ b/.github/workflows/claude-one-extension-guard.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'agentos_node/claude_one_mcp_stdio.py'
       - 'scripts/install_claude_one_oracle.py'
+      - 'scripts/advance_issue_185_to_claude_extension.py'
+      - 'scripts/prepare_issue_185_claude_extension_oracle.sh'
+      - 'scripts/inspect_issue_185_claude_extension.sh'
       - 'tests/test_claude_one_mcp_stdio.py'
       - 'tests/test_install_claude_one_oracle.py'
       - '.github/workflows/claude-one-extension-guard.yml'
@@ -30,8 +33,13 @@ jobs:
           python -m py_compile \
             agentos_node/claude_one_mcp_stdio.py \
             scripts/install_claude_one_oracle.py \
+            scripts/advance_issue_185_to_claude_extension.py \
             tests/test_claude_one_mcp_stdio.py \
             tests/test_install_claude_one_oracle.py
+      - name: Validate shell helpers
+        run: |
+          bash -n scripts/prepare_issue_185_claude_extension_oracle.sh
+          bash -n scripts/inspect_issue_185_claude_extension.sh
       - name: Run Claude ONE contract tests
         run: |
           python -m unittest -v \

--- a/.github/workflows/claude-one-live-inspect-185.yml
+++ b/.github/workflows/claude-one-live-inspect-185.yml
@@ -1,0 +1,24 @@
+name: Claude Extension ONE Live Inspect #185
+
+on:
+  push:
+    branches:
+      - core/issue-185-claude-extension-one
+    paths:
+      - '.agentos/acceptance/issue-185-claude-inspect-request.json'
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inspect independent Claude extension ONE receipt
+        env:
+          AGENT_DATA_ROOT: /home/ubuntu/agent-data
+        run: |
+          set -euo pipefail
+          bash scripts/inspect_issue_185_claude_extension.sh

--- a/agentos_node/claude_one_mcp_stdio.py
+++ b/agentos_node/claude_one_mcp_stdio.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.active_continuation import resolve_active_continuation
+from agentos_node.one_mcp import OracleLocalGateway
+
+SURFACE = "anthropic-claude-code-extension"
+EXECUTOR_ADAPTER = "claude-code-extension-adapter"
+EXECUTOR_CLASS = "anthropic-claude-code-local"
+RECEIPT_SCHEMA = "agentos.claude-extension-one-active-resolve-receipt/v1"
+_SAFE_IDENTITY = re.compile(r"^[A-Za-z0-9._:/+-]{1,128}$")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _runtime_source_commit() -> str | None:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    candidate = Path(__file__).resolve().parents[1].name
+    return candidate if len(candidate) >= 12 else None
+
+
+def _bounded_identity(name: str) -> str | None:
+    value = str(os.environ.get(name) or "").strip()
+    if not value:
+        return None
+    if not _SAFE_IDENTITY.fullmatch(value):
+        raise ValueError(f"unsafe {name} value")
+    return value
+
+
+def _backend_identity() -> dict[str, Any]:
+    backend_class = _bounded_identity("AGENTOS_CLAUDE_BACKEND_CLASS")
+    backend_id = _bounded_identity("AGENTOS_CLAUDE_BACKEND_ID")
+    bound = bool(backend_id)
+    return {
+        "backend_class": backend_class or "unknown",
+        "backend_identity": backend_id or "unknown",
+        "backend_identity_bound": bound,
+        "backend_identity_source": "trusted-local-config" if bound else None,
+    }
+
+
+def _receipt_path(data_root: Path) -> Path:
+    explicit = str(os.environ.get("AGENTOS_CLAUDE_ONE_RECEIPT_PATH") or "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return data_root / "runtime" / "claude-extension-one-active-resolve-last.json"
+
+
+def _write_resolve_receipt(data_root: Path, selector: dict[str, Any]) -> None:
+    path = _receipt_path(data_root)
+    if path.is_symlink():
+        raise ValueError("Claude extension ONE receipt path may not be a symlink")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "schema": RECEIPT_SCHEMA,
+        "recorded_at": _now(),
+        "runtime_source_commit": _runtime_source_commit(),
+        "surface": SURFACE,
+        "executor_adapter": EXECUTOR_ADAPTER,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "executor_identity_source": "claude-user-mcp-config",
+        **_backend_identity(),
+        "source": "ONE_ACTIVE_CONTINUATION",
+        "selection_source": "ONE_ACTIVE_CONTINUATION",
+        "project_id": selector.get("project_id"),
+        "index_id": selector.get("index_id"),
+        "ir_id": selector.get("ir_id"),
+        "credential_exposed": False,
+    }
+    fd, raw = tempfile.mkstemp(prefix=".claude-one-resolve-", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(raw)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o640)
+            json.dump(record, handle, ensure_ascii=False, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        tmp = None
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
+
+
+def _project_claude_client(value: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(value)
+    result["surface"] = SURFACE
+    result["executor_adapter"] = EXECUTOR_ADAPTER
+    result["executor_class"] = EXECUTOR_CLASS
+    result["executor_identity_bound"] = True
+    result["executor_identity_source"] = "claude-user-mcp-config"
+    result.update(_backend_identity())
+    result["credential_exposed"] = False
+    return result
+
+
+def _active_projection(one: OracleLocalGateway, *, write_receipt: bool = False) -> dict[str, Any]:
+    active = resolve_active_continuation(data_root=one.data_root)
+    selector = active["selector"]
+    resolution = active["resolution"]
+    if write_receipt:
+        _write_resolve_receipt(Path(one.data_root), selector)
+    return _project_claude_client(
+        {
+            "schema": "agentos.one-active-resolve/v1",
+            "source": "ONE_ACTIVE_CONTINUATION",
+            "selection_source": "ONE_ACTIVE_CONTINUATION",
+            "selector": {
+                "project_id": selector.get("project_id"),
+                "index_id": selector.get("index_id"),
+                "ir_id": selector.get("ir_id"),
+            },
+            "resolution": resolution,
+            "credential_exposed": False,
+        }
+    )
+
+
+def create_server(gateway: OracleLocalGateway | None = None):
+    from mcp.server.mcpserver import MCPServer
+
+    one = gateway or OracleLocalGateway()
+    server = MCPServer("AgentOS ONE for Claude Code", version="0.1.0")
+
+    @server.tool()
+    def one_status() -> dict[str, Any]:
+        """Verify the Claude Code extension adapter can reach the trusted local ONE projection."""
+        return _project_claude_client(one.status())
+
+    @server.tool()
+    def one_capabilities() -> dict[str, Any]:
+        """Return bounded ONE capabilities available to the Claude Code extension adapter."""
+        return _project_claude_client(one.capabilities())
+
+    @server.tool()
+    def one_resolve_active() -> dict[str, Any]:
+        """Resolve the ONE-selected active Canonical IR; never infer continuation from IDE workspace state."""
+        return _active_projection(one, write_receipt=True)
+
+    @server.tool()
+    def one_resolve(project: str) -> dict[str, Any]:
+        """Explicitly resolve a named canonical project through ONE."""
+        return _project_claude_client(one.resolve(project))
+
+    return server
+
+
+def main() -> int:
+    create_server().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/advance_issue_185_to_claude_extension.py
+++ b/scripts/advance_issue_185_to_claude_extension.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent_core.active_continuation import activate_continuation, resolve_active_continuation
+from agent_core.canonical_ir_handoff import advance_canonical_ir
+
+PROJECT_ID = "agentos-core"
+NEW_INDEX = "idx-core-185-claude-ext-1"
+NEW_IR = "ir-core-185-claude-ext-1"
+GOAL = (
+    "Prove Anthropic Claude Code IDE extension -> AgentOS ONE continuity with a local/unknown backend identity kept "
+    "separate from the Anthropic extension surface, using completely fresh extension threads and no copied vendor history."
+)
+NEXT_ACTION = (
+    "Install/reload the Claude Code ONE bootstrap, then open a completely fresh Claude Code extension thread and send only "
+    "'繼續'; Claude must call agentos-one.one_resolve_active before workspace reconstruction, report "
+    "source=ONE_ACTIVE_CONTINUATION with project=agentos-core, index_id=idx-core-185-claude-ext-1, "
+    "ir_id=ir-core-185-claude-ext-1, preserve backend identity uncertainty, and continue this #185 goal."
+)
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))
+
+
+def _required(name: str) -> str:
+    value = str(os.environ.get(name) or "").strip()
+    if not value:
+        raise ValueError(f"{name} is required for exact-parent handoff")
+    return value
+
+
+def _activate(root: Path) -> dict:
+    return activate_continuation(
+        PROJECT_ID,
+        index_id=NEW_INDEX,
+        ir_id=NEW_IR,
+        reason="#185 Claude Code extension continuity acceptance target",
+        data_root=root,
+    )
+
+
+def main() -> int:
+    root = _data_root()
+    expected_index = _required("AGENTOS_EXPECTED_PARENT_INDEX")
+    expected_ir = _required("AGENTOS_EXPECTED_PARENT_IR")
+    active = resolve_active_continuation(data_root=root)
+    selector = active.get("selector") if isinstance(active.get("selector"), dict) else {}
+    current_project = str(selector.get("project_id") or "").strip()
+    current_index = str(selector.get("index_id") or "").strip()
+    current_ir = str(selector.get("ir_id") or "").strip()
+
+    if current_project != PROJECT_ID:
+        print(json.dumps({
+            "schema": "agentos.issue-185-claude-extension-handoff/v1",
+            "ok": False,
+            "advanced": False,
+            "reason": "active project is not agentos-core; refusing cross-project overwrite",
+            "found": {"project_id": current_project or None, "index_id": current_index or None, "ir_id": current_ir or None},
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 3
+
+    if current_index == NEW_INDEX and current_ir == NEW_IR:
+        activation = _activate(root)
+        print(json.dumps({
+            "schema": "agentos.issue-185-claude-extension-handoff/v1",
+            "ok": True,
+            "advanced": False,
+            "reason": "already advanced; active selector reconciled",
+            "project_id": PROJECT_ID,
+            "index_id": NEW_INDEX,
+            "ir_id": NEW_IR,
+            "active_selector": activation,
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    if current_index != expected_index or current_ir != expected_ir:
+        print(json.dumps({
+            "schema": "agentos.issue-185-claude-extension-handoff/v1",
+            "ok": False,
+            "advanced": False,
+            "reason": "unexpected canonical parent; refusing to overwrite",
+            "expected": {"index_id": expected_index, "ir_id": expected_ir},
+            "found": {"index_id": current_index or None, "ir_id": current_ir or None},
+            "credential_exposed": False,
+        }, ensure_ascii=False, indent=2, sort_keys=True))
+        return 3
+
+    receipt = advance_canonical_ir(
+        {
+            "project_id": PROJECT_ID,
+            "expected_index_id": expected_index,
+            "expected_ir_id": expected_ir,
+            "new_index_id": NEW_INDEX,
+            "new_ir_id": NEW_IR,
+            "goal": GOAL,
+            "next_action": NEXT_ACTION,
+            "pending_tasks": [
+                "Install the Claude Code user-scope AgentOS ONE MCP and managed user CLAUDE.md bootstrap without copying Canonical IR or Realm credentials.",
+                "Reload/open a completely fresh Claude Code IDE extension thread and send only '繼續'.",
+                "Require ONE_ACTIVE_CONTINUATION resolution of idx-core-185-claude-ext-1 / ir-core-185-claude-ext-1 before workspace/local-history reconstruction.",
+                "Inspect the independent Node-local Claude ONE receipt and require credential_exposed=false plus explicit surface/executor/backend identity separation.",
+                "Repeat a second completely fresh Claude Code extension thread with a newer receipt before marking #185 continuity VERIFIED.",
+                "After continuity is verified, hand the Claude-extension/local-backend surface to #117 for separate Experience A/B regression.",
+            ],
+            "decisions_append": [
+                "Claude Code extension continuity reuses ONE active selector + Canonical IR; it does not create a Claude-specific state protocol.",
+                "Claude Code uses its native user CLAUDE.md plus user-scope stdio MCP bootstrap; Gemini PreInvocation and Codex AGENTS semantics are not assumed.",
+                "Anthropic extension surface identity must not imply backend/model=Claude. Backend identity is recorded only from explicit trusted-local configuration; otherwise it remains unbound/unknown.",
+                "Realm/node credentials remain inside the trusted Node-local ONE runtime and are not copied into Claude settings or receipts.",
+            ],
+            "evidence": [
+                {
+                    "kind": "claude-extension-bootstrap-contract",
+                    "verdict": "STATIC_CANDIDATE",
+                    "summary": "#185 branch defines user CLAUDE.md + user-scope stdio MCP bootstrap, identity separation, sanitized receipt, and hosted contract tests; live fresh-session proof remains pending.",
+                    "date": "2026-09-02",
+                }
+            ],
+            "execution_status": "in_progress",
+            "execution_metadata": {"issue": "#185", "phase": "claude-extension-one-continuity"},
+        },
+        data_root=root,
+    )
+    activation = _activate(root)
+    print(json.dumps({
+        "schema": "agentos.issue-185-claude-extension-handoff/v1",
+        "ok": True,
+        "advanced": True,
+        "project_id": PROJECT_ID,
+        "parent": {"index_id": expected_index, "ir_id": expected_ir},
+        "child": {"index_id": NEW_INDEX, "ir_id": NEW_IR},
+        "active_selector": activation,
+        "credential_exposed": False,
+        "handoff_receipt": receipt,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inspect_issue_185_claude_extension.sh
+++ b/scripts/inspect_issue_185_claude_extension.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RECEIPT_PATH="${AGENTOS_CLAUDE_ONE_RECEIPT_PATH:-/home/ubuntu/agent-data/runtime/claude-extension-one-active-resolve-last.json}"
+EXPECTED_PROJECT="agentos-core"
+EXPECTED_INDEX="idx-core-185-claude-ext-1"
+EXPECTED_IR="ir-core-185-claude-ext-1"
+
+printf 'agentos_claude_e185_receipt_path=%s\n' "$RECEIPT_PATH"
+
+python3 - "$RECEIPT_PATH" "$EXPECTED_PROJECT" "$EXPECTED_INDEX" "$EXPECTED_IR" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+expected_project, expected_index, expected_ir = sys.argv[2:5]
+
+if not path.is_file():
+    print(json.dumps({
+        "schema": "agentos.issue-185-claude-extension-inspection/v1",
+        "ok": False,
+        "verdict": "CLAUDE_ONE_RESOLVE_RECEIPT_MISSING",
+        "credential_exposed": False,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    raise SystemExit(4)
+
+record = json.loads(path.read_text(encoding="utf-8"))
+checks = {
+    "schema_ok": record.get("schema") == "agentos.claude-extension-one-active-resolve-receipt/v1",
+    "surface_ok": record.get("surface") == "anthropic-claude-code-extension",
+    "executor_ok": record.get("executor_adapter") == "claude-code-extension-adapter" and record.get("executor_identity_bound") is True,
+    "source_ok": record.get("source") == "ONE_ACTIVE_CONTINUATION" and record.get("selection_source") == "ONE_ACTIVE_CONTINUATION",
+    "generation_ok": record.get("project_id") == expected_project and record.get("index_id") == expected_index and record.get("ir_id") == expected_ir,
+    "credential_ok": record.get("credential_exposed") is False,
+    "backend_boundary_ok": (
+        (record.get("backend_identity_bound") is False and record.get("backend_identity") == "unknown")
+        or (record.get("backend_identity_bound") is True and record.get("backend_identity_source") == "trusted-local-config")
+    ),
+}
+ok = all(checks.values())
+out = {
+    "schema": "agentos.issue-185-claude-extension-inspection/v1",
+    "ok": ok,
+    "verdict": "CLAUDE_ONE_ACTIVE_RESOLVE_OBSERVED" if ok else "CLAUDE_ONE_ACTIVE_RESOLVE_MISMATCH",
+    "checks": checks,
+    "recorded_at": record.get("recorded_at"),
+    "runtime_source_commit": record.get("runtime_source_commit"),
+    "surface": record.get("surface"),
+    "executor_adapter": record.get("executor_adapter"),
+    "executor_class": record.get("executor_class"),
+    "executor_identity_bound": record.get("executor_identity_bound"),
+    "backend_class": record.get("backend_class"),
+    "backend_identity": record.get("backend_identity"),
+    "backend_identity_bound": record.get("backend_identity_bound"),
+    "backend_identity_source": record.get("backend_identity_source"),
+    "source": record.get("source"),
+    "selection_source": record.get("selection_source"),
+    "project_id": record.get("project_id"),
+    "index_id": record.get("index_id"),
+    "ir_id": record.get("ir_id"),
+    "credential_exposed": record.get("credential_exposed"),
+}
+print(json.dumps(out, ensure_ascii=False, indent=2, sort_keys=True))
+raise SystemExit(0 if ok else 5)
+PY

--- a/scripts/install_claude_one_oracle.py
+++ b/scripts/install_claude_one_oracle.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+BOOTSTRAP_START = "<!-- AGENTOS_ONE_CLAUDE_BOOTSTRAP_START -->"
+BOOTSTRAP_END = "<!-- AGENTOS_ONE_CLAUDE_BOOTSTRAP_END -->"
+SERVER_NAME = "agentos-one"
+
+BOOTSTRAP_BLOCK = f"""{BOOTSTRAP_START}
+## AgentOS ONE bootstrap for Claude Code
+
+This Claude Code extension surface participates in AgentOS ONE through the `{SERVER_NAME}` MCP server.
+
+For a completely fresh thread, when the user's instruction is relative continuation such as `continue` or `繼續` and there is no newer explicit task, resolve current work from ONE before inspecting workspace-local TODOs, status files, open editors, local conversation history, or git state.
+
+Required startup action:
+1. call `{SERVER_NAME}.one_resolve_active`;
+2. treat `selector.project_id + selector.index_id + selector.ir_id` and the returned Canonical IR as the authoritative continuation generation;
+3. continue from that IR's goal, constraints, decisions, pending tasks, continuation, and next action;
+4. report provenance `source=ONE_ACTIVE_CONTINUATION` plus project/index/IR identifiers when beginning a relative continuation;
+5. newer explicit user intent always wins over hydrated state.
+
+Do not infer backend/model identity from the Claude Code extension surface. Surface identity, executor adapter identity, backend/model identity, and session identity are separate dimensions. If the trusted ONE projection reports backend identity as unbound/unknown, preserve that uncertainty.
+
+Do not infer the current project from the IDE workspace. Do not reconstruct continuation from local memory, git diff, STATUS files, or previous Claude/Codex/Gemini conversation history when ONE is available.
+
+If `one_resolve_active` is unavailable, missing, stale, or fails, report `ONE_ACTIVE_CONTINUATION_UNRESOLVED` and do not fabricate continuation.
+
+Never request, print, copy, or expose Realm/node credentials. The MCP process exposes only the trusted local read-only ONE projection.
+{BOOTSTRAP_END}
+"""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")).expanduser()
+
+
+def _claude_home() -> Path:
+    return Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))).expanduser()
+
+
+def _venv_python() -> Path:
+    candidate = Path.home() / ".local" / "share" / "agentos" / "one-mcp" / "venv" / "bin" / "python"
+    if not candidate.is_file():
+        raise FileNotFoundError(
+            "shared AgentOS ONE MCP venv is missing; install the existing ONE MCP runtime before Claude bootstrap"
+        )
+    return candidate
+
+
+def _discover_claude() -> Path:
+    explicit = str(os.environ.get("AGENTOS_CLAUDE_EXECUTABLE") or "").strip()
+    if explicit:
+        candidate = Path(explicit).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+        raise FileNotFoundError(f"configured Claude executable is not executable: {candidate}")
+
+    patterns = [
+        str(Path.home() / ".antigravity-ide-server/extensions/anthropic.claude-code-*-linux-arm64/resources/native-binary/claude"),
+        str(Path.home() / ".antigravity-ide-server/extensions/anthropic.claude-code-*/resources/native-binary/claude"),
+    ]
+    matches: list[str] = []
+    for pattern in patterns:
+        matches.extend(glob.glob(pattern))
+    for item in sorted(set(matches), reverse=True):
+        candidate = Path(item)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    from_path = shutil.which("claude")
+    if from_path:
+        return Path(from_path)
+    raise FileNotFoundError("Anthropic Claude Code executable not found")
+
+
+def _backup(path: Path) -> None:
+    if not path.exists():
+        return
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    shutil.copy2(path, path.with_name(path.name + f".agentos-backup-{stamp}"))
+
+
+def _replace_block(existing: str, start: str, end: str, block: str) -> str:
+    if start in existing or end in existing:
+        if start not in existing or end not in existing:
+            raise ValueError(f"partial managed block found: {start}")
+        before, rest = existing.split(start, 1)
+        _, after = rest.split(end, 1)
+        return before.rstrip() + "\n\n" + block.strip() + "\n" + after.lstrip()
+    prefix = existing.rstrip()
+    return (prefix + "\n\n" if prefix else "") + block.strip() + "\n"
+
+
+def write_bootstrap(path: Path) -> Path:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    updated = _replace_block(existing, BOOTSTRAP_START, BOOTSTRAP_END, BOOTSTRAP_BLOCK)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _backup(path)
+    tmp = path.with_suffix(path.suffix + ".agentos.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def _mcp_payload(*, python: Path, repo_root: Path) -> dict[str, object]:
+    env: dict[str, str] = {
+        "PYTHONPATH": str(repo_root),
+        "AGENT_DATA_ROOT": str(_data_root()),
+        "AGENTOS_ONE_MCP_MODE": "oracle-local",
+        "AGENTOS_CORE_NODE_ID": str(os.environ.get("AGENTOS_CORE_NODE_ID", "oracle-core-node")),
+    }
+    backend_class = str(os.environ.get("AGENTOS_CLAUDE_BACKEND_CLASS") or "").strip()
+    backend_id = str(os.environ.get("AGENTOS_CLAUDE_BACKEND_ID") or "").strip()
+    if backend_class:
+        env["AGENTOS_CLAUDE_BACKEND_CLASS"] = backend_class
+    if backend_id:
+        env["AGENTOS_CLAUDE_BACKEND_ID"] = backend_id
+    return {
+        "type": "stdio",
+        "command": str(python),
+        "args": ["-m", "agentos_node.claude_one_mcp_stdio"],
+        "env": env,
+    }
+
+
+def _run(args: list[str], *, timeout: float = 20.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, timeout=timeout, check=False)
+
+
+def install_user_mcp(claude: Path, *, python: Path, repo_root: Path) -> dict[str, object]:
+    marker_root = Path.home() / ".local" / "share" / "agentos" / "claude-one"
+    marker_root.mkdir(parents=True, exist_ok=True)
+    marker_path = marker_root / "managed-mcp.json"
+    payload = _mcp_payload(python=python, repo_root=repo_root)
+    expected = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    probe = _run([str(claude), "mcp", "get", SERVER_NAME])
+    exists = probe.returncode == 0
+    owned = False
+    if marker_path.is_file():
+        try:
+            marker = json.loads(marker_path.read_text(encoding="utf-8"))
+            owned = marker.get("server") == SERVER_NAME and marker.get("payload") == payload
+        except (OSError, json.JSONDecodeError):
+            owned = False
+
+    if exists and not owned:
+        raise ValueError(f"unmanaged Claude MCP server {SERVER_NAME!r} already exists; refusing to overwrite")
+
+    if not exists:
+        add = _run(
+            [str(claude), "mcp", "add-json", "--scope", "user", SERVER_NAME, json.dumps(payload, ensure_ascii=False)]
+        )
+        if add.returncode != 0:
+            raise RuntimeError("Claude MCP add-json failed: " + (add.stderr or add.stdout)[-4000:])
+
+    marker_path.write_text(
+        json.dumps({"schema": "agentos.claude-one-managed-mcp/v1", "server": SERVER_NAME, "payload": payload}, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.chmod(marker_path, 0o600)
+    return {"server": SERVER_NAME, "already_present": exists, "managed": True, "payload": payload}
+
+
+def probe_projection(python: Path, repo_root: Path) -> dict[str, object]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["AGENT_DATA_ROOT"] = str(_data_root())
+    code = """
+import json
+from agentos_node.claude_one_mcp_stdio import _active_projection
+from agentos_node.one_mcp import OracleLocalGateway
+r = _active_projection(OracleLocalGateway())
+s = r.get('selector') or {}
+print(json.dumps({
+  'ok': True,
+  'schema': r.get('schema'),
+  'source': r.get('source'),
+  'selection_source': r.get('selection_source'),
+  'surface': r.get('surface'),
+  'executor_adapter': r.get('executor_adapter'),
+  'executor_class': r.get('executor_class'),
+  'backend_class': r.get('backend_class'),
+  'backend_identity': r.get('backend_identity'),
+  'backend_identity_bound': r.get('backend_identity_bound'),
+  'project_id': s.get('project_id'),
+  'index_id': s.get('index_id'),
+  'ir_id': s.get('ir_id'),
+  'credential_exposed': r.get('credential_exposed'),
+}, ensure_ascii=False))
+"""
+    result = subprocess.run(
+        [str(python), "-c", code],
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("Claude ONE projection probe failed: " + (result.stderr or result.stdout)[-4000:])
+    payload = json.loads(result.stdout)
+    if payload.get("source") != "ONE_ACTIVE_CONTINUATION":
+        raise RuntimeError(f"Claude ONE active selector probe failed: {payload}")
+    if payload.get("credential_exposed") is not False:
+        raise RuntimeError("Claude ONE credential isolation not proven")
+    return payload
+
+
+def main() -> int:
+    if os.name == "nt":
+        raise RuntimeError("Oracle-local Claude installer must run on Oracle/Linux")
+    repo_root = _repo_root()
+    required = repo_root / "agentos_node" / "claude_one_mcp_stdio.py"
+    if not required.is_file():
+        raise FileNotFoundError(f"required Claude ONE MCP module missing: {required}")
+    if not (_data_root() / "runtime" / "active-continuation.json").is_file():
+        raise FileNotFoundError("ONE active continuation selector is missing")
+
+    python = _venv_python()
+    evidence = probe_projection(python, repo_root)
+    claude = _discover_claude()
+    bootstrap = write_bootstrap(_claude_home() / "CLAUDE.md")
+    mcp = install_user_mcp(claude, python=python, repo_root=repo_root)
+
+    print(json.dumps({
+        "schema": "agentos.claude-one-oracle-install/v0.1",
+        "ok": True,
+        "mode": "oracle-local",
+        "probe": evidence,
+        "claude_executable_class": "anthropic-claude-code-extension",
+        "claude_home": str(_claude_home()),
+        "bootstrap_path": str(bootstrap),
+        "mcp_server": mcp["server"],
+        "mcp_managed": mcp["managed"],
+        "canonical_ir_copied": False,
+        "credential_in_config": False,
+        "backend_identity_inferred_from_surface": False,
+        "reload_required": True,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_issue_185_claude_extension_oracle.sh
+++ b/scripts/prepare_issue_185_claude_extension_oracle.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: #185 Claude extension preparation must run as ubuntu on Oracle" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_REF="core/issue-185-claude-extension-one"
+RUNTIME_ROOT="${AGENTOS_CLAUDE_ONE_SOURCE_ROOT:-/home/ubuntu/.local/share/agentos/claude-one-source}"
+DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
+EXPECTED_INDEX="idx-core-185-claude-ext-1"
+EXPECTED_IR="ir-core-185-claude-ext-1"
+
+test -d "$REPO/.git" || { echo "ERROR: AgentOS repo missing: $REPO" >&2; exit 3; }
+test -f "$DATA_ROOT/runtime/active-continuation.json" || { echo "ERROR: ONE active continuation selector missing" >&2; exit 4; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT="$(git -C "$REPO" rev-parse FETCH_HEAD)"
+TARGET="$RUNTIME_ROOT/$SOURCE_COMMIT"
+
+if [ ! -f "$TARGET/scripts/install_claude_one_oracle.py" ]; then
+  TMP="$RUNTIME_ROOT/.claude-e185-$SOURCE_COMMIT-$$"
+  rm -rf "$TMP"
+  mkdir -p "$TMP" "$RUNTIME_ROOT"
+  git -C "$REPO" archive "$SOURCE_COMMIT" | tar -x -C "$TMP"
+  mv "$TMP" "$TARGET"
+fi
+
+cd "$TARGET"
+echo "agentos_claude_e185_source_commit=$SOURCE_COMMIT"
+echo "agentos_claude_e185_runtime_source=$TARGET"
+echo "agentos_claude_e185_execution_cwd=$PWD"
+
+echo "agentos_claude_e185_contract_tests=RUNNING"
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" \
+  python3 -m unittest \
+    tests.test_project_continuation_index \
+    tests.test_canonical_ir_handoff \
+    tests.test_active_continuation \
+    tests.test_claude_one_mcp_stdio \
+    tests.test_install_claude_one_oracle \
+    -v
+echo "agentos_claude_e185_contract_tests=PASS"
+
+read -r ACTIVE_PROJECT ACTIVE_INDEX ACTIVE_IR < <(
+  PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" python3 - <<'PY'
+from agent_core.active_continuation import resolve_active_continuation
+import os
+from pathlib import Path
+r = resolve_active_continuation(data_root=Path(os.environ["AGENT_DATA_ROOT"]))
+s = r.get("selector") or {}
+print(s.get("project_id") or "", s.get("index_id") or "", s.get("ir_id") or "")
+PY
+)
+
+if [ "$ACTIVE_PROJECT" != "agentos-core" ]; then
+  echo "ERROR: active project is not agentos-core: $ACTIVE_PROJECT" >&2
+  exit 5
+fi
+
+echo "agentos_claude_e185_parent_index=$ACTIVE_INDEX"
+echo "agentos_claude_e185_parent_ir=$ACTIVE_IR"
+echo "agentos_claude_e185_canonical_handoff=RUNNING"
+PYTHONPATH="$TARGET" \
+AGENT_DATA_ROOT="$DATA_ROOT" \
+AGENTOS_EXPECTED_PARENT_INDEX="$ACTIVE_INDEX" \
+AGENTOS_EXPECTED_PARENT_IR="$ACTIVE_IR" \
+  python3 "$TARGET/scripts/advance_issue_185_to_claude_extension.py"
+echo "agentos_claude_e185_canonical_handoff=PASS"
+
+echo "agentos_claude_e185_install=RUNNING"
+PYTHONPATH="$TARGET" \
+AGENT_DATA_ROOT="$DATA_ROOT" \
+AGENTOS_RUNTIME_SOURCE_COMMIT="$SOURCE_COMMIT" \
+  python3 "$TARGET/scripts/install_claude_one_oracle.py"
+echo "agentos_claude_e185_install=PASS"
+
+PYTHONPATH="$TARGET" AGENT_DATA_ROOT="$DATA_ROOT" python3 - <<'PY'
+import json
+from agentos_node.claude_one_mcp_stdio import _active_projection
+from agentos_node.one_mcp import OracleLocalGateway
+
+result = _active_projection(OracleLocalGateway())
+selector = result.get("selector") or {}
+if selector.get("project_id") != "agentos-core":
+    raise SystemExit(f"Claude active project mismatch: {selector}")
+if selector.get("index_id") != "idx-core-185-claude-ext-1" or selector.get("ir_id") != "ir-core-185-claude-ext-1":
+    raise SystemExit(f"Claude active generation mismatch: {selector}")
+if result.get("credential_exposed") is not False:
+    raise SystemExit("Claude ONE credential isolation not proven")
+print(json.dumps({
+    "schema": "agentos.issue-185-claude-extension-probe/v1",
+    "ok": True,
+    "source": result.get("source"),
+    "selection_source": result.get("selection_source"),
+    "surface": result.get("surface"),
+    "executor_adapter": result.get("executor_adapter"),
+    "executor_class": result.get("executor_class"),
+    "backend_class": result.get("backend_class"),
+    "backend_identity": result.get("backend_identity"),
+    "backend_identity_bound": result.get("backend_identity_bound"),
+    "project_id": selector.get("project_id"),
+    "index_id": selector.get("index_id"),
+    "ir_id": selector.get("ir_id"),
+    "credential_exposed": result.get("credential_exposed"),
+}, ensure_ascii=False, indent=2, sort_keys=True))
+PY
+
+echo "agentos_issue_185_claude_extension=PREPARED"
+echo "agentos_claude_e185_index_id=$EXPECTED_INDEX"
+echo "agentos_claude_e185_ir_id=$EXPECTED_IR"
+echo "claude_extension_reload_required=YES"

--- a/tests/test_claude_one_mcp_stdio.py
+++ b/tests/test_claude_one_mcp_stdio.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentos_node.claude_one_mcp_stdio import _active_projection, _project_claude_client
+
+
+class FakeGateway:
+    data_root = "/tmp/agent-data"
+
+
+class ClaudeOneMcpTests(unittest.TestCase):
+    def test_projection_separates_surface_from_backend_identity(self):
+        with patch.dict(os.environ, {}, clear=True):
+            value = _project_claude_client({"schema": "x", "credential_exposed": False})
+        self.assertEqual(value["surface"], "anthropic-claude-code-extension")
+        self.assertEqual(value["executor_adapter"], "claude-code-extension-adapter")
+        self.assertEqual(value["executor_class"], "anthropic-claude-code-local")
+        self.assertTrue(value["executor_identity_bound"])
+        self.assertEqual(value["executor_identity_source"], "claude-user-mcp-config")
+        self.assertEqual(value["backend_class"], "unknown")
+        self.assertEqual(value["backend_identity"], "unknown")
+        self.assertFalse(value["backend_identity_bound"])
+        self.assertIsNone(value["backend_identity_source"])
+        self.assertFalse(value["credential_exposed"])
+
+    def test_trusted_local_backend_identity_is_explicit_not_surface_inferred(self):
+        with patch.dict(
+            os.environ,
+            {"AGENTOS_CLAUDE_BACKEND_CLASS": "local-model", "AGENTOS_CLAUDE_BACKEND_ID": "ollama/qwen3-coder"},
+            clear=True,
+        ):
+            value = _project_claude_client({"schema": "x"})
+        self.assertEqual(value["backend_class"], "local-model")
+        self.assertEqual(value["backend_identity"], "ollama/qwen3-coder")
+        self.assertTrue(value["backend_identity_bound"])
+        self.assertEqual(value["backend_identity_source"], "trusted-local-config")
+
+    @patch("agentos_node.claude_one_mcp_stdio.resolve_active_continuation")
+    def test_active_projection_uses_one_selector_not_workspace(self, resolve_active):
+        resolve_active.return_value = {
+            "selector": {
+                "project_id": "agentos-core",
+                "index_id": "idx-core-185-1",
+                "ir_id": "ir-core-185-1",
+            },
+            "resolution": {"schema": "agentos.resolve/v1", "project": {"id": "agentos-core"}},
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            result = _active_projection(FakeGateway())
+        resolve_active.assert_called_once_with(data_root="/tmp/agent-data")
+        self.assertEqual(result["source"], "ONE_ACTIVE_CONTINUATION")
+        self.assertEqual(result["selection_source"], "ONE_ACTIVE_CONTINUATION")
+        self.assertEqual(result["selector"]["project_id"], "agentos-core")
+        self.assertEqual(result["selector"]["index_id"], "idx-core-185-1")
+        self.assertEqual(result["selector"]["ir_id"], "ir-core-185-1")
+        self.assertNotIn("workspace", json.dumps(result).casefold())
+
+    @patch("agentos_node.claude_one_mcp_stdio.resolve_active_continuation")
+    def test_active_resolve_receipt_is_sanitized_generation_and_backend_bound(self, resolve_active):
+        resolve_active.return_value = {
+            "selector": {
+                "project_id": "agentos-core",
+                "index_id": "idx-core-185-1",
+                "ir_id": "ir-core-185-1",
+            },
+            "resolution": {"schema": "agentos.resolve/v1"},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            receipt = Path(td) / "receipt.json"
+            with patch.dict(
+                os.environ,
+                {
+                    "AGENTOS_CLAUDE_ONE_RECEIPT_PATH": str(receipt),
+                    "AGENTOS_RUNTIME_SOURCE_COMMIT": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    "AGENTOS_CLAUDE_BACKEND_CLASS": "local-model",
+                },
+                clear=True,
+            ):
+                _active_projection(FakeGateway(), write_receipt=True)
+            record = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(record["schema"], "agentos.claude-extension-one-active-resolve-receipt/v1")
+            self.assertEqual(record["runtime_source_commit"], "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+            self.assertEqual(record["project_id"], "agentos-core")
+            self.assertEqual(record["index_id"], "idx-core-185-1")
+            self.assertEqual(record["ir_id"], "ir-core-185-1")
+            self.assertEqual(record["surface"], "anthropic-claude-code-extension")
+            self.assertEqual(record["executor_adapter"], "claude-code-extension-adapter")
+            self.assertEqual(record["backend_class"], "local-model")
+            self.assertEqual(record["backend_identity"], "unknown")
+            self.assertFalse(record["backend_identity_bound"])
+            self.assertFalse(record["credential_exposed"])
+            serialized = json.dumps(record, ensure_ascii=False).casefold()
+            self.assertNotIn("workspace", serialized)
+            self.assertNotIn("prompt", serialized)
+            self.assertNotIn("session", serialized)
+            self.assertNotIn("credential", serialized.replace('"credential_exposed": false', ""))
+
+    def test_backend_identity_rejects_unbounded_or_secret_like_text(self):
+        with patch.dict(os.environ, {"AGENTOS_CLAUDE_BACKEND_ID": "local model with spaces"}, clear=True):
+            with self.assertRaises(ValueError):
+                _project_claude_client({"schema": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_claude_one_oracle.py
+++ b/tests/test_install_claude_one_oracle.py
@@ -95,6 +95,31 @@ class InstallClaudeOneOracleTests(unittest.TestCase):
             saved = json.loads(marker.read_text(encoding="utf-8"))
             self.assertEqual(saved["server"], SERVER_NAME)
 
+    def test_existing_owned_same_payload_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as td, patch("pathlib.Path.home", return_value=Path(td)):
+            home = Path(td)
+            marker = home / ".local" / "share" / "agentos" / "claude-one" / "managed-mcp.json"
+            marker.parent.mkdir(parents=True)
+            with patch.dict(os.environ, {}, clear=True):
+                payload = _mcp_payload(python=Path("/venv/python"), repo_root=Path("/runtime/snapshot"))
+            marker.write_text(
+                json.dumps({"schema": "agentos.claude-one-managed-mcp/v1", "server": SERVER_NAME, "payload": payload}),
+                encoding="utf-8",
+            )
+            calls: list[list[str]] = []
+
+            def fake_run(args: list[str], *, timeout: float = 20.0):
+                calls.append(args)
+                return FakeResult(returncode=0, stdout="exists")
+
+            with patch.dict(os.environ, {}, clear=True), patch("scripts.install_claude_one_oracle._run", side_effect=fake_run):
+                result = install_user_mcp(
+                    Path("/fake/claude"), python=Path("/venv/python"), repo_root=Path("/runtime/snapshot")
+                )
+            self.assertTrue(result["already_present"])
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][1:4], ["mcp", "get", SERVER_NAME])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_install_claude_one_oracle.py
+++ b/tests/test_install_claude_one_oracle.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.install_claude_one_oracle import (
+    BOOTSTRAP_BLOCK,
+    SERVER_NAME,
+    _mcp_payload,
+    install_user_mcp,
+    write_bootstrap,
+)
+
+
+class FakeResult:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class InstallClaudeOneOracleTests(unittest.TestCase):
+    def test_bootstrap_resolves_one_before_workspace_and_separates_backend_identity(self):
+        text = BOOTSTRAP_BLOCK
+        self.assertIn("agentos-one.one_resolve_active", text)
+        self.assertLess(text.index("agentos-one.one_resolve_active"), text.index("Do not infer the current project from the IDE workspace"))
+        self.assertIn("Do not infer backend/model identity from the Claude Code extension surface", text)
+        self.assertNotIn("idx-core-", text)
+        self.assertNotIn("ir-core-", text)
+
+    def test_bootstrap_managed_block_preserves_unmanaged_content(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "CLAUDE.md"
+            path.write_text("# Personal preferences\nKeep this.\n", encoding="utf-8")
+            write_bootstrap(path)
+            first = path.read_text(encoding="utf-8")
+            self.assertIn("Keep this.", first)
+            self.assertEqual(first.count("AGENTOS_ONE_CLAUDE_BOOTSTRAP_START"), 1)
+            write_bootstrap(path)
+            second = path.read_text(encoding="utf-8")
+            self.assertIn("Keep this.", second)
+            self.assertEqual(second.count("AGENTOS_ONE_CLAUDE_BOOTSTRAP_START"), 1)
+
+    def test_mcp_payload_uses_readonly_one_module_without_credentials_or_ir_body(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AGENT_DATA_ROOT": "/srv/agent-data",
+                "AGENTOS_CLAUDE_BACKEND_CLASS": "local-model",
+                "AGENTOS_CLAUDE_BACKEND_ID": "ollama/qwen3-coder",
+            },
+            clear=True,
+        ):
+            payload = _mcp_payload(python=Path("/venv/bin/python"), repo_root=Path("/runtime/snapshot"))
+        self.assertEqual(payload["type"], "stdio")
+        self.assertEqual(payload["command"], "/venv/bin/python")
+        self.assertEqual(payload["args"], ["-m", "agentos_node.claude_one_mcp_stdio"])
+        env = payload["env"]
+        self.assertEqual(env["AGENT_DATA_ROOT"], "/srv/agent-data")
+        self.assertEqual(env["AGENTOS_CLAUDE_BACKEND_CLASS"], "local-model")
+        serialized = json.dumps(payload, ensure_ascii=False).casefold()
+        for forbidden in ("canonical_ir", "bearer", "password", "secret", "auth_token"):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_existing_unmanaged_server_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td, patch("pathlib.Path.home", return_value=Path(td)):
+            with patch("scripts.install_claude_one_oracle._run", return_value=FakeResult(returncode=0, stdout="exists")):
+                with self.assertRaisesRegex(ValueError, "unmanaged Claude MCP server"):
+                    install_user_mcp(Path("/fake/claude"), python=Path("/venv/python"), repo_root=Path("/runtime"))
+
+    def test_missing_server_is_added_at_user_scope_and_marker_is_private(self):
+        calls: list[list[str]] = []
+
+        def fake_run(args: list[str], *, timeout: float = 20.0):
+            calls.append(args)
+            if args[1:4] == ["mcp", "get", SERVER_NAME]:
+                return FakeResult(returncode=1, stderr="not found")
+            return FakeResult(returncode=0, stdout="added")
+
+        with tempfile.TemporaryDirectory() as td, patch("pathlib.Path.home", return_value=Path(td)):
+            with patch("scripts.install_claude_one_oracle._run", side_effect=fake_run):
+                result = install_user_mcp(
+                    Path("/fake/claude"), python=Path("/venv/python"), repo_root=Path("/runtime/snapshot")
+                )
+            self.assertTrue(result["managed"])
+            add = calls[1]
+            self.assertEqual(add[:6], ["/fake/claude", "mcp", "add-json", "--scope", "user", SERVER_NAME])
+            marker = Path(td) / ".local" / "share" / "agentos" / "claude-one" / "managed-mcp.json"
+            self.assertTrue(marker.is_file())
+            self.assertEqual(marker.stat().st_mode & 0o777, 0o600)
+            saved = json.loads(marker.read_text(encoding="utf-8"))
+            self.assertEqual(saved["server"], SERVER_NAME)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements the #185 candidate for **Anthropic Claude Code IDE extension → AgentOS ONE** continuity without creating a Claude-specific state protocol.

## Native Claude bootstrap

Uses Claude Code's own supported surfaces:
- managed user memory block in `~/.claude/CLAUDE.md`;
- user-scope stdio MCP configured through `claude mcp add-json --scope user`;
- existing ONE active-continuation selector and canonical `agentos.ir/v1` resolution.

The installer does not guess Claude's internal MCP config file location and does not copy Canonical IR into Claude settings.

## Identity boundary

The ONE projection and independent receipt keep these dimensions separate:
- surface: `anthropic-claude-code-extension`;
- executor adapter: `claude-code-extension-adapter`;
- executor class: `anthropic-claude-code-local`;
- backend class/model identity: explicit trusted-local config only;
- backend identity defaults to `unknown` / `backend_identity_bound=false`.

The implementation never infers `model=Claude` from the Anthropic extension surface. This is required because the initial real target may use a local model backend.

## Credential / state boundary

- Realm/node credentials stay in the trusted local ONE runtime.
- Claude config receives no Realm bearer credential.
- No prompt/session transcript is needed for continuity proof.
- No Canonical IR body is copied into `CLAUDE.md` or MCP config.
- Resolve receipt stores only bounded identity/provenance + project/index/IR ids and `credential_exposed=false`.

## Current files

- `agentos_node/claude_one_mcp_stdio.py`
- `scripts/install_claude_one_oracle.py`
- `scripts/advance_issue_185_to_claude_extension.py`
- `scripts/prepare_issue_185_claude_extension_oracle.sh`
- `scripts/inspect_issue_185_claude_extension.sh`
- `.github/workflows/claude-one-extension-guard.yml`
- `.github/workflows/claude-one-live-inspect-185.yml`
- `tests/test_claude_one_mcp_stdio.py`
- `tests/test_install_claude_one_oracle.py`

## Static evidence

Static candidate head before live-inspector workflow: `0fc7df17e25ff30608eba203557906b640ac5120`.

`Claude Extension ONE Guard` run `33603658331` completed with `success`.

The installer is idempotent for the same managed immutable payload and fails closed rather than overwriting an unmanaged or different Claude MCP entry.

## Live Oracle preparation — PASS

The governed immutable prepare helper has now been executed successfully as ubuntu on Oracle.

Observed:
- contract tests: **28/28 PASS**;
- exact parent: `idx-core-152-post-e3-1 / ir-core-152-post-e3-1`;
- guarded Canonical IR handoff: PASS;
- active generation: `idx-core-185-claude-ext-1 / ir-core-185-claude-ext-1`;
- managed `~/.claude/CLAUDE.md` bootstrap installed;
- user-scope MCP server `agentos-one` installed;
- Canonical IR copied into config: false;
- credential in config: false;
- backend identity inferred from surface: false;
- backend identity: `unknown`, `backend_identity_bound=false`;
- ONE probe: `source=ONE_ACTIVE_CONTINUATION`, exact #185 generation, `credential_exposed=false`;
- final status: `agentos_issue_185_claude_extension=PREPARED`;
- extension reload required: yes.

This is **LIVE_PREPARED**, not VERIFIED.

## Fresh-thread receipt inspection without user terminal

A worker-branch-only self-hosted workflow now exists for read-only acceptance inspection. It is triggered only by an explicit acceptance-marker push and runs `scripts/inspect_issue_185_claude_extension.sh` against the independent receipt. This lets the ChatGPT Core thread trigger/read the receipt after the user completes the Claude UI fresh-thread step; the user does not need to run terminal commands or paste Claude output.

## Acceptance still pending

1. Reload Anthropic Claude Code extension.
2. Open a completely fresh Claude Code extension thread and send only `繼續`.
3. Independent receipt must prove the exact #185 generation and identity boundary.
4. Repeat a second independent fresh thread with a newer receipt.
5. Only then mark #185 continuity VERIFIED.
6. #117 Experience A/B regression through this Claude-extension/local-backend surface remains separate and follows continuity verification.

## Related issues

- #152 owns generic Node↔executor onboarding/liveness semantics and the no-per-executor-terminal Golden Path.
- #117 owns Experience hydration / Master Experience Floor.
- #72 is the separate ubuntu-owned native Claude relay liveness path; do not conflate it with this extension bootstrap.

No protected-main merge is authorized by this PR.