### PR TITLE
Core #152: make Employee wake delivery explicitly configurable on live Nodes

### DIFF
--- a/.github/workflows/node-employee-wake-policy-guard.yml
+++ b/.github/workflows/node-employee-wake-policy-guard.yml
@@ -1,0 +1,36 @@
+name: Node Employee Wake Policy Guard
+
+on:
+  push:
+    branches:
+      - core/issue-152-live-employee-wake-policy
+      - core/integration
+    paths:
+      - 'agentos_node/client_cli.py'
+      - 'agentos_node/thin_client.py'
+      - 'tests/test_client_employee_wake_policy.py'
+      - 'tests/test_thin_client.py'
+      - '.github/workflows/node-employee-wake-policy-guard.yml'
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agentos_node/client_cli.py'
+      - 'agentos_node/thin_client.py'
+      - 'tests/test_client_employee_wake_policy.py'
+      - 'tests/test_thin_client.py'
+      - '.github/workflows/node-employee-wake-policy-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  node-wake-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run Node wake policy and ThinClient regressions
+        run: python -m unittest tests.test_client_employee_wake_policy tests.test_thin_client -v

--- a/agentos_node/client_cli.py
+++ b/agentos_node/client_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import socket
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -70,7 +71,9 @@ def _load_policy(path: Path) -> ThinClientPolicy:
     if not isinstance(data, dict):
         raise ValueError('client_policy_must_be_object')
     wake_raw = data.get('employee_wake_root')
