### PR TITLE
Core #197: add governed Spec Steward Employee worker for O3 live acceptance

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -24,6 +24,7 @@ on:
       - 'agent_core/spec_steward_acceptance.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
+      - 'agentos_node/spec_steward_worker.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -47,6 +48,7 @@ on:
       - 'tests/test_role_runtime.py'
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
+      - 'tests/test_spec_steward_worker.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -57,6 +59,7 @@ on:
     branches:
       - core/issue-197-governed-wake-delivery-v2
       - core/issue-197-spec-steward-bootstrap
+      - core/issue-197-spec-steward-worker
       - core/issue-200-persistent-supervisor-loop
       - core/issue-200-governed-supervisor-delivery
       - core/integration
@@ -79,6 +82,7 @@ on:
       - 'agent_core/spec_steward_acceptance.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
+      - 'agentos_node/spec_steward_worker.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -102,6 +106,7 @@ on:
       - 'tests/test_role_runtime.py'
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
+      - 'tests/test_spec_steward_worker.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -159,5 +164,6 @@ jobs:
       - name: Run Spec Steward bootstrap regressions
         run: python -m unittest tests.test_spec_steward_bootstrap -v
       - name: Run Spec Steward O3 acceptance regressions
-        if: ${{ hashFiles('tests/test_spec_steward_acceptance.py') != '' }}
         run: python -m unittest tests.test_spec_steward_acceptance -v
+      - name: Run Spec Steward Employee worker regressions
+        run: python -m unittest tests.test_spec_steward_worker -v

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -22,6 +22,8 @@ on:
       - 'agent_core/core_supervisor_delivery.py'
       - 'agent_core/spec_steward_bootstrap.py'
       - 'agent_core/spec_steward_acceptance.py'
+      - 'agent_core/spec_steward_o3_cli.py'
+      - 'agent_core/spec_steward_presence_cli.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
@@ -50,6 +52,8 @@ on:
       - 'tests/test_role_runtime.py'
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
+      - 'tests/test_spec_steward_o3_cli.py'
+      - 'tests/test_spec_steward_presence_cli.py'
       - 'tests/test_spec_steward_worker.py'
       - 'tests/test_governed_spec_steward_worker.py'
       - 'tests/test_spec_steward_worker_cli.py'
@@ -85,6 +89,8 @@ on:
       - 'agent_core/core_supervisor_delivery.py'
       - 'agent_core/spec_steward_bootstrap.py'
       - 'agent_core/spec_steward_acceptance.py'
+      - 'agent_core/spec_steward_o3_cli.py'
+      - 'agent_core/spec_steward_presence_cli.py'
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
@@ -113,6 +119,8 @@ on:
       - 'tests/test_role_runtime.py'
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
+      - 'tests/test_spec_steward_o3_cli.py'
+      - 'tests/test_spec_steward_presence_cli.py'
       - 'tests/test_spec_steward_worker.py'
       - 'tests/test_governed_spec_steward_worker.py'
       - 'tests/test_spec_steward_worker_cli.py'
@@ -175,6 +183,10 @@ jobs:
         run: python -m unittest tests.test_spec_steward_bootstrap -v
       - name: Run Spec Steward O3 acceptance regressions
         run: python -m unittest tests.test_spec_steward_acceptance -v
+      - name: Run Spec Steward O3 operator CLI regressions
+        run: python -m unittest tests.test_spec_steward_o3_cli -v
+      - name: Run Spec Steward presence CLI regressions
+        run: python -m unittest tests.test_spec_steward_presence_cli -v
       - name: Run Spec Steward Employee worker regressions
         run: python -m unittest tests.test_spec_steward_worker -v
       - name: Run governed Spec Steward worker authority regressions

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -26,6 +26,7 @@ on:
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
       - 'agentos_node/governed_spec_steward_worker.py'
+      - 'agentos_node/spec_steward_worker_cli.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -51,11 +52,13 @@ on:
       - 'tests/test_spec_steward_acceptance.py'
       - 'tests/test_spec_steward_worker.py'
       - 'tests/test_governed_spec_steward_worker.py'
+      - 'tests/test_spec_steward_worker_cli.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'docs/CORE_SUPERVISOR.md'
+      - 'docs/SPEC_STEWARD_O3_LIVE_RUNBOOK.md'
       - '.github/workflows/employee-runtime-guard.yml'
   push:
     branches:
@@ -86,6 +89,7 @@ on:
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
       - 'agentos_node/governed_spec_steward_worker.py'
+      - 'agentos_node/spec_steward_worker_cli.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -111,11 +115,13 @@ on:
       - 'tests/test_spec_steward_acceptance.py'
       - 'tests/test_spec_steward_worker.py'
       - 'tests/test_governed_spec_steward_worker.py'
+      - 'tests/test_spec_steward_worker_cli.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'docs/CORE_SUPERVISOR.md'
+      - 'docs/SPEC_STEWARD_O3_LIVE_RUNBOOK.md'
       - '.github/workflows/employee-runtime-guard.yml'
   workflow_dispatch:
 
@@ -173,3 +179,5 @@ jobs:
         run: python -m unittest tests.test_spec_steward_worker -v
       - name: Run governed Spec Steward worker authority regressions
         run: python -m unittest tests.test_governed_spec_steward_worker -v
+      - name: Run Spec Steward worker CLI regressions
+        run: python -m unittest tests.test_spec_steward_worker_cli -v

--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -25,6 +25,7 @@ on:
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
+      - 'agentos_node/governed_spec_steward_worker.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -49,6 +50,7 @@ on:
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
       - 'tests/test_spec_steward_worker.py'
+      - 'tests/test_governed_spec_steward_worker.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -83,6 +85,7 @@ on:
       - 'agent_core/role_runtime.py'
       - 'agentos_node/employee_wake_inbox.py'
       - 'agentos_node/spec_steward_worker.py'
+      - 'agentos_node/governed_spec_steward_worker.py'
       - 'agentos_node/thin_client.py'
       - 'governance/employee-memory-policy.json'
       - 'governance/employee-skills.json'
@@ -107,6 +110,7 @@ on:
       - 'tests/test_spec_steward_bootstrap.py'
       - 'tests/test_spec_steward_acceptance.py'
       - 'tests/test_spec_steward_worker.py'
+      - 'tests/test_governed_spec_steward_worker.py'
       - '.agent/roles/**'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
@@ -167,3 +171,5 @@ jobs:
         run: python -m unittest tests.test_spec_steward_acceptance -v
       - name: Run Spec Steward Employee worker regressions
         run: python -m unittest tests.test_spec_steward_worker -v
+      - name: Run governed Spec Steward worker authority regressions
+        run: python -m unittest tests.test_governed_spec_steward_worker -v

