### PR TITLE
Core #200: make runtime deployment fail closed on service-install drift

### DIFF
--- a/.github/workflows/strict-runtime-deploy-guard.yml
+++ b/.github/workflows/strict-runtime-deploy-guard.yml
@@ -1,0 +1,48 @@
+name: Strict Runtime Deploy Guard
+
+on:
+  push:
+    branches:
+      - core/issue-200-strict-runtime-deploy
+      - core/integration
+    paths:
+      - 'scripts/install_services.py'
+      - 'agent_core/platform/linux.py'
+      - 'tests/test_install_services_strict.py'
+      - 'tests/test_platform_runtime.py'
+      - 'tests/test_core_supervisor_installer_runtime.py'
+      - 'tests/test_employee_worker_host_installer_runtime.py'
+      - '.github/workflows/strict-runtime-deploy-guard.yml'
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'scripts/install_services.py'
+      - 'agent_core/platform/linux.py'
+      - 'tests/test_install_services_strict.py'
+      - 'tests/test_platform_runtime.py'
+      - 'tests/test_core_supervisor_installer_runtime.py'
+      - 'tests/test_employee_worker_host_installer_runtime.py'
+      - '.github/workflows/strict-runtime-deploy-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deployment-truth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install role parser dependency
+        run: python -m pip install --disable-pip-version-check PyYAML
+      - name: Run deployment truth regressions
+        run: >-
+          python -m unittest
+          tests.test_install_services_strict
+          tests.test_platform_runtime
+          tests.test_core_supervisor_installer_runtime
+          tests.test_employee_worker_host_installer_runtime
+          -v

--- a/.github/workflows/strict-runtime-deploy-guard.yml
+++ b/.github/workflows/strict-runtime-deploy-guard.yml
@@ -9,7 +9,6 @@ on:
       - 'scripts/install_services.py'
       - 'agent_core/platform/linux.py'
       - 'tests/test_install_services_strict.py'
-      - 'tests/test_platform_runtime.py'
       - 'tests/test_core_supervisor_installer_runtime.py'
       - 'tests/test_employee_worker_host_installer_runtime.py'
       - '.github/workflows/strict-runtime-deploy-guard.yml'
@@ -20,7 +19,6 @@ on:
       - 'scripts/install_services.py'
       - 'agent_core/platform/linux.py'
       - 'tests/test_install_services_strict.py'
-      - 'tests/test_platform_runtime.py'
       - 'tests/test_core_supervisor_installer_runtime.py'
       - 'tests/test_employee_worker_host_installer_runtime.py'
       - '.github/workflows/strict-runtime-deploy-guard.yml'
@@ -42,7 +40,6 @@ jobs:
         run: >-
           python -m unittest
           tests.test_install_services_strict
-          tests.test_platform_runtime
           tests.test_core_supervisor_installer_runtime
           tests.test_employee_worker_host_installer_runtime
           -v

--- a/scripts/install_services.py
+++ b/scripts/install_services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -18,12 +19,42 @@ def _native_install_failed(result: dict[str, object]) -> bool:
     """Return true only when a native service install was actually attempted and failed.
 
     Platforms without a native service manager may intentionally use the portable
-    fallback manifest.  A Linux host that *has* systemd and ran the systemd
+    fallback manifest. A Linux host that *has* systemd and ran the systemd
     installer must not silently downgrade a failed mutation to a successful
     manifest-only receipt.
     """
     raw = result.get("systemd_returncode")
     return isinstance(raw, int) and not isinstance(raw, bool) and raw != 0
+
+
+def _systemd_active(unit: str) -> bool:
+    completed = subprocess.run(
+        ["systemctl", "--user", "is-active", "--quiet", unit],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _verify_linux_core_services(result: dict[str, object]) -> str | None:
+    """Verify the autonomous Core services that the successful systemd install promises.
+
+    The control-plane deployment workflow validates its HTTP service separately.
+    This verifier prevents a green service-install receipt while the newly
+    installed persistent Supervisor or explicitly enabled shared Worker Host has
+    already failed to stay active.
+    """
+    if result.get("mode") != "systemd":
+        return None
+    if str(os.environ.get("AGENT_MODE") or "CLIENT").strip().upper() != "CORE":
+        return None
+    if not _systemd_active("agentos-core-supervisor.service"):
+        return "core_supervisor_service_not_active"
+    if str(os.environ.get("AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE") or "0").strip() == "1":
+        if not _systemd_active("agentos-employee-worker-host.service"):
+            return "employee_worker_host_service_not_active"
+    return None
 
 
 def main() -> int:
@@ -45,6 +76,15 @@ def main() -> int:
         payload["error_code"] = "native_background_service_install_failed"
         print(json.dumps(payload, indent=2, ensure_ascii=False))
         return 2
+
+    if driver.platform_name() == "linux":
+        verification_error = _verify_linux_core_services(result)
+        if verification_error:
+            payload["ok"] = False
+            payload["error_code"] = verification_error
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return 2
+
     payload["ok"] = True
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0

--- a/scripts/install_services.py
+++ b/scripts/install_services.py
@@ -14,6 +14,18 @@ if PROJECT_ROOT not in sys.path:
 from agent_core.platform import get_platform_driver
 
 
+def _native_install_failed(result: dict[str, object]) -> bool:
+    """Return true only when a native service install was actually attempted and failed.
+
+    Platforms without a native service manager may intentionally use the portable
+    fallback manifest.  A Linux host that *has* systemd and ran the systemd
+    installer must not silently downgrade a failed mutation to a successful
+    manifest-only receipt.
+    """
+    raw = result.get("systemd_returncode")
+    return isinstance(raw, int) and not isinstance(raw, bool) and raw != 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Install AgentOS services using the selected platform driver")
     parser.add_argument("--platform", default=None, help="Override platform selection")
@@ -27,7 +39,14 @@ def main() -> int:
         data_root=Path(args.data_root) if args.data_root else None,
     )
     result = driver.install_background_services()