-    wake_root = None if wake_raw in {None, ''} else _absolute_policy_path(str(wake_raw), 'employee_wake_root')
+    if wake_raw is not None and not isinstance(wake_raw, str):
+        raise ValueError('employee_wake_root_must_be_string_or_null')
+    wake_root = None if wake_raw in (None, '') else _absolute_policy_path(wake_raw, 'employee_wake_root')
     return ThinClientPolicy(
         allowed_executables=set(data.get('allowed_executables') or []),
         readable_roots=tuple(Path(p) for p in (data.get('readable_roots') or [])),
@@ -87,7 +90,7 @@ def _save_default_policy(
 ) -> None:
     workspace = str(Path(root or Path.home() / 'AgentOS').expanduser().resolve())
     wake_root = None
-    if employee_wake_root not in {None, ''}:
+    if employee_wake_root is not None and str(employee_wake_root) != '':
         wake_root = str(_absolute_policy_path(str(employee_wake_root), 'employee_wake_root'))
     payload = {
         'schema': 'agentos.client-policy/v0.1',
@@ -143,7 +146,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             _save_default_policy(args.policy, args.root, args.employee_wake_root)
         except ValueError as exc:
-            print(f'error: {exc}', file=os.sys.stderr)
+            print(f'error: {exc}', file=sys.stderr)
             return 2
         return 0
 

--- a/agentos_node/client_cli.py
+++ b/agentos_node/client_cli.py
@@ -56,25 +56,45 @@ def _default_policy() -> Path:
     return Path.home() / '.agentos' / 'policy.json'
 
 
+def _absolute_policy_path(value: str | Path, field: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise ValueError(f'{field}_must_be_absolute')
+    return path.resolve()
+
+
 def _load_policy(path: Path) -> ThinClientPolicy:
     if not path.exists():
         raise FileNotFoundError(f'policy file not found: {path}; run `agentos-client policy-init` first')
     data = json.loads(path.read_text(encoding='utf-8-sig'))
+    if not isinstance(data, dict):
+        raise ValueError('client_policy_must_be_object')
+    wake_raw = data.get('employee_wake_root')
+    wake_root = None if wake_raw in {None, ''} else _absolute_policy_path(str(wake_raw), 'employee_wake_root')
     return ThinClientPolicy(
         allowed_executables=set(data.get('allowed_executables') or []),
         readable_roots=tuple(Path(p) for p in (data.get('readable_roots') or [])),
         writable_roots=tuple(Path(p) for p in (data.get('writable_roots') or [])),
+        employee_wake_root=wake_root,
         max_timeout_seconds=int(data.get('max_timeout_seconds') or 300),
     )
 
 
-def _save_default_policy(path: Path, root: str | None = None) -> None:
+def _save_default_policy(
+    path: Path,
+    root: str | None = None,
+    employee_wake_root: str | Path | None = None,
+) -> None:
     workspace = str(Path(root or Path.home() / 'AgentOS').expanduser().resolve())
+    wake_root = None
+    if employee_wake_root not in {None, ''}:
+        wake_root = str(_absolute_policy_path(str(employee_wake_root), 'employee_wake_root'))
     payload = {
         'schema': 'agentos.client-policy/v0.1',
         'allowed_executables': ['git', 'python', 'python.exe', 'python3', 'powershell', 'powershell.exe', 'pwsh', 'cmd', 'cmd.exe'],
         'readable_roots': [workspace],
         'writable_roots': [workspace],
+        'employee_wake_root': wake_root,
         'max_timeout_seconds': 120,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -82,7 +102,7 @@ def _save_default_policy(path: Path, root: str | None = None) -> None:
     print(path)
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog='agentos-client')
     parser.add_argument('--config', type=Path, default=_default_config())
     parser.add_argument('--policy', type=Path, default=_default_policy())
@@ -90,6 +110,10 @@ def main() -> int:
 
     p_policy = sub.add_parser('policy-init', help='create a conservative local execution policy')
     p_policy.add_argument('--root', help='workspace root ONE may read/write')
+    p_policy.add_argument(
+        '--employee-wake-root',
+        help='absolute local inbox root for governed Employee wake delivery; omitted means capability disabled',
+    )
 
     p_join = sub.add_parser('join', help='join Realm, install lifecycle supervisor, bootstrap inherited cognition, run regression, become ready')
     p_join.add_argument('--one', required=True, help='ONE base URL')
@@ -109,11 +133,18 @@ def main() -> int:
     sub.add_parser('verify', help='verify an already-enrolled Node including lifecycle supervisor and persist regression evidence')
     sub.add_parser('once', help='heartbeat, refresh discovery, pull tasks once, execute, return receipts')
     sub.add_parser('run', help='run persistent polling daemon')
+    return parser
 
-    args = parser.parse_args()
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
 
     if args.command == 'policy-init':
-        _save_default_policy(args.policy, args.root)
+        try:
+            _save_default_policy(args.policy, args.root, args.employee_wake_root)
+        except ValueError as exc:
+            print(f'error: {exc}', file=os.sys.stderr)
+            return 2
         return 0
 
     policy = _load_policy(args.policy)

--- a/tests/test_client_employee_wake_policy.py
+++ b/tests/test_client_employee_wake_policy.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from agentos_node.client_cli import _load_policy, main
+from agentos_node.thin_client import NodeIdentity, ThinClient
+
+
+WAKE_CAPABILITY = 'agent.employee.wake.deliver'
+
+
+class ClientEmployeeWakePolicyTests(unittest.TestCase):
+    def _write_policy(self, root: Path, *, wake_root=None, allowed=None, writable=None) -> Path:
+        path = root / 'policy.json'
+        payload = {
+            'schema': 'agentos.client-policy/v0.1',
+            'allowed_executables': list(allowed or []),
+            'readable_roots': [],
+            'writable_roots': list(writable or []),
+            'employee_wake_root': wake_root,
+            'max_timeout_seconds': 120,
+        }
+        path.write_text(json.dumps(payload) + '\n', encoding='utf-8')
+        return path
+
+    def test_null_wake_root_does_not_advertise_capability(self):
+        with tempfile.TemporaryDirectory() as td:
+            policy = _load_policy(self._write_policy(Path(td), wake_root=None))
+            self.assertIsNone(policy.employee_wake_root)
+            manifest = ThinClient(NodeIdentity('realm-test', 'node-test'), policy).capability_manifest()
+            self.assertNotIn(WAKE_CAPABILITY, manifest['capabilities'])
+
+    def test_absolute_wake_root_loads_and_advertises_only_typed_wake(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            wake_root = (root / 'wake').resolve()
+            policy = _load_policy(self._write_policy(root, wake_root=str(wake_root)))
+            self.assertEqual(policy.employee_wake_root, wake_root)
+            self.assertEqual(policy.writable_roots, ())
+            self.assertEqual(policy.allowed_executables, set())
+            manifest = ThinClient(NodeIdentity('realm-test', 'node-test'), policy).capability_manifest()
+            self.assertIn(WAKE_CAPABILITY, manifest['capabilities'])
+            self.assertNotIn('filesystem.write', manifest['capabilities'])
+            self.assertNotIn('shell.exec', manifest['capabilities'])
+
+    def test_relative_wake_root_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_policy(Path(td), wake_root='relative/wake')
+            with self.assertRaisesRegex(ValueError, 'employee_wake_root_must_be_absolute'):
+                _load_policy(path)
+
+    def test_non_string_wake_root_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_policy(Path(td), wake_root=['not', 'a', 'path'])
+            with self.assertRaisesRegex(ValueError, 'employee_wake_root_must_be_string_or_null'):
+                _load_policy(path)
+
+    def test_policy_init_defaults_wake_capability_off(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            policy_path = root / 'policy.json'
+            with redirect_stdout(StringIO()):
+                rc = main(['--policy', str(policy_path), 'policy-init', '--root', str(root / 'workspace')])
+            self.assertEqual(rc, 0)
+            payload = json.loads(policy_path.read_text(encoding='utf-8'))
+            self.assertIsNone(payload['employee_wake_root'])
+
+    def test_policy_init_persists_explicit_absolute_wake_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            policy_path = root / 'policy.json'
+            wake_root = (root / 'employee-wake').resolve()
+            with redirect_stdout(StringIO()):
+                rc = main([
+                    '--policy', str(policy_path),
+                    'policy-init',
+                    '--root', str(root / 'workspace'),
+                    '--employee-wake-root', str(wake_root),
+                ])
+            self.assertEqual(rc, 0)
+            payload = json.loads(policy_path.read_text(encoding='utf-8'))
+            self.assertEqual(payload['employee_wake_root'], str(wake_root))
+            self.assertNotIn(str(wake_root), payload['writable_roots'])
+
+    def test_policy_init_rejects_relative_wake_root_without_writing_policy(self):
+        with tempfile.TemporaryDirectory() as td:
+            policy_path = Path(td) / 'policy.json'
+            stderr = StringIO()
+            with redirect_stdout(StringIO()), redirect_stderr(stderr):
+                rc = main([
+                    '--policy', str(policy_path),
+                    'policy-init',
+                    '--employee-wake-root', 'relative/wake',
+                ])
+            self.assertEqual(rc, 2)
+            self.assertIn('employee_wake_root_must_be_absolute', stderr.getvalue())
+            self.assertFalse(policy_path.exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Relates to #152 and unblocks the live Node side of #197/#200 without changing execution authority.

Current gap fixed here:
- `ThinClientPolicy` already supported `employee_wake_root`, but `agentos-client` policy loading/initialization ignored it, so real client daemons could never advertise `agent.employee.wake.deliver` through their normal policy path.

Changes:
- load optional `employee_wake_root` from client policy;
- require it to be an explicit absolute path; malformed/non-string/relative values fail closed;
- `policy-init` persists `employee_wake_root: null` by default;
- optional `policy-init --employee-wake-root <absolute>` enables the typed wake inbox;
- wake root remains separate from `writable_roots` and does not grant `filesystem.write` or `shell.exec`;
- add focused Node wake policy + existing ThinClient regression guard.

Non-claims/non-authorities:
- this does not deploy or change a live Node policy;
- it does not start an Employee worker host;
- it does not grant Employee claim/executor authority;
- no Realm credentials are moved to an executor;
- no GitHub Actions fallback;
- no protected-main publication.

Branch evidence: Node Employee Wake Policy Guard run `33614904532` SUCCESS on exact head `dd0aa4c7dd6a437a006f330f57d4835800b525d7`.

Next #152 slice after integration: one shared credential-isolated Employee Worker Host that consumes the configured local wake inbox and launches only source-registered bounded adapters; not one daemon per role.