### PR TITLE
Core #194: rebase bounded executor-job path onto current integration

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -1,0 +1,125 @@
+name: Bounded Executor Job Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agent_core/executor_job_contract.py'
+      - 'agent_core/controller_service.py'
+      - 'agent_core/controller_api.py'
+      - 'agent_core/control_inbox_bridge.py'
+      - 'agentos_node/executor_job_adapter.py'
+      - 'agentos_node/executor_job_action_relay.py'
+      - 'agentos_node/issue117_experience_provider.py'
+      - 'scripts/install_action_relay_user.sh'
+      - 'scripts/repair_antigravity_relay_user.sh'
+      - 'tests/test_executor_job_contract.py'
+      - 'tests/test_executor_job_adapter.py'
+      - 'tests/test_executor_job_action_relay.py'
+      - 'tests/test_executor_job_controller_route.py'
+      - 'tests/test_executor_job_receipt_facade.py'
+      - 'tests/test_executor_job_runtime_installer.py'
+      - 'tests/test_issue117_experience_provider.py'
+      - 'tests/test_control_inbox_bridge.py'
+      - '.github/workflows/bounded-executor-job-guard.yml'
+  push:
+    branches:
+      - core/issue-194-bounded-executor-jobs
+    paths:
+      - 'agent_core/executor_job_contract.py'
+      - 'agent_core/controller_service.py'
+      - 'agent_core/controller_api.py'
+      - 'agent_core/control_inbox_bridge.py'
+      - 'agentos_node/executor_job_adapter.py'
+      - 'agentos_node/executor_job_action_relay.py'
+      - 'agentos_node/issue117_experience_provider.py'
+      - 'scripts/install_action_relay_user.sh'
+      - 'scripts/repair_antigravity_relay_user.sh'
+      - 'tests/test_executor_job_contract.py'
+      - 'tests/test_executor_job_adapter.py'
+      - 'tests/test_executor_job_action_relay.py'
+      - 'tests/test_executor_job_controller_route.py'
+      - 'tests/test_executor_job_receipt_facade.py'
+      - 'tests/test_executor_job_runtime_installer.py'
+      - 'tests/test_issue117_experience_provider.py'
+      - 'tests/test_control_inbox_bridge.py'
+      - '.github/workflows/bounded-executor-job-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run bounded executor-job contract tests
+        run: |
+          python -m pip install --disable-pip-version-check pytest
+          python -m pytest \
+            tests/test_executor_job_contract.py \
+            tests/test_executor_job_adapter.py \
+            tests/test_executor_job_action_relay.py \
+            tests/test_executor_job_controller_route.py \
+            tests/test_executor_job_receipt_facade.py \
+            tests/test_executor_job_runtime_installer.py \
+            tests/test_issue117_experience_provider.py \
+            tests/test_control_inbox_bridge.py \
+            -q
+      - name: Verify current issue117 worker contract compatibility
+        run: |
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          mkdir -p "$tmp/scripts"
+          git fetch --no-tags origin core/issue-117-experience-memory
+          dep=$(git rev-parse FETCH_HEAD)
+          git show "$dep:scripts/oracle_codex_experience_regression.py" > "$tmp/scripts/oracle_codex_experience_regression.py"
+          git show "$dep:scripts/oracle_codex_experience_regression_entry_v2.py" > "$tmp/scripts/oracle_codex_experience_regression_entry_v2.py"
+          ISSUE117_ROOT="$tmp" ISSUE117_COMMIT="$dep" AGENTOS_CODEX_EXECUTABLE=/__agentos_intentionally_missing_codex__ python - <<'PY'
+          import os
+          from pathlib import Path
+          from agent_core.executor_job_contract import canonical_experience_regression_request
+          from agentos_node.executor_job_adapter import ExecutorJobProviderRegistry, execute_registered_executor_job
+          from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+
+          root = Path(os.environ['ISSUE117_ROOT'])
+          base = (root / 'scripts/oracle_codex_experience_regression.py').read_text(encoding='utf-8')
+          entry = (root / 'scripts/oracle_codex_experience_regression_entry_v2.py').read_text(encoding='utf-8')
+          assert 'parser.add_argument("--output", required=True)' in base
+          assert 'parser.add_argument("--timeout", type=int, default=180)' in base
+          assert 'from scripts import oracle_codex_experience_regression as regression' in entry
+          assert 'regression.main()' in entry
+
+          registry = ExecutorJobProviderRegistry()
+          assert register_issue117_provider_if_available(registry=registry, runtime_root=root) is True
+          receipt = execute_registered_executor_job(
+              job_id='job-cross-lane-117',
+              request=canonical_experience_regression_request(),
+              registry=registry,
+          )
+          assert receipt['executor_available'] is False, receipt
+          assert receipt['routable'] is True, receipt
+          assert receipt['authorized'] is True, receipt
+          assert receipt['successful'] is False, receipt
+          assert receipt['classification'] == 'EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE', receipt
+          assert receipt['credential_exposed'] is False, receipt
+          print('issue117_provider_contract=PASS')
+          print('issue117_source_commit=' + os.environ['ISSUE117_COMMIT'])
+          PY
+      - name: Compile contract modules
+        run: |
+          python -m py_compile \
+            agent_core/executor_job_contract.py \
+            agent_core/controller_service.py \
+            agent_core/controller_api.py \
+            agent_core/control_inbox_bridge.py \
+            agentos_node/executor_job_adapter.py \
+            agentos_node/executor_job_action_relay.py \
+            agentos_node/issue117_experience_provider.py
+      - name: Validate governed runtime installers
+        run: |
+          bash -n scripts/install_action_relay_user.sh
+          bash -n scripts/repair_antigravity_relay_user.sh

--- a/agent_core/control_inbox_bridge.py
+++ b/agent_core/control_inbox_bridge.py
@@ -29,6 +29,12 @@ COMMON_RECEIPT_FIELDS = (
     'schema', 'node_id', 'task_id', 'action', 'ok', 'realm_id',
     'received_at', 'started_at', 'completed_at', 'status', 'state',
 )
+EXECUTOR_JOB_RECEIPT_FIELDS = (
+    'job_id', 'job_type', 'project_id', 'executor_class', 'capability',
+    'executor_available', 'routable', 'authorized', 'successful',
+    'credential_exposed', 'classification', 'experiment_id', 'verdict',
+    'baseline_score', 'hydrated_score', 'uplift', 'hydration_receipt_ok',
+)
 
 
 class OneControllerError(RuntimeError):
@@ -74,7 +80,7 @@ def _safe_scalar(value: Any) -> Any:
     if isinstance(value, (bool, int, float)) or value is None:
         return value
     if isinstance(value, str):
-        # Receipts are evidence, not a secret-bearing debug channel.  Keep bounded
+        # Receipts are evidence, not a secret-bearing debug channel. Keep bounded
         # scalar protocol data only; never echo authorization/token-like strings.
         lowered = value.lower()
         if any(marker in lowered for marker in ('bearer ', 'github_pat_', 'ghp_', 'token=', 'secret=')):
@@ -143,6 +149,17 @@ def _project_receipt(receipt: Any, action: str) -> dict[str, Any] | None:
                 processes.append(window['process_name'][:128])
         if processes:
             projected['processes'] = sorted(set(processes))[:64]
+    elif action == 'agentos.executor.job':
+        # Executor receipts are already sanitized by the Node-local adapter, but
+        # the public Control Inbox applies an independent allowlist. No raw model
+        # output, prompt, path, session identifier, provider detail, or credential
+        # can cross this GitHub-backed bootstrap surface.
+        for key in EXECUTOR_JOB_RECEIPT_FIELDS:
+            if key not in receipt:
+                continue
+            safe = _safe_scalar(receipt.get(key))
+            if safe is not None or receipt.get(key) is None:
+                projected[key] = safe
     return projected
 
 

