### PR TITLE
Core #200: wire persistent Supervisor into governed user-service install

### DIFF
--- a/.agent/scripts/agentos-core-supervisor.service
+++ b/.agent/scripts/agentos-core-supervisor.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=AgentOS Core Supervisor (observe and plan only)
+Description=AgentOS Core Supervisor (observe and plan by default)
 After=local-fs.target
 
 [Service]
 Type=simple
-User=ubuntu
 WorkingDirectory=/home/ubuntu/agentmanager
 EnvironmentFile=/home/ubuntu/.config/agentos/core-supervisor.env
+EnvironmentFile=-/home/ubuntu/.config/agentos/core-supervisor-delivery.env
 ExecStart=/usr/bin/python3 -m agent_core.core_supervisor_daemon
 Restart=always
 RestartSec=5
@@ -18,4 +18,4 @@ ProtectHome=read-only
 ReadWritePaths=/home/ubuntu/agent-data/employee-runtime
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ AGENT_DATA_DIR=$AGENT_DATA_ROOT
 # Runtime role: CORE runs background services; CLIENT only reads/syncs memory.
 AGENT_MODE=CLIENT
 
+# Core Supervisor S4 is fail-closed by default. Set to 1 only on a CORE host
+# after the existing ONE realm/fabric.json and realm/nodes.json are verified.
+# This gate permits installer wiring for local one_direct wake delivery; it does
+# not grant Employee claim, executor selection, shell, or publication authority.
+AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=0
+
 # 🔑 Secrets & Tokens
 # Your GitHub Personal Access Token (with repo scope)
 GITHUB_TOKEN=your_github_token_here

--- a/.github/workflows/core-supervisor-install-guard.yml
+++ b/.github/workflows/core-supervisor-install-guard.yml
@@ -12,6 +12,7 @@ on:
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_core_supervisor_install_contract.py'
+      - 'tests/test_core_supervisor_installer_runtime.py'
       - '.github/workflows/core-supervisor-install-guard.yml'
   pull_request:
     branches:
@@ -23,6 +24,7 @@ on:
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_core_supervisor_install_contract.py'
+      - 'tests/test_core_supervisor_installer_runtime.py'
       - '.github/workflows/core-supervisor-install-guard.yml'
 
 permissions:
@@ -39,4 +41,9 @@ jobs:
       - name: Validate installer shell syntax
         run: bash -n scripts/install_systemd_user.sh
       - name: Validate Supervisor service and install contracts
-        run: python -m unittest tests.test_core_supervisor_assets tests.test_core_supervisor_install_contract -v
+        run: >-
+          python -m unittest
+          tests.test_core_supervisor_assets
+          tests.test_core_supervisor_install_contract
+          tests.test_core_supervisor_installer_runtime
+          -v

--- a/.github/workflows/core-supervisor-install-guard.yml
+++ b/.github/workflows/core-supervisor-install-guard.yml
@@ -1,0 +1,42 @@
+name: Core Supervisor Install Guard
+
+on:
+  push:
+    branches:
+      - core/issue-200-supervisor-install-contract
+      - core/integration
+    paths:
+      - 'scripts/install_systemd_user.sh'
+      - '.agent/scripts/agentos-core-supervisor.service'
+      - '.agent/scripts/agentos-core-supervisor.env.example'
+      - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
+      - 'tests/test_core_supervisor_assets.py'
+      - 'tests/test_core_supervisor_install_contract.py'
+      - '.github/workflows/core-supervisor-install-guard.yml'
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'scripts/install_systemd_user.sh'
+      - '.agent/scripts/agentos-core-supervisor.service'
+      - '.agent/scripts/agentos-core-supervisor.env.example'
+      - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
+      - 'tests/test_core_supervisor_assets.py'
+      - 'tests/test_core_supervisor_install_contract.py'
+      - '.github/workflows/core-supervisor-install-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  supervisor-install-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate installer shell syntax
+        run: bash -n scripts/install_systemd_user.sh
+      - name: Validate Supervisor service and install contracts
+        run: python -m unittest tests.test_core_supervisor_assets tests.test_core_supervisor_install_contract -v

--- a/.github/workflows/core-supervisor-install-guard.yml
+++ b/.github/workflows/core-supervisor-install-guard.yml
@@ -6,10 +6,12 @@ on:
       - core/issue-200-supervisor-install-contract
       - core/integration
     paths:
+      - '.env.example'
       - 'scripts/install_systemd_user.sh'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
