### PR TITLE
Core: exact-generation Oracle executor-job rollout

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -9,6 +9,7 @@ on:
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
+      - 'agentos_node/bootstrap_control.py'
       - 'agentos_node/executor_job_adapter.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/issue117_experience_provider.py'
@@ -22,7 +23,9 @@ on:
       - 'tests/test_executor_job_runtime_installer.py'
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_control_inbox_bridge.py'
+      - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
+      - '.github/workflows/oracle-exact-generation-executor-job-rollout.yml'
   push:
     branches:
       - core/issue-194-bounded-executor-jobs
@@ -31,6 +34,7 @@ on:
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
+      - 'agentos_node/bootstrap_control.py'
       - 'agentos_node/executor_job_adapter.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/issue117_experience_provider.py'
@@ -44,7 +48,9 @@ on:
       - 'tests/test_executor_job_runtime_installer.py'
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_control_inbox_bridge.py'
+      - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
+      - '.github/workflows/oracle-exact-generation-executor-job-rollout.yml'
   workflow_dispatch:
 
 permissions:
@@ -68,6 +74,7 @@ jobs:
             tests/test_executor_job_runtime_installer.py \
             tests/test_issue117_experience_provider.py \
             tests/test_control_inbox_bridge.py \
+            tests/test_exact_generation_live_rollout_contract.py \
             -q
       - name: Verify current issue117 worker contract compatibility
         run: |
@@ -116,6 +123,7 @@ jobs:
             agent_core/controller_service.py \
             agent_core/controller_api.py \
             agent_core/control_inbox_bridge.py \
+            agentos_node/bootstrap_control.py \
             agentos_node/executor_job_adapter.py \
             agentos_node/executor_job_action_relay.py \
             agentos_node/issue117_experience_provider.py