--- a/agent_core/controller_api.py
+++ b/agent_core/controller_api.py
@@ -24,9 +24,16 @@ CONTROLLER_ACTION_CAPABILITY = {
 class ControllerService:
     """Governed controller-side facade for ONE."""
 
-    def __init__(self, fabric: RealmFabricStore, ota_policy: RuntimeOTAPolicyStore | None = None):
+    def __init__(self, fabric: RealmFabricStore, ota_policy: RuntimeOTAPolicyStore | None = None, executor_job_dispatcher: Any | None = None):
         self.fabric = fabric
         self.ota_policy = ota_policy or RuntimeOTAPolicyStore()
+        self._executor_job_dispatcher = executor_job_dispatcher
+
+    def _executor_dispatcher(self):
+        if self._executor_job_dispatcher is None:
+            from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
+            self._executor_job_dispatcher = ActionRelayExecutorJobDispatcher()
+        return self._executor_job_dispatcher
 
     def realm(self) -> dict[str, Any]:
         node_map = self.nodes()
@@ -336,6 +343,11 @@ Write-Output 'agentos_source_commit=SOURCE_COMMIT'
         task_id = str(task_id or '').strip()
         if not task_id:
             raise ValueError('task_id is required')
+        if task_id.startswith('action-'):
+            receipt = self._executor_dispatcher().inspect(task_id)
+            if receipt is None:
+                raise KeyError(task_id)
+            return dict(receipt)
         receipt = self.fabric.get_receipt(task_id)
         if receipt is None:
             raise KeyError(task_id)

--- a/agent_core/controller_service.py
+++ b/agent_core/controller_service.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from agent_core.executor_job_contract import validate_executor_job
 from agent_core.realm_fabric import RealmFabricStore
 
 
@@ -16,13 +17,50 @@ class ControllerService:
 
     This service preserves the accepted #64 controller-dispatch contract. Newer
     privileged controller/runtime APIs live in agent_core.controller_api.
+
+    #194 adds exactly one typed local-executor branch. It does not turn the
+    compatibility controller into a generic command router.
     """
 
     REQUEST_SCHEMA = 'agentos.controller-dispatch/v0.1'
     RECEIPT_SCHEMA = 'agentos.controller-dispatch-receipt/v0.1'
+    EXECUTOR_JOB_ACTION = 'agentos.executor.job'
+    EXECUTOR_JOB_NODE = 'oracle-core-node'
 
-    def __init__(self, fabric: RealmFabricStore):
+    def __init__(self, fabric: RealmFabricStore, executor_job_dispatcher: Any | None = None):
         self.fabric = fabric
+        self._executor_job_dispatcher = executor_job_dispatcher
+
+    def _executor_dispatcher(self):
+        if self._executor_job_dispatcher is None:
+            from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
+            self._executor_job_dispatcher = ActionRelayExecutorJobDispatcher()
+        return self._executor_job_dispatcher
+
+    def _node_for_dispatch(self, node_id: str) -> dict[str, Any]:
+        node_map = self.fabric.node_registry.node_map()
+        matches = [node for node in node_map.get('nodes', []) if node.get('node_id') == node_id]
+        if not matches:
+            raise KeyError(node_id)
+        node = matches[0]
+        if node.get('status') != 'online':
+            raise ValueError(f'target node is not online: {node_id}')
+        return node
+
+    def _dispatch_executor_job(self, *, node_id: str, payload: Any, passthrough: dict[str, Any]) -> dict[str, Any]:
+        if passthrough:
+            raise ValueError(f'unexpected executor-job controller fields: {sorted(passthrough)}')
+        if not isinstance(payload, dict):
+            raise ValueError('executor-job payload must be an object')
+        validate_executor_job(payload)
+        if node_id != self.EXECUTOR_JOB_NODE:
+            raise ValueError(f'executor job is not routable to target node: {node_id}')
+        submission = dict(self._executor_dispatcher().submit(node_id=node_id, request=payload))
+        job_id = str(submission.get('job_id') or '')
+        if not job_id:
+            raise RuntimeError('executor-job dispatcher returned no job_id')
+        submission['task_id'] = job_id
+        return submission
 
     def dispatch(self, request: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(request, dict):
@@ -38,19 +76,7 @@ class ControllerService:
         if not action:
             raise ValueError('action is required')
 
-        node_map = self.fabric.node_registry.node_map()
-        matches = [node for node in node_map.get('nodes', []) if node.get('node_id') == node_id]
-        if not matches:
-            raise KeyError(node_id)
-        node = matches[0]
-        if node.get('status') != 'online':
-            raise ValueError(f'target node is not online: {node_id}')
-
-        advertised = {str(x) for x in (node.get('capabilities') or []) if str(x)}
-        if action not in advertised:
-            raise ValueError(f'target node does not advertise capability: {action}')
-
-        task_id = str(request.get('task_id') or ('task-' + uuid.uuid4().hex))
+        node = self._node_for_dispatch(node_id)
         payload = request.get('payload')
         if payload is None:
             payload = {}
@@ -59,6 +85,19 @@ class ControllerService:
 
         reserved = {'schema', 'task_id', 'action', 'node_id', 'target_node', 'capability', 'payload'}
         passthrough = {key: value for key, value in request.items() if key not in reserved}
+
+        if action == self.EXECUTOR_JOB_ACTION:
+            return self._dispatch_executor_job(
+                node_id=node_id,
+                payload=payload,
+                passthrough=passthrough,
+            )
+
+        advertised = {str(x) for x in (node.get('capabilities') or []) if str(x)}
+        if action not in advertised:
+            raise ValueError(f'target node does not advertise capability: {action}')
+
+        task_id = str(request.get('task_id') or ('task-' + uuid.uuid4().hex))
         task = {
             'schema': 'agentos.node-task/v0.1',
             'task_id': task_id,

--- a/agent_core/controller_service.py
+++ b/agent_core/controller_service.py
@@ -56,6 +56,10 @@ class ControllerService:
         if node_id != self.EXECUTOR_JOB_NODE:
             raise ValueError(f'executor job is not routable to target node: {node_id}')
         submission = dict(self._executor_dispatcher().submit(node_id=node_id, request=payload))
+        # #50's hardened bridge historically calls the returned opaque id
+        # ``task_id``. Preserve that field name as a compatibility alias only;
+        # both values are the SAME Action Relay capsule/job ID. The caller's
+        # incoming ctl_* hint never becomes execution identity.
         job_id = str(submission.get('job_id') or '')
         if not job_id:
             raise RuntimeError('executor-job dispatcher returned no job_id')
@@ -87,6 +91,8 @@ class ControllerService:
         passthrough = {key: value for key, value in request.items() if key not in reserved}
 
         if action == self.EXECUTOR_JOB_ACTION:
+            # A legacy ctl_* task_id may arrive from #50. It is deliberately
+            # ignored and cannot select/reuse the Action Relay capsule ID.
             return self._dispatch_executor_job(
                 node_id=node_id,
                 payload=payload,

--- a/agent_core/executor_job_contract.py
+++ b/agent_core/executor_job_contract.py
@@ -36,6 +36,10 @@ FORBIDDEN_REQUEST_KEYS = {
     "password",
 }
 
+# Opaque identifiers may cross the control plane, but path-like or URL-like
+# values may not. The format is intentionally transport-neutral; Oracle's
+# Action Relay currently produces ``action-<uuidhex>`` while another Node may
+# use a different safe prefix.
 _OPAQUE_JOB_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{7,127}\Z")
 
 
@@ -80,19 +84,30 @@ def _reject_forbidden_keys(value: Any, *, prefix: str = "request") -> None:
 
 
 def validate_executor_job(request: Mapping[str, Any]) -> JobTypeSpec:
+    """Validate a declarative executor job without granting execution authority."""
     if not isinstance(request, Mapping):
         raise ExecutorJobContractError("executor job must be an object")
     _reject_forbidden_keys(request)
-    allowed = {"schema", "job_type", "project_id", "executor_class", "workload_ref", "authority"}
+
+    allowed = {
+        "schema",
+        "job_type",
+        "project_id",
+        "executor_class",
+        "workload_ref",
+        "authority",
+    }
     unexpected = set(request) - allowed
     if unexpected:
         raise ExecutorJobContractError(f"unexpected executor-job fields: {sorted(unexpected)}")
     if request.get("schema") != EXECUTOR_JOB_SCHEMA:
         raise ExecutorJobContractError("unsupported executor-job schema")
+
     job_type = str(request.get("job_type") or "").strip()
     spec = JOB_TYPES.get(job_type)
     if spec is None:
         raise ExecutorJobContractError("unsupported executor job type")
+
     exact = {
         "project_id": spec.project_id,
         "executor_class": spec.executor_class,
@@ -106,6 +121,7 @@ def validate_executor_job(request: Mapping[str, Any]) -> JobTypeSpec:
 
 
 def validate_executor_job_id(job_id: str) -> str:
+    """Validate an opaque durable identifier without accepting filesystem input."""
     value = str(job_id or "").strip()
     if not _OPAQUE_JOB_ID.fullmatch(value):
         raise ExecutorJobContractError("job_id must be an opaque non-path identifier")
@@ -124,7 +140,14 @@ def canonical_experience_regression_request() -> dict[str, str]:
     }
 
 
-def project_executor_job_submission(*, job_id: str, node_id: str, request: Mapping[str, Any], reused: bool = False) -> dict[str, Any]:
+def project_executor_job_submission(
+    *,
+    job_id: str,
+    node_id: str,
+    request: Mapping[str, Any],
+    reused: bool = False,
+) -> dict[str, Any]:
+    """Project the asynchronous acknowledgement returned before execution ends."""
     spec = validate_executor_job(request)
     job_id = validate_executor_job_id(job_id)
     node_id = str(node_id or "").strip()
@@ -145,7 +168,17 @@ def project_executor_job_submission(*, job_id: str, node_id: str, request: Mappi
     }
 
 
-def project_executor_job_receipt(*, job_id: str, request: Mapping[str, Any], executor_available: bool, routable: bool, authorized: bool, successful: bool, result: Mapping[str, Any] | None = None) -> dict[str, Any]:
+def project_executor_job_receipt(
+    *,
+    job_id: str,
+    request: Mapping[str, Any],
+    executor_available: bool,
+    routable: bool,
+    authorized: bool,
+    successful: bool,
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create the bounded model-visible result; never infer one state from another."""
     spec = validate_executor_job(request)
     job_id = validate_executor_job_id(job_id)
     summary: dict[str, Any] = {
@@ -162,7 +195,16 @@ def project_executor_job_receipt(*, job_id: str, request: Mapping[str, Any], exe
         "credential_exposed": False,
     }
     if result is not None:
-        for key in ("experiment_id", "verdict", "baseline_score", "hydrated_score", "uplift", "hydration_receipt_ok", "classification"):
+        # Only explicitly safe scalar regression fields cross the boundary.
+        for key in (
+            "experiment_id",
+            "verdict",
+            "baseline_score",
+            "hydrated_score",
+            "uplift",
+            "hydration_receipt_ok",
+            "classification",
+        ):
             value = result.get(key)
             if isinstance(value, (str, int, float, bool)) or value is None:
                 summary[key] = value

--- a/agent_core/executor_job_contract.py
+++ b/agent_core/executor_job_contract.py
@@ -1,0 +1,169 @@
+"""Governed bounded executor-job contract for AgentOS ONE.
+
+This is deliberately not a remote shell contract. A caller selects only a
+registered job type plus its bounded semantic inputs. Node-local adapters own
+the executable mapping and credentials. Long-running executor work is submitted
+as an asynchronous job and observed later through an opaque job identifier.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Mapping
+
+
+EXECUTOR_JOB_SCHEMA = "agentos.executor-job/v1"
+EXECUTOR_JOB_SUBMISSION_SCHEMA = "agentos.executor-job-submission/v1"
+EXECUTOR_JOB_RECEIPT_SCHEMA = "agentos.executor-job-receipt/v1"
+
+FORBIDDEN_REQUEST_KEYS = {
+    "command",
+    "cmd",
+    "shell",
+    "script",
+    "argv",
+    "executable",
+    "binary",
+    "cwd",
+    "path",
+    "paths",
+    "env",
+    "environment",
+    "token",
+    "credential",
+    "credentials",
+    "secret",
+    "password",
+}
+
+_OPAQUE_JOB_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{7,127}\Z")
+
+
+class ExecutorJobContractError(ValueError):
+    """Raised when a caller attempts to escape a bounded executor-job contract."""
+
+
+@dataclass(frozen=True)
+class JobTypeSpec:
+    job_type: str
+    capability: str
+    authority: str
+    executor_class: str
+    project_id: str
+    workload_ref: str
+    read_only: bool
+
+
+JOB_TYPES: dict[str, JobTypeSpec] = {
+    "experience.regression": JobTypeSpec(
+        job_type="experience.regression",
+        capability="agentos.experience.regression",
+        authority="read-only-regression",
+        executor_class="openai-codex-local",
+        project_id="agentos-core",
+        workload_ref="issue://117",
+        read_only=True,
+    ),
+}
+
+
+def _reject_forbidden_keys(value: Any, *, prefix: str = "request") -> None:
+    if isinstance(value, Mapping):
+        for raw_key, child in value.items():
+            key = str(raw_key).strip().casefold()
+            if key in FORBIDDEN_REQUEST_KEYS:
+                raise ExecutorJobContractError(f"forbidden generic-execution field: {prefix}.{raw_key}")
+            _reject_forbidden_keys(child, prefix=f"{prefix}.{raw_key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_keys(child, prefix=f"{prefix}[{index}]")
+
+
+def validate_executor_job(request: Mapping[str, Any]) -> JobTypeSpec:
+    if not isinstance(request, Mapping):
+        raise ExecutorJobContractError("executor job must be an object")
+    _reject_forbidden_keys(request)
+    allowed = {"schema", "job_type", "project_id", "executor_class", "workload_ref", "authority"}
+    unexpected = set(request) - allowed
+    if unexpected:
+        raise ExecutorJobContractError(f"unexpected executor-job fields: {sorted(unexpected)}")
+    if request.get("schema") != EXECUTOR_JOB_SCHEMA:
+        raise ExecutorJobContractError("unsupported executor-job schema")
+    job_type = str(request.get("job_type") or "").strip()
+    spec = JOB_TYPES.get(job_type)
+    if spec is None:
+        raise ExecutorJobContractError("unsupported executor job type")
+    exact = {
+        "project_id": spec.project_id,
+        "executor_class": spec.executor_class,
+        "workload_ref": spec.workload_ref,
+        "authority": spec.authority,
+    }
+    for field, expected in exact.items():
+        if request.get(field) != expected:
+            raise ExecutorJobContractError(f"{field} must equal the registered job contract")
+    return spec
+
+
+def validate_executor_job_id(job_id: str) -> str:
+    value = str(job_id or "").strip()
+    if not _OPAQUE_JOB_ID.fullmatch(value):
+        raise ExecutorJobContractError("job_id must be an opaque non-path identifier")
+    return value
+
+
+def canonical_experience_regression_request() -> dict[str, str]:
+    spec = JOB_TYPES["experience.regression"]
+    return {
+        "schema": EXECUTOR_JOB_SCHEMA,
+        "job_type": spec.job_type,
+        "project_id": spec.project_id,
+        "executor_class": spec.executor_class,
+        "workload_ref": spec.workload_ref,
+        "authority": spec.authority,
+    }
+
+
+def project_executor_job_submission(*, job_id: str, node_id: str, request: Mapping[str, Any], reused: bool = False) -> dict[str, Any]:
+    spec = validate_executor_job(request)
+    job_id = validate_executor_job_id(job_id)
+    node_id = str(node_id or "").strip()
+    if not node_id:
+        raise ExecutorJobContractError("node_id is required")
+    return {
+        "schema": EXECUTOR_JOB_SUBMISSION_SCHEMA,
+        "ok": True,
+        "state": "queued",
+        "job_id": job_id,
+        "node_id": node_id,
+        "job_type": spec.job_type,
+        "project_id": spec.project_id,
+        "executor_class": spec.executor_class,
+        "capability": spec.capability,
+        "reused": bool(reused),
+        "credential_exposed": False,
+    }
+
+
+def project_executor_job_receipt(*, job_id: str, request: Mapping[str, Any], executor_available: bool, routable: bool, authorized: bool, successful: bool, result: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    spec = validate_executor_job(request)
+    job_id = validate_executor_job_id(job_id)
+    summary: dict[str, Any] = {
+        "schema": EXECUTOR_JOB_RECEIPT_SCHEMA,
+        "job_id": job_id,
+        "job_type": spec.job_type,
+        "project_id": spec.project_id,
+        "executor_class": spec.executor_class,
+        "capability": spec.capability,
+        "executor_available": bool(executor_available),
+        "routable": bool(routable),
+        "authorized": bool(authorized),
+        "successful": bool(successful),
+        "credential_exposed": False,
+    }
+    if result is not None:
+        for key in ("experiment_id", "verdict", "baseline_score", "hydrated_score", "uplift", "hydration_receipt_ok", "classification"):
+            value = result.get(key)
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                summary[key] = value
+    return summary

--- a/agent_core/executor_job_controller.py
+++ b/agent_core/executor_job_controller.py
@@ -29,7 +29,10 @@ class ExecutorJobRoutingError(RuntimeError):
 
 
 class ExecutorJobDispatcher(Protocol):
+    """Node/runtime-owned asynchronous transport used by the Core controller."""
+
     def submit(self, *, node_id: str, request: Mapping[str, Any]) -> str: ...
+
     def inspect(self, *, node_id: str, job_id: str) -> Mapping[str, Any]: ...
 
 
@@ -59,10 +62,22 @@ class ExecutorJobController:
             raise ExecutorJobRoutingError("NODE_OFFLINE")
         if self._dispatcher is None:
             raise ExecutorJobRoutingError("EXECUTOR_JOB_DISPATCHER_UNAVAILABLE")
+
+        # Node liveness is a routing prerequisite only. Do not infer executor
+        # availability from the Node's generic capability list; the Node-local
+        # dispatcher/provider observation owns executor_available, routable,
+        # authorized, and successful as independent dimensions.
         job_id = self._dispatcher.submit(node_id=str(node_id), request=request)
-        return project_executor_job_submission(job_id=job_id, node_id=str(node_id), request=request)
+        return project_executor_job_submission(
+            job_id=job_id,
+            node_id=str(node_id),
+            request=request,
+        )
 
     def inspect(self, *, node_id: str, job_id: str) -> dict[str, Any]:
+        # A completed durable receipt must remain readable after the Node goes
+        # offline. Therefore inspect validates Node identity but intentionally
+        # does not impose an online/liveness gate.
         self._node(node_id)
         job_id = validate_executor_job_id(job_id)
         if self._dispatcher is None:
@@ -72,9 +87,11 @@ class ExecutorJobController:
             raise ExecutorJobRoutingError("EXECUTOR_JOB_OBSERVATION_INVALID")
         if observed.get("node_id") != str(node_id) or observed.get("job_id") != job_id:
             raise ExecutorJobRoutingError("EXECUTOR_JOB_IDENTITY_MISMATCH")
+
         state = str(observed.get("state") or "").strip()
         if state not in _NONTERMINAL_STATES | _TERMINAL_STATES:
             raise ExecutorJobRoutingError("EXECUTOR_JOB_STATE_INVALID")
+
         result = observed.get("result")
         projection: dict[str, Any] = {
             "schema": EXECUTOR_JOB_INSPECTION_SCHEMA,
@@ -88,6 +105,7 @@ class ExecutorJobController:
         classification = observed.get("classification")
         if isinstance(classification, str) and classification:
             projection["classification"] = classification
+
         if result is not None:
             if not isinstance(result, Mapping):
                 raise ExecutorJobRoutingError("EXECUTOR_JOB_RESULT_INVALID")
@@ -100,4 +118,5 @@ class ExecutorJobController:
             projection["result"] = dict(result)
         elif state == "completed":
             raise ExecutorJobRoutingError("EXECUTOR_JOB_TERMINAL_RESULT_MISSING")
+
         return projection

--- a/agent_core/executor_job_controller.py
+++ b/agent_core/executor_job_controller.py
@@ -1,0 +1,103 @@
+"""Controller-side routing boundary for bounded asynchronous executor jobs.
+
+Core deliberately knows nothing about Oracle spool paths, Linux users, or
+ActionRelay implementation details. A Node/runtime supplies an
+``ExecutorJobDispatcher`` implementation. This keeps the ONE contract portable
+across Nodes while preserving the rule that executor-local credentials and
+implementation choices never become model input.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Protocol
+
+from agent_core.executor_job_contract import (
+    EXECUTOR_JOB_RECEIPT_SCHEMA,
+    ExecutorJobContractError,
+    project_executor_job_submission,
+    validate_executor_job,
+    validate_executor_job_id,
+)
+
+
+EXECUTOR_JOB_INSPECTION_SCHEMA = "agentos.executor-job-inspection/v1"
+_TERMINAL_STATES = {"completed", "failed", "unknown"}
+_NONTERMINAL_STATES = {"queued", "processing"}
+
+
+class ExecutorJobRoutingError(RuntimeError):
+    """Stable fail-closed routing error; no provider-local detail is included."""
+
+
+class ExecutorJobDispatcher(Protocol):
+    def submit(self, *, node_id: str, request: Mapping[str, Any]) -> str: ...
+    def inspect(self, *, node_id: str, job_id: str) -> Mapping[str, Any]: ...
+
+
+NodeLookup = Callable[[str], Mapping[str, Any]]
+
+
+class ExecutorJobController:
+    """Validate, route, and inspect declared executor jobs without generic exec."""
+
+    def __init__(self, *, node_lookup: NodeLookup, dispatcher: ExecutorJobDispatcher | None):
+        self._node_lookup = node_lookup
+        self._dispatcher = dispatcher
+
+    def _node(self, node_id: str) -> Mapping[str, Any]:
+        value = str(node_id or "").strip()
+        if not value:
+            raise ExecutorJobContractError("node_id is required")
+        node = self._node_lookup(value)
+        if not isinstance(node, Mapping):
+            raise ExecutorJobRoutingError("NODE_RECORD_INVALID")
+        return node
+
+    def submit(self, *, node_id: str, request: Mapping[str, Any]) -> dict[str, Any]:
+        validate_executor_job(request)
+        node = self._node(node_id)
+        if node.get("status") != "online":
+            raise ExecutorJobRoutingError("NODE_OFFLINE")
+        if self._dispatcher is None:
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_DISPATCHER_UNAVAILABLE")
+        job_id = self._dispatcher.submit(node_id=str(node_id), request=request)
+        return project_executor_job_submission(job_id=job_id, node_id=str(node_id), request=request)
+
+    def inspect(self, *, node_id: str, job_id: str) -> dict[str, Any]:
+        self._node(node_id)
+        job_id = validate_executor_job_id(job_id)
+        if self._dispatcher is None:
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_DISPATCHER_UNAVAILABLE")
+        observed = self._dispatcher.inspect(node_id=str(node_id), job_id=job_id)
+        if not isinstance(observed, Mapping):
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_OBSERVATION_INVALID")
+        if observed.get("node_id") != str(node_id) or observed.get("job_id") != job_id:
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_IDENTITY_MISMATCH")
+        state = str(observed.get("state") or "").strip()
+        if state not in _NONTERMINAL_STATES | _TERMINAL_STATES:
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_STATE_INVALID")
+        result = observed.get("result")
+        projection: dict[str, Any] = {
+            "schema": EXECUTOR_JOB_INSPECTION_SCHEMA,
+            "ok": True,
+            "job_id": job_id,
+            "node_id": str(node_id),
+            "state": state,
+            "terminal": state in _TERMINAL_STATES,
+            "credential_exposed": False,
+        }
+        classification = observed.get("classification")
+        if isinstance(classification, str) and classification:
+            projection["classification"] = classification
+        if result is not None:
+            if not isinstance(result, Mapping):
+                raise ExecutorJobRoutingError("EXECUTOR_JOB_RESULT_INVALID")
+            if result.get("schema") != EXECUTOR_JOB_RECEIPT_SCHEMA:
+                raise ExecutorJobRoutingError("EXECUTOR_JOB_RESULT_SCHEMA_INVALID")
+            if result.get("job_id") != job_id:
+                raise ExecutorJobRoutingError("EXECUTOR_JOB_RESULT_ID_MISMATCH")
+            if result.get("credential_exposed") is not False:
+                raise ExecutorJobRoutingError("EXECUTOR_JOB_CREDENTIAL_BOUNDARY_NOT_PROVEN")
+            projection["result"] = dict(result)
+        elif state == "completed":
+            raise ExecutorJobRoutingError("EXECUTOR_JOB_TERMINAL_RESULT_MISSING")
+        return projection

--- a/agentos_node/executor_job_action_relay.py
+++ b/agentos_node/executor_job_action_relay.py
@@ -1,0 +1,137 @@
+"""Bounded executor-job extension for the existing ubuntu Action Relay.
+
+This module deliberately reuses ``agentos_node.action_relay`` and its spool,
+digest, at-most-once, quarantine, and ubuntu-owned worker boundary. It adds one
+fixed semantic action only; no generic shell or argv surface is introduced.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from agent_core.executor_job_contract import (
+    EXECUTOR_JOB_SCHEMA,
+    project_executor_job_receipt,
+    project_executor_job_submission,
+    validate_executor_job,
+    validate_executor_job_id,
+)
+from agentos_node.action_relay import ACTIONS, ActionRelayClient, main as action_relay_main
+from agentos_node.executor_job_adapter import run_registered_executor_job
+from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+
+
+ACTION = "agentos.executor.job"
+DEFAULT_ROOT = Path("/home/ubuntu/agent-data/runtime/action-relay")
+_REQUEST_FIELDS = ("job_type", "project_id", "executor_class", "workload_ref", "authority")
+
+ISSUE117_PROVIDER_REGISTERED = register_issue117_provider_if_available()
+
+
+def _request_projection(request: Mapping[str, Any]) -> dict[str, Any]:
+    validate_executor_job(request)
+    return {key: request[key] for key in _REQUEST_FIELDS}
+
+
+def _request_from_receipt(receipt: Mapping[str, Any]) -> dict[str, Any] | None:
+    candidate = {"schema": EXECUTOR_JOB_SCHEMA}
+    for key in _REQUEST_FIELDS:
+        value = receipt.get(key)
+        if not isinstance(value, str) or not value:
+            return None
+        candidate[key] = value
+    validate_executor_job(candidate)
+    return candidate
+
+
+def _execute(params: dict[str, Any]) -> dict[str, Any]:
+    if set(params) != {"request"} or not isinstance(params.get("request"), dict):
+        raise ValueError("executor-job relay accepts only a canonical request object")
+    request = dict(params["request"])
+    validate_executor_job(request)
+    return {**_request_projection(request), **run_registered_executor_job(request=request)}
+
+
+if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
+    raise RuntimeError("executor-job Action Relay action already registered differently")
+ACTIONS[ACTION] = _execute
+
+
+class ActionRelayExecutorJobDispatcher:
+    """Submit/inspect bounded jobs through the existing Action Relay spool."""
+
+    def __init__(self, root: str | Path = DEFAULT_ROOT):
+        self.root = Path(root)
+        self.client = ActionRelayClient(self.root)
+        self._requests: dict[str, dict[str, Any]] = {}
+
+    def submit(self, *, node_id: str, request: Mapping[str, Any]) -> dict[str, Any]:
+        validate_executor_job(request)
+        capsule = self.client.submit(ACTION, {"request": dict(request)})
+        job_id = validate_executor_job_id(str(capsule["capsule_id"]))
+        self._requests[job_id] = dict(request)
+        return project_executor_job_submission(job_id=job_id, node_id=node_id, request=request)
+
+    def _recover_request(self, job_id: str) -> dict[str, Any] | None:
+        request = self._requests.get(job_id)
+        if request is not None:
+            return request
+        for base in (self.root / "inbox", self.root / "processing", self.root / "quarantine"):
+            path = base / f"{job_id}.json"
+            if not path.is_file():
+                continue
+            capsule = json.loads(path.read_text(encoding="utf-8"))
+            params = capsule.get("params") or {}
+            candidate = params.get("request") if isinstance(params, dict) else None
+            if isinstance(candidate, dict):
+                validate_executor_job(candidate)
+                request = dict(candidate)
+                self._requests[job_id] = request
+                return request
+        receipt_path = self.root / "receipts" / f"{job_id}.json"
+        if receipt_path.is_file():
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            request = _request_from_receipt(receipt)
+            if request is not None:
+                self._requests[job_id] = request
+                return request
+        return None
+
+    def inspect(self, job_id: str) -> dict[str, Any] | None:
+        job_id = validate_executor_job_id(job_id)
+        request = self._recover_request(job_id)
+        receipt = self.client.receipt(job_id)
+        if receipt is None:
+            return None
+        if request is None:
+            raise RuntimeError("executor-job request provenance unavailable")
+        if receipt.get("action") not in (None, ACTION):
+            raise RuntimeError("executor-job relay receipt action mismatch")
+        if receipt.get("outcome") == "unknown":
+            return project_executor_job_receipt(
+                job_id=job_id,
+                request=request,
+                executor_available=True,
+                routable=True,
+                authorized=True,
+                successful=False,
+                result={"classification": "EXECUTION_OUTCOME_UNKNOWN"},
+            )
+        return project_executor_job_receipt(
+            job_id=job_id,
+            request=request,
+            executor_available=bool(receipt.get("executor_available")),
+            routable=bool(receipt.get("routable")),
+            authorized=bool(receipt.get("authorized")),
+            successful=bool(receipt.get("successful")),
+            result=receipt,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    return action_relay_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/executor_job_action_relay.py
+++ b/agentos_node/executor_job_action_relay.py
@@ -26,10 +26,14 @@ ACTION = "agentos.executor.job"
 DEFAULT_ROOT = Path("/home/ubuntu/agent-data/runtime/action-relay")
 _REQUEST_FIELDS = ("job_type", "project_id", "executor_class", "workload_ref", "authority")
 
+# Cross-slice integration is conditional by construction. #194 remains usable
+# without #117; once both are present in the same immutable runtime generation,
+# the trusted provider becomes available without a second daemon or model input.
 ISSUE117_PROVIDER_REGISTERED = register_issue117_provider_if_available()
 
 
 def _request_projection(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Persist only semantic identity fields, never transport-reserved fields."""
     validate_executor_job(request)
     return {key: request[key] for key in _REQUEST_FIELDS}
 
@@ -50,9 +54,13 @@ def _execute(params: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("executor-job relay accepts only a canonical request object")
     request = dict(params["request"])
     validate_executor_job(request)
+    # ActionRelay owns receipt schema/capsule/action/timestamps. Persist only
+    # fixed job identity plus the adapter's already-sanitized semantic result.
     return {**_request_projection(request), **run_registered_executor_job(request=request)}
 
 
+# Trusted-process registration. Importing this module extends the same fixed
+# Action Relay ACTIONS table used by both producer and ubuntu worker process.
 if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
     raise RuntimeError("executor-job Action Relay action already registered differently")
 ACTIONS[ACTION] = _execute
@@ -130,6 +138,7 @@ class ActionRelayExecutorJobDispatcher:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the original Action Relay worker with the fixed job action loaded."""
     return action_relay_main(argv)
 
 

--- a/agentos_node/executor_job_adapter.py
+++ b/agentos_node/executor_job_adapter.py
@@ -1,0 +1,142 @@
+"""Node-local adapter for registered ONE executor jobs.
+
+The adapter separates the generic ONE job transport from workload ownership.
+Core owns validation/routing semantics; issue-specific providers register a fixed
+callable under a known job type. No caller-supplied command, argv, path, module,
+or executable can influence provider selection.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from agent_core.executor_job_contract import (
+    project_executor_job_receipt,
+    validate_executor_job,
+)
+
+
+Provider = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+_SAFE_PROVIDER_RESULT_FIELDS = (
+    "experiment_id",
+    "verdict",
+    "baseline_score",
+    "hydrated_score",
+    "uplift",
+    "hydration_receipt_ok",
+    "classification",
+)
+_PROVIDER_STATE_FIELDS = (
+    "executor_available",
+    "routable",
+    "authorized",
+    "successful",
+)
+
+
+@dataclass(frozen=True)
+class ProviderBinding:
+    job_type: str
+    provider_id: str
+    executor_class: str
+    handler: Provider
+
+
+class ExecutorJobProviderRegistry:
+    """Trusted-process provider registry; registrations are not model input."""
+
+    def __init__(self) -> None:
+        self._bindings: dict[str, ProviderBinding] = {}
+
+    def register(self, *, job_type: str, provider_id: str, executor_class: str, handler: Provider) -> None:
+        job_type = str(job_type or "").strip()
+        provider_id = str(provider_id or "").strip()
+        executor_class = str(executor_class or "").strip()
+        if not job_type or not provider_id or not executor_class or not callable(handler):
+            raise ValueError("complete trusted provider binding is required")
+        if job_type in self._bindings:
+            raise ValueError(f"provider already registered for job type: {job_type}")
+        self._bindings[job_type] = ProviderBinding(job_type=job_type, provider_id=provider_id, executor_class=executor_class, handler=handler)
+
+    def get(self, job_type: str) -> ProviderBinding | None:
+        return self._bindings.get(str(job_type or ""))
+
+
+DEFAULT_PROVIDERS = ExecutorJobProviderRegistry()
+
+
+def _semantic_failure(classification: str, *, executor_available: bool, routable: bool, authorized: bool) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "executor_available": bool(executor_available),
+        "routable": bool(routable),
+        "authorized": bool(authorized),
+        "successful": False,
+        "classification": classification,
+        "credential_exposed": False,
+    }
+
+
+def _sanitize_provider_result(raw: Mapping[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key in _SAFE_PROVIDER_RESULT_FIELDS:
+        value = raw.get(key)
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            safe[key] = value
+    return safe
+
+
+def _trusted_provider_state(raw: Mapping[str, Any], key: str, default: bool) -> bool:
+    if key not in raw:
+        return bool(default)
+    value = raw.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"trusted provider state must be boolean: {key}")
+    return value
+
+
+def run_registered_executor_job(*, request: Mapping[str, Any], registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS) -> dict[str, Any]:
+    spec = validate_executor_job(request)
+    binding = registry.get(spec.job_type)
+    if binding is None:
+        return _semantic_failure("JOB_IMPLEMENTATION_UNAVAILABLE", executor_available=False, routable=False, authorized=False)
+    if binding.executor_class != spec.executor_class:
+        return _semantic_failure("EXECUTOR_CLASS_MISMATCH", executor_available=True, routable=False, authorized=False)
+    try:
+        raw = binding.handler(request)
+    except Exception as exc:
+        return _semantic_failure(f"PROVIDER_ERROR_{type(exc).__name__.upper()}", executor_available=True, routable=True, authorized=True)
+    if not isinstance(raw, Mapping):
+        return _semantic_failure("PROVIDER_RESULT_INVALID", executor_available=True, routable=True, authorized=True)
+    result = _sanitize_provider_result(raw)
+    try:
+        executor_available = _trusted_provider_state(raw, "executor_available", True)
+        routable = _trusted_provider_state(raw, "routable", True)
+        authorized = _trusted_provider_state(raw, "authorized", True)
+        default_success = result.get("verdict") == "PASS" and raw.get("credential_exposed") is not True
+        successful = _trusted_provider_state(raw, "successful", default_success)
+    except ValueError:
+        return _semantic_failure("PROVIDER_STATE_INVALID", executor_available=True, routable=True, authorized=True)
+    if raw.get("credential_exposed") is True:
+        successful = False
+        result["classification"] = "PROVIDER_CREDENTIAL_BOUNDARY_VIOLATION"
+    result["executor_available"] = executor_available
+    result["routable"] = routable
+    result["authorized"] = authorized
+    result["successful"] = successful
+    result["credential_exposed"] = False
+    result["ok"] = bool(successful)
+    return result
+
+
+def execute_registered_executor_job(*, job_id: str, request: Mapping[str, Any], registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS) -> dict[str, Any]:
+    semantic = run_registered_executor_job(request=request, registry=registry)
+    return project_executor_job_receipt(
+        job_id=job_id,
+        request=request,
+        executor_available=bool(semantic.get("executor_available")),
+        routable=bool(semantic.get("routable")),
+        authorized=bool(semantic.get("authorized")),
+        successful=bool(semantic.get("successful")),
+        result=semantic,
+    )

--- a/agentos_node/executor_job_adapter.py
+++ b/agentos_node/executor_job_adapter.py
@@ -48,7 +48,14 @@ class ExecutorJobProviderRegistry:
     def __init__(self) -> None:
         self._bindings: dict[str, ProviderBinding] = {}
 
-    def register(self, *, job_type: str, provider_id: str, executor_class: str, handler: Provider) -> None:
+    def register(
+        self,
+        *,
+        job_type: str,
+        provider_id: str,
+        executor_class: str,
+        handler: Provider,
+    ) -> None:
         job_type = str(job_type or "").strip()
         provider_id = str(provider_id or "").strip()
         executor_class = str(executor_class or "").strip()
@@ -56,7 +63,12 @@ class ExecutorJobProviderRegistry:
             raise ValueError("complete trusted provider binding is required")
         if job_type in self._bindings:
             raise ValueError(f"provider already registered for job type: {job_type}")
-        self._bindings[job_type] = ProviderBinding(job_type=job_type, provider_id=provider_id, executor_class=executor_class, handler=handler)
+        self._bindings[job_type] = ProviderBinding(
+            job_type=job_type,
+            provider_id=provider_id,
+            executor_class=executor_class,
+            handler=handler,
+        )
 
     def get(self, job_type: str) -> ProviderBinding | None:
         return self._bindings.get(str(job_type or ""))
@@ -78,6 +90,12 @@ def _semantic_failure(classification: str, *, executor_available: bool, routable
 
 
 def _sanitize_provider_result(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Bound provider output before it is persisted by Action Relay.
+
+    Final model-visible projection is also bounded by the Core receipt contract,
+    but persistence must be safe on its own. In particular stdout/stderr, paths,
+    prompts, session data and credentials never enter the relay receipt.
+    """
     safe: dict[str, Any] = {}
     for key in _SAFE_PROVIDER_RESULT_FIELDS:
         value = raw.get(key)
@@ -95,19 +113,55 @@ def _trusted_provider_state(raw: Mapping[str, Any], key: str, default: bool) -> 
     return value
 
 
-def run_registered_executor_job(*, request: Mapping[str, Any], registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS) -> dict[str, Any]:
+def run_registered_executor_job(
+    *,
+    request: Mapping[str, Any],
+    registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS,
+) -> dict[str, Any]:
+    """Run one trusted semantic provider without knowing the transport job ID.
+
+    This is the Action Relay boundary: providers receive only the validated
+    semantic request. They never receive capsule IDs, spool paths, commands,
+    credentials, or other transport authority.
+
+    Presence of a provider implementation does not imply that its executor is
+    currently available. A trusted provider may therefore report the four state
+    dimensions explicitly; model input can never set those values because it
+    cannot register or control the provider callable.
+    """
     spec = validate_executor_job(request)
     binding = registry.get(spec.job_type)
     if binding is None:
-        return _semantic_failure("JOB_IMPLEMENTATION_UNAVAILABLE", executor_available=False, routable=False, authorized=False)
+        return _semantic_failure(
+            "JOB_IMPLEMENTATION_UNAVAILABLE",
+            executor_available=False,
+            routable=False,
+            authorized=False,
+        )
     if binding.executor_class != spec.executor_class:
-        return _semantic_failure("EXECUTOR_CLASS_MISMATCH", executor_available=True, routable=False, authorized=False)
+        return _semantic_failure(
+            "EXECUTOR_CLASS_MISMATCH",
+            executor_available=True,
+            routable=False,
+            authorized=False,
+        )
     try:
         raw = binding.handler(request)
     except Exception as exc:
-        return _semantic_failure(f"PROVIDER_ERROR_{type(exc).__name__.upper()}", executor_available=True, routable=True, authorized=True)
+        return _semantic_failure(
+            f"PROVIDER_ERROR_{type(exc).__name__.upper()}",
+            executor_available=True,
+            routable=True,
+            authorized=True,
+        )
     if not isinstance(raw, Mapping):
-        return _semantic_failure("PROVIDER_RESULT_INVALID", executor_available=True, routable=True, authorized=True)
+        return _semantic_failure(
+            "PROVIDER_RESULT_INVALID",
+            executor_available=True,
+            routable=True,
+            authorized=True,
+        )
+
     result = _sanitize_provider_result(raw)
     try:
         executor_available = _trusted_provider_state(raw, "executor_available", True)
@@ -116,10 +170,20 @@ def run_registered_executor_job(*, request: Mapping[str, Any], registry: Executo
         default_success = result.get("verdict") == "PASS" and raw.get("credential_exposed") is not True
         successful = _trusted_provider_state(raw, "successful", default_success)
     except ValueError:
-        return _semantic_failure("PROVIDER_STATE_INVALID", executor_available=True, routable=True, authorized=True)
+        return _semantic_failure(
+            "PROVIDER_STATE_INVALID",
+            executor_available=True,
+            routable=True,
+            authorized=True,
+        )
+
+    # An explicit credential-boundary violation can never be successful even if
+    # a faulty trusted provider reports otherwise. The unsafe value itself is
+    # not persisted or projected.
     if raw.get("credential_exposed") is True:
         successful = False
         result["classification"] = "PROVIDER_CREDENTIAL_BOUNDARY_VIOLATION"
+
     result["executor_available"] = executor_available
     result["routable"] = routable
     result["authorized"] = authorized
@@ -129,7 +193,13 @@ def run_registered_executor_job(*, request: Mapping[str, Any], registry: Executo
     return result
 
 
-def execute_registered_executor_job(*, job_id: str, request: Mapping[str, Any], registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS) -> dict[str, Any]:
+def execute_registered_executor_job(
+    *,
+    job_id: str,
+    request: Mapping[str, Any],
+    registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS,
+) -> dict[str, Any]:
+    """Compatibility wrapper that projects a formal transport receipt."""
     semantic = run_registered_executor_job(request=request, registry=registry)
     return project_executor_job_receipt(
         job_id=job_id,

--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -1,0 +1,152 @@
+"""Trusted provider bridge from the generic executor-job contract to issue #117.
+
+#117 owns Experience discovery/hydration/regression semantics. This module does
+not copy or reimplement that benchmark. It registers only when the same
+immutable runtime generation already contains #117's regression entrypoint.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any, Mapping
+
+from agent_core.executor_job_contract import validate_executor_job
+from agentos_node.executor_job_adapter import DEFAULT_PROVIDERS, ExecutorJobProviderRegistry
+
+JOB_TYPE = "experience.regression"
+PROVIDER_ID = "issue117-experience-regression-v2"
+EXECUTOR_CLASS = "openai-codex-local"
+_ENTRY_REL = Path("scripts/oracle_codex_experience_regression_entry_v2.py")
+_BASE_REL = Path("scripts/oracle_codex_experience_regression.py")
+_PROVIDER_TIMEOUT_SECONDS = 420
+_INNER_TIMEOUT_SECONDS = 180
+
+
+def _runtime_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _provider_files(root: Path) -> tuple[Path, Path]:
+    return root / _ENTRY_REL, root / _BASE_REL
+
+
+def provider_implementation_available(root: str | Path | None = None) -> bool:
+    runtime = Path(root) if root is not None else _runtime_root()
+    entry, base = _provider_files(runtime)
+    return entry.is_file() and base.is_file()
+
+
+def _load_regression_module(path: Path):
+    spec = importlib.util.spec_from_file_location("_agentos_issue117_regression", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("issue117 regression module load failed")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _score(payload: Mapping[str, Any], lane: str) -> float | None:
+    branch = payload.get(lane)
+    if not isinstance(branch, Mapping):
+        return None
+    score = branch.get("score")
+    if not isinstance(score, Mapping):
+        return None
+    value = score.get("score")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _bounded_failure(classification: str, *, executor_available: bool, routable: bool = True, authorized: bool = True) -> dict[str, Any]:
+    return {
+        "verdict": "FAIL",
+        "classification": classification,
+        "executor_available": executor_available,
+        "routable": routable,
+        "authorized": authorized,
+        "successful": False,
+        "credential_exposed": False,
+    }
+
+
+def run_issue117_experience_regression(request: Mapping[str, Any], *, runtime_root: str | Path | None = None) -> dict[str, Any]:
+    spec = validate_executor_job(request)
+    if spec.job_type != JOB_TYPE or spec.executor_class != EXECUTOR_CLASS:
+        return _bounded_failure("EXPERIENCE_PROVIDER_CONTRACT_MISMATCH", executor_available=False, routable=False, authorized=False)
+    root = Path(runtime_root) if runtime_root is not None else _runtime_root()
+    entry, base = _provider_files(root)
+    if not entry.is_file() or not base.is_file():
+        return _bounded_failure("EXPERIENCE_PROVIDER_IMPLEMENTATION_UNAVAILABLE", executor_available=False, routable=False, authorized=False)
+    try:
+        regression = _load_regression_module(base)
+        regression.find_codex()
+    except FileNotFoundError:
+        return _bounded_failure("EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE", executor_available=False)
+    except Exception:
+        return _bounded_failure("EXPERIENCE_CODEX_DISCOVERY_ERROR", executor_available=False)
+    with tempfile.TemporaryDirectory(prefix="agentos-issue117-provider-") as tmp:
+        output = Path(tmp) / "regression.json"
+        argv = [sys.executable, str(entry), "--output", str(output), "--timeout", str(_INNER_TIMEOUT_SECONDS)]
+        try:
+            proc = subprocess.run(argv, cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=_PROVIDER_TIMEOUT_SECONDS, check=False)
+        except subprocess.TimeoutExpired:
+            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_TIMEOUT", executor_available=True)
+        except Exception:
+            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_ERROR", executor_available=True)
+        if not output.is_file():
+            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_MISSING", executor_available=True)
+        try:
+            payload = json.loads(output.read_text(encoding="utf-8"))
+        except Exception:
+            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
+    if not isinstance(payload, Mapping):
+        return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
+    if payload.get("schema") != "agentos.experience-regression/v1":
+        return _bounded_failure("EXPERIENCE_REGRESSION_SCHEMA_INVALID", executor_available=True)
+    if payload.get("project_id") != "agentos-core" or payload.get("executor") != EXECUTOR_CLASS:
+        return _bounded_failure("EXPERIENCE_REGRESSION_IDENTITY_MISMATCH", executor_available=True)
+    verdict = payload.get("verdict")
+    if verdict not in {"PASS", "FAIL"}:
+        return _bounded_failure("EXPERIENCE_REGRESSION_VERDICT_INVALID", executor_available=True)
+    checks = payload.get("checks") if isinstance(payload.get("checks"), Mapping) else {}
+    classification = payload.get("classification")
+    if not isinstance(classification, str) or not classification:
+        classification = "EXPERIENCE_REGRESSION_PASS" if verdict == "PASS" else "EXPERIENCE_REGRESSION_FAILED"
+    if (proc.returncode == 0) != (verdict == "PASS"):
+        classification = "EXPERIENCE_REGRESSION_EXIT_MISMATCH"
+    credential_boundary_ok = payload.get("credential_exposed") is False
+    successful = bool(proc.returncode == 0 and verdict == "PASS" and credential_boundary_ok)
+    return {
+        "experiment_id": payload.get("experiment_id"),
+        "verdict": verdict,
+        "baseline_score": _score(payload, "baseline"),
+        "hydrated_score": _score(payload, "hydrated"),
+        "uplift": payload.get("uplift") if isinstance(payload.get("uplift"), (int, float)) else None,
+        "hydration_receipt_ok": checks.get("hydration_receipt_ok") is True,
+        "classification": classification,
+        "executor_available": True,
+        "routable": True,
+        "authorized": True,
+        "successful": successful,
+        "credential_exposed": not credential_boundary_ok,
+    }
+
+
+def register_issue117_provider_if_available(*, registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS, runtime_root: str | Path | None = None) -> bool:
+    root = Path(runtime_root) if runtime_root is not None else _runtime_root()
+    if not provider_implementation_available(root):
+        return False
+    existing = registry.get(JOB_TYPE)
+    if existing is not None:
+        if existing.provider_id == PROVIDER_ID and existing.executor_class == EXECUTOR_CLASS:
+            return True
+        raise RuntimeError("experience.regression provider already registered differently")
+    def handler(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return run_issue117_experience_regression(request, runtime_root=root)
+    registry.register(job_type=JOB_TYPE, provider_id=PROVIDER_ID, executor_class=EXECUTOR_CLASS, handler=handler)
+    return True

--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -1,8 +1,13 @@
 """Trusted provider bridge from the generic executor-job contract to issue #117.
 
 #117 owns Experience discovery/hydration/regression semantics. This module does
-not copy or reimplement that benchmark. It registers only when the same
-immutable runtime generation already contains #117's regression entrypoint.
+not copy or reimplement that benchmark. It registers only when the *same
+immutable runtime generation* already contains #117's regression entrypoint.
+
+The provider executes a fixed read-only regression entry with fixed arguments,
+uses a private temporary evidence file, and returns only bounded scalar evidence.
+No caller-controlled command, argv, executable path, output path, or environment
+is accepted through the executor-job request.
 """
 from __future__ import annotations
 
@@ -16,6 +21,7 @@ from typing import Any, Mapping
 
 from agent_core.executor_job_contract import validate_executor_job
 from agentos_node.executor_job_adapter import DEFAULT_PROVIDERS, ExecutorJobProviderRegistry
+
 
 JOB_TYPE = "experience.regression"
 PROVIDER_ID = "issue117-experience-regression-v2"
@@ -62,7 +68,13 @@ def _score(payload: Mapping[str, Any], lane: str) -> float | None:
     return None
 
 
-def _bounded_failure(classification: str, *, executor_available: bool, routable: bool = True, authorized: bool = True) -> dict[str, Any]:
+def _bounded_failure(
+    classification: str,
+    *,
+    executor_available: bool,
+    routable: bool = True,
+    authorized: bool = True,
+) -> dict[str, Any]:
     return {
         "verdict": "FAIL",
         "classification": classification,
@@ -74,53 +86,114 @@ def _bounded_failure(classification: str, *, executor_available: bool, routable:
     }
 
 
-def run_issue117_experience_regression(request: Mapping[str, Any], *, runtime_root: str | Path | None = None) -> dict[str, Any]:
+def run_issue117_experience_regression(
+    request: Mapping[str, Any],
+    *,
+    runtime_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Execute #117's existing entrypoint with fixed provider-owned authority."""
     spec = validate_executor_job(request)
     if spec.job_type != JOB_TYPE or spec.executor_class != EXECUTOR_CLASS:
-        return _bounded_failure("EXPERIENCE_PROVIDER_CONTRACT_MISMATCH", executor_available=False, routable=False, authorized=False)
+        return _bounded_failure(
+            "EXPERIENCE_PROVIDER_CONTRACT_MISMATCH",
+            executor_available=False,
+            routable=False,
+            authorized=False,
+        )
+
     root = Path(runtime_root) if runtime_root is not None else _runtime_root()
     entry, base = _provider_files(root)
     if not entry.is_file() or not base.is_file():
-        return _bounded_failure("EXPERIENCE_PROVIDER_IMPLEMENTATION_UNAVAILABLE", executor_available=False, routable=False, authorized=False)
+        return _bounded_failure(
+            "EXPERIENCE_PROVIDER_IMPLEMENTATION_UNAVAILABLE",
+            executor_available=False,
+            routable=False,
+            authorized=False,
+        )
+
+    # Reuse #117's own Codex discovery function rather than creating another
+    # executor-discovery truth inside #194. Any path remains trusted-process
+    # local and is never returned through the executor-job receipt.
     try:
         regression = _load_regression_module(base)
         regression.find_codex()
     except FileNotFoundError:
-        return _bounded_failure("EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE", executor_available=False)
+        return _bounded_failure(
+            "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE",
+            executor_available=False,
+        )
     except Exception:
-        return _bounded_failure("EXPERIENCE_CODEX_DISCOVERY_ERROR", executor_available=False)
+        return _bounded_failure(
+            "EXPERIENCE_CODEX_DISCOVERY_ERROR",
+            executor_available=False,
+        )
+
     with tempfile.TemporaryDirectory(prefix="agentos-issue117-provider-") as tmp:
         output = Path(tmp) / "regression.json"
-        argv = [sys.executable, str(entry), "--output", str(output), "--timeout", str(_INNER_TIMEOUT_SECONDS)]
+        argv = [
+            sys.executable,
+            str(entry),
+            "--output",
+            str(output),
+            "--timeout",
+            str(_INNER_TIMEOUT_SECONDS),
+        ]
         try:
-            proc = subprocess.run(argv, cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=_PROVIDER_TIMEOUT_SECONDS, check=False)
+            proc = subprocess.run(
+                argv,
+                cwd=root,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=_PROVIDER_TIMEOUT_SECONDS,
+                check=False,
+            )
         except subprocess.TimeoutExpired:
-            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_TIMEOUT", executor_available=True)
+            return _bounded_failure(
+                "EXPERIENCE_REGRESSION_PROVIDER_TIMEOUT",
+                executor_available=True,
+            )
         except Exception:
-            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_ERROR", executor_available=True)
+            return _bounded_failure(
+                "EXPERIENCE_REGRESSION_PROVIDER_ERROR",
+                executor_available=True,
+            )
+
         if not output.is_file():
-            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_MISSING", executor_available=True)
+            return _bounded_failure(
+                "EXPERIENCE_REGRESSION_EVIDENCE_MISSING",
+                executor_available=True,
+            )
         try:
             payload = json.loads(output.read_text(encoding="utf-8"))
         except Exception:
-            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
+            return _bounded_failure(
+                "EXPERIENCE_REGRESSION_EVIDENCE_INVALID",
+                executor_available=True,
+            )
+
     if not isinstance(payload, Mapping):
         return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
     if payload.get("schema") != "agentos.experience-regression/v1":
         return _bounded_failure("EXPERIENCE_REGRESSION_SCHEMA_INVALID", executor_available=True)
     if payload.get("project_id") != "agentos-core" or payload.get("executor") != EXECUTOR_CLASS:
         return _bounded_failure("EXPERIENCE_REGRESSION_IDENTITY_MISMATCH", executor_available=True)
+
     verdict = payload.get("verdict")
     if verdict not in {"PASS", "FAIL"}:
         return _bounded_failure("EXPERIENCE_REGRESSION_VERDICT_INVALID", executor_available=True)
+
     checks = payload.get("checks") if isinstance(payload.get("checks"), Mapping) else {}
     classification = payload.get("classification")
     if not isinstance(classification, str) or not classification:
         classification = "EXPERIENCE_REGRESSION_PASS" if verdict == "PASS" else "EXPERIENCE_REGRESSION_FAILED"
+
     if (proc.returncode == 0) != (verdict == "PASS"):
         classification = "EXPERIENCE_REGRESSION_EXIT_MISMATCH"
     credential_boundary_ok = payload.get("credential_exposed") is False
     successful = bool(proc.returncode == 0 and verdict == "PASS" and credential_boundary_ok)
+
     return {
         "experiment_id": payload.get("experiment_id"),
         "verdict": verdict,
@@ -133,11 +206,18 @@ def run_issue117_experience_regression(request: Mapping[str, Any], *, runtime_ro
         "routable": True,
         "authorized": True,
         "successful": successful,
+        # The generic adapter converts an explicit violation into a fixed safe
+        # classification and never persists the unsafe provider value.
         "credential_exposed": not credential_boundary_ok,
     }
 
 
-def register_issue117_provider_if_available(*, registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS, runtime_root: str | Path | None = None) -> bool:
+def register_issue117_provider_if_available(
+    *,
+    registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS,
+    runtime_root: str | Path | None = None,
+) -> bool:
+    """Register only when #117 exists in this same immutable runtime snapshot."""
     root = Path(runtime_root) if runtime_root is not None else _runtime_root()
     if not provider_implementation_available(root):
         return False
@@ -146,7 +226,14 @@ def register_issue117_provider_if_available(*, registry: ExecutorJobProviderRegi
         if existing.provider_id == PROVIDER_ID and existing.executor_class == EXECUTOR_CLASS:
             return True
         raise RuntimeError("experience.regression provider already registered differently")
+
     def handler(request: Mapping[str, Any]) -> Mapping[str, Any]:
         return run_issue117_experience_regression(request, runtime_root=root)
-    registry.register(job_type=JOB_TYPE, provider_id=PROVIDER_ID, executor_class=EXECUTOR_CLASS, handler=handler)
+
+    registry.register(
+        job_type=JOB_TYPE,
+        provider_id=PROVIDER_ID,
+        executor_class=EXECUTOR_CLASS,
+        handler=handler,
+    )
     return True

--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -12,6 +12,17 @@ RUNTIME_ROOT="${AGENTOS_ACTION_RUNTIME_ROOT:-$HOME/.local/share/agentos/action-r
 RELAY_ROOT="$DATA/runtime/action-relay"
 UNIT_DIR="$HOME/.config/systemd/user"
 UNIT="$UNIT_DIR/agentos-action-relay.service"
+SOURCE_REF="${AGENTOS_ACTION_SOURCE_REF:-main}"
+EXPECTED_SOURCE_COMMIT="${AGENTOS_ACTION_SOURCE_COMMIT:-}"
+
+case "$SOURCE_REF" in
+  main|core/integration|feature/realm-node-fabric-readiness) ;;
+  *) echo "ERROR: AGENTOS_ACTION_SOURCE_REF is not allowlisted: $SOURCE_REF" >&2; exit 4 ;;
+esac
+if [ -n "$EXPECTED_SOURCE_COMMIT" ] && ! printf '%s' "$EXPECTED_SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "ERROR: AGENTOS_ACTION_SOURCE_COMMIT must be a lowercase 40-character git SHA" >&2
+  exit 4
+fi
 
 for user in ubuntu agentos-node; do
   id -Gn "$user" | tr ' ' '\n' | grep -qx agentos || { echo "ERROR: $user must belong to agentos group" >&2; exit 3; }
@@ -64,22 +75,34 @@ else
   ensure_shared_dir "$RELAY_ROOT/quarantine"
 fi
 
-git -C "$REPO" fetch origin main
+# A caller may choose only an allowlisted source ref; the installer resolves it
+# once to an immutable commit. When an expected commit is supplied by an outer
+# governed repair/rollout, both generations must match exactly.
+git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
+if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
+  echo "ERROR: Action Relay source generation mismatch: expected=$EXPECTED_SOURCE_COMMIT observed=$SOURCE_COMMIT" >&2
+  exit 4
+fi
+
 if [ -e "$RUNTIME_ROOT/.git" ]; then
-  git -C "$RUNTIME_ROOT" reset --hard origin/main
+  git -C "$RUNTIME_ROOT" reset --hard "$SOURCE_COMMIT"
 else
   if [ -e "$RUNTIME_ROOT" ] && [ -n "$(find "$RUNTIME_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
     echo "ERROR: non-empty runtime root is not a worktree: $RUNTIME_ROOT" >&2; exit 2
   fi
   rmdir "$RUNTIME_ROOT" 2>/dev/null || true
-  git -C "$REPO" worktree add --detach "$RUNTIME_ROOT" origin/main
+  git -C "$REPO" worktree add --detach "$RUNTIME_ROOT" "$SOURCE_COMMIT"
 fi
 
 (
   cd "$RUNTIME_ROOT"
   PYTHONPATH="$RUNTIME_ROOT" python3 - <<'PY'
-from agentos_node.action_relay import ACTIONS
+from agentos_node.executor_job_action_relay import ACTION, ACTIONS
+assert ACTION == 'agentos.executor.job'
+assert ACTION in ACTIONS
 print('action_runtime_import=ok')
+print('executor_job_action_loaded=PASS')
 print('actions='+','.join(sorted(ACTIONS)))
 PY
 )
@@ -93,6 +116,8 @@ After=default.target
 Type=simple
 WorkingDirectory=$RUNTIME_ROOT
 Environment=PYTHONPATH=$RUNTIME_ROOT
+Environment=AGENTOS_ACTION_RUNTIME_SOURCE_REF=$SOURCE_REF
+Environment=AGENTOS_ACTION_RUNTIME_SOURCE_COMMIT=$SOURCE_COMMIT
 # Actions such as agentos.antigravity.restart and layoutlab.api.restart call
 # systemctl --user from inside the relay worker. Pin them to ubuntu's existing
 # user manager explicitly; the GitHub runner has a different session/bus.
@@ -103,7 +128,10 @@ UMask=0007
 # ubuntu user-manager session. NoNewPrivileges cannot be enabled here because
 # it prevents the setgid helper from establishing the already-authorized
 # agentos group context.
-ExecStart=/usr/bin/sg agentos -c '/usr/bin/python3 -m agentos_node.action_relay --root $RELAY_ROOT'
+# The extension module registers only the fixed bounded executor-job action,
+# then delegates to the original Action Relay main. There is still one worker,
+# one spool, and one at-most-once transport.
+ExecStart=/usr/bin/sg agentos -c '/usr/bin/python3 -m agentos_node.executor_job_action_relay --root $RELAY_ROOT'
 Restart=on-failure
 RestartSec=3
 PrivateTmp=true
@@ -138,9 +166,12 @@ if [ "$stable" -lt 3 ]; then
 fi
 
 echo "action_relay_install=PASS"
+echo "action_relay_executor_job_extension=PASS"
 echo "action_relay_group_context=agentos"
 echo "action_relay_user_bus=ubuntu:/run/user/1001/bus"
 echo "action_relay_stable_liveness=PASS"
+echo "action_relay_source_ref=$SOURCE_REF"
+echo "action_relay_source_commit=$SOURCE_COMMIT"
 echo "runtime=$RUNTIME_ROOT"
 echo "spool=$RELAY_ROOT"
 echo "unit=$UNIT"

--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -19,7 +19,7 @@ REALM_UNIT="$UNIT_DIR/agentos-realm-fabric.service"
 MANIFEST="$RUNTIME/runtime-provenance.json"
 
 case "$SOURCE_REF" in
-  main|feature/realm-node-fabric-readiness) ;;
+  main|core/integration|feature/realm-node-fabric-readiness) ;;
   *) echo "ERROR: AGENTOS_REF is not allowlisted: $SOURCE_REF" >&2; exit 4 ;;
 esac
 
@@ -167,7 +167,12 @@ print('antigravity_provider=' + worker.provider)
 PY
 )
 
-AGENTOS_REPO="$REPO" bash "$TMPDIR/install_action_relay_user.sh"
+# The Action Relay must consume the exact same governed generation selected by
+# this repair. It must not independently fall back to mutable origin/main.
+AGENTOS_REPO="$REPO" \
+AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
+AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT" \
+bash "$TMPDIR/install_action_relay_user.sh"
 systemctl --user is-active --quiet agentos-action-relay.service
 systemctl --user is-active --quiet agentos-realm-fabric.service
 for i in $(seq 1 20); do
@@ -194,6 +199,7 @@ echo "antigravity_worker_sha256=$WORKER_SHA256"
 echo "antigravity_runtime_manifest=$MANIFEST"
 echo "antigravity_restart_pending=YES"
 echo "action_relay_install=PASS"
+echo "action_relay_source_generation_pinned=PASS"
 echo "realm_fabric_install=PASS"
 echo "realm_fabric_device_flow=PASS"
 echo "realm_fabric_bootstrap_route=PASS"

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -15,7 +15,10 @@ class AntigravityRepairContractTests(unittest.TestCase):
     def test_repair_is_branch_aware_and_allowlisted(self):
         text = _text(SCRIPT)
         self.assertIn('SOURCE_REF="${AGENTOS_REF:-main}"', text)
-        self.assertIn('main|feature/realm-node-fabric-readiness', text)
+        # core/integration is the governed integration generation. Development
+        # worker branches remain excluded from the runtime repair allowlist.
+        self.assertIn('main|core/integration|feature/realm-node-fabric-readiness', text)
+        self.assertNotIn('core/issue-194-bounded-executor-jobs)', text)
         self.assertIn('git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"', text)
         self.assertIn('SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)', text)
         self.assertNotIn('origin/main:', text)
@@ -54,6 +57,13 @@ class AntigravityRepairContractTests(unittest.TestCase):
         self.assertIn('Environment=AGENTOS_RUNTIME_SOURCE_COMMIT=$SOURCE_COMMIT', text)
         self.assertIn('Environment=AGENTOS_RUNTIME_WORKER_SHA256=$WORKER_SHA256', text)
         self.assertIn('antigravity_runtime_manifest=$MANIFEST', text)
+
+    def test_action_relay_receives_same_immutable_runtime_generation(self):
+        text = _text(SCRIPT)
+        self.assertIn('AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF"', text)
+        self.assertIn('AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT"', text)
+        self.assertIn('bash "$TMPDIR/install_action_relay_user.sh"', text)
+        self.assertIn('action_relay_source_generation_pinned=PASS', text)
 
     def test_action_relay_installer_preserves_correct_foreign_owned_shared_boundary(self):
         text = _text(ACTION_INSTALLER)

--- a/tests/test_control_inbox_bridge.py
+++ b/tests/test_control_inbox_bridge.py
@@ -287,6 +287,46 @@ def test_receipt_projection_drops_username_paths_and_window_titles():
     assert 'C:/Users/private' not in rendered
 
 
+def test_executor_job_receipt_projection_preserves_governance_evidence_only():
+    projected = _project_receipt({
+        'schema': 'agentos.executor-job-receipt/v1',
+        'job_id': 'action-12345678',
+        'job_type': 'experience.regression',
+        'project_id': 'agentos-core',
+        'executor_class': 'openai-codex-local',
+        'capability': 'agentos.experience.regression',
+        'executor_available': True,
+        'routable': True,
+        'authorized': True,
+        'successful': True,
+        'credential_exposed': False,
+        'classification': 'EXPERIENCE_REGRESSION_PASS',
+        'experiment_id': 'exp-1',
+        'verdict': 'PASS',
+        'baseline_score': 0.25,
+        'hydrated_score': 0.95,
+        'uplift': 0.70,
+        'hydration_receipt_ok': True,
+        'stdout': 'private model output',
+        'stderr': '/home/ubuntu/private/log',
+        'prompt': 'private prompt',
+        'session_id': 'private-session',
+        'provider': 'private-provider',
+        'credentials': 'do-not-publish',
+    }, 'agentos.executor.job')
+    assert projected['job_id'] == 'action-12345678'
+    assert projected['executor_available'] is True
+    assert projected['routable'] is True
+    assert projected['authorized'] is True
+    assert projected['successful'] is True
+    assert projected['credential_exposed'] is False
+    assert projected['verdict'] == 'PASS'
+    assert projected['hydration_receipt_ok'] is True
+    rendered = json.dumps(projected)
+    for forbidden in ('private model output', '/home/ubuntu/private', 'private prompt', 'private-session', 'private-provider', 'do-not-publish'):
+        assert forbidden not in rendered
+
+
 def test_generic_execution_action_cannot_be_allowlisted(tmp_path: Path):
     with pytest.raises(ValueError, match='cannot be allowlisted'):
         _config(tmp_path, actions={'shell.exec'})

--- a/tests/test_executor_job_action_relay.py
+++ b/tests/test_executor_job_action_relay.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_core.executor_job_contract import canonical_experience_regression_request
+from agentos_node import action_relay
+from agentos_node.action_relay import ActionRelayWorker
+from agentos_node.executor_job_action_relay import ACTION, ActionRelayExecutorJobDispatcher
+
+
+@pytest.fixture(autouse=True)
+def _no_system_group_mutation(monkeypatch):
+    monkeypatch.setattr(action_relay, "_share", lambda *args, **kwargs: None)
+
+
+def test_submit_uses_existing_action_relay_capsule_and_same_job_id(tmp_path: Path) -> None:
+    dispatcher = ActionRelayExecutorJobDispatcher(tmp_path / "relay")
+    submission = dispatcher.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
+    job_id = submission["job_id"]
+
+    capsule_path = tmp_path / "relay" / "inbox" / f"{job_id}.json"
+    capsule = json.loads(capsule_path.read_text(encoding="utf-8"))
+    assert capsule["action"] == ACTION
+    assert capsule["capsule_id"] == job_id
+    assert capsule["authority"]["arbitrary_shell"] is False
+    assert set(capsule["params"]) == {"request"}
+    assert "command" not in json.dumps(capsule).casefold()
+
+
+def test_worker_terminal_receipt_projects_missing_provider_without_shell_fallback(tmp_path: Path) -> None:
+    root = tmp_path / "relay"
+    dispatcher = ActionRelayExecutorJobDispatcher(root)
+    submission = dispatcher.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
+
+    raw = ActionRelayWorker(root).process_one()
+    assert raw is not None
+    assert raw["schema"] == "agentos.action-receipt/v1"
+    assert raw["action"] == ACTION
+    assert raw["executor_available"] is False
+    assert raw["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+
+    receipt = dispatcher.inspect(submission["job_id"])
+    assert receipt is not None
+    assert receipt["job_id"] == submission["job_id"]
+    assert receipt["executor_available"] is False
+    assert receipt["routable"] is False
+    assert receipt["authorized"] is False
+    assert receipt["successful"] is False
+    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert receipt["credential_exposed"] is False
+
+
+def test_terminal_receipt_reconstructs_job_provenance_after_dispatcher_restart(tmp_path: Path) -> None:
+    root = tmp_path / "relay"
+    first = ActionRelayExecutorJobDispatcher(root)
+    submission = first.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
+    job_id = submission["job_id"]
+    ActionRelayWorker(root).process_one()
+
+    # A fresh controller/dispatcher has no in-memory request cache. It must be
+    # able to recover only the fixed semantic identity persisted in the receipt.
+    restarted = ActionRelayExecutorJobDispatcher(root)
+    receipt = restarted.inspect(job_id)
+    assert receipt is not None
+    assert receipt["job_id"] == job_id
+    assert receipt["job_type"] == "experience.regression"
+    assert receipt["project_id"] == "agentos-core"
+    assert receipt["executor_class"] == "openai-codex-local"
+    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+
+    persisted = json.loads((root / "receipts" / f"{job_id}.json").read_text(encoding="utf-8"))
+    assert persisted["schema"] == "agentos.action-receipt/v1"
+    assert persisted["action"] == ACTION
+    assert persisted["job_type"] == "experience.regression"
+    assert "request" not in persisted
+    assert "prompt" not in persisted
+    assert "stdout" not in persisted
+    assert "credential" not in persisted
+
+
+def test_interrupted_processing_is_unknown_and_never_replayed(tmp_path: Path) -> None:
+    root = tmp_path / "relay"
+    dispatcher = ActionRelayExecutorJobDispatcher(root)
+    submission = dispatcher.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
+    job_id = submission["job_id"]
+
+    source = root / "inbox" / f"{job_id}.json"
+    processing = root / "processing" / source.name
+    processing.parent.mkdir(parents=True, exist_ok=True)
+    source.replace(processing)
+
+    recovered = ActionRelayWorker(root).recover_interrupted()
+    assert recovered == [job_id]
+    assert not (root / "inbox" / f"{job_id}.json").exists()
+    assert (root / "quarantine" / f"{job_id}.json").exists()
+
+    receipt = dispatcher.inspect(job_id)
+    assert receipt is not None
+    assert receipt["successful"] is False
+    assert receipt["classification"] == "EXECUTION_OUTCOME_UNKNOWN"
+
+
+def test_forbidden_generic_execution_fields_are_rejected_before_spool(tmp_path: Path) -> None:
+    dispatcher = ActionRelayExecutorJobDispatcher(tmp_path / "relay")
+    request = canonical_experience_regression_request()
+    request["command"] = "whoami"
+    with pytest.raises(ValueError, match="forbidden generic-execution field"):
+        dispatcher.submit(node_id="oracle-core-node", request=request)
+    assert not (tmp_path / "relay" / "inbox").exists()

--- a/tests/test_executor_job_adapter.py
+++ b/tests/test_executor_job_adapter.py
@@ -1,0 +1,142 @@
+from agent_core.executor_job_contract import canonical_experience_regression_request
+from agentos_node.executor_job_adapter import (
+    ExecutorJobProviderRegistry,
+    execute_registered_executor_job,
+    run_registered_executor_job,
+)
+
+
+def test_missing_provider_fails_without_fallback():
+    receipt = execute_registered_executor_job(
+        job_id="job-missing",
+        request=canonical_experience_regression_request(),
+        registry=ExecutorJobProviderRegistry(),
+    )
+    assert receipt["executor_available"] is False
+    assert receipt["routable"] is False
+    assert receipt["authorized"] is False
+    assert receipt["successful"] is False
+    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert receipt["credential_exposed"] is False
+
+
+def test_executor_class_mismatch_is_not_routable_or_authorized():
+    registry = ExecutorJobProviderRegistry()
+    registry.register(
+        job_type="experience.regression",
+        provider_id="test-provider",
+        executor_class="wrong-executor",
+        handler=lambda request: {"verdict": "PASS"},
+    )
+    receipt = execute_registered_executor_job(
+        job_id="job-mismatch",
+        request=canonical_experience_regression_request(),
+        registry=registry,
+    )
+    assert receipt["executor_available"] is True
+    assert receipt["routable"] is False
+    assert receipt["authorized"] is False
+    assert receipt["successful"] is False
+    assert receipt["classification"] == "EXECUTOR_CLASS_MISMATCH"
+
+
+def _private_provider_result():
+    return {
+        "experiment_id": "exp-1",
+        "verdict": "PASS",
+        "baseline_score": 0.14,
+        "hydrated_score": 1.0,
+        "uplift": 0.86,
+        "hydration_receipt_ok": True,
+        "credential_exposed": False,
+        "stdout": "private model output",
+        "stderr": "private diagnostics",
+        "prompt": "private prompt",
+        "session_id": "private session",
+        "path": "/home/ubuntu/private",
+        "credential": "must-not-persist",
+    }
+
+
+def _private_registry():
+    registry = ExecutorJobProviderRegistry()
+    registry.register(
+        job_type="experience.regression",
+        provider_id="issue117-v1",
+        executor_class="openai-codex-local",
+        handler=lambda request: _private_provider_result(),
+    )
+    return registry
+
+
+def test_registered_provider_is_sanitized_before_transport_persistence():
+    semantic = run_registered_executor_job(
+        request=canonical_experience_regression_request(),
+        registry=_private_registry(),
+    )
+    assert semantic["successful"] is True
+    assert semantic["credential_exposed"] is False
+    assert semantic["verdict"] == "PASS"
+    for forbidden in ("stdout", "stderr", "prompt", "session_id", "path", "credential"):
+        assert forbidden not in semantic
+
+
+def test_registered_provider_returns_only_sanitized_result_projection():
+    receipt = execute_registered_executor_job(
+        job_id="job-pass",
+        request=canonical_experience_regression_request(),
+        registry=_private_registry(),
+    )
+    assert receipt["executor_available"] is True
+    assert receipt["routable"] is True
+    assert receipt["authorized"] is True
+    assert receipt["successful"] is True
+    assert receipt["verdict"] == "PASS"
+    assert receipt["hydration_receipt_ok"] is True
+    assert receipt["credential_exposed"] is False
+    for forbidden in ("stdout", "stderr", "prompt", "session_id", "path", "credential"):
+        assert forbidden not in receipt
+
+
+def test_provider_exception_is_classified_without_exception_text():
+    registry = ExecutorJobProviderRegistry()
+
+    def fail(request):
+        raise RuntimeError("/home/ubuntu/private/path token=secret")
+
+    registry.register(
+        job_type="experience.regression",
+        provider_id="issue117-v1",
+        executor_class="openai-codex-local",
+        handler=fail,
+    )
+    receipt = execute_registered_executor_job(
+        job_id="job-error",
+        request=canonical_experience_regression_request(),
+        registry=registry,
+    )
+    assert receipt["classification"] == "PROVIDER_ERROR_RUNTIMEERROR"
+    text = str(receipt)
+    assert "/home/ubuntu/private/path" not in text
+    assert "token=secret" not in text
+
+
+def test_duplicate_provider_registration_fails_closed():
+    registry = ExecutorJobProviderRegistry()
+    registry.register(
+        job_type="experience.regression",
+        provider_id="first",
+        executor_class="openai-codex-local",
+        handler=lambda request: {"verdict": "FAIL"},
+    )
+    try:
+        registry.register(
+            job_type="experience.regression",
+            provider_id="second",
+            executor_class="openai-codex-local",
+            handler=lambda request: {"verdict": "PASS"},
+        )
+    except ValueError as exc:
+        assert "already registered" in str(exc)
+    else:
+        raise AssertionError("duplicate provider registration must fail closed")

--- a/tests/test_executor_job_contract.py
+++ b/tests/test_executor_job_contract.py
@@ -1,0 +1,100 @@
+import pytest
+
+from agent_core.executor_job_contract import (
+    EXECUTOR_JOB_RECEIPT_SCHEMA,
+    ExecutorJobContractError,
+    canonical_experience_regression_request,
+    project_executor_job_receipt,
+    validate_executor_job,
+)
+
+
+def test_canonical_experience_regression_is_exact_and_read_only():
+    request = canonical_experience_regression_request()
+    spec = validate_executor_job(request)
+    assert spec.job_type == "experience.regression"
+    assert spec.capability == "agentos.experience.regression"
+    assert spec.executor_class == "openai-codex-local"
+    assert spec.project_id == "agentos-core"
+    assert spec.workload_ref == "issue://117"
+    assert spec.authority == "read-only-regression"
+    assert spec.read_only is True
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("command", "bash -lc whoami"),
+        ("argv", ["bash", "-lc", "whoami"]),
+        ("executable", "/bin/bash"),
+        ("cwd", "/home/ubuntu"),
+        ("env", {"TOKEN": "x"}),
+        ("credential", "secret"),
+    ],
+)
+def test_generic_execution_and_credentials_are_rejected(field, value):
+    request = canonical_experience_regression_request()
+    request[field] = value
+    with pytest.raises(ExecutorJobContractError):
+        validate_executor_job(request)
+
+
+def test_nested_forbidden_execution_field_is_rejected_before_unknown_field_handling():
+    request = canonical_experience_regression_request()
+    request["options"] = {"shell": "whoami"}
+    with pytest.raises(ExecutorJobContractError, match="forbidden generic-execution field"):
+        validate_executor_job(request)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("project_id", "other-project"),
+        ("executor_class", "anthropic-claude-code-extension"),
+        ("workload_ref", "issue://999"),
+        ("authority", "admin"),
+    ],
+)
+def test_registered_semantics_cannot_be_overridden(field, value):
+    request = canonical_experience_regression_request()
+    request[field] = value
+    with pytest.raises(ExecutorJobContractError):
+        validate_executor_job(request)
+
+
+def test_unknown_job_type_fails_closed():
+    request = canonical_experience_regression_request()
+    request["job_type"] = "shell.exec"
+    with pytest.raises(ExecutorJobContractError, match="unsupported executor job type"):
+        validate_executor_job(request)
+
+
+def test_receipt_keeps_availability_routing_authority_and_success_independent():
+    request = canonical_experience_regression_request()
+    receipt = project_executor_job_receipt(
+        job_id="job-12345678",
+        request=request,
+        executor_available=True,
+        routable=False,
+        authorized=False,
+        successful=False,
+        result={
+            "experiment_id": "exp-1",
+            "verdict": "FAIL",
+            "baseline_score": 0.0,
+            "hydrated_score": 0.0,
+            "uplift": 0.0,
+            "hydration_receipt_ok": False,
+            "classification": "EXECUTOR_NOT_ROUTABLE",
+            "stdout": "must not cross boundary",
+            "credential": "must not cross boundary",
+        },
+    )
+    assert receipt["schema"] == EXECUTOR_JOB_RECEIPT_SCHEMA
+    assert receipt["executor_available"] is True
+    assert receipt["routable"] is False
+    assert receipt["authorized"] is False
+    assert receipt["successful"] is False
+    assert receipt["credential_exposed"] is False
+    assert "stdout" not in receipt
+    assert "credential" not in receipt

--- a/tests/test_executor_job_controller_route.py
+++ b/tests/test_executor_job_controller_route.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.controller_service import ControllerService
+from agent_core.executor_job_contract import canonical_experience_regression_request
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+
+
+class FakeDispatcher:
+    def __init__(self):
+        self.calls = []
+
+    def submit(self, *, node_id, request):
+        self.calls.append((node_id, dict(request)))
+        return {
+            "schema": "agentos.executor-job-submission/v1",
+            "ok": True,
+            "state": "queued",
+            "job_id": "action-12345678",
+            "node_id": node_id,
+            "job_type": request["job_type"],
+            "project_id": request["project_id"],
+            "executor_class": request["executor_class"],
+            "capability": "agentos.experience.regression",
+            "reused": False,
+            "credential_exposed": False,
+        }
+
+
+def _fabric(tmp_path: Path, *, node_id: str = "oracle-core-node", include_capability: bool = False) -> RealmFabricStore:
+    registry = NodeRegistry(tmp_path / "nodes.json")
+    fabric = RealmFabricStore(tmp_path / "fabric.json", node_registry=registry)
+    fabric.initialize_realm("realm-test")
+    capabilities = ["agentos.experience.regression"] if include_capability else []
+    manifest = {
+        "schema": "agentos.node-manifest/v0.1",
+        "realm_id": "realm-test",
+        "node_id": node_id,
+        "role": "core",
+        "hostname": "oracle",
+        "platform": "Linux",
+        "platform_release": "test",
+        "capabilities": capabilities,
+        "tool_presence": {},
+        "surface_inventory": {"surfaces": []},
+    }
+    registry.record_heartbeat({
+        "schema": "agentos.node-heartbeat/v0.1",
+        "realm_id": "realm-test",
+        "node_id": node_id,
+        "role": "core",
+        "status": "online",
+        "observed_at": "2099-01-01T00:00:00Z",
+        "uptime_seconds": 1,
+        "surface_count": 0,
+        "manifest": manifest,
+    })
+    return fabric
+
+
+def test_executor_job_routes_to_local_dispatcher_not_thin_client_queue(tmp_path: Path) -> None:
+    fabric = _fabric(tmp_path)
+    dispatcher = FakeDispatcher()
+    controller = ControllerService(fabric, executor_job_dispatcher=dispatcher)
+    job = canonical_experience_regression_request()
+    result = controller.dispatch({
+        "schema": "agentos.controller-dispatch/v0.1",
+        "node_id": "oracle-core-node",
+        "action": "agentos.executor.job",
+        "payload": job,
+    })
+    assert result["schema"] == "agentos.executor-job-submission/v1"
+    assert result["job_id"] == "action-12345678"
+    assert result["task_id"] == result["job_id"]
+    assert dispatcher.calls == [("oracle-core-node", job)]
+    assert fabric.load()["tasks"].get("oracle-core-node", []) == []
+
+
+def test_node_capability_does_not_claim_executor_availability(tmp_path: Path) -> None:
+    fabric = _fabric(tmp_path, include_capability=False)
+    dispatcher = FakeDispatcher()
+    controller = ControllerService(fabric, executor_job_dispatcher=dispatcher)
+    result = controller.dispatch({
+        "node_id": "oracle-core-node",
+        "action": "agentos.executor.job",
+        "payload": canonical_experience_regression_request(),
+    })
+    assert result["ok"] is True
+    assert len(dispatcher.calls) == 1
+    assert fabric.load()["tasks"].get("oracle-core-node", []) == []
+
+
+def test_first_registered_executor_job_cannot_be_routed_to_arbitrary_node(tmp_path: Path) -> None:
+    fabric = _fabric(tmp_path, node_id="other-node")
+    controller = ControllerService(fabric, executor_job_dispatcher=FakeDispatcher())
+    with pytest.raises(ValueError, match="not routable to target node"):
+        controller.dispatch({
+            "node_id": "other-node",
+            "action": "agentos.executor.job",
+            "payload": canonical_experience_regression_request(),
+        })
+
+
+def test_executor_job_rejects_passthrough_but_bridge_task_id_has_no_job_authority(tmp_path: Path) -> None:
+    fabric = _fabric(tmp_path)
+    dispatcher = FakeDispatcher()
+    controller = ControllerService(fabric, executor_job_dispatcher=dispatcher)
+    base = {
+        "node_id": "oracle-core-node",
+        "action": "agentos.executor.job",
+        "payload": canonical_experience_regression_request(),
+    }
+    with pytest.raises(ValueError, match="unexpected executor-job controller fields"):
+        controller.dispatch({**base, "provider": "anything"})
+    result = controller.dispatch({**base, "task_id": "ctl_caller_selected_but_non_authoritative"})
+    assert result["job_id"] == "action-12345678"
+    assert result["task_id"] == "action-12345678"
+    assert result["task_id"] != "ctl_caller_selected_but_non_authoritative"
+    assert fabric.load()["tasks"].get("oracle-core-node", []) == []

--- a/tests/test_executor_job_receipt_facade.py
+++ b/tests/test_executor_job_receipt_facade.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_core.controller_api import ControllerService
+
+
+class FakeFabric:
+    def __init__(self):
+        self.receipts = {
+            "ctl-existing": {
+                "schema": "agentos.node-receipt/v0.1",
+                "task_id": "ctl-existing",
+                "node_id": "node-a",
+                "action": "agent.surface.inspect",
+                "ok": True,
+            }
+        }
+
+    def get_receipt(self, task_id):
+        return self.receipts.get(task_id)
+
+
+class FakeExecutorDispatcher:
+    def __init__(self, receipt=None):
+        self.receipt = receipt
+        self.inspected = []
+
+    def inspect(self, job_id):
+        self.inspected.append(job_id)
+        return self.receipt
+
+
+def test_action_job_receipt_delegates_to_executor_store_not_realm_fabric():
+    dispatcher = FakeExecutorDispatcher({
+        "schema": "agentos.executor-job-receipt/v1",
+        "job_id": "action-12345678",
+        "job_type": "experience.regression",
+        "project_id": "agentos-core",
+        "executor_class": "openai-codex-local",
+        "executor_available": False,
+        "routable": False,
+        "authorized": False,
+        "successful": False,
+        "credential_exposed": False,
+        "classification": "JOB_IMPLEMENTATION_UNAVAILABLE",
+    })
+    controller = ControllerService(FakeFabric(), executor_job_dispatcher=dispatcher)
+
+    receipt = controller.receipt("action-12345678")
+    assert receipt["job_id"] == "action-12345678"
+    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert dispatcher.inspected == ["action-12345678"]
+
+
+def test_pending_action_job_is_reported_as_not_found_for_existing_poll_contract():
+    dispatcher = FakeExecutorDispatcher(None)
+    controller = ControllerService(FakeFabric(), executor_job_dispatcher=dispatcher)
+    with pytest.raises(KeyError):
+        controller.receipt("action-12345678")
+    assert dispatcher.inspected == ["action-12345678"]
+
+
+def test_ordinary_node_receipt_stays_on_realm_fabric_path():
+    dispatcher = FakeExecutorDispatcher({"unexpected": True})
+    controller = ControllerService(FakeFabric(), executor_job_dispatcher=dispatcher)
+    receipt = controller.receipt("ctl-existing")
+    assert receipt["schema"] == "agentos.node-receipt/v0.1"
+    assert receipt["task_id"] == "ctl-existing"
+    assert dispatcher.inspected == []

--- a/tests/test_executor_job_runtime_installer.py
+++ b/tests/test_executor_job_runtime_installer.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install_action_relay_user.sh"
+REPAIR = ROOT / "scripts" / "repair_antigravity_relay_user.sh"
+
+
+def test_action_relay_installer_keeps_single_service_and_loads_executor_job_extension():
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert 'UNIT="$UNIT_DIR/agentos-action-relay.service"' in text
+    assert "agentos_node.executor_job_action_relay --root $RELAY_ROOT" in text
+    assert "from agentos_node.executor_job_action_relay import ACTION, ACTIONS" in text
+    assert "assert ACTION in ACTIONS" in text
+    assert "agentos-action-relay-executor" not in text
+    assert "agentos-executor-job.service" not in text
+
+
+def test_action_relay_runtime_is_resolved_once_to_an_immutable_commit():
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert 'SOURCE_REF="${AGENTOS_ACTION_SOURCE_REF:-main}"' in text
+    assert 'EXPECTED_SOURCE_COMMIT="${AGENTOS_ACTION_SOURCE_COMMIT:-}"' in text
+    assert "main|core/integration|feature/realm-node-fabric-readiness" in text
+    assert 'git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"' in text
+    assert 'SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)' in text
+    assert 'if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then' in text
+    assert 'git -C "$RUNTIME_ROOT" reset --hard "$SOURCE_COMMIT"' in text
+    assert 'worktree add --detach "$RUNTIME_ROOT" "$SOURCE_COMMIT"' in text
+    assert 'reset --hard origin/main' not in text
+    assert 'worktree add --detach "$RUNTIME_ROOT" origin/main' not in text
+
+
+def test_outer_repair_passes_same_generation_to_action_relay_installer():
+    text = REPAIR.read_text(encoding="utf-8")
+    assert "main|core/integration|feature/realm-node-fabric-readiness" in text
+    assert 'SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)' in text
+    assert 'AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF"' in text
+    assert 'AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT"' in text
+    assert 'bash "$TMPDIR/install_action_relay_user.sh"' in text
+    assert "action_relay_source_generation_pinned=PASS" in text

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_core.executor_job_contract import canonical_experience_regression_request
+from agentos_node.executor_job_adapter import ExecutorJobProviderRegistry, execute_registered_executor_job
+from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+
+
+def _write_runtime(root: Path, *, codex_available: bool = True, credential_exposed: bool = False) -> None:
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    if codex_available:
+        find_codex = "return Path('/fixed/trusted/codex')"
+    else:
+        find_codex = "raise FileNotFoundError('not installed')"
+    (scripts / "oracle_codex_experience_regression.py").write_text(
+        "from pathlib import Path\n"
+        "def find_codex():\n"
+        f"    {find_codex}\n",
+        encoding="utf-8",
+    )
+    (scripts / "oracle_codex_experience_regression_entry_v2.py").write_text(
+        "import argparse, json, sys\n"
+        "p=argparse.ArgumentParser()\n"
+        "p.add_argument('--output', required=True)\n"
+        "p.add_argument('--timeout')\n"
+        "a=p.parse_args()\n"
+        "payload={\n"
+        " 'schema':'agentos.experience-regression/v1',\n"
+        " 'experiment_id':'exp-provider-test',\n"
+        " 'project_id':'agentos-core',\n"
+        " 'executor':'openai-codex-local',\n"
+        " 'baseline':{'score':{'score':0.25},'run':{'stdout':'PRIVATE MODEL OUTPUT'}},\n"
+        " 'hydrated':{'score':{'score':1.0},'run':{'stderr_tail':'/home/ubuntu/private'}},\n"
+        " 'checks':{'hydration_receipt_ok':True},\n"
+        " 'uplift':0.75,\n"
+        " 'verdict':'PASS',\n"
+        f" 'credential_exposed':{credential_exposed!r}\n"
+        "}\n"
+        "open(a.output,'w',encoding='utf-8').write(json.dumps(payload))\n"
+        "print('Bearer TOPSECRET /private/provider/stdout')\n"
+        "print('secret stderr', file=sys.stderr)\n"
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+
+
+def test_provider_is_not_registered_when_issue117_is_absent(tmp_path: Path) -> None:
+    registry = ExecutorJobProviderRegistry()
+    assert register_issue117_provider_if_available(registry=registry, runtime_root=tmp_path) is False
+    assert registry.get("experience.regression") is None
+
+
+def test_integrated_issue117_provider_returns_only_bounded_regression_evidence(tmp_path: Path) -> None:
+    _write_runtime(tmp_path)
+    registry = ExecutorJobProviderRegistry()
+    assert register_issue117_provider_if_available(registry=registry, runtime_root=tmp_path) is True
+
+    receipt = execute_registered_executor_job(
+        job_id="job-provider-pass",
+        request=canonical_experience_regression_request(),
+        registry=registry,
+    )
+    assert receipt["executor_available"] is True
+    assert receipt["routable"] is True
+    assert receipt["authorized"] is True
+    assert receipt["successful"] is True
+    assert receipt["verdict"] == "PASS"
+    assert receipt["baseline_score"] == 0.25
+    assert receipt["hydrated_score"] == 1.0
+    assert receipt["uplift"] == 0.75
+    assert receipt["hydration_receipt_ok"] is True
+    assert receipt["credential_exposed"] is False
+    rendered = str(receipt)
+    for forbidden in ("PRIVATE MODEL OUTPUT", "/home/ubuntu/private", "TOPSECRET", "/private/provider", "secret stderr"):
+        assert forbidden not in rendered
+
+
+def test_registered_provider_can_report_codex_executor_unavailable_independently(tmp_path: Path) -> None:
+    _write_runtime(tmp_path, codex_available=False)
+    registry = ExecutorJobProviderRegistry()
+    assert register_issue117_provider_if_available(registry=registry, runtime_root=tmp_path) is True
+
+    receipt = execute_registered_executor_job(
+        job_id="job-provider-unavailable",
+        request=canonical_experience_regression_request(),
+        registry=registry,
+    )
+    assert receipt["executor_available"] is False
+    assert receipt["routable"] is True
+    assert receipt["authorized"] is True
+    assert receipt["successful"] is False
+    assert receipt["classification"] == "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE"
+
+
+def test_provider_credential_boundary_violation_is_forced_to_failure(tmp_path: Path) -> None:
+    _write_runtime(tmp_path, credential_exposed=True)
+    registry = ExecutorJobProviderRegistry()
+    assert register_issue117_provider_if_available(registry=registry, runtime_root=tmp_path) is True
+
+    receipt = execute_registered_executor_job(
+        job_id="job-provider-credential",
+        request=canonical_experience_regression_request(),
+        registry=registry,
+    )
+    assert receipt["executor_available"] is True
+    assert receipt["successful"] is False
+    assert receipt["credential_exposed"] is False
+    assert receipt["classification"] == "PROVIDER_CREDENTIAL_BOUNDARY_VIOLATION"


### PR DESCRIPTION
## Goal
Rebase the already-proven #194 bounded executor-job architecture onto the current `core/integration` generation without replaying the stale branch that is now far behind Core.

Issue: #194
Supersedes implementation lineage of draft PR #199 after divergence.
Target: `core/integration`

## Rebased production skeleton now present
- `agent_core/executor_job_contract.py` — declarative `agentos.executor-job/v1`; no shell/argv/path/env/credential fields.
- `agent_core/executor_job_controller.py` — portable Core-side submit/inspect boundary.
- `agentos_node/executor_job_adapter.py` — trusted provider registry with independent executor_available/routable/authorized/successful dimensions.
- `agentos_node/executor_job_action_relay.py` — reuses the existing Action Relay spool/worker and fixed `agentos.executor.job` action.
- `agentos_node/issue117_experience_provider.py` — conditional bridge to #117 only when the same immutable runtime generation contains its accepted runner.
- `agent_core/controller_service.py` — typed executor-job branch bypasses the Thin Client generic task queue; Action Relay `action-*` remains canonical job identity.

## Deliberately not claimed complete yet
The following ingress/deployment pieces are still being minimally rebased instead of copying stale files wholesale:
1. `controller_api` durable `action-*` receipt facade;
2. #50 Control Inbox independent executor-job allowlist/sanitized projection;
3. Action Relay governed installer/runtime-generation pinning;
4. rebased #194 guards/tests;
5. accepted #117 runner in the same immutable generation for the first real workload;
6. live Oracle rollout and fresh ChatGPT self-dispatch/self-read acceptance.

## Governance
- no generic remote shell;
- no arbitrary executable/argv/path/env/provider selection;
- no credential/session export;
- no protected-main authority;
- no live rollout from this draft branch.

This PR remains Draft until the current-generation test/receipt/deployment closure is complete.