+      - 'docs/CORE_SUPERVISOR_INSTALL.md'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_core_supervisor_install_contract.py'
       - 'tests/test_core_supervisor_installer_runtime.py'
@@ -18,10 +20,12 @@ on:
     branches:
       - core/integration
     paths:
+      - '.env.example'
       - 'scripts/install_systemd_user.sh'
       - '.agent/scripts/agentos-core-supervisor.service'
       - '.agent/scripts/agentos-core-supervisor.env.example'
       - '.agent/scripts/agentos-core-supervisor-delivery.conf.example'
+      - 'docs/CORE_SUPERVISOR_INSTALL.md'
       - 'tests/test_core_supervisor_assets.py'
       - 'tests/test_core_supervisor_install_contract.py'
       - 'tests/test_core_supervisor_installer_runtime.py'

--- a/docs/CORE_SUPERVISOR_INSTALL.md
+++ b/docs/CORE_SUPERVISOR_INSTALL.md
@@ -1,0 +1,71 @@
+# Core Supervisor installation contract
+
+Status: **source deployment contract only; Oracle live activation and operating acceptance remain pending**.
+
+The Core Supervisor is the single persistent Core reconciliation process. Employees are durable identities, not per-role daemons.
+
+## Actual Linux install path
+
+The existing Core deploy carrier eventually calls:
+
+```text
+scripts/install_services.py
+  -> LinuxPlatformDriver.install_background_services()
+  -> scripts/install_systemd_user.sh
+  -> systemctl --user
+```
+
+Therefore `agentos-core-supervisor.service` is a **user service**. The source asset must not contain a fixed `User=` directive and uses `WantedBy=default.target`. During installation, host-specific checkout, Python, configuration, and data-root paths are rendered into the user unit.
+
+Repository merge does not run this installer. Running the deploy carrier, installing/restarting the service, or changing the host-local delivery gate is a privileged runtime mutation requiring separate authority and evidence.
+
+## Safe default: S3 observe/plan
+
+On a CORE host, the installer materializes and enables the persistent Supervisor. If the host-local Supervisor environment does not yet exist, it is created with:
+
+```text
+AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled
+```
+
+An existing host-local `core-supervisor.env` is preserved rather than overwritten from the repository example. The base unit retains `PrivateNetwork=true`, `NoNewPrivileges=true`, `ProtectSystem=strict`, and only the Employee runtime is writable.
+
+This means a normal Core service installation can make the reconciliation heart persistent without silently granting the S4 ONE delivery boundary.
+
+## Explicit S4 one_direct gate
+
+Installer wiring for S4 requires:
+
+```text
+AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1
+```
+
+and both pre-existing canonical ONE files:
+
+```text
+$AGENT_DATA_ROOT/realm/fabric.json
+$AGENT_DATA_ROOT/realm/nodes.json
+```
+
+If either file is absent, installation fails closed. The installer does **not** initialize a Realm or create shadow ONE state.
+
+With the explicit gate, the installer renders the narrow filesystem drop-in and a host-local delivery environment containing:
+
+```text
+AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct
+AGENTOS_SUPERVISOR_ONE_DATA_ROOT=$AGENT_DATA_ROOT
+```
+
+The drop-in grants write access only to the existing `realm/` store needed by the local file-backed ONE queue. `PrivateNetwork=true` remains in force. There is no GitHub Actions fallback.
+
+If the base host environment itself requests `one_direct` but the explicit install gate is absent, installation refuses to proceed. This prevents a routine deploy from silently inheriting expanded delivery authority.
+
+## What this still does not prove
+
+Even after this source contract merges, neither marker is valid until a governed live run occurs:
+
+- `CORE_SUPERVISOR_PERSISTENT_RECONCILIATION=VERIFIED`
+- `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED`
+
+The live acceptance must still prove the real Supervisor process, existing ONE/Node boundary, Node receipt, Employee generation-1 checkpoint, executor/process turnover, generation-2+ resume, memory/thread continuity, sanitized terminal receipt, and terminal wake suppression without a user saying `繼續`.
+
+**Repository merge != installer execution != Oracle deployment != operating acceptance.**

--- a/scripts/install_systemd_user.sh
+++ b/scripts/install_systemd_user.sh
@@ -29,7 +29,85 @@ if [ ! -x "$PYTHON_BIN" ]; then
   PYTHON_BIN="$(command -v python3)"
 fi
 
