### PR TITLE
Core: scope rollout safe-directory trust to live worktree

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -139,7 +139,10 @@ jobs:
           ACTION_ROOT=/home/ubuntu/agent-data/runtime/action-relay
           EVIDENCE="$RUNNER_TEMP/executor-job-live-receipt.json"
 
-          test "$(git -C "$RUNTIME" rev-parse HEAD)" = "$GITHUB_SHA"
+          # The canonical worktree is ubuntu-owned by design while this workflow
+          # runs as agentos-node. Trust only this one path for this one command;
+          # do not mutate global Git safe.directory configuration.
+          test "$(git -c safe.directory="$RUNTIME" -C "$RUNTIME" rev-parse HEAD)" = "$GITHUB_SHA"
           grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_REF=core/integration" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
           grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_COMMIT=$GITHUB_SHA" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
 

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -36,6 +36,11 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
         self.assertNotIn('HEAD:main', text)
         self.assertNotIn('origin/main', text)
 
+    def test_rollout_scopes_cross_owner_git_trust_without_global_mutation(self):
+        text = _text(WORKFLOW)
+        self.assertIn('git -c safe.directory="$RUNTIME" -C "$RUNTIME" rev-parse HEAD', text)
+        self.assertNotIn('git config --global --add safe.directory', text)
+
     def test_rollout_records_bounded_executor_job_receipt_without_requiring_workload_success(self):
         text = _text(WORKFLOW)
         self.assertIn('canonical_experience_regression_request', text)


### PR DESCRIPTION
## Live failure evidence
Canonical Oracle rollout run `33702742236` successfully completed exact-generation transport repair for `673cf9d9424838c5d0042c733a80ddf550dbaabf`, then the smoke precheck failed because the workflow runs as `agentos-node` while the canonical worktree is ubuntu-owned. Git rejected `rev-parse` as dubious ownership before the executor job was submitted.

## Fix
- keep the runtime ubuntu-owned
- use one command-scoped `git -c safe.directory="$RUNTIME"` only for the exact HEAD check
- do not mutate global Git configuration
- add regression coverage requiring scoped trust and forbidding global `safe.directory` writes

This changes only verification context; runtime ownership, exact-generation pinning, bounded job schema, and credential boundaries are unchanged.