--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -1,0 +1,200 @@
+name: Oracle Exact Generation Executor Job Rollout
+
+# Canonical live rollout for the bounded executor-job transport. This workflow
+# runs only after the rollout contract itself (or one of its pinned runtime
+# inputs) lands on core/integration. It never writes repository state and never
+# grants shell/argv/env authority to the submitted executor job.
+on:
+  push:
+    branches:
+      - core/integration
+    paths:
+      - '.github/workflows/oracle-exact-generation-executor-job-rollout.yml'
+      - 'agentos_node/bootstrap_control.py'
+      - 'scripts/repair_antigravity_relay_user.sh'
+      - 'scripts/install_action_relay_user.sh'
+      - 'agent_core/executor_job_contract.py'
+      - 'agentos_node/executor_job_action_relay.py'
+      - 'agentos_node/executor_job_adapter.py'
+      - 'agentos_node/issue117_experience_provider.py'
+
+permissions:
+  contents: read
+
+jobs:
+  rollout:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight immutable integration generation
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/core/integration'
+          test "$(id -un)" = 'agentos-node'
+          printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          git cat-file -e "$GITHUB_SHA^{commit}"
+          echo "rollout_source_ref=core/integration"
+          echo "rollout_source_commit=$GITHUB_SHA"
+
+      - name: Publish bounded bootstrap hook and request exact transport generation
+        shell: bash
+        run: |
+          set -euo pipefail
+          LIVE=/home/ubuntu/agentmanager
+          ROOT=/tmp/agentos-bootstrap-control
+          REQUESTS="$ROOT/requests"
+          RECEIPTS="$ROOT/receipts"
+          REQUEST_ID="exact-rollout-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          REQUEST="$REQUESTS/$REQUEST_ID.request.json"
+          RECEIPT="$RECEIPTS/$REQUEST_ID.json"
+
+          python3 -m py_compile agentos_node/bootstrap_control.py scripts/update_scheduler_board.py
+          test -w "$LIVE/scripts/update_scheduler_board.py"
+          test -w "$LIVE/agentos_node" || test -w "$LIVE/agentos_node/bootstrap_control.py"
+          cat scripts/update_scheduler_board.py > "$LIVE/scripts/update_scheduler_board.py"
+          if [ -e "$LIVE/agentos_node/bootstrap_control.py" ]; then
+            cat agentos_node/bootstrap_control.py > "$LIVE/agentos_node/bootstrap_control.py"
+          else
+            cp agentos_node/bootstrap_control.py "$LIVE/agentos_node/bootstrap_control.py"
+          fi
+          chmod 0664 "$LIVE/scripts/update_scheduler_board.py" "$LIVE/agentos_node/bootstrap_control.py" || true
+          python3 -m py_compile "$LIVE/agentos_node/bootstrap_control.py" "$LIVE/scripts/update_scheduler_board.py"
+
+          for i in $(seq 1 120); do
+            [ -d "$REQUESTS" ] && [ -d "$RECEIPTS" ] && break
+            sleep 1
+          done
+          test -d "$REQUESTS"
+          test -d "$RECEIPTS"
+          test "$(stat -c '%U' "$REQUESTS")" = ubuntu
+          test "$(stat -c '%a' "$REQUESTS")" = 1777
+
+          python3 - "$REQUEST" "$REQUEST_ID" "$GITHUB_SHA" <<'PY'
+          import json, os, sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          request_id = sys.argv[2]
+          sha = sys.argv[3]
+          params={"source_commit": sha}
+          payload = {
+              "schema": "agentos.bootstrap-request/v1",
+              "request_id": request_id,
+              "action": "agentos.transport.repair",
+              "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "params": params,
+              "authority": {
+                  "source": "github-actions",
+                  "target_user": "ubuntu",
+                  "arbitrary_shell": False,
+              },
+          }
+          tmp = path.with_suffix(path.suffix + ".tmp")
+          tmp.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+          os.chmod(tmp, 0o644)
+          tmp.replace(path)
+          os.chmod(path, 0o644)
+          PY
+
+          for i in $(seq 1 360); do
+            [ -f "$RECEIPT" ] && break
+            sleep 1
+          done
+          test -f "$RECEIPT" || { echo 'exact_generation_bootstrap_receipt=TIMEOUT'; exit 3; }
+
+          python3 - "$RECEIPT" "$GITHUB_SHA" <<'PY'
+          import json, sys
+          receipt = json.load(open(sys.argv[1], encoding="utf-8"))
+          expected = sys.argv[2]
+          assert receipt.get("schema") == "agentos.bootstrap-receipt/v1", receipt
+          assert receipt.get("action") == "agentos.transport.repair", receipt
+          assert receipt.get("executor_user") == "ubuntu", receipt
+          assert receipt.get("executor_uid") == 1001, receipt
+          assert receipt.get("source_commit") == expected, receipt
+          assert receipt.get("ok") is True, receipt
+          text = "\n".join(
+              str(step.get("stdout", "")) + "\n" + str(step.get("stderr", ""))
+              for step in receipt.get("steps", [])
+          )
+          assert "antigravity_repair=PASS" in text, text[-12000:]
+          assert "agentos_source_ref=core/integration" in text, text[-12000:]
+          assert f"agentos_source_commit={expected}" in text, text[-12000:]
+          assert "action_relay_install=PASS" in text, text[-12000:]
+          assert "action_relay_source_generation_pinned=PASS" in text, text[-12000:]
+          print("exact_generation_transport_repair=PASS")
+          print("action_relay_exact_generation=PASS")
+          PY
+          # AGENTOS_REF=core/integration is fixed by bootstrap_control for exact repairs;
+          # the request itself cannot select or widen the runtime source lane.
+
+      - name: Submit real bounded executor job and collect sanitized action receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUNTIME=/home/ubuntu/.local/share/agentos/action-runtime
+          ACTION_ROOT=/home/ubuntu/agent-data/runtime/action-relay
+          EVIDENCE="$RUNNER_TEMP/executor-job-live-receipt.json"
+
+          test "$(git -C "$RUNTIME" rev-parse HEAD)" = "$GITHUB_SHA"
+          grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_REF=core/integration" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
+          grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_COMMIT=$GITHUB_SHA" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
+
+          PYTHONPATH="$RUNTIME" python3 - "$ACTION_ROOT" "$EVIDENCE" <<'PY'
+          import json, sys, time
+          from pathlib import Path
+          from agent_core.executor_job_contract import canonical_experience_regression_request
+          from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
+
+          root = Path(sys.argv[1])
+          evidence = Path(sys.argv[2])
+          dispatcher = ActionRelayExecutorJobDispatcher(root)
+          submission = dispatcher.submit(
+              node_id="oracle-action-relay",
+              request=canonical_experience_regression_request(),
+          )
+          job_id = submission["job_id"]
+          assert job_id.startswith("action-"), submission
+          receipt_path = root / "receipts" / f"{job_id}.json"
+          for _ in range(500):
+              if receipt_path.is_file():
+                  break
+              time.sleep(1)
+          else:
+              raise SystemExit("executor job action receipt timeout")
+
+          receipt = dispatcher.inspect(job_id)
+          assert isinstance(receipt, dict), receipt
+          assert receipt.get("job_id") == job_id, receipt
+          assert receipt.get("job_type") == "experience.regression", receipt
+          assert receipt.get("project_id") == "agentos-core", receipt
+          assert receipt.get("credential_exposed") is False, receipt
+          safe = {
+              key: receipt.get(key)
+              for key in (
+                  "schema", "job_id", "job_type", "project_id", "executor_class",
+                  "capability", "executor_available", "routable", "authorized",
+                  "successful", "credential_exposed", "experiment_id", "verdict",
+                  "baseline_score", "hydrated_score", "uplift",
+                  "hydration_receipt_ok", "classification",
+              )
+              if key in receipt
+          }
+          evidence.write_text(json.dumps(safe, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+          print("executor_job_transport_receipt=PASS")
+          print("executor_job_id=" + job_id)
+          print("executor_job_classification=" + str(receipt.get("classification")))
+          print("executor_job_successful=" + str(bool(receipt.get("successful"))).lower())
+          PY
+
+      - name: Upload sanitized rollout evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-exact-generation-executor-job-${{ github.run_id }}
+          path: ${{ runner.temp }}/executor-job-live-receipt.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/agentos_node/bootstrap_control.py
+++ b/agentos_node/bootstrap_control.py
@@ -138,7 +138,13 @@ def _run_canonical_script(
 
 def _execute(action: str, source_commit: str | None) -> dict[str, Any]:
     if action == ACTION_REPAIR_TRANSPORT:
-        return _run_canonical_script("scripts/repair_antigravity_relay_user.sh", timeout=180, source_commit=source_commit, env_extra={"AGENTOS_ACTION_SPOOL_PREPROVISIONED": "1"})
+        env_extra = {"AGENTOS_ACTION_SPOOL_PREPROVISIONED": "1"}
+        if source_commit:
+            # Exact-generation transport repairs are an integration-lane rollout.
+            # The request cannot select a branch; Core fixes the only allowed lane
+            # and the repair script independently verifies FETCH_HEAD == source_commit.
+            env_extra["AGENTOS_REF"] = "core/integration"
+        return _run_canonical_script("scripts/repair_antigravity_relay_user.sh", timeout=180, source_commit=source_commit, env_extra=env_extra)
     if action == ACTION_DEPLOY_REALM_GATEWAY:
         return _run_canonical_script("scripts/deploy_realm_gateway_user.sh", timeout=300, source_commit=source_commit)
     raise ValueError("unsupported bootstrap action")

--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -11,6 +11,7 @@ RUNTIME="${AGENTOS_RUNTIME_VNEXT:-/home/ubuntu/.local/share/agentos/runtime-vnex
 REALM_RUNTIME="${AGENTOS_REALM_RUNTIME:-/home/ubuntu/.local/share/agentos/realm-fabric/current}"
 DATA_ROOT="${AGENT_DATA_ROOT:-/home/ubuntu/agent-data}"
 SOURCE_REF="${AGENTOS_REF:-main}"
+EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"
 PROVIDER="${AGENTOS_ANTIGRAVITY_PROVIDER:-claude}"
 SPOOL="$DATA_ROOT/runtime/antigravity-relay"
 UNIT_DIR="/home/ubuntu/.config/systemd/user"
@@ -22,6 +23,11 @@ case "$SOURCE_REF" in
   main|core/integration|feature/realm-node-fabric-readiness) ;;
   *) echo "ERROR: AGENTOS_REF is not allowlisted: $SOURCE_REF" >&2; exit 4 ;;
 esac
+
+if [ -n "$EXPECTED_SOURCE_COMMIT" ] && ! printf '%s' "$EXPECTED_SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "ERROR: AGENTOS_SOURCE_COMMIT must be an exact lowercase 40-hex commit SHA" >&2
+  exit 6
+fi
 
 case "$PROVIDER" in
   claude|agy) ;;