+SUPERVISOR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/agentos"
+SUPERVISOR_ENV_FILE="$SUPERVISOR_CONFIG_DIR/core-supervisor.env"
+SUPERVISOR_DELIVERY_ENV_FILE="$SUPERVISOR_CONFIG_DIR/core-supervisor-delivery.env"
+SUPERVISOR_UNIT_SRC="$LOGIC_ROOT/.agent/scripts/agentos-core-supervisor.service"
+SUPERVISOR_UNIT_DST="$USER_SYSTEMD_DIR/agentos-core-supervisor.service"
+SUPERVISOR_DELIVERY_DROPIN_SRC="$LOGIC_ROOT/.agent/scripts/agentos-core-supervisor-delivery.conf.example"
+SUPERVISOR_DROPIN_DIR="$USER_SYSTEMD_DIR/agentos-core-supervisor.service.d"
+SUPERVISOR_DELIVERY_DROPIN_DST="$SUPERVISOR_DROPIN_DIR/20-one-direct-filesystem.conf"
+
 mkdir -p "$USER_SYSTEMD_DIR" "$DATA_ROOT/logs"
+
+render_supervisor_asset() {
+  local src="$1"
+  local dst="$2"
+  "$PYTHON_BIN" - "$src" "$dst" "$LOGIC_ROOT" "$SUPERVISOR_ENV_FILE" "$SUPERVISOR_DELIVERY_ENV_FILE" "$PYTHON_BIN" "$DATA_ROOT" <<'PY'
+from pathlib import Path
+import sys
+
+src, dst, logic_root, env_file, delivery_env_file, python_bin, data_root = sys.argv[1:]
+text = Path(src).read_text(encoding="utf-8")
+replacements = {
+    "/home/ubuntu/agentmanager": logic_root,
+    "/home/ubuntu/.config/agentos/core-supervisor.env": env_file,
+    "/home/ubuntu/.config/agentos/core-supervisor-delivery.env": delivery_env_file,
+    "/usr/bin/python3": python_bin,
+    "/home/ubuntu/agent-data/employee-runtime": str(Path(data_root) / "employee-runtime"),
+    "/home/ubuntu/agent-data/realm": str(Path(data_root) / "realm"),
+}
+for old, new in replacements.items():
+    text = text.replace(old, new)
+Path(dst).parent.mkdir(parents=True, exist_ok=True)
+Path(dst).write_text(text, encoding="utf-8")
+PY
+}
+
+install_core_supervisor() {
+  test -f "$SUPERVISOR_UNIT_SRC" || { echo "Missing Supervisor service asset: $SUPERVISOR_UNIT_SRC" >&2; exit 2; }
+  test -f "$SUPERVISOR_DELIVERY_DROPIN_SRC" || { echo "Missing Supervisor delivery asset: $SUPERVISOR_DELIVERY_DROPIN_SRC" >&2; exit 2; }
+
+  mkdir -p "$SUPERVISOR_CONFIG_DIR" "$SUPERVISOR_DROPIN_DIR" "$DATA_ROOT/employee-runtime"
+  render_supervisor_asset "$SUPERVISOR_UNIT_SRC" "$SUPERVISOR_UNIT_DST"
+
+  # First install is deliberately S3-only. Existing host-local configuration is
+  # never replaced wholesale by the repository example.
+  if [ ! -f "$SUPERVISOR_ENV_FILE" ]; then
+    cat > "$SUPERVISOR_ENV_FILE" <<EOF
+AGENTOS_EMPLOYEE_RUNTIME_ROOT=$DATA_ROOT/employee-runtime
+AGENTOS_SUPERVISOR_SERVICE_ID=agentos-core-supervisor
+AGENTOS_SUPERVISOR_BASE_POLL_SECONDS=5
+AGENTOS_SUPERVISOR_MAX_POLL_SECONDS=60
+AGENTOS_SUPERVISOR_LEADER_LEASE_SECONDS=30
+AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled
+EOF
+    chmod 600 "$SUPERVISOR_ENV_FILE"
+  fi
+
+  if [ "${AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT:-0}" = "1" ]; then
+    test -f "$DATA_ROOT/realm/fabric.json" || {
+      echo "Refusing Supervisor one_direct: missing existing $DATA_ROOT/realm/fabric.json" >&2
+      exit 2
+    }
+    test -f "$DATA_ROOT/realm/nodes.json" || {
+      echo "Refusing Supervisor one_direct: missing existing $DATA_ROOT/realm/nodes.json" >&2
+      exit 2
+    }
+    render_supervisor_asset "$SUPERVISOR_DELIVERY_DROPIN_SRC" "$SUPERVISOR_DELIVERY_DROPIN_DST"
+    cat > "$SUPERVISOR_DELIVERY_ENV_FILE" <<EOF
+AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct
+AGENTOS_SUPERVISOR_ONE_DATA_ROOT=$DATA_ROOT
+EOF
+    chmod 600 "$SUPERVISOR_DELIVERY_ENV_FILE"
+  else
+    if grep -Eq '^AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct([[:space:]]*)$' "$SUPERVISOR_ENV_FILE"; then
+      echo "Refusing Supervisor install: host env requests one_direct without AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1" >&2
+      exit 2
+    fi
+    rm -f "$SUPERVISOR_DELIVERY_ENV_FILE" "$SUPERVISOR_DELIVERY_DROPIN_DST"
+  fi
+}
 
 cat > "$USER_SYSTEMD_DIR/os-chronos.service" <<EOF
 [Unit]