--- a/agent_core/spec_steward_o3_cli.py
+++ b/agent_core/spec_steward_o3_cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.spec_steward_acceptance import inspect_spec_steward_acceptance
+from agent_core.spec_steward_bootstrap import ensure_spec_steward
+
+
+def _absolute_runtime_root(value: str) -> str:
+    path = Path(str(value or "").strip()).expanduser()
+    if not path.is_absolute():
+        raise argparse.ArgumentTypeError("runtime_root_must_be_absolute")
+    return str(path.resolve())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agentos-spec-steward-o3",
+        description="Explicit Core-side bootstrap/inspection for #197 O3. No ONE dispatch or VERIFIED emission.",
+    )
+    parser.add_argument("--runtime-root", required=True, type=_absolute_runtime_root)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser(
+        "bootstrap",
+        help="Idempotently materialize the canonical Spec Steward Employee/WorkItem/assignment only.",
+    )
+    sub.add_parser(
+        "inspect",
+        help="Read persisted O3 evidence without mutating Employee/Supervisor/ONE state.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    runtime = EmployeeRuntime(args.runtime_root)
+    if args.command == "bootstrap":
+        result = ensure_spec_steward(runtime)
+        payload = result.as_dict()
+        payload["verified_marker_emitted"] = False
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return 0
+    if args.command == "inspect":
+        report = inspect_spec_steward_acceptance(runtime)
+        print(json.dumps(report.as_dict(), ensure_ascii=False, sort_keys=True))
+        return 0 if report.ready_for_live_marker else 3
+    raise RuntimeError("unsupported_spec_steward_o3_command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_core/spec_steward_presence_cli.py
+++ b/agent_core/spec_steward_presence_cli.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agent_core.employee_presence import EmployeePresenceRegistry
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.node_registry import NodeRegistry
+from agent_core.spec_steward_worker_contract import SPEC_STEWARD_EMPLOYEE_ID
+
+
+def _absolute_path(value: str, field: str) -> Path:
+    path = Path(str(value or "").strip()).expanduser()
+    if not path.is_absolute():
+        raise argparse.ArgumentTypeError(f"{field}_must_be_absolute")
+    return path.resolve()
+
+
+def _runtime_root(value: str) -> Path:
+    return _absolute_path(value, "runtime_root")
+
+
+def _one_root(value: str) -> Path:
+    return _absolute_path(value, "one_data_root")
+
+
+def _existing_node_registry(one_root: Path) -> NodeRegistry:
+    fabric_path = one_root / "realm" / "fabric.json"
+    nodes_path = one_root / "realm" / "nodes.json"
+    if not fabric_path.is_file() or not nodes_path.is_file():
+        raise RuntimeError("spec_steward_presence_one_control_plane_state_missing")
+    fabric = json.loads(fabric_path.read_text(encoding="utf-8"))
+    nodes = json.loads(nodes_path.read_text(encoding="utf-8"))
+    if not isinstance(fabric, dict) or fabric.get("schema") != "agentos.realm-fabric/v0.1":
+        raise RuntimeError("spec_steward_presence_fabric_schema_invalid")
+    if not isinstance(nodes, dict) or nodes.get("schema") != "agentos.node-registry/v0.1":
+        raise RuntimeError("spec_steward_presence_node_registry_schema_invalid")
+    fabric_realm = str(fabric.get("realm_id") or "").strip()
+    nodes_realm = str(nodes.get("realm_id") or "").strip()
+    if not fabric_realm or fabric_realm != nodes_realm:
+        raise RuntimeError("spec_steward_presence_realm_mismatch")
+    return NodeRegistry(path=nodes_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agentos-spec-steward-presence",
+        description="Bounded #197 O3 Employee presence acceptance utility. Never creates Realm/Node/Employee state.",
+    )
+    parser.add_argument("--runtime-root", required=True, type=_runtime_root)
+    parser.add_argument("--one-data-root", required=True, type=_one_root)
+    parser.add_argument("--node-id", required=True)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bind = sub.add_parser("bind")
+    bind.add_argument("--presence-id", required=True)
+    bind.add_argument("--ttl-seconds", type=int, default=300)
+    bind.add_argument("--supersede-presence-id")
+
+    heartbeat = sub.add_parser("heartbeat")
+    heartbeat.add_argument("--presence-id", required=True)
+    heartbeat.add_argument("--ttl-seconds", type=int, default=300)
+
+    sub.add_parser("inspect")
+    return parser
+
+
+def _safe_presence(presence) -> dict:
+    if presence is None:
+        return {
+            "schema": "agentos.spec-steward-o3-presence-cli-result/v1",
+            "status": "absent",
+            "employee_id": SPEC_STEWARD_EMPLOYEE_ID,
+            "credential_exposed": False,
+            "executor_identity_bound": False,
+        }
+    return {
+        "schema": "agentos.spec-steward-o3-presence-cli-result/v1",
+        "status": "present",
+        "employee_id": presence.employee_id,
+        "node_id": presence.node_id,
+        "presence_id": presence.presence_id,
+        "generation": presence.generation,
+        "bound_at": presence.bound_at,
+        "heartbeat_at": presence.heartbeat_at,
+        "expires_at": presence.expires_at,
+        "required_capability": presence.required_capability,
+        "executor_identity_bound": False,
+        "credential_exposed": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    runtime = EmployeeRuntime(args.runtime_root)
+    runtime.get_employee(SPEC_STEWARD_EMPLOYEE_ID)
+    registry = _existing_node_registry(args.one_data_root)
+    presence = EmployeePresenceRegistry(runtime, registry)
+
+    if args.command == "bind":
+        result = presence.bind(
+            SPEC_STEWARD_EMPLOYEE_ID,
+            args.node_id,
+            args.presence_id,
+            ttl_seconds=args.ttl_seconds,
+            supersede_presence_id=args.supersede_presence_id,
+        )
+    elif args.command == "heartbeat":
+        current = presence.get(SPEC_STEWARD_EMPLOYEE_ID)
+        if current is None or current.node_id != args.node_id:
+            raise PermissionError("spec_steward_presence_node_not_owner")
+        result = presence.heartbeat(
+            SPEC_STEWARD_EMPLOYEE_ID,
+            args.presence_id,
+            ttl_seconds=args.ttl_seconds,
+        )
+    elif args.command == "inspect":
+        result = presence.get(SPEC_STEWARD_EMPLOYEE_ID)
+    else:
+        raise RuntimeError("unsupported_spec_steward_presence_command")
+
+    print(json.dumps(_safe_presence(result), ensure_ascii=False, sort_keys=True))
+    return 0 if result is not None else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_core/spec_steward_presence_cli.py
+++ b/agent_core/spec_steward_presence_cli.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from agent_core.employee_presence import EmployeePresenceRegistry
 from agent_core.employee_runtime import EmployeeRuntime
 from agent_core.node_registry import NodeRegistry
-from agent_core.spec_steward_worker_contract import SPEC_STEWARD_EMPLOYEE_ID
+
+
+SPEC_STEWARD_EMPLOYEE_ID = "agentos-spec-steward"
 
 
 def _absolute_path(value: str, field: str) -> Path:

--- a/agentos_node/governed_spec_steward_worker.py
+++ b/agentos_node/governed_spec_steward_worker.py
@@ -17,7 +17,12 @@ from agentos_node.spec_steward_worker import (
 )
 
 
-ELIGIBLE_PRECLAIM_DELIVERY_STATES = {"queued", "awaiting_claim"}
+# `queued` proves that ONE accepted a task into its controller queue, but not that
+# the target Node actually received the wake.  Pre-claim worker authority begins
+# only after the Supervisor has reconciled a successful Node delivery receipt to
+# `awaiting_claim`.  This prevents a local wake-spool writer from pairing a forged
+# capsule with a merely queued Core delivery record.
+ELIGIBLE_PRECLAIM_DELIVERY_STATES = {"awaiting_claim"}
 
 
 def _read(path: Path) -> dict[str, Any] | None:
@@ -37,11 +42,12 @@ def require_governed_spec_steward_delivery(
     runtime_root: str | Path,
     capsule: dict[str, Any],
 ) -> dict[str, Any]:
-    """Require one exact Core/S4 authority record before Employee claim.
+    """Require one exact Node-acknowledged Core/S4 authority record before claim.
 
     Node wake persistence proves delivery only. It does not grant worker execution
     authority. This check binds the capsule back to the immutable Supervisor
-    reconcile intent and its separate one_direct delivery ledger.
+    reconcile intent and its separate one_direct delivery ledger, and requires the
+    Supervisor to have reconciled the Node delivery receipt before Employee claim.
     """
     root = Path(runtime_root).expanduser().resolve()
     wake = capsule.get("wake_intent")

--- a/agentos_node/governed_spec_steward_worker.py
+++ b/agentos_node/governed_spec_steward_worker.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.spec_steward_acceptance import EXPECTED_AUTHORITY_POLICY, EXPECTED_TRANSPORT
+from agentos_node.spec_steward_worker import (
+    ASSIGNMENT_ID,
+    EMPLOYEE_ID,
+    SpecStewardWakeWorker,
+    SpecStewardWorkerState,
+)
+
+
+ELIGIBLE_PRECLAIM_DELIVERY_STATES = {"queued", "awaiting_claim"}
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("governed_spec_steward_worker_evidence_invalid")
+    return payload
+
+
+def _same_wake(left: Any, right: Any) -> bool:
+    return isinstance(left, dict) and isinstance(right, dict) and left == right
+
+
+def require_governed_spec_steward_delivery(
+    runtime_root: str | Path,
+    capsule: dict[str, Any],
+) -> dict[str, Any]:
+    """Require one exact Core/S4 authority record before Employee claim.
+
+    Node wake persistence proves delivery only. It does not grant worker execution
+    authority. This check binds the capsule back to the immutable Supervisor
+    reconcile intent and its separate one_direct delivery ledger.
+    """
+    root = Path(runtime_root).expanduser().resolve()
+    wake = capsule.get("wake_intent")
+    if not isinstance(wake, dict):
+        raise PermissionError("spec_steward_worker_governed_wake_missing")
+    if capsule.get("employee_id") != EMPLOYEE_ID or capsule.get("assignment_id") != ASSIGNMENT_ID:
+        raise PermissionError("spec_steward_worker_governed_scope_mismatch")
+
+    deliveries = root / "supervisor" / "deliveries"
+    intents = root / "supervisor" / "intents"
+    if not deliveries.is_dir() or not intents.is_dir():
+        raise PermissionError("spec_steward_worker_governed_delivery_missing")
+
+    matches: list[dict[str, Any]] = []
+    for path in sorted(deliveries.glob("reconcile_*.json")):
+        try:
+            delivery = _read(path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not delivery or delivery.get("schema") != DELIVERY_STATE_SCHEMA:
+            continue
+        if delivery.get("status") not in ELIGIBLE_PRECLAIM_DELIVERY_STATES:
+            continue
+        if delivery.get("employee_id") != EMPLOYEE_ID or delivery.get("assignment_id") != ASSIGNMENT_ID:
+            continue
+        if delivery.get("wake_id") != capsule.get("wake_id"):
+            continue
+        if delivery.get("transport") != EXPECTED_TRANSPORT:
+            continue
+        if delivery.get("authority_policy_id") != EXPECTED_AUTHORITY_POLICY:
+            continue
+        if delivery.get("capability") != WAKE_CAPABILITY:
+            continue
+        if delivery.get("dispatch_performed") is not True:
+            continue
+        if delivery.get("node_id") != capsule.get("node_id"):
+            continue
+        if delivery.get("presence_id") != capsule.get("presence_id"):
+            continue
+        if int(delivery.get("presence_generation") or 0) != int(capsule.get("presence_generation") or 0):
+            continue
+        if not delivery.get("task_id") or not delivery.get("wake_attempt_id"):
+            continue
+
+        reconcile_id = str(delivery.get("reconcile_id") or "").strip()
+        if not reconcile_id or path.stem != reconcile_id:
+            continue
+        try:
+            record = _read(intents / f"{reconcile_id}.json")
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not record or record.get("schema") != INTENT_RECORD_SCHEMA:
+            continue
+        if record.get("reconcile_id") != reconcile_id or record.get("state") != "planned":
+            continue
+        if record.get("dispatch_performed") is not False:
+            continue
+        intent = record.get("intent")
+        if not isinstance(intent, dict) or intent.get("schema") != RECONCILE_INTENT_SCHEMA:
+            continue
+        if intent.get("kind") != "employee_wake":
+            continue
+        if intent.get("employee_id") != EMPLOYEE_ID or intent.get("assignment_id") != ASSIGNMENT_ID:
+            continue
+        if intent.get("authority_boundary") != "observe_and_select_only":
+            continue
+        if any(
+            intent.get(key) != "unbound"
+            for key in ("node_selection", "executor_selection", "transport_selection", "capability_authority")
+        ):
+            continue
+        if intent.get("credential_exposed") is not False:
+            continue
+        if not _same_wake(intent.get("wake_intent"), wake):
+            continue
+        matches.append(delivery)
+
+    if len(matches) != 1:
+        raise PermissionError(
+            "spec_steward_worker_governed_delivery_ambiguous"
+            if len(matches) > 1
+            else "spec_steward_worker_governed_delivery_missing"
+        )
+    return matches[0]
+
+
+class GovernedSpecStewardWakeWorker:
+    """Deployment surface for the bounded O3 worker.
+
+    `SpecStewardWakeWorker` is the lifecycle kernel. Runtime deployments must use
+    this wrapper so a locally persisted wake capsule cannot bypass Core/S4
+    authority resolution.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.worker = SpecStewardWakeWorker(**kwargs)
+
+    def process_one(self, *, now=None) -> SpecStewardWorkerState | None:
+        candidates = self.worker._capsules()  # noqa: SLF001 - same bounded worker package
+        if not candidates:
+            return None
+        _, _, capsule = candidates[0]
+        require_governed_spec_steward_delivery(self.worker.runtime_root, capsule)
+        return self.worker.process_one(now=now)

--- a/agentos_node/spec_steward_worker.py
+++ b/agentos_node/spec_steward_worker.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_memory import EmployeeMemoryPolicy, EmployeeMemoryService
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_skills import EmployeeSkillRegistry, EmployeeSkillService
+from agent_core.employee_wake import EmployeeWakeIntent, EmployeeWakePlanner, WAKE_INTENT_SCHEMA
+from agent_core.role_runtime import RoleRegistry
+from agent_core.spec_steward_acceptance import (
+    DEFAULT_MEMORY_POLICY_PATH,
+    LIVE_WITNESS_SCHEMA,
+    MEMORY_CLASS,
+    MEMORY_EVIDENCE_SCHEMA,
+    MEMORY_KEY,
+    inspect_spec_steward_acceptance,
+)
+from agent_core.spec_steward_bootstrap import (
+    DEFAULT_ROLE_REGISTRY_PATH,
+    DEFAULT_SKILL_REGISTRY_PATH,
+    build_spec_steward_audit_request,
+    load_spec_steward_contract,
+)
+from agentos_node.employee_wake_inbox import (
+    ALLOWED_INTENT_KEYS,
+    ROUTE_KEYS,
+    WAKE_RECEIPT_SCHEMA,
+    WAKE_ROUTE_SCHEMA,
+)
+
+
+WORKER_STATE_SCHEMA = "agentos.spec-steward-o3-worker-state/v1"
+CONTINUITY_SCHEMA = "agentos.spec-steward-o3-worker-continuity/v1"
+EMPLOYEE_ID = "agentos-spec-steward"
+ASSIGNMENT_ID = "spec-steward-o3-acceptance-v1"
+SKILL_ID = "spec.audit"
+EXECUTOR_PROVIDER = "agentos-native-spec-audit"
+EXECUTOR_MODEL = "spec-audit-v1"
+CAPSULE_KEYS = {
+    "schema",
+    "wake_id",
+    "employee_id",
+    "assignment_id",
+    "node_id",
+    "presence_id",
+    "presence_generation",
+    "expected_lease_generation",
+    "digest",
+    "wake_intent",
+    "employee_wake_route",
+}
+TERMINAL_LOCAL_STATES = {"checkpointed", "completed", "unknown", "failed"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _safe_id(value: Any, field: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 256 or any(ch in text for ch in "/\\\0") or text in {".", ".."}:
+        raise ValueError(f"invalid_spec_steward_worker_{field}")
+    return text
+
+
+def _atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("spec_steward_worker_state_invalid")
+    return payload
+
+
+def _inside(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _require_separate_roots(runtime_root: Path, wake_root: Path, state_root: Path) -> None:
+    roots = [runtime_root.resolve(), wake_root.resolve(), state_root.resolve()]
+    if len(set(roots)) != 3:
+        raise ValueError("spec_steward_worker_roots_must_be_distinct")
+    if _inside(wake_root.resolve(), runtime_root.resolve()) or _inside(runtime_root.resolve(), wake_root.resolve()):
+        raise ValueError("spec_steward_worker_wake_root_must_not_be_canonical_runtime")
+    if _inside(state_root.resolve(), runtime_root.resolve()) or _inside(runtime_root.resolve(), state_root.resolve()):
+        raise ValueError("spec_steward_worker_state_root_must_not_be_canonical_runtime")
+
+
+def _capsule_digest(intent: dict[str, Any], route: dict[str, Any]) -> str:
+    raw = json.dumps(
+        {"wake_intent": intent, "employee_wake_route": route},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _instance_digest(instance_id: str) -> str:
+    return hashlib.sha256(instance_id.encode("utf-8")).hexdigest()[:24]
+
+
+def _lease_id(wake_id: str, presence_generation: int, digest: str) -> str:
+    raw = f"{wake_id}\0{presence_generation}\0{digest}".encode("utf-8")
+    return "employeelease_" + hashlib.sha256(raw).hexdigest()[:24]
+
+
+def _thread_head(generation: int, audit: dict[str, Any]) -> str:
+    raw = json.dumps(audit, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"o3:checkpoint:g{int(generation)}:{hashlib.sha256(raw).hexdigest()[:16]}"
+
+
+@dataclass(slots=True)
+class SpecStewardWorkerState:
+    schema: str
+    wake_id: str
+    digest: str
+    employee_id: str
+    assignment_id: str
+    node_id: str
+    presence_id: str
+    presence_generation: int
+    expected_lease_generation: int
+    lease_id: str
+    lease_generation: int | None
+    status: str
+    process_instance_digest: str
+    executor_provider: str
+    executor_model: str
+    created_at: str
+    updated_at: str
+    thread_head: str = ""
+    error_code: str | None = None
+    credential_exposed: bool = False
+    session_identity_exposed: bool = False
+    verified_marker_emitted: bool = False
+
+
+class NativeSpecStewardAuditExecutor:
+    """Fixed read-only O3 audit executor.
+
+    It does not run shell, select a provider, call a network endpoint, or mutate the
+    target project. It audits the already-persisted O3 acceptance evidence and
+    returns bounded closure-gap data for the Employee lifecycle to checkpoint.
+    """
+
+    provider = EXECUTOR_PROVIDER
+    model = EXECUTOR_MODEL
+    skill_id = SKILL_ID
+
+    def execute(
+        self,
+        runtime: EmployeeRuntime,
+        *,
+        skill_request: dict[str, Any],
+        lease_generation: int,
+    ) -> tuple[str, dict[str, Any]]:
+        if skill_request.get("intent") != "audit":
+            raise PermissionError("spec_steward_worker_intent_not_audit")
+        if (skill_request.get("skill") or {}).get("skill_id") != SKILL_ID:
+            raise PermissionError("spec_steward_worker_skill_mismatch")
+        if skill_request.get("capability_authorization") != "required_downstream":
+            raise PermissionError("spec_steward_worker_skill_authority_boundary_invalid")
+        if skill_request.get("credential_exposed") is not False:
+            raise PermissionError("spec_steward_worker_skill_credential_boundary_invalid")
+        args = skill_request.get("args") or {}
+        if args.get("scope") != "core-issue-197-o3":
+            raise PermissionError("spec_steward_worker_scope_mismatch")
+
+        report = inspect_spec_steward_acceptance(runtime)
+        audit = {
+            "schema": "agentos.spec-steward-o3-native-audit/v1",
+            "scope": "core-issue-197-o3",
+            "lease_generation": int(lease_generation),
+            "blocking_count": len(report.blocking_reasons),
+            "blocking_checks": list(report.blocking_reasons),
+            "qualifying_wake_generations": list(report.qualifying_wake_generations),
+            "credential_exposed": False,
+            "session_identity_exposed": False,
+        }
+        return _thread_head(lease_generation, audit), audit
+
+
+class SpecStewardWakeWorker:
+    """Consume exact Spec Steward wake capsules without turning wake into authority.
+
+    The wake inbox remains delivery-only. This worker is a separately configured,
+    fixed Employee/skill executor. It requires an already-materialized canonical
+    EmployeeRuntime and never creates an Employee or assignment. The first O3 lease
+    intentionally stops after checkpoint; only a later wake generation may resume
+    and finish, which lets the live acceptance prove process/executor continuity.
+    """
+
+    def __init__(
+        self,
+        *,
+        runtime_root: str | Path,
+        wake_root: str | Path,
+        worker_state_root: str | Path,
+        node_id: str,
+        process_instance_id: str | None = None,
+        lease_seconds: int = 60,
+        executor: NativeSpecStewardAuditExecutor | None = None,
+    ) -> None:
+        self.runtime_root = Path(runtime_root).expanduser().resolve()
+        self.wake_root = Path(wake_root).expanduser().resolve()
+        self.worker_state_root = Path(worker_state_root).expanduser().resolve()
+        _require_separate_roots(self.runtime_root, self.wake_root, self.worker_state_root)
+        self.node_id = _safe_id(node_id, "node_id")
+        if lease_seconds < 30 or lease_seconds > 3600:
+            raise ValueError("spec_steward_worker_lease_seconds_out_of_range")
+        self.lease_seconds = int(lease_seconds)
+        self.process_instance_digest = _instance_digest(process_instance_id or uuid.uuid4().hex)
+        self.executor = executor or NativeSpecStewardAuditExecutor()
+        if self.executor.provider != EXECUTOR_PROVIDER or self.executor.skill_id != SKILL_ID:
+            raise ValueError("spec_steward_worker_executor_contract_mismatch")
+
+        # Fail before creating local worker state if the caller points at an empty
+        # or competing runtime. Bootstrap must already have materialized canonical
+        # Employee state through Core.
+        if not (self.runtime_root / "employees" / f"{EMPLOYEE_ID}.json").is_file():
+            raise RuntimeError("spec_steward_worker_canonical_employee_missing")
+        if not (self.runtime_root / "assignments" / f"{ASSIGNMENT_ID}.json").is_file():
+            raise RuntimeError("spec_steward_worker_canonical_assignment_missing")
+
+        self.runtime = EmployeeRuntime(self.runtime_root)
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.role_registry = RoleRegistry(DEFAULT_ROLE_REGISTRY_PATH)
+        self.skill_registry = EmployeeSkillRegistry(DEFAULT_SKILL_REGISTRY_PATH)
+        self.skill_service = EmployeeSkillService(self.runtime, self.role_registry, self.skill_registry)
+        self.memory = EmployeeMemoryService(
+            self.runtime,
+            self.role_registry,
+            EmployeeMemoryPolicy(DEFAULT_MEMORY_POLICY_PATH),
+        )
+        self.contract = load_spec_steward_contract()
+        self.state_dir = self.worker_state_root / EMPLOYEE_ID
+
+    def _state_path(self, wake_id: str, presence_generation: int) -> Path:
+        return self.state_dir / f"{_safe_id(wake_id, 'wake_id')}.{int(presence_generation):06d}.json"
+
+    def _load_state(self, wake_id: str, presence_generation: int) -> SpecStewardWorkerState | None:
+        payload = _read(self._state_path(wake_id, presence_generation))
+        if payload is None:
+            return None
+        if payload.get("schema") != WORKER_STATE_SCHEMA:
+            raise ValueError("spec_steward_worker_state_schema_invalid")
+        return SpecStewardWorkerState(**payload)
+
+    def _persist(self, state: SpecStewardWorkerState) -> SpecStewardWorkerState:
+        _atomic(self._state_path(state.wake_id, state.presence_generation), asdict(state))
+        return state
+
+    def _capsules(self) -> list[tuple[int, Path, dict[str, Any]]]:
+        employee_dir = self.wake_root / EMPLOYEE_ID
+        if not employee_dir.is_dir():
+            return []
+        candidates: list[tuple[int, Path, dict[str, Any]]] = []
+        for path in sorted(employee_dir.glob("*.json")):
+            try:
+                payload = _read(path)
+                if not payload or payload.get("schema") != WAKE_RECEIPT_SCHEMA:
+                    continue
+                generation = int(payload.get("expected_lease_generation") or 0)
+                if generation < 1:
+                    continue
+                state = self._load_state(
+                    str(payload.get("wake_id") or ""),
+                    int(payload.get("presence_generation") or 0),
+                )
+                if state is not None and state.status in TERMINAL_LOCAL_STATES:
+                    continue
+                candidates.append((generation, path, payload))
+            except Exception:
+                continue
+        candidates.sort(key=lambda item: (item[0], item[1].name))
+        return candidates
+
+    def _validate_capsule(self, capsule: dict[str, Any], *, now: datetime) -> EmployeeWakeIntent:
+        if set(capsule) != CAPSULE_KEYS:
+            raise ValueError("spec_steward_worker_capsule_fields_invalid")
+        if capsule.get("schema") != WAKE_RECEIPT_SCHEMA:
+            raise ValueError("spec_steward_worker_capsule_schema_invalid")
+        if capsule.get("employee_id") != EMPLOYEE_ID or capsule.get("assignment_id") != ASSIGNMENT_ID:
+            raise PermissionError("spec_steward_worker_capsule_scope_mismatch")
+        if capsule.get("node_id") != self.node_id:
+            raise PermissionError("spec_steward_worker_node_mismatch")
+        presence_generation = int(capsule.get("presence_generation") or 0)
+        if presence_generation < 1:
+            raise ValueError("spec_steward_worker_presence_generation_invalid")
+
+        intent = capsule.get("wake_intent")
+        route = capsule.get("employee_wake_route")
+        if not isinstance(intent, dict) or set(intent) != ALLOWED_INTENT_KEYS:
+            raise ValueError("spec_steward_worker_wake_intent_invalid")
+        if not isinstance(route, dict) or set(route) != ROUTE_KEYS:
+            raise ValueError("spec_steward_worker_wake_route_invalid")
+        if intent.get("schema") != WAKE_INTENT_SCHEMA or route.get("schema") != WAKE_ROUTE_SCHEMA:
+            raise ValueError("spec_steward_worker_wake_schema_invalid")
+        if intent.get("employee_id") != EMPLOYEE_ID or intent.get("assignment_id") != ASSIGNMENT_ID:
+            raise PermissionError("spec_steward_worker_wake_scope_mismatch")
+        if route.get("employee_id") != EMPLOYEE_ID or route.get("node_id") != self.node_id:
+            raise PermissionError("spec_steward_worker_route_scope_mismatch")
+        if route.get("presence_id") != capsule.get("presence_id"):
+            raise ValueError("spec_steward_worker_presence_id_mismatch")
+        if int(route.get("presence_generation") or 0) != presence_generation:
+            raise ValueError("spec_steward_worker_presence_generation_mismatch")
+        if intent.get("wake_id") != capsule.get("wake_id"):
+            raise ValueError("spec_steward_worker_wake_id_mismatch")
+        if int(intent.get("expected_lease_generation") or 0) != int(capsule.get("expected_lease_generation") or 0):
+            raise ValueError("spec_steward_worker_lease_generation_mismatch")
+        if intent.get("authority_boundary") != "selection_only_no_execution":
+            raise PermissionError("spec_steward_worker_wake_authority_boundary_invalid")
+        if intent.get("executor_selection") != "unbound" or intent.get("transport_selection") != "unbound":
+            raise PermissionError("spec_steward_worker_wake_prebound_execution_rejected")
+        if intent.get("credential_exposed") is not False:
+            raise PermissionError("spec_steward_worker_wake_credential_boundary_invalid")
+        if intent.get("role_ids") != ["governance.spec_steward"] or intent.get("skill_ids") != [SKILL_ID]:
+            raise PermissionError("spec_steward_worker_role_skill_scope_mismatch")
+        if intent.get("mode") not in {"fresh", "resume"}:
+            raise ValueError("spec_steward_worker_wake_mode_invalid")
+
+        digest = _capsule_digest(intent, route)
+        if capsule.get("digest") != digest:
+            raise ValueError("spec_steward_worker_capsule_digest_mismatch")
+
+        employee = self.runtime.get_employee(EMPLOYEE_ID)
+        assignment = self.runtime.get_assignment(ASSIGNMENT_ID)
+        if employee.role_ids != ["governance.spec_steward"] or employee.skill_ids != [SKILL_ID]:
+            raise PermissionError("spec_steward_worker_employee_contract_drift")
+        if assignment.employee_id != EMPLOYEE_ID:
+            raise PermissionError("spec_steward_worker_assignment_employee_mismatch")
+
+        wake = EmployeeWakeIntent(
+            schema=WAKE_INTENT_SCHEMA,
+            wake_id=str(intent["wake_id"]),
+            employee_id=EMPLOYEE_ID,
+            assignment_id=ASSIGNMENT_ID,
+            mode=str(intent["mode"]),
+            expected_lease_generation=int(intent["expected_lease_generation"]),
+            goal=str(intent["goal"]),
+            thread_head=str(intent["thread_head"]),
+            constraints=tuple(str(item) for item in intent["constraints"]),
+            role_ids=("governance.spec_steward",),
+            skill_ids=(SKILL_ID,),
+            resume_required=intent.get("resume_required") is True,
+            prior_execution_state=str(intent["prior_execution_state"]),
+        )
+        current = EmployeeWakePlanner(self.lifecycle).plan_next(EMPLOYEE_ID, now=now)
+        if current is None or current.as_dict() != wake.as_dict():
+            raise RuntimeError("spec_steward_worker_wake_no_longer_current")
+        return wake
+
+    def _initial_state(self, capsule: dict[str, Any], *, now: datetime) -> SpecStewardWorkerState:
+        wake_id = str(capsule["wake_id"])
+        presence_generation = int(capsule["presence_generation"])
+        return SpecStewardWorkerState(
+            schema=WORKER_STATE_SCHEMA,
+            wake_id=wake_id,
+            digest=str(capsule["digest"]),
+            employee_id=EMPLOYEE_ID,
+            assignment_id=ASSIGNMENT_ID,
+            node_id=self.node_id,
+            presence_id=str(capsule["presence_id"]),
+            presence_generation=presence_generation,
+            expected_lease_generation=int(capsule["expected_lease_generation"]),
+            lease_id=_lease_id(wake_id, presence_generation, str(capsule["digest"])),
+            lease_generation=None,
+            status="accepted",
+            process_instance_digest=self.process_instance_digest,
+            executor_provider=self.executor.provider,
+            executor_model=self.executor.model,
+            created_at=_iso(now),
+            updated_at=_iso(now),
+        )
+
+    def _previous_checkpoint_state(self, generation: int, thread_head: str) -> SpecStewardWorkerState | None:
+        if generation <= 1 or not self.state_dir.is_dir():
+            return None
+        candidates: list[SpecStewardWorkerState] = []
+        for path in self.state_dir.glob("*.json"):
+            try:
+                payload = _read(path)
+                if not payload or payload.get("schema") != WORKER_STATE_SCHEMA:
+                    continue
+                state = SpecStewardWorkerState(**payload)
+            except Exception:
+                continue
+            if (
+                state.lease_generation == generation - 1
+                and state.status == "checkpointed"
+                and state.thread_head == thread_head
+            ):
+                candidates.append(state)
+        candidates.sort(key=lambda item: (item.updated_at, item.wake_id), reverse=True)
+        return candidates[0] if candidates else None
+
+    def _write_generation_continuity(self, generation: int, thread_head: str) -> None:
+        self.memory.write(
+            EMPLOYEE_ID,
+            "continuity",
+            f"spec-steward-o3-generation-{int(generation)}",
+            {
+                "schema": CONTINUITY_SCHEMA,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "lease_generation": int(generation),
+                "thread_head": thread_head,
+                "credential_exposed": False,
+                "session_identity_exposed": False,
+            },
+        )
+
+    def _prior_continuity_ok(self, generation: int, thread_head: str) -> bool:
+        if generation <= 1:
+            return False
+        try:
+            payload = self.memory.read(
+                EMPLOYEE_ID,
+                "continuity",
+                f"spec-steward-o3-generation-{int(generation) - 1}",
+            )
+        except (FileNotFoundError, PermissionError, ValueError):
+            return False
+        return bool(
+            isinstance(payload, dict)
+            and payload.get("schema") == CONTINUITY_SCHEMA
+            and payload.get("employee_id") == EMPLOYEE_ID
+            and payload.get("assignment_id") == ASSIGNMENT_ID
+            and int(payload.get("lease_generation") or 0) == generation - 1
+            and payload.get("thread_head") == thread_head
+            and payload.get("credential_exposed") is False
+            and payload.get("session_identity_exposed") is False
+        )
+
+    def _write_live_witness(self, state: SpecStewardWorkerState, lease: Any, previous: SpecStewardWorkerState, *, now: datetime) -> bool:
+        if previous.process_instance_digest == self.process_instance_digest:
+            return False
+        if lease.resumed_from_lease_id != previous.lease_id:
+            return False
+        if previous.lease_generation != lease.generation - 1:
+            return False
+        _atomic(
+            self.runtime_root / "acceptance" / "spec-steward-o3-live-witness.json",
+            {
+                "schema": LIVE_WITNESS_SCHEMA,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "witness_kind": "fresh_executor_or_session_transition",
+                "from_lease_id": previous.lease_id,
+                "to_lease_id": state.lease_id,
+                "from_generation": previous.lease_generation,
+                "to_generation": lease.generation,
+                "fresh_executor_or_session": True,
+                "process_boundary_observed": True,
+                "session_identity_exposed": False,
+                "credential_exposed": False,
+                "observed_at": _iso(now),
+            },
+        )
+        return True
+
+    def process_one(self, *, now: datetime | None = None) -> SpecStewardWorkerState | None:
+        current_time = now or _utcnow()
+        candidates = self._capsules()
+        if not candidates:
+            return None
+        _, _, capsule = candidates[0]
+        wake_id = str(capsule.get("wake_id") or "")
+        presence_generation = int(capsule.get("presence_generation") or 0)
+        state = self._load_state(wake_id, presence_generation)
+        if state is not None and state.status == "executing":
+            state.status = "unknown"
+            state.error_code = "worker_interrupted_after_execution_boundary"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+        if state is not None and state.status in TERMINAL_LOCAL_STATES:
+            return state
+
+        try:
+            wake = self._validate_capsule(capsule, now=current_time)
+            if state is None:
+                state = self._persist(self._initial_state(capsule, now=current_time))
+
+            self.skill_service.hydrate_employee_skills(EMPLOYEE_ID)
+            skill_request = build_spec_steward_audit_request(self.runtime)
+            if skill_request.get("execution_authority") != "external_governed_dispatcher":
+                raise PermissionError("spec_steward_worker_skill_execution_boundary_invalid")
+
+            self.runtime.bind_executor(
+                EMPLOYEE_ID,
+                provider=self.executor.provider,
+                model=self.executor.model,
+                session_id="",
+            )
+            lease = self.lifecycle.claim(
+                ASSIGNMENT_ID,
+                EMPLOYEE_ID,
+                state.lease_id,
+                lease_seconds=self.lease_seconds,
+                now=current_time,
+            )
+            if lease.generation != wake.expected_lease_generation:
+                raise RuntimeError("spec_steward_worker_claim_generation_mismatch")
+            if wake.mode == "resume" and not lease.resume_required:
+                raise RuntimeError("spec_steward_worker_resume_lease_not_marked")
+            if wake.mode == "fresh" and lease.resume_required:
+                raise RuntimeError("spec_steward_worker_fresh_lease_marked_resume")
+            state.lease_generation = lease.generation
+            state.status = "leased"
+            state.process_instance_digest = self.process_instance_digest
+            state.updated_at = _iso(current_time)
+            self._persist(state)
+
+            self.lifecycle.build_work_packet(
+                ASSIGNMENT_ID,
+                state.lease_id,
+                self.role_registry,
+                now=current_time,
+            )
+            previous = self._previous_checkpoint_state(lease.generation, wake.thread_head)
+            prior_memory_ok = self._prior_continuity_ok(lease.generation, wake.thread_head)
+
+            state.status = "executing"
+            state.updated_at = _iso(current_time)
+            self._persist(state)
+            thread_head, audit = self.executor.execute(
+                self.runtime,
+                skill_request=skill_request,
+                lease_generation=lease.generation,
+            )
+            self.lifecycle.checkpoint(
+                ASSIGNMENT_ID,
+                state.lease_id,
+                thread_head,
+                now=current_time,
+            )
+            state.thread_head = thread_head
+            self._write_generation_continuity(lease.generation, thread_head)
+
+            if wake.mode == "fresh":
+                # O3 intentionally requires a later process/executor transition.
+                # Do not finish generation 1; the lease must expire and be resumed.
+                state.status = "checkpointed"
+                state.error_code = None
+                state.updated_at = _iso(current_time)
+                return self._persist(state)
+
+            if previous is None or not prior_memory_ok:
+                raise RuntimeError("spec_steward_worker_resume_continuity_evidence_missing")
+            self._write_live_witness(state, lease, previous, now=current_time)
+            self.memory.write(
+                EMPLOYEE_ID,
+                MEMORY_CLASS,
+                MEMORY_KEY,
+                {
+                    "schema": MEMORY_EVIDENCE_SCHEMA,
+                    "employee_id": EMPLOYEE_ID,
+                    "assignment_id": ASSIGNMENT_ID,
+                    "thread_head": thread_head,
+                    "observed_after_resume": True,
+                    "session_identity_exposed": False,
+                    "credential_exposed": False,
+                },
+            )
+
+            preterminal = inspect_spec_steward_acceptance(self.runtime)
+            receipt = self.lifecycle.finish(
+                ASSIGNMENT_ID,
+                state.lease_id,
+                result_summary={
+                    "acceptance_scope": "core-issue-197-o3",
+                    "audit_blocking_count_before_terminal": len(preterminal.blocking_reasons),
+                    "audit_blocking_checks_before_terminal": list(preterminal.blocking_reasons),
+                    "native_audit_blocking_count": int(audit.get("blocking_count") or 0),
+                    "credential_exposed": False,
+                    "session_identity_exposed": False,
+                },
+                now=current_time,
+            )
+            if receipt.credential_exposed is not False:
+                raise RuntimeError("spec_steward_worker_terminal_receipt_privacy_invalid")
+            final_report = inspect_spec_steward_acceptance(self.runtime)
+            state.status = "completed"
+            state.error_code = None if final_report.ready_for_live_marker else "o3_acceptance_evidence_incomplete"
+            state.updated_at = _iso(current_time)
+            return self._persist(state)
+        except Exception:
+            if state is None:
+                state = self._initial_state(capsule, now=current_time)
+            state.status = "unknown" if state.status == "executing" else "failed"
+            state.error_code = (
+                "worker_execution_uncertain" if state.status == "unknown" else "worker_pre_execution_failed"
+            )
+            state.updated_at = _iso(current_time)
+            return self._persist(state)

--- a/agentos_node/spec_steward_worker_cli.py
+++ b/agentos_node/spec_steward_worker_cli.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from agentos_node.governed_spec_steward_worker import GovernedSpecStewardWakeWorker
+
+
+def _absolute_path(value: str, field: str) -> str:
+    path = Path(str(value or "").strip()).expanduser()
+    if not path.is_absolute():
+        raise argparse.ArgumentTypeError(f"{field}_must_be_absolute")
+    return str(path.resolve())
+
+
+def _runtime_root(value: str) -> str:
+    return _absolute_path(value, "runtime_root")
+
+
+def _wake_root(value: str) -> str:
+    return _absolute_path(value, "wake_root")
+
+
+def _worker_state_root(value: str) -> str:
+    return _absolute_path(value, "worker_state_root")
+
+
+def _safe_output(state: Any) -> dict[str, Any]:
+    if state is None:
+        return {
+            "schema": "agentos.spec-steward-o3-worker-cli-result/v1",
+            "status": "idle",
+            "work_performed": False,
+            "credential_exposed": False,
+            "session_identity_exposed": False,
+            "verified_marker_emitted": False,
+        }
+    return {
+        "schema": "agentos.spec-steward-o3-worker-cli-result/v1",
+        "status": state.status,
+        "work_performed": state.status in {"checkpointed", "completed", "unknown"},
+        "employee_id": state.employee_id,
+        "assignment_id": state.assignment_id,
+        "lease_generation": state.lease_generation,
+        "thread_head": state.thread_head,
+        "error_code": state.error_code,
+        "executor_provider": state.executor_provider,
+        "executor_model": state.executor_model,
+        "credential_exposed": False,
+        "session_identity_exposed": False,
+        "verified_marker_emitted": False,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agentos-spec-steward-worker",
+        description="Run one governed Spec Steward O3 Employee wake. This does not bootstrap state or emit VERIFIED.",
+    )
+    parser.add_argument("--runtime-root", required=True, type=_runtime_root)
+    parser.add_argument("--wake-root", required=True, type=_wake_root)
+    parser.add_argument("--worker-state-root", required=True, type=_worker_state_root)
+    parser.add_argument("--node-id", required=True)
+    parser.add_argument("--lease-seconds", type=int, default=60)
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        required=True,
+        help="Required O3 mode: process at most one governed wake, then exit so a later process can prove resume continuity.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    worker = GovernedSpecStewardWakeWorker(
+        runtime_root=args.runtime_root,
+        wake_root=args.wake_root,
+        worker_state_root=args.worker_state_root,
+        node_id=args.node_id,
+        lease_seconds=args.lease_seconds,
+    )
+    state = worker.process_one()
+    print(json.dumps(_safe_output(state), ensure_ascii=False, sort_keys=True))
+    if state is None or state.status in {"checkpointed", "completed"}:
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/SPEC_STEWARD_O3_LIVE_RUNBOOK.md
+++ b/docs/SPEC_STEWARD_O3_LIVE_RUNBOOK.md
@@ -1,0 +1,221 @@
+# Spec Steward O3 Live Acceptance Runbook
+
+Status: source-controlled acceptance procedure for AgentOS Core issue #197.
+
+This runbook proves one narrow claim only: the durable `agentos-spec-steward` Employee can receive a governed ONE wake, checkpoint work, lose its first worker process/lease, resume in a later worker process, preserve Employee memory/thread state, and produce a sanitized terminal receipt.
+
+It does **not** authorize protected-main publication, production deployment, arbitrary Node execution, shell/argv tunneling, credential access, session identity persistence, or GitHub Actions as a control-plane fallback.
+
+## Acceptance boundary
+
+The required chain is:
+
+`canonical Employee -> Core Supervisor reconcile intent -> one_direct S4 delivery -> existing online wake-capable Node -> Node wake inbox -> governed Spec Steward worker -> lease generation 1 checkpoint -> expired lease / prior execution UNKNOWN -> governed resume wake -> fresh worker process -> lease generation 2+ -> memory/thread continuity -> terminal Employee receipt -> read-only acceptance inspector`
+
+Static CI may prove the implementation contract, but static CI can never emit `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`.
+
+## Required preconditions
+
+Use the accepted `core/integration` source SHA containing this runbook and worker code. Do not run the live acceptance from an unmerged feature branch.
+
+The operator must provide these existing absolute paths/identities:
+
+- `<ABS_EMPLOYEE_RUNTIME_ROOT>`: canonical Employee runtime root used by Core Supervisor.
+- `<ABS_ONE_DATA_ROOT>`: existing ONE control-plane data root containing `realm/fabric.json` and `realm/nodes.json` for the same Realm.
+- `<ABS_NODE_WAKE_ROOT>`: the wake inbox root already configured on the selected Node's `ThinClientPolicy.employee_wake_root`.
+- `<ABS_WORKER_STATE_ROOT>`: separate Node-local Spec Steward worker state root. It must not overlap the canonical Employee runtime or wake root.
+- `<NODE_ID>`: existing Node ID already registered in ONE.
+- `<PRESENCE_ID>`: opaque operator-generated presence identifier. It is Employee-to-Node presence, not executor/session identity.
+
+The selected Node must already be online and advertise `agent.employee.wake.deliver`. The presence CLI enforces this. If the Node lacks that capability, stop; this runbook does not authorize registering a new Node or broadening its capability set.
+
+The ONE control plane and Node consumer must already be operating. Do not use GitHub Actions to replace ONE delivery.
+
+## 1. Bootstrap canonical Spec Steward state
+
+Run exactly once or idempotently repeat:
+
+```bash
+python -m agent_core.spec_steward_o3_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  bootstrap
+```
+
+Expected properties:
+
+- canonical Employee ID is `agentos-spec-steward`;
+- assignment ID is `spec-steward-o3-acceptance-v1`;
+- the command may create the canonical Employee/work item/assignment on first execution;
+- repeated bootstrap does not reset progressed thread, lease, terminal state, or live evidence;
+- output always reports `verified_marker_emitted=false`.
+
+A bootstrap-only inspect must remain blocked:
+
+```bash
+python -m agent_core.spec_steward_o3_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  inspect
+```
+
+Exit code `3` is expected until all live evidence exists.
+
+## 2. Bind bounded Employee presence to the existing Node
+
+```bash
+python -m agent_core.spec_steward_presence_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  --one-data-root <ABS_ONE_DATA_ROOT> \
+  --node-id <NODE_ID> \
+  bind \
+  --presence-id <PRESENCE_ID> \
+  --ttl-seconds 300
+```
+
+This command must fail closed if ONE state is missing/mismatched, if the Node is offline/stale, or if the Node does not advertise `agent.employee.wake.deliver`.
+
+Presence does not bind Employee identity to an executor/model/session. Output must keep `executor_identity_bound=false` and `credential_exposed=false`.
+
+If the acceptance takes long enough that presence freshness is at risk, refresh the same owned presence without changing Employee identity:
+
+```bash
+python -m agent_core.spec_steward_presence_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  --one-data-root <ABS_ONE_DATA_ROOT> \
+  --node-id <NODE_ID> \
+  heartbeat \
+  --presence-id <PRESENCE_ID> \
+  --ttl-seconds 300
+```
+
+## 3. Run Core Supervisor with explicit S4 `one_direct` delivery
+
+Run the existing Core Supervisor as an operator-controlled foreground/service process with delivery explicitly enabled:
+
+```bash
+AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct \
+AGENTOS_SUPERVISOR_ONE_DATA_ROOT=<ABS_ONE_DATA_ROOT> \
+python -m agent_core.core_supervisor_daemon \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT>
+```
+
+Do not enable another transport. The Supervisor must persist the immutable S3 reconcile intent first, then the separate S4 delivery ledger. The worker will refuse to claim work unless it can find exactly one matching persisted authority chain for the wake:
+
+- `kind=employee_wake`;
+- `authority_policy_id=core-supervisor-employee-wake-v1`;
+- `transport=one_direct`;
+- `capability=agent.employee.wake.deliver`;
+- exact Employee, assignment, wake, Node and presence;
+- `dispatch_performed=true`;
+- delivery still eligible for pre-claim execution.
+
+A locally injected wake capsule without this Core-side authority evidence must not claim the Employee assignment.
+
+## 4. First worker process: claim generation 1 and checkpoint only
+
+Invoke the governed worker as a separate process. `--once` is mandatory:
+
+```bash
+python -m agentos_node.spec_steward_worker_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  --wake-root <ABS_NODE_WAKE_ROOT> \
+  --worker-state-root <ABS_WORKER_STATE_ROOT> \
+  --node-id <NODE_ID> \
+  --lease-seconds 30 \
+  --once
+```
+
+Expected result:
+
+- `status=checkpointed`;
+- `lease_generation=1`;
+- assignment becomes active;
+- thread head advances from the bootstrap head;
+- no terminal Employee receipt exists for generation 1;
+- no raw process ID/session ID/credential is persisted in the canonical receipt surface;
+- the process exits after processing at most one wake.
+
+Do not immediately restart the same lease as if nothing happened. The O3 acceptance specifically requires the first lease to cease being live so the next planner pass treats prior execution as `UNKNOWN` and emits a resume wake.
+
+## 5. Resume in a fresh worker process
+
+After generation 1 is no longer a live lease, the persistent Supervisor must plan and deliver the exact resume wake through ONE. Keep the Employee presence fresh if required.
+
+Then invoke the same worker CLI again as a new OS process:
+
+```bash
+python -m agentos_node.spec_steward_worker_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  --wake-root <ABS_NODE_WAKE_ROOT> \
+  --worker-state-root <ABS_WORKER_STATE_ROOT> \
+  --node-id <NODE_ID> \
+  --lease-seconds 30 \
+  --once
+```
+
+Expected result:
+
+- `status=completed`;
+- lease generation is `2` or greater;
+- the lease records `resume_required=true`, `prior_execution_state=unknown`, and a different `resumed_from_lease_id`;
+- the worker observes the previous checkpoint and persists private Employee memory continuity;
+- a privacy-safe fresh-process witness is created without raw PID/session identity;
+- the terminal Employee receipt is sanitized and bound to the current lease generation/thread head.
+
+Invoking both generations from the same worker process is not sufficient evidence; the worker intentionally refuses to create the fresh-executor witness in that case.
+
+## 6. Let Supervisor observe claim/terminal state
+
+Keep the Supervisor running until its S4 delivery ledger has observed both the initial and resume wake generations as governed deliveries (`claimed` or terminal-observed evidence as applicable).
+
+Do not manually edit delivery ledgers, reconcile intents, lifecycle receipts, witness files, or memory evidence to satisfy the inspector.
+
+## 7. Read-only acceptance inspection
+
+Run:
+
+```bash
+python -m agent_core.spec_steward_o3_cli \
+  --runtime-root <ABS_EMPLOYEE_RUNTIME_ROOT> \
+  inspect
+```
+
+A source/live evidence chain ready for final attestation has:
+
+- exit code `0`;
+- `ready_for_live_marker=true`;
+- `blocking_reasons=[]`;
+- qualifying governed wake generations include generation `1` and the resumed terminal generation;
+- `resumed_assignment_lease=true`;
+- `fresh_executor_or_session_live_witness=true`;
+- `private_memory_continuity=true`;
+- `terminal_sanitized_employee_receipt=true`;
+- `assignment_completed=true`;
+- `carrier_and_authority_evidence=true`;
+- `credential_and_session_identity_not_exposed=true`;
+- `verified_marker_emitted=false`.
+
+The last field is intentionally false. This source slice stops at `ready_for_live_marker`. A separate explicit live-attestation authority must decide whether to publish `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`; neither CI nor this inspector may self-certify it.
+
+## Failure and interruption rules
+
+- If worker execution entered its side-effect boundary and then the process died, treat the prior attempt as `UNKNOWN`; do not blindly replay the same claimed execution.
+- If S4 authority evidence is missing, wrong, ambiguous, GitHub-Actions-like, terminal/unknown before claim, or mismatched to Node/presence/wake, the governed worker must fail before acquiring the Employee lease.
+- If presence expires, refresh/rebind only through the bounded presence utility and existing ONE Node authority; do not rewrite presence JSON manually.
+- If ONE is unavailable, the acceptance is blocked. Do not fall back to GitHub Actions.
+- If the Node capability is absent, the acceptance is blocked. Do not add shell or generic execution authority as a workaround.
+- Preserve failed/unknown evidence for reconciliation. Do not delete canonical runtime evidence to make a retry appear clean.
+
+## Acceptance record
+
+For #197 closure, preserve at minimum:
+
+- accepted Core source SHA containing the O3 worker/runbook;
+- selected Realm and Node logical IDs (no credentials/session IDs);
+- Supervisor S3/S4 reconcile and delivery evidence for initial + resume wakes;
+- Employee lease generations and sanitized terminal receipt;
+- privacy-safe fresh-process witness;
+- Employee memory continuity evidence;
+- final read-only inspector output;
+- explicit live attestation that is external to static CI.
+
+`core/integration` merge proves the implementation is accepted for integration. It does not by itself prove the Employee is OPERATING in the live Realm.

--- a/tests/test_governed_spec_steward_worker.py
+++ b/tests/test_governed_spec_steward_worker.py
@@ -136,6 +136,13 @@ class GovernedSpecStewardWorkerTests(unittest.TestCase):
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
         self.assertEqual(self.runtime.get_assignment(ASSIGNMENT_ID).state, "pending")
 
+    def test_merely_queued_delivery_cannot_authorize_local_capsule(self):
+        self._record_delivery("reconcile_queued", status="queued")
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+        self.assertEqual(self.runtime.get_assignment(ASSIGNMENT_ID).state, "pending")
+
     def test_actions_like_transport_cannot_authorize_worker(self):
         self._record_delivery("reconcile_actions", transport="github_actions")
         with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
@@ -148,8 +155,8 @@ class GovernedSpecStewardWorkerTests(unittest.TestCase):
             self._worker().process_one(now=T0)
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
 
-    def test_exact_s4_delivery_allows_bounded_worker_claim(self):
-        self._record_delivery("reconcile_exact")
+    def test_exact_node_acknowledged_s4_delivery_allows_bounded_worker_claim(self):
+        self._record_delivery("reconcile_exact", status="awaiting_claim")
         state = self._worker().process_one(now=T0)
         self.assertEqual(state.status, "checkpointed")
         self.assertEqual(state.lease_generation, 1)

--- a/tests/test_governed_spec_steward_worker.py
+++ b/tests/test_governed_spec_steward_worker.py
@@ -76,6 +76,7 @@ class GovernedSpecStewardWorkerTests(unittest.TestCase):
         authority_policy_id: str = EXPECTED_AUTHORITY_POLICY,
         status: str = "awaiting_claim",
     ) -> None:
+        self.assertTrue(reconcile_id.startswith("reconcile_"))
         _write(
             self.runtime_root / "supervisor" / "intents" / f"{reconcile_id}.json",
             {
@@ -136,19 +137,19 @@ class GovernedSpecStewardWorkerTests(unittest.TestCase):
         self.assertEqual(self.runtime.get_assignment(ASSIGNMENT_ID).state, "pending")
 
     def test_actions_like_transport_cannot_authorize_worker(self):
-        self._record_delivery("reconcile-actions", transport="github_actions")
+        self._record_delivery("reconcile_actions", transport="github_actions")
         with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
             self._worker().process_one(now=T0)
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
 
     def test_wrong_authority_policy_cannot_authorize_worker(self):
-        self._record_delivery("reconcile-wrong-policy", authority_policy_id="unrelated-policy")
+        self._record_delivery("reconcile_wrong_policy", authority_policy_id="unrelated-policy")
         with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
             self._worker().process_one(now=T0)
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
 
     def test_exact_s4_delivery_allows_bounded_worker_claim(self):
-        self._record_delivery("reconcile-exact")
+        self._record_delivery("reconcile_exact")
         state = self._worker().process_one(now=T0)
         self.assertEqual(state.status, "checkpointed")
         self.assertEqual(state.lease_generation, 1)
@@ -157,14 +158,14 @@ class GovernedSpecStewardWorkerTests(unittest.TestCase):
         self.assertEqual(lease.generation, 1)
 
     def test_duplicate_authority_records_fail_ambiguous_instead_of_picking_one(self):
-        self._record_delivery("reconcile-one")
-        self._record_delivery("reconcile-two")
+        self._record_delivery("reconcile_one")
+        self._record_delivery("reconcile_two")
         with self.assertRaisesRegex(PermissionError, "governed_delivery_ambiguous"):
             self._worker().process_one(now=T0)
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
 
     def test_terminal_or_unknown_delivery_is_not_preclaim_authority(self):
-        self._record_delivery("reconcile-unknown", status="unknown")
+        self._record_delivery("reconcile_unknown", status="unknown")
         with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
             self._worker().process_one(now=T0)
         self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))

--- a/tests/test_governed_spec_steward_worker.py
+++ b/tests/test_governed_spec_steward_worker.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import EmployeeWakePlanner
+from agent_core.spec_steward_acceptance import EXPECTED_AUTHORITY_POLICY
+from agent_core.spec_steward_bootstrap import ensure_spec_steward
+from agentos_node.employee_wake_inbox import deliver_employee_wake
+from agentos_node.governed_spec_steward_worker import GovernedSpecStewardWakeWorker
+from agentos_node.spec_steward_worker import ASSIGNMENT_ID, EMPLOYEE_ID
+
+
+T0 = datetime(2026, 9, 2, 7, 30, 0, tzinfo=timezone.utc)
+NODE_ID = "node-o3"
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+class GovernedSpecStewardWorkerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name)
+        self.runtime_root = base / "canonical"
+        self.wake_root = base / "wake"
+        self.state_root = base / "state"
+        self.runtime = EmployeeRuntime(self.runtime_root)
+        ensure_spec_steward(self.runtime)
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        wake = EmployeeWakePlanner(self.lifecycle).plan_next(EMPLOYEE_ID, now=T0)
+        self.assertIsNotNone(wake)
+        self.wake = wake
+        self.route = {
+            "schema": "agentos.employee-wake-route/v1",
+            "employee_id": EMPLOYEE_ID,
+            "node_id": NODE_ID,
+            "presence_id": "presence-o3-1",
+            "presence_generation": 1,
+        }
+        deliver_employee_wake(
+            {"wake_intent": wake.as_dict(), "employee_wake_route": self.route},
+            self.wake_root,
+            expected_node_id=NODE_ID,
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _worker(self):
+        return GovernedSpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="governed-process-a",
+            lease_seconds=60,
+        )
+
+    def _record_delivery(
+        self,
+        reconcile_id: str,
+        *,
+        transport: str = "one_direct",
+        authority_policy_id: str = EXPECTED_AUTHORITY_POLICY,
+        status: str = "awaiting_claim",
+    ) -> None:
+        _write(
+            self.runtime_root / "supervisor" / "intents" / f"{reconcile_id}.json",
+            {
+                "schema": INTENT_RECORD_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "state": "planned",
+                "planned_at": T0.isoformat(),
+                "planned_by_cycle": 1,
+                "intent": {
+                    "schema": RECONCILE_INTENT_SCHEMA,
+                    "reconcile_id": reconcile_id,
+                    "kind": "employee_wake",
+                    "employee_id": EMPLOYEE_ID,
+                    "assignment_id": ASSIGNMENT_ID,
+                    "reason": "assignment_pending",
+                    "wake_intent": self.wake.as_dict(),
+                    "authority_boundary": "observe_and_select_only",
+                    "node_selection": "unbound",
+                    "executor_selection": "unbound",
+                    "transport_selection": "unbound",
+                    "capability_authority": "unbound",
+                    "credential_exposed": False,
+                },
+                "dispatch_performed": False,
+            },
+        )
+        _write(
+            self.runtime_root / "supervisor" / "deliveries" / f"{reconcile_id}.json",
+            {
+                "schema": DELIVERY_STATE_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "wake_id": self.wake.wake_id,
+                "status": status,
+                "created_at": T0.isoformat(),
+                "updated_at": T0.isoformat(),
+                "authority_policy_id": authority_policy_id,
+                "transport_policy_id": "transport-routing-v1",
+                "transport": transport,
+                "transport_authority": "core_policy",
+                "capability": WAKE_CAPABILITY,
+                "supervisor_leader_generation": 1,
+                "dispatch_performed": True,
+                "presence_id": self.route["presence_id"],
+                "presence_generation": self.route["presence_generation"],
+                "node_id": NODE_ID,
+                "wake_attempt_id": f"attempt-{reconcile_id}",
+                "task_id": f"task-{reconcile_id}",
+                "error_code": None,
+            },
+        )
+
+    def test_local_capsule_without_s4_delivery_never_claims(self):
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+        self.assertEqual(self.runtime.get_assignment(ASSIGNMENT_ID).state, "pending")
+
+    def test_actions_like_transport_cannot_authorize_worker(self):
+        self._record_delivery("reconcile-actions", transport="github_actions")
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+
+    def test_wrong_authority_policy_cannot_authorize_worker(self):
+        self._record_delivery("reconcile-wrong-policy", authority_policy_id="unrelated-policy")
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+
+    def test_exact_s4_delivery_allows_bounded_worker_claim(self):
+        self._record_delivery("reconcile-exact")
+        state = self._worker().process_one(now=T0)
+        self.assertEqual(state.status, "checkpointed")
+        self.assertEqual(state.lease_generation, 1)
+        lease = self.lifecycle.get_lease(ASSIGNMENT_ID)
+        self.assertIsNotNone(lease)
+        self.assertEqual(lease.generation, 1)
+
+    def test_duplicate_authority_records_fail_ambiguous_instead_of_picking_one(self):
+        self._record_delivery("reconcile-one")
+        self._record_delivery("reconcile-two")
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_ambiguous"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+
+    def test_terminal_or_unknown_delivery_is_not_preclaim_authority(self):
+        self._record_delivery("reconcile-unknown", status="unknown")
+        with self.assertRaisesRegex(PermissionError, "governed_delivery_missing"):
+            self._worker().process_one(now=T0)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_steward_o3_cli.py
+++ b/tests/test_spec_steward_o3_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_core import spec_steward_o3_cli as cli
+
+
+class SpecStewardO3CliTests(unittest.TestCase):
+    def test_runtime_root_must_be_absolute(self):
+        parser = cli.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["--runtime-root", "relative/runtime", "bootstrap"])
+
+    def test_bootstrap_is_idempotent_and_never_emits_verified_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = str(Path(tmp).resolve() / "runtime")
+            first_out = io.StringIO()
+            with patch("sys.stdout", first_out):
+                first_code = cli.main(["--runtime-root", root, "bootstrap"])
+            second_out = io.StringIO()
+            with patch("sys.stdout", second_out):
+                second_code = cli.main(["--runtime-root", root, "bootstrap"])
+            self.assertEqual(first_code, 0)
+            self.assertEqual(second_code, 0)
+            first = json.loads(first_out.getvalue())
+            second = json.loads(second_out.getvalue())
+            self.assertTrue(first["employee_created"])
+            self.assertFalse(second["employee_created"])
+            self.assertFalse(first["verified_marker_emitted"])
+            self.assertFalse(second["verified_marker_emitted"])
+
+    def test_inspect_is_blocked_after_bootstrap_only_and_read_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve() / "runtime"
+            with patch("sys.stdout", io.StringIO()):
+                cli.main(["--runtime-root", str(root), "bootstrap"])
+            before = {
+                str(path.relative_to(root)): path.read_bytes()
+                for path in root.rglob("*")
+                if path.is_file()
+            }
+            out = io.StringIO()
+            with patch("sys.stdout", out):
+                code = cli.main(["--runtime-root", str(root), "inspect"])
+            after = {
+                str(path.relative_to(root)): path.read_bytes()
+                for path in root.rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(code, 3)
+            self.assertEqual(before, after)
+            payload = json.loads(out.getvalue())
+            self.assertFalse(payload["ready_for_live_marker"])
+            self.assertFalse(payload["verified_marker_emitted"])
+
+    def test_cli_has_no_dispatch_deploy_or_main_publish_subcommand(self):
+        parser = cli.build_parser()
+        subparsers = [action for action in parser._actions if hasattr(action, "choices") and action.choices]
+        choices = set()
+        for action in subparsers:
+            choices.update(action.choices)
+        self.assertEqual(choices, {"bootstrap", "inspect"})
+        self.assertNotIn("dispatch", choices)
+        self.assertNotIn("deploy", choices)
+        self.assertNotIn("publish", choices)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_steward_presence_cli.py
+++ b/tests/test_spec_steward_presence_cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_core import spec_steward_presence_cli as cli
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.spec_steward_bootstrap import ensure_spec_steward
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+class SpecStewardPresenceCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name).resolve()
+        self.runtime_root = base / "runtime"
+        self.one_root = base / "one"
+        ensure_spec_steward(EmployeeRuntime(self.runtime_root))
+        now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        _write(
+            self.one_root / "realm" / "fabric.json",
+            {"schema": "agentos.realm-fabric/v0.1", "realm_id": "realm-o3"},
+        )
+        _write(
+            self.one_root / "realm" / "nodes.json",
+            {
+                "schema": "agentos.node-registry/v0.1",
+                "realm_id": "realm-o3",
+                "nodes": {
+                    "node-o3": {
+                        "node_id": "node-o3",
+                        "role": "client",
+                        "hostname": "o3-test",
+                        "platform": "linux",
+                        "platform_release": "test",
+                        "capabilities": [WAKE_CAPABILITY],
+                        "tool_presence": {},
+                        "surface_inventory": {},
+                        "runtime": {},
+                        "workspace_roots": {},
+                        "status": "online",
+                        "first_seen_at": now,
+                        "last_manifest_at": now,
+                        "last_heartbeat_at": now,
+                        "benchmark": None,
+                    }
+                },
+            },
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _args(self, command: str, *extra: str) -> list[str]:
+        return [
+            "--runtime-root", str(self.runtime_root),
+            "--one-data-root", str(self.one_root),
+            "--node-id", "node-o3",
+            command,
+            *extra,
+        ]
+
+    def test_cli_has_no_arbitrary_employee_or_node_registration_surface(self):
+        parser = cli.build_parser()
+        option_strings = {
+            option
+            for action in parser._actions
+            for option in action.option_strings
+        }
+        self.assertNotIn("--employee-id", option_strings)
+        self.assertNotIn("--capability", option_strings)
+        self.assertNotIn("--register-node", option_strings)
+        self.assertNotIn("--create-realm", option_strings)
+
+    def test_bind_requires_existing_online_wake_capable_node(self):
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            code = cli.main(self._args("bind", "--presence-id", "presence-o3", "--ttl-seconds", "300"))
+        self.assertEqual(code, 0)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["employee_id"], "agentos-spec-steward")
+        self.assertEqual(payload["node_id"], "node-o3")
+        self.assertEqual(payload["required_capability"], WAKE_CAPABILITY)
+        self.assertFalse(payload["executor_identity_bound"])
+        self.assertFalse(payload["credential_exposed"])
+
+    def test_bind_fails_if_node_lacks_wake_capability(self):
+        nodes_path = self.one_root / "realm" / "nodes.json"
+        nodes = json.loads(nodes_path.read_text(encoding="utf-8"))
+        nodes["nodes"]["node-o3"]["capabilities"] = []
+        _write(nodes_path, nodes)
+        with self.assertRaisesRegex(PermissionError, "lacks_wake_capability"):
+            cli.main(self._args("bind", "--presence-id", "presence-o3"))
+        self.assertFalse(
+            (self.runtime_root / "realm" / "employee-presence" / "agentos-spec-steward.json").exists()
+        )
+
+    def test_missing_one_state_fails_without_initializing_shadow_realm(self):
+        (self.one_root / "realm" / "fabric.json").unlink()
+        (self.one_root / "realm" / "nodes.json").unlink()
+        with self.assertRaisesRegex(RuntimeError, "one_control_plane_state_missing"):
+            cli.main(self._args("bind", "--presence-id", "presence-o3"))
+        self.assertFalse((self.one_root / "realm" / "fabric.json").exists())
+        self.assertFalse((self.one_root / "realm" / "nodes.json").exists())
+
+    def test_inspect_does_not_bind_absent_presence(self):
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            code = cli.main(self._args("inspect"))
+        self.assertEqual(code, 3)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["status"], "absent")
+        self.assertFalse(
+            (self.runtime_root / "realm" / "employee-presence" / "agentos-spec-steward.json").exists()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_steward_worker.py
+++ b/tests/test_spec_steward_worker.py
@@ -36,6 +36,16 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
+def _assert_no_exact_keys(testcase: unittest.TestCase, value, forbidden: set[str]) -> None:
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            testcase.assertNotIn(str(raw_key).casefold(), forbidden)
+            _assert_no_exact_keys(testcase, item, forbidden)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_exact_keys(testcase, item, forbidden)
+
+
 class SpecStewardWorkerTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -198,7 +208,7 @@ class SpecStewardWorkerTests(unittest.TestCase):
         serialized = json.dumps(receipt, ensure_ascii=False)
         self.assertNotIn("process-a", serialized)
         self.assertNotIn("process-b", serialized)
-        self.assertNotIn("session_id", serialized)
+        _assert_no_exact_keys(self, receipt, {"session", "session_id"})
 
         # The worker may finish before the next Supervisor cycle observes the claim.
         blocked = inspect_spec_steward_acceptance(self.runtime)
@@ -218,6 +228,7 @@ class SpecStewardWorkerTests(unittest.TestCase):
         self.assertTrue(witness["fresh_executor_or_session"])
         self.assertTrue(witness["process_boundary_observed"])
         self.assertFalse(witness["session_identity_exposed"])
+        _assert_no_exact_keys(self, witness, {"session", "session_id"})
 
     def test_same_process_resume_cannot_produce_fresh_executor_witness(self):
         self._deliver_current_wake(now=T0, presence_generation=1)

--- a/tests/test_spec_steward_worker.py
+++ b/tests/test_spec_steward_worker.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import EmployeeWakePlanner
+from agent_core.spec_steward_acceptance import (
+    EXPECTED_AUTHORITY_POLICY,
+    inspect_spec_steward_acceptance,
+)
+from agent_core.spec_steward_bootstrap import ensure_spec_steward
+from agentos_node.employee_wake_inbox import deliver_employee_wake
+from agentos_node.spec_steward_worker import (
+    ASSIGNMENT_ID,
+    EMPLOYEE_ID,
+    WORKER_STATE_SCHEMA,
+    SpecStewardWakeWorker,
+)
+
+
+T0 = datetime(2026, 9, 2, 7, 0, 0, tzinfo=timezone.utc)
+NODE_ID = "node-o3"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+class SpecStewardWorkerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name)
+        self.runtime_root = base / "canonical-employee-runtime"
+        self.wake_root = base / "node-wake-inbox"
+        self.state_root = base / "node-worker-state"
+        self.runtime = EmployeeRuntime(self.runtime_root)
+        ensure_spec_steward(self.runtime)
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.planner = EmployeeWakePlanner(self.lifecycle)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _deliver_current_wake(self, *, now: datetime, presence_generation: int):
+        wake = self.planner.plan_next(EMPLOYEE_ID, now=now)
+        self.assertIsNotNone(wake)
+        route = {
+            "schema": "agentos.employee-wake-route/v1",
+            "employee_id": EMPLOYEE_ID,
+            "node_id": NODE_ID,
+            "presence_id": f"presence-o3-{presence_generation}",
+            "presence_generation": presence_generation,
+        }
+        result = deliver_employee_wake(
+            {
+                "wake_intent": wake.as_dict(),
+                "employee_wake_route": route,
+            },
+            self.wake_root,
+            expected_node_id=NODE_ID,
+        )
+        self.assertTrue(result["wake_delivery"]["accepted"])
+        return wake, route
+
+    def _record_supervisor_delivery(self, wake, route, reconcile_id: str, *, status: str) -> Path:
+        _write_json(
+            self.runtime_root / "supervisor" / "intents" / f"{reconcile_id}.json",
+            {
+                "schema": INTENT_RECORD_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "state": "planned",
+                "planned_at": T0.isoformat(),
+                "planned_by_cycle": int(wake.expected_lease_generation),
+                "intent": {
+                    "schema": RECONCILE_INTENT_SCHEMA,
+                    "reconcile_id": reconcile_id,
+                    "kind": "employee_wake",
+                    "employee_id": EMPLOYEE_ID,
+                    "assignment_id": ASSIGNMENT_ID,
+                    "reason": "assignment_pending" if wake.mode == "fresh" else "assignment_resume_required",
+                    "wake_intent": wake.as_dict(),
+                    "authority_boundary": "observe_and_select_only",
+                    "node_selection": "unbound",
+                    "executor_selection": "unbound",
+                    "transport_selection": "unbound",
+                    "capability_authority": "unbound",
+                    "credential_exposed": False,
+                },
+                "dispatch_performed": False,
+            },
+        )
+        path = self.runtime_root / "supervisor" / "deliveries" / f"{reconcile_id}.json"
+        _write_json(
+            path,
+            {
+                "schema": DELIVERY_STATE_SCHEMA,
+                "reconcile_id": reconcile_id,
+                "employee_id": EMPLOYEE_ID,
+                "assignment_id": ASSIGNMENT_ID,
+                "wake_id": wake.wake_id,
+                "status": status,
+                "created_at": T0.isoformat(),
+                "updated_at": T0.isoformat(),
+                "authority_policy_id": EXPECTED_AUTHORITY_POLICY,
+                "transport_policy_id": "transport-routing-v1",
+                "transport": "one_direct",
+                "transport_authority": "core_policy",
+                "capability": WAKE_CAPABILITY,
+                "supervisor_leader_generation": 1,
+                "dispatch_performed": True,
+                "presence_id": route["presence_id"],
+                "presence_generation": route["presence_generation"],
+                "node_id": NODE_ID,
+                "wake_attempt_id": f"attempt-{reconcile_id}",
+                "task_id": f"task-{reconcile_id}",
+                "error_code": None,
+            },
+        )
+        return path
+
+    def test_fresh_process_checkpoints_without_terminal_receipt(self):
+        wake, _ = self._deliver_current_wake(now=T0, presence_generation=1)
+        worker = SpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="process-a",
+            lease_seconds=60,
+        )
+        state = worker.process_one(now=T0)
+        self.assertIsNotNone(state)
+        self.assertEqual(state.schema, WORKER_STATE_SCHEMA)
+        self.assertEqual(state.status, "checkpointed")
+        self.assertEqual(state.lease_generation, 1)
+        self.assertNotEqual(state.thread_head, wake.thread_head)
+        assignment = self.runtime.get_assignment(ASSIGNMENT_ID)
+        self.assertEqual(assignment.state, "active")
+        self.assertEqual(assignment.thread_head, state.thread_head)
+        self.assertFalse(
+            (self.runtime_root / "lifecycle" / "receipts" / ASSIGNMENT_ID / "000001.json").exists()
+        )
+        employee = self.runtime.get_employee(EMPLOYEE_ID)
+        self.assertEqual(employee.executor.provider, "agentos-native-spec-audit")
+        self.assertEqual(employee.executor.session_id, "")
+        self.assertIsNone(worker.process_one(now=T0 + timedelta(seconds=1)))
+
+    def test_new_process_resumes_generation_two_and_final_evidence_becomes_ready_after_supervisor_reconcile(self):
+        wake1, route1 = self._deliver_current_wake(now=T0, presence_generation=1)
+        delivery1 = self._record_supervisor_delivery(wake1, route1, "reconcile-o3-g1", status="awaiting_claim")
+        first = SpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="process-a",
+            lease_seconds=60,
+        )
+        state1 = first.process_one(now=T0)
+        self.assertEqual(state1.status, "checkpointed")
+        payload1 = json.loads(delivery1.read_text(encoding="utf-8"))
+        payload1["status"] = "claimed"
+        _write_json(delivery1, payload1)
+
+        resume_time = T0 + timedelta(seconds=61)
+        wake2, route2 = self._deliver_current_wake(now=resume_time, presence_generation=2)
+        self.assertEqual(wake2.mode, "resume")
+        self.assertEqual(wake2.expected_lease_generation, 2)
+        delivery2 = self._record_supervisor_delivery(wake2, route2, "reconcile-o3-g2", status="awaiting_claim")
+
+        second = SpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="process-b",
+            lease_seconds=60,
+        )
+        state2 = second.process_one(now=resume_time)
+        self.assertEqual(state2.status, "completed")
+        self.assertEqual(state2.lease_generation, 2)
+        lease = self.lifecycle.get_lease(ASSIGNMENT_ID)
+        self.assertEqual(lease.generation, 2)
+        self.assertEqual(lease.status, "completed")
+        receipt_path = self.runtime_root / "lifecycle" / "receipts" / ASSIGNMENT_ID / "000002.json"
+        self.assertTrue(receipt_path.is_file())
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        serialized = json.dumps(receipt, ensure_ascii=False)
+        self.assertNotIn("process-a", serialized)
+        self.assertNotIn("process-b", serialized)
+        self.assertNotIn("session_id", serialized)
+
+        # The worker may finish before the next Supervisor cycle observes the claim.
+        blocked = inspect_spec_steward_acceptance(self.runtime)
+        self.assertFalse(blocked.ready_for_live_marker)
+        self.assertFalse(blocked.checks["initial_and_resume_wakes_governed"])
+
+        payload2 = json.loads(delivery2.read_text(encoding="utf-8"))
+        payload2["status"] = "claimed"
+        _write_json(delivery2, payload2)
+        ready = inspect_spec_steward_acceptance(self.runtime)
+        self.assertTrue(ready.ready_for_live_marker)
+        self.assertFalse(ready.verified_marker_emitted)
+        self.assertEqual(ready.qualifying_wake_generations, (1, 2))
+        witness = json.loads(
+            (self.runtime_root / "acceptance" / "spec-steward-o3-live-witness.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(witness["fresh_executor_or_session"])
+        self.assertTrue(witness["process_boundary_observed"])
+        self.assertFalse(witness["session_identity_exposed"])
+
+    def test_same_process_resume_cannot_produce_fresh_executor_witness(self):
+        self._deliver_current_wake(now=T0, presence_generation=1)
+        worker = SpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="same-process",
+            lease_seconds=60,
+        )
+        state1 = worker.process_one(now=T0)
+        self.assertEqual(state1.status, "checkpointed")
+        resume_time = T0 + timedelta(seconds=61)
+        self._deliver_current_wake(now=resume_time, presence_generation=2)
+        state2 = worker.process_one(now=resume_time)
+        self.assertEqual(state2.status, "completed")
+        self.assertFalse(
+            (self.runtime_root / "acceptance" / "spec-steward-o3-live-witness.json").exists()
+        )
+        report = inspect_spec_steward_acceptance(self.runtime)
+        self.assertFalse(report.ready_for_live_marker)
+        self.assertFalse(report.checks["fresh_executor_or_session_live_witness"])
+
+    def test_tampered_capsule_fails_before_claiming_assignment(self):
+        wake, _ = self._deliver_current_wake(now=T0, presence_generation=1)
+        capsule_path = next((self.wake_root / EMPLOYEE_ID).glob("*.json"))
+        capsule = json.loads(capsule_path.read_text(encoding="utf-8"))
+        capsule["wake_intent"]["goal"] = "tampered"
+        _write_json(capsule_path, capsule)
+        worker = SpecStewardWakeWorker(
+            runtime_root=self.runtime_root,
+            wake_root=self.wake_root,
+            worker_state_root=self.state_root,
+            node_id=NODE_ID,
+            process_instance_id="process-a",
+        )
+        state = worker.process_one(now=T0)
+        self.assertEqual(state.status, "failed")
+        self.assertEqual(state.error_code, "worker_pre_execution_failed")
+        assignment = self.runtime.get_assignment(ASSIGNMENT_ID)
+        self.assertEqual(assignment.state, "pending")
+        self.assertEqual(assignment.thread_head, wake.thread_head)
+        self.assertIsNone(self.lifecycle.get_lease(ASSIGNMENT_ID))
+
+    def test_worker_refuses_wake_root_inside_canonical_runtime(self):
+        with self.assertRaisesRegex(ValueError, "wake_root_must_not_be_canonical_runtime"):
+            SpecStewardWakeWorker(
+                runtime_root=self.runtime_root,
+                wake_root=self.runtime_root / "node-wake",
+                worker_state_root=self.state_root,
+                node_id=NODE_ID,
+            )
+
+    def test_worker_refuses_empty_runtime_instead_of_bootstrapping_shadow_employee(self):
+        empty = Path(self.tmp.name) / "empty-runtime"
+        with self.assertRaisesRegex(RuntimeError, "canonical_employee_missing"):
+            SpecStewardWakeWorker(
+                runtime_root=empty,
+                wake_root=self.wake_root,
+                worker_state_root=self.state_root,
+                node_id=NODE_ID,
+            )
+        self.assertFalse((empty / "employees" / f"{EMPLOYEE_ID}.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_steward_worker_cli.py
+++ b/tests/test_spec_steward_worker_cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agentos_node import spec_steward_worker_cli as cli
+
+
+class SpecStewardWorkerCliTests(unittest.TestCase):
+    def test_cli_requires_absolute_roots_and_explicit_once(self):
+        parser = cli.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--runtime-root", "relative/runtime",
+                    "--wake-root", "/tmp/wake",
+                    "--worker-state-root", "/tmp/state",
+                    "--node-id", "node-o3",
+                    "--once",
+                ]
+            )
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--runtime-root", "/tmp/runtime",
+                    "--wake-root", "/tmp/wake",
+                    "--worker-state-root", "/tmp/state",
+                    "--node-id", "node-o3",
+                ]
+            )
+
+    def test_cli_exposes_no_provider_session_shell_or_argv_switches(self):
+        parser = cli.build_parser()
+        option_strings = {
+            option
+            for action in parser._actions
+            for option in action.option_strings
+        }
+        for forbidden in (
+            "--provider",
+            "--model",
+            "--session",
+            "--session-id",
+            "--shell",
+            "--command",
+            "--argv",
+            "--url",
+            "--token",
+            "--credential",
+        ):
+            self.assertNotIn(forbidden, option_strings)
+
+    def test_cli_uses_governed_wrapper_and_outputs_sanitized_state(self):
+        state = SimpleNamespace(
+            status="checkpointed",
+            employee_id="agentos-spec-steward",
+            assignment_id="spec-steward-o3-acceptance-v1",
+            lease_generation=1,
+            thread_head="o3:checkpoint:g1:abc",
+            error_code=None,
+            executor_provider="agentos-native-spec-audit",
+            executor_model="spec-audit-v1",
+            process_instance_digest="must-not-print",
+        )
+        fake_worker = SimpleNamespace(process_one=lambda: state)
+        out = io.StringIO()
+        with patch.object(cli, "GovernedSpecStewardWakeWorker", return_value=fake_worker) as factory:
+            with patch("sys.stdout", out):
+                code = cli.main(
+                    [
+                        "--runtime-root", "/tmp/runtime",
+                        "--wake-root", "/tmp/wake",
+                        "--worker-state-root", "/tmp/state",
+                        "--node-id", "node-o3",
+                        "--once",
+                    ]
+                )
+        self.assertEqual(code, 0)
+        factory.assert_called_once()
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["status"], "checkpointed")
+        self.assertFalse(payload["verified_marker_emitted"])
+        self.assertFalse(payload["credential_exposed"])
+        self.assertFalse(payload["session_identity_exposed"])
+        self.assertNotIn("process_instance_digest", payload)
+        self.assertNotIn("must-not-print", out.getvalue())
+
+    def test_idle_cli_is_success_and_never_claims_verification(self):
+        fake_worker = SimpleNamespace(process_one=lambda: None)
+        out = io.StringIO()
+        with patch.object(cli, "GovernedSpecStewardWakeWorker", return_value=fake_worker):
+            with patch("sys.stdout", out):
+                code = cli.main(
+                    [
+                        "--runtime-root", "/tmp/runtime",
+                        "--wake-root", "/tmp/wake",
+                        "--worker-state-root", "/tmp/state",
+                        "--node-id", "node-o3",
+                        "--once",
+                    ]
+                )
+        self.assertEqual(code, 0)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["status"], "idle")
+        self.assertFalse(payload["verified_marker_emitted"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relates to #197.

This PR adds the bounded Node-side Employee worker slice needed to move Spec Steward O3 from source contract toward a real live Employee lifecycle acceptance.

What it adds:
- fixed `agentos-spec-steward` / `spec-steward-o3-acceptance-v1` / `spec.audit` worker kernel;
- governed pre-claim authority fence requiring the exact persisted Core Supervisor S3/S4 chain through `one_direct`;
- generation-1 checkpoint then generation-2+ resume semantics across distinct worker processes;
- privacy-safe fresh-process witness, Employee memory/thread continuity, and sanitized terminal receipt;
- bounded Core bootstrap/inspect CLI, bounded Employee presence CLI, and governed Node worker `--once` CLI;
- `docs/SPEC_STEWARD_O3_LIVE_RUNBOOK.md` with explicit live acceptance and fail-closed rules;
- focused worker, authority, CLI, and presence regressions wired into Employee Runtime Guard.

Important non-claims / non-authorities:
- does not emit `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`;
- static CI is not live acceptance;
- does not deploy/enable an Oracle service or mutate a live Realm;
- does not grant shell/argv/provider/session/credential authority;
- GitHub Actions is not a ONE/control-plane fallback;
- no protected-main authority.

Branch guard evidence before PR: Employee Runtime Guard run 33607161409 succeeded with all Employee/Supervisor/O3/CLI regressions.

Remaining #197 acceptance after source merge: run the documented flow on an accepted `core/integration` SHA against the real existing ONE/Node boundary, preserve initial + resume governed delivery evidence, fresh-process continuity, terminal receipt, final read-only `ready_for_live_marker=true`, and separate explicit live attestation.