@@ -39,10 +45,14 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 # Runtime repair must not depend on the mutable checkout being clean or fast-forwardable.
 # Fetch one explicitly allowlisted ref, then materialize only trusted runtime inputs from
-# FETCH_HEAD. This preserves local checkout state and lets a development branch be tested
-# without writing or merging main.
+# FETCH_HEAD. When an exact commit is supplied by the bounded bootstrap contract, fail
+# closed unless that allowlisted ref resolves to the same immutable generation.
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
 SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
+if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
+  echo "ERROR: runtime source generation mismatch: ref=$SOURCE_REF observed=$SOURCE_COMMIT expected=$EXPECTED_SOURCE_COMMIT" >&2
+  exit 7
+fi
 show_source() {
   git -C "$REPO" show "$SOURCE_COMMIT:$1"
 }

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -1,0 +1,50 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPAIR = ROOT / "scripts" / "repair_antigravity_relay_user.sh"
+BOOTSTRAP = ROOT / "agentos_node" / "bootstrap_control.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "oracle-exact-generation-executor-job-rollout.yml"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
+    def test_transport_repair_fails_closed_on_generation_drift(self):
+        text = _text(REPAIR)
+        self.assertIn('EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"', text)
+        self.assertIn('^[0-9a-f]{40}$', text)
+        self.assertIn('[ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]', text)
+        self.assertIn('runtime source generation mismatch', text)
+        self.assertIn('AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT"', text)
+
+    def test_bootstrap_exact_repair_owns_integration_lane_selection(self):
+        text = _text(BOOTSTRAP)
+        self.assertIn('env_extra["AGENTOS_REF"] = "core/integration"', text)
+        self.assertIn('env["AGENTOS_SOURCE_COMMIT"] = source_commit', text)
+        self.assertNotIn('source_ref', text.split('unknown = set(params) - {"source_commit"}', 1)[0])
+
+    def test_rollout_is_integration_only_and_never_writes_main(self):
+        text = _text(WORKFLOW)
+        self.assertIn('branches:\n      - core/integration', text)
+        self.assertIn('params={"source_commit": sha}', text)
+        self.assertIn('AGENTOS_REF=core/integration', text)
+        self.assertNotIn('git push', text)
+        self.assertNotIn('HEAD:main', text)
+        self.assertNotIn('origin/main', text)
+
+    def test_rollout_records_bounded_executor_job_receipt_without_requiring_workload_success(self):
+        text = _text(WORKFLOW)
+        self.assertIn('canonical_experience_regression_request', text)
+        self.assertIn('ActionRelayExecutorJobDispatcher', text)
+        self.assertIn('credential_exposed', text)
+        self.assertIn('executor_job_transport_receipt=PASS', text)
+        self.assertIn('actions/upload-artifact@v4', text)
+        self.assertNotIn("assert receipt['successful'] is True", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Close the live-rollout gap after #214 without introducing a workflow-dispatch or generic-shell escape hatch.

## Changes
- fail closed when transport repair's allowlisted ref does not resolve to the requested exact commit
- bind exact transport repairs to the Core-owned `core/integration` lane; request payload still carries only `source_commit`
- add regression guards for immutable generation pinning and no-main-write behavior
- add an Oracle self-hosted rollout that triggers only after the rollout contract/runtime inputs land on `core/integration`
- install Action Relay from the merge commit and submit a real bounded `agentos.executor.job`
- upload only the sanitized executor-job receipt as workflow evidence; no evidence commits and no writes to `main`

## Truth boundary
This PR can establish exact-generation transport operation and a real `action-*` receipt. It must not claim the `experience.regression` workload is successful until #117's regression entrypoint is integrated into the same immutable Core generation.