@@ -156,6 +234,10 @@ StandardError=append:$DATA_ROOT/logs/lobster.log
 WantedBy=default.target
 EOF
 
+if [ "${AGENT_MODE:-CLIENT}" = "CORE" ]; then
+  install_core_supervisor
+fi
+
 systemctl --user daemon-reload
 
 # Stop and disable legacy pulse service if it exists
@@ -176,8 +258,11 @@ if [ "${AGENT_MODE:-CLIENT}" = "CORE" ]; then
   systemctl --user restart tg-commander.service
   systemctl --user restart cat-ink-syncer.service
   systemctl --user restart os-lobster.service
+  systemctl --user enable agentos-core-supervisor.service >/dev/null
+  systemctl --user restart agentos-core-supervisor.service
 else
-  echo "AGENT_MODE is not CORE; tg-commander.service, cat-ink-syncer.service, and os-lobster.service installed but not started."
+  systemctl --user disable --now agentos-core-supervisor.service 2>/dev/null || true
+  echo "AGENT_MODE is not CORE; tg-commander.service, cat-ink-syncer.service, os-lobster.service, and agentos-core-supervisor.service are not started."
 fi
 
 systemctl --user restart os-chronos.service

--- a/tests/test_core_supervisor_install_contract.py
+++ b/tests/test_core_supervisor_install_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install_systemd_user.sh"
+SERVICE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.service"
+ENV_EXAMPLE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.env.example"
+DELIVERY_DROPIN = ROOT / ".agent" / "scripts" / "agentos-core-supervisor-delivery.conf.example"
+
+
+class CoreSupervisorInstallContractTests(unittest.TestCase):
+    def test_supervisor_asset_is_user_service_compatible(self):
+        text = SERVICE.read_text(encoding="utf-8")
+        self.assertNotRegex(text, re.compile(r"^User=", re.MULTILINE))
+        self.assertIn("WantedBy=default.target", text)
+        self.assertIn("PrivateNetwork=true", text)
+        self.assertIn("NoNewPrivileges=true", text)
+
+    def test_installer_materializes_s3_supervisor_on_core(self):
+        text = INSTALLER.read_text(encoding="utf-8")
+        self.assertIn("agentos-core-supervisor.service", text)
+        self.assertIn("core-supervisor.env", text)
+        self.assertIn("AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled", text)
+        self.assertIn("systemctl --user enable agentos-core-supervisor.service", text)
+        self.assertIn("systemctl --user restart agentos-core-supervisor.service", text)
+        self.assertIn('if [ ! -f "$SUPERVISOR_ENV_FILE" ]', text)
+
+    def test_one_direct_install_requires_explicit_gate_and_existing_one(self):
+        text = INSTALLER.read_text(encoding="utf-8")
+        self.assertIn("AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT", text)
+        self.assertIn("agentos-core-supervisor-delivery.conf", text)
+        self.assertIn("realm/fabric.json", text)
+        self.assertIn("realm/nodes.json", text)
+        self.assertIn("AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct", text)
+        self.assertIn("AGENTOS_SUPERVISOR_ONE_DATA_ROOT=", text)
+        self.assertNotIn("github_actions", text.casefold())
+
+    def test_installer_preserves_existing_host_local_supervisor_env(self):
+        text = INSTALLER.read_text(encoding="utf-8")
+        self.assertIn('if [ ! -f "$SUPERVISOR_ENV_FILE" ]', text)
+        self.assertNotIn('cp "$LOGIC_ROOT/.agent/scripts/agentos-core-supervisor.env.example" "$SUPERVISOR_ENV_FILE"', text)
+
+    def test_source_assets_remain_secret_free(self):
+        combined = "\n".join(
+            p.read_text(encoding="utf-8") for p in (SERVICE, ENV_EXAMPLE, DELIVERY_DROPIN)
+        ).casefold()
+        for forbidden in ("password=", "token=", "secret=", "authorization=", "bearer "):
+            self.assertNotIn(forbidden, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_supervisor_install_contract.py
+++ b/tests/test_core_supervisor_install_contract.py
@@ -9,7 +9,9 @@ ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "install_systemd_user.sh"
 SERVICE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.service"
 ENV_EXAMPLE = ROOT / ".agent" / "scripts" / "agentos-core-supervisor.env.example"
+ROOT_ENV_EXAMPLE = ROOT / ".env.example"
 DELIVERY_DROPIN = ROOT / ".agent" / "scripts" / "agentos-core-supervisor-delivery.conf.example"
+DOC = ROOT / "docs" / "CORE_SUPERVISOR_INSTALL.md"
 
 
 class CoreSupervisorInstallContractTests(unittest.TestCase):
@@ -43,6 +45,21 @@ class CoreSupervisorInstallContractTests(unittest.TestCase):
         text = INSTALLER.read_text(encoding="utf-8")
         self.assertIn('if [ ! -f "$SUPERVISOR_ENV_FILE" ]', text)
         self.assertNotIn('cp "$LOGIC_ROOT/.agent/scripts/agentos-core-supervisor.env.example" "$SUPERVISOR_ENV_FILE"', text)
+
+    def test_repository_env_defaults_s4_install_gate_closed(self):
+        text = ROOT_ENV_EXAMPLE.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            re.compile(r"^AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=0$", re.MULTILINE),
+        )
+
+    def test_deployment_doc_keeps_source_install_and_live_acceptance_separate(self):
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("systemctl --user", text)
+        self.assertIn("AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1", text)
+        self.assertIn("does **not** initialize a Realm", text)
+        self.assertIn("Repository merge != installer execution != Oracle deployment != operating acceptance", text)
+        self.assertIn("CORE_SUPERVISOR_PERSISTENT_RECONCILIATION=VERIFIED", text)
 
     def test_source_assets_remain_secret_free(self):
         combined = "\n".join(

--- a/tests/test_core_supervisor_installer_runtime.py
+++ b/tests/test_core_supervisor_installer_runtime.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CoreSupervisorInstallerRuntimeTests(unittest.TestCase):
+    def _fixture(self) -> tuple[tempfile.TemporaryDirectory[str], Path, dict[str, str]]:
+        td = tempfile.TemporaryDirectory()
+        root = Path(td.name) / "agentmanager"
+        (root / "scripts").mkdir(parents=True)
+        (root / ".agent" / "scripts").mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts" / "install_systemd_user.sh", root / "scripts" / "install_systemd_user.sh")
+        for name in (
+            "agentos-core-supervisor.service",
+            "agentos-core-supervisor-delivery.conf.example",
+        ):
+            shutil.copy2(ROOT / ".agent" / "scripts" / name, root / ".agent" / "scripts" / name)
+
+        home = Path(td.name) / "home"
+        fakebin = Path(td.name) / "bin"
+        fakebin.mkdir()
+        systemctl = fakebin / "systemctl"
+        systemctl.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        systemctl.chmod(0o755)
+
+        data_root = Path(td.name) / "data"
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "PATH": f"{fakebin}:{env.get('PATH', '')}",
+            }
+        )
+        self._write_env(root, data_root, one_direct=False)
+        return td, root, env
+
+    @staticmethod
+    def _write_env(root: Path, data_root: Path, *, one_direct: bool) -> None:
+        lines = ["AGENT_MODE=CORE", f"AGENT_DATA_ROOT={data_root}"]
+        if one_direct:
+            lines.append("AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1")
+        (root / ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _run(root: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(root / "scripts" / "install_systemd_user.sh")],
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_core_install_renders_user_supervisor_and_defaults_s3(self):
+        td, root, env = self._fixture()
+        self.addCleanup(td.cleanup)
+        result = self._run(root, env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        home = Path(env["HOME"])
+        unit = (home / ".config" / "systemd" / "user" / "agentos-core-supervisor.service").read_text(encoding="utf-8")
+        supervisor_env = (home / ".config" / "agentos" / "core-supervisor.env").read_text(encoding="utf-8")
+        self.assertNotIn("User=ubuntu", unit)
+        self.assertIn("WantedBy=default.target", unit)
+        self.assertIn(f"WorkingDirectory={root}", unit)
+        self.assertIn(f"ReadWritePaths={Path(td.name) / 'data' / 'employee-runtime'}", unit)
+        self.assertIn("PrivateNetwork=true", unit)
+        self.assertIn("AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled", supervisor_env)
+        self.assertFalse((home / ".config" / "agentos" / "core-supervisor-delivery.env").exists())
+
+    def test_one_direct_fails_closed_without_existing_one_state(self):
+        td, root, env = self._fixture()
+        self.addCleanup(td.cleanup)
+        data_root = Path(td.name) / "data"
+        self._write_env(root, data_root, one_direct=True)
+        result = self._run(root, env)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("missing existing", result.stderr)
+        self.assertFalse((data_root / "realm" / "fabric.json").exists())
+        self.assertFalse((data_root / "realm" / "nodes.json").exists())
+
+    def test_explicit_one_direct_renders_narrow_dropin_and_delivery_env(self):
+        td, root, env = self._fixture()
+        self.addCleanup(td.cleanup)
+        data_root = Path(td.name) / "data"
+        realm = data_root / "realm"
+        realm.mkdir(parents=True)
+        (realm / "fabric.json").write_text("{}\n", encoding="utf-8")
+        (realm / "nodes.json").write_text("{}\n", encoding="utf-8")
+        self._write_env(root, data_root, one_direct=True)
+
+        result = self._run(root, env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        home = Path(env["HOME"])
+        delivery_env = (home / ".config" / "agentos" / "core-supervisor-delivery.env").read_text(encoding="utf-8")
+        dropin = (
+            home
+            / ".config"
+            / "systemd"
+            / "user"
+            / "agentos-core-supervisor.service.d"
+            / "20-one-direct-filesystem.conf"
+        ).read_text(encoding="utf-8")
+        self.assertIn("AGENTOS_SUPERVISOR_DELIVERY_MODE=one_direct", delivery_env)
+        self.assertIn(f"AGENTOS_SUPERVISOR_ONE_DATA_ROOT={data_root}", delivery_env)
+        self.assertIn(f"ReadWritePaths={realm}", dropin)
+        self.assertNotIn("PrivateNetwork=false", dropin)
+
+    def test_existing_host_env_is_preserved(self):
+        td, root, env = self._fixture()
+        self.addCleanup(td.cleanup)
+        host_env = Path(env["HOME"]) / ".config" / "agentos" / "core-supervisor.env"
+        host_env.parent.mkdir(parents=True)
+        sentinel = "AGENTOS_EMPLOYEE_RUNTIME_ROOT=/custom/runtime\nAGENTOS_SUPERVISOR_DELIVERY_MODE=disabled\nCUSTOM_SENTINEL=keep\n"
+        host_env.write_text(sentinel, encoding="utf-8")
+        result = self._run(root, env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(host_env.read_text(encoding="utf-8"), sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relates to #200 and prepares the deployment source path needed by #197 live acceptance.

This PR fixes the gap between the integrated persistent Supervisor source and the actual Linux/Oracle service installer.

Changes:
- makes `agentos-core-supervisor.service` compatible with the existing `systemctl --user` installation scope (no fixed `User=`, `WantedBy=default.target`);
- makes CORE service installation materialize/enable/restart the persistent Supervisor in safe S3 observe/plan mode;
- preserves an existing host-local Supervisor env instead of overwriting it from repository examples;
- defaults first install to `AGENTOS_SUPERVISOR_DELIVERY_MODE=disabled`;
- requires host-local `AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1` before installer wiring may enable S4;
- requires pre-existing `realm/fabric.json` and `realm/nodes.json` and never creates shadow ONE;
- keeps the S4 filesystem extension narrow and `PrivateNetwork=true`;
- adds static + isolated runtime installer regressions and deployment documentation.

Important non-claims/non-authorities:
- this PR does not run the installer on Oracle;
- it does not enable S4 on any live host;
- no `CORE_SUPERVISOR_PERSISTENT_RECONCILIATION=VERIFIED` or `SPEC_STEWARD_PERSISTENT_EMPLOYEE=VERIFIED` claim;
- no protected-main publication;
- no GitHub Actions control-plane fallback;
- no #50 mutation.

Branch guard: Core Supervisor Install Guard run `33614102367` SUCCESS on exact source head `0e0c666c99d2cd7d26e4d00434aa3129f935d239`.