-    print(json.dumps({"platform": driver.platform_name(), **result}, indent=2, ensure_ascii=False))
+    payload = {"platform": driver.platform_name(), **result}
+    if _native_install_failed(result):
+        payload["ok"] = False
+        payload["error_code"] = "native_background_service_install_failed"
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 2
+    payload["ok"] = True
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 
 

--- a/tests/test_install_services_strict.py
+++ b/tests/test_install_services_strict.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from unittest.mock import Mock, patch
+
+from scripts import install_services
+
+
+class StrictInstallServicesTests(unittest.TestCase):
+    def _run(self, *, result: dict, platform: str = "linux", env: dict[str, str] | None = None):
+        driver = Mock()
+        driver.platform_name.return_value = platform
+        driver.install_background_services.return_value = result
+        output = StringIO()
+        with (
+            patch.object(install_services, "get_platform_driver", return_value=driver),
+            patch.object(sys, "argv", ["install_services.py"]),
+            patch.dict(os.environ, env or {}, clear=True),
+            redirect_stdout(output),
+        ):
+            rc = install_services.main()
+        return rc, output.getvalue()
+
+    def test_attempted_systemd_failure_is_never_reported_success(self):
+        rc, output = self._run(
+            result={
+                "installed": 0,
+                "mode": "fallback-manifest",
+                "systemd_returncode": 2,
+                "systemd_stderr": "private detail not asserted",
+            }
+        )
+        self.assertEqual(rc, 2)
+        self.assertIn('"ok": false', output)
+        self.assertIn("native_background_service_install_failed", output)
+
+    def test_portable_fallback_without_native_attempt_remains_valid(self):
+        rc, output = self._run(result={"installed": 1, "mode": "fallback-manifest"})
+        self.assertEqual(rc, 0)
+        self.assertIn('"ok": true', output)
+
+    def test_core_systemd_install_requires_persistent_supervisor_active(self):
+        with patch.object(install_services, "_systemd_active", return_value=False) as active:
+            rc, output = self._run(result={"installed": 1, "mode": "systemd"}, env={"AGENT_MODE": "CORE"})
+        self.assertEqual(rc, 2)
+        self.assertIn("core_supervisor_service_not_active", output)
+        active.assert_called_once_with("agentos-core-supervisor.service")
+
+    def test_enabled_worker_host_must_also_be_active(self):
+        with patch.object(install_services, "_systemd_active", side_effect=[True, False]) as active:
+            rc, output = self._run(
+                result={"installed": 1, "mode": "systemd"},
+                env={
+                    "AGENT_MODE": "CORE",
+                    "AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE": "1",
+                },
+            )
+        self.assertEqual(rc, 2)
+        self.assertIn("employee_worker_host_service_not_active", output)
+        self.assertEqual(
+            [call.args[0] for call in active.call_args_list],
+            ["agentos-core-supervisor.service", "agentos-employee-worker-host.service"],
+        )
+
+    def test_disabled_worker_host_is_not_required(self):
+        with patch.object(install_services, "_systemd_active", return_value=True) as active:
+            rc, output = self._run(
+                result={"installed": 1, "mode": "systemd"},
+                env={
+                    "AGENT_MODE": "CORE",
+                    "AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE": "0",
+                },
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn('"ok": true', output)
+        active.assert_called_once_with("agentos-core-supervisor.service")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relates to #200 and hardens the existing Oracle deployment carrier before live Supervisor/Employee acceptance.

Preflight found a real false-green path: on Linux, `LinuxPlatformDriver.install_background_services()` may return a portable `fallback-manifest` after an attempted systemd installer failure, while `scripts/install_services.py` previously always exited 0. The existing deploy workflow could therefore continue to control-plane health verification even though the autonomous Supervisor/Worker Host installation had failed.

This PR makes the service-install entrypoint truthful without changing the current deployment workflow:
- an explicitly attempted systemd install with non-zero `systemd_returncode` now exits 2 with stable `native_background_service_install_failed`;
- portable fallback remains valid when no native service manager was attempted;
- after a successful Linux systemd install on a CORE host, `agentos-core-supervisor.service` must be active;
- when `AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE=1`, `agentos-employee-worker-host.service` must also be active;
- Worker Host remains optional when its host-local gate is off;
- no raw service output is used as an authority signal.

This lets the already-existing `deploy-agentos-core.yml` rollback trap react to failures using the deploy_ref's updated `install_services.py`; no protected-main workflow edit is required for this safety fix.

Non-claims/non-authorities:
- no live Oracle deployment or host mutation;
- no S4/Worker Host activation;
- no protected-main publication;
- no #50 mutation;
- no VERIFIED marker.

Branch evidence: Strict Runtime Deploy Guard run `33628012662` SUCCESS on exact head `1e7845a58143298803f5adebb124526cb29b970c`.