### PR TITLE
Core #184: expose bounded Oracle runtime inspection through ONE MCP

### DIFF
--- a/.github/workflows/one-mcp-safety-guard.yml
+++ b/.github/workflows/one-mcp-safety-guard.yml
@@ -7,20 +7,25 @@ on:
     paths:
       - 'agentos_node/one_mcp.py'
       - 'agentos_node/one_mcp_stdio.py'
+      - 'agentos_node/one_runtime_inspect.py'
       - 'agentos_node/antigravity_one_hook.py'
       - 'tests/test_one_mcp.py'
       - 'tests/test_one_mcp_stdio_identity.py'
+      - 'tests/test_one_runtime_inspect.py'
       - 'tests/test_antigravity_one_hook.py'
       - '.github/workflows/one-mcp-safety-guard.yml'
   push:
     branches:
       - core/issue-152-executor-awareness
+      - core/issue-184-one-runtime-inspect
     paths:
       - 'agentos_node/one_mcp.py'
       - 'agentos_node/one_mcp_stdio.py'
+      - 'agentos_node/one_runtime_inspect.py'
       - 'agentos_node/antigravity_one_hook.py'
       - 'tests/test_one_mcp.py'
       - 'tests/test_one_mcp_stdio_identity.py'
+      - 'tests/test_one_runtime_inspect.py'
       - 'tests/test_antigravity_one_hook.py'
       - '.github/workflows/one-mcp-safety-guard.yml'
   workflow_dispatch:
@@ -40,4 +45,6 @@ jobs:
       - name: Run ONE MCP and PreInvocation safety regressions
         run: |
           python -m unittest tests.test_one_mcp -v
+          python -m unittest tests.test_one_mcp_stdio_identity -v
+          python -m unittest tests.test_one_runtime_inspect -v
           python -m unittest tests.test_antigravity_one_hook -v

--- a/agentos_node/one_mcp_stdio.py
+++ b/agentos_node/one_mcp_stdio.py
@@ -4,6 +4,7 @@ import copy
 from typing import Any
 
 from agentos_node.one_mcp import Gateway, create_gateway
+from agentos_node.one_runtime_inspect import inspect_oracle_runtime
 
 
 def _unbind_executor_identity(value: dict[str, Any]) -> dict[str, Any]:
@@ -27,6 +28,22 @@ def _unbind_executor_identity(value: dict[str, Any]) -> dict[str, Any]:
     mark_unbound(result)
     mark_unbound(result.get("node_context"))
     return result
+
+
+def _runtime_inspect(one: Gateway) -> dict[str, Any]:
+    if str(getattr(one, "mode", "")) != "oracle-local":
+        return {
+            "schema": "agentos.one-runtime-inspect/v0.1",
+            "mode": str(getattr(one, "mode", "unknown")),
+            "supported": False,
+            "reason": "oracle_local_only",
+            "credential_exposed": False,
+            "mutation_allowed": False,
+        }
+    return inspect_oracle_runtime(
+        data_root=getattr(one, "data_root", None),
+        core_node_id=getattr(one, "core_node_id", None),
+    )
 
 
 def create_server(gateway: Gateway | None = None):
@@ -54,6 +71,11 @@ def create_server(gateway: Gateway | None = None):
     def one_resolve(project: str) -> dict[str, Any]:
         """Resolve project identity, active goal, continuation and mutation boundary from ONE."""
         return _unbind_executor_identity(one.resolve(project))
+
+    @server.tool()
+    def one_runtime_inspect() -> dict[str, Any]:
+        """Return fixed, sanitized Oracle runtime facts; accepts no command, path, unit, or credential input."""
+        return _unbind_executor_identity(_runtime_inspect(one))
 
     return server
 

--- a/agentos_node/one_runtime_inspect.py
+++ b/agentos_node/one_runtime_inspect.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+RUNTIME_INSPECT_SCHEMA = "agentos.one-runtime-inspect/v0.1"
+FIXED_SERVICES = {
+    "core_supervisor": "agentos-core-supervisor.service",
+    "employee_worker_host": "agentos-employee-worker-host.service",
+    "legacy_native_node": "agentos-node.service",
+    "chatgpt_mcp": "agentos-chatgpt-mcp.service",
+}
+
+
+def _git(repo_root: Path, *args: str) -> str | None:
+    if not repo_root.is_dir() or not (repo_root / ".git").exists():
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return completed.stdout.strip()
+
+
+def _git_projection(repo_root: Path) -> dict[str, Any]:
+    head = _git(repo_root, "rev-parse", "HEAD")
+    branch = _git(repo_root, "branch", "--show-current")
+    status = _git(repo_root, "status", "--porcelain", "--untracked-files=no")
+    return {
+        "present": bool(head),
+        "head_sha": head if head and len(head) == 40 else None,
+        "branch": branch or None,
+        "dirty_tracked": bool(status) if status is not None else None,
+    }
+
+
+def _service_state(unit: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["systemctl", "--user", "is-active", unit],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    state = completed.stdout.strip().lower()
+    if state in {"active", "inactive", "activating", "deactivating", "failed"}:
+        return state
+    if completed.returncode == 4:
+        return "missing"
+    return "unknown"
+
+
+def _realm_projection(data_root: Path, core_node_id: str) -> dict[str, Any]:
+    nodes_path = data_root / "realm" / "nodes.json"
+    fabric_path = data_root / "realm" / "fabric.json"
+    try:
+        payload = json.loads(nodes_path.read_text(encoding="utf-8")) if nodes_path.is_file() else {}
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    nodes_obj = payload.get("nodes") if isinstance(payload, dict) else None
+    if isinstance(nodes_obj, dict):
+        node = nodes_obj.get(core_node_id)
+        node_count = len(nodes_obj)
+    elif isinstance(nodes_obj, list):
+        node = next((item for item in nodes_obj if isinstance(item, dict) and item.get("node_id") == core_node_id), None)
+        node_count = len(nodes_obj)
+    else:
+        node = None
+        node_count = 0
+    node = node if isinstance(node, dict) else {}
+    return {
+        "realm_id": payload.get("realm_id") if isinstance(payload, dict) else None,
+        "fabric_present": fabric_path.is_file(),
+        "registry_present": nodes_path.is_file(),
+        "node_count": node_count,
+        "core_node": {
+            "node_id": core_node_id,
+            "registered": bool(node),
+            "status": node.get("status"),
+            "last_heartbeat_at": node.get("last_heartbeat_at"),
+            "capabilities": sorted(str(v)[:128] for v in (node.get("capabilities") or []) if isinstance(v, str))[:128],
+            "employee_wake_capable": "agent.employee.wake.deliver" in set(node.get("capabilities") or []),
+        },
+    }
+
+
+def inspect_oracle_runtime(
+    *,
+    data_root: Path | None = None,
+    core_repo_root: Path | None = None,
+    legacy_repo_root: Path | None = None,
+    core_node_id: str | None = None,
+) -> dict[str, Any]:
+    """Return fixed, sanitized Oracle runtime facts without accepting command/path inputs."""
+    root = (data_root or Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+    core_repo = (core_repo_root or Path(os.environ.get("AGENTOS_CORE_SOURCE_ROOT", "/home/ubuntu/agentmanager"))).expanduser()
+    legacy_repo = (legacy_repo_root or Path(os.environ.get("AGENTOS_LEGACY_RUNTIME_ROOT", "/home/ubuntu/agentos-distributed"))).expanduser()
+    node_id = str(core_node_id or os.environ.get("AGENTOS_CORE_NODE_ID", "oracle-core-node")).strip()
+    if not node_id:
+        raise ValueError("core_node_id_required")
+
+    return {
+        "schema": RUNTIME_INSPECT_SCHEMA,
+        "mode": "oracle-local-readonly",
+        "credential_exposed": False,
+        "mutation_allowed": False,
+        "core_source": _git_projection(core_repo),
+        "legacy_runtime_source": _git_projection(legacy_repo),
+        "realm": _realm_projection(root, node_id),
+        "services": {name: _service_state(unit) for name, unit in FIXED_SERVICES.items()},
+    }

--- a/tests/test_one_runtime_inspect.py
+++ b/tests/test_one_runtime_inspect.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from agentos_node.one_mcp_stdio import _runtime_inspect
+from agentos_node.one_runtime_inspect import FIXED_SERVICES, inspect_oracle_runtime
+
+
+class FakeClientGateway:
+    mode = "client"
+
+
+class FakeOracleGateway:
+    mode = "oracle-local"
+
+    def __init__(self, data_root: Path, core_node_id: str = "oracle-core-node"):
+        self.data_root = data_root
+        self.core_node_id = core_node_id
+
+
+class OneRuntimeInspectTests(unittest.TestCase):
+    def _write_realm(self, root: Path, capabilities: list[str]) -> None:
+        realm = root / "realm"
+        realm.mkdir(parents=True)
+        (realm / "fabric.json").write_text('{"realm_id":"realm-alston"}\n', encoding="utf-8")
+        (realm / "nodes.json").write_text(
+            json.dumps(
+                {
+                    "schema": "agentos.node-registry/v0.1",
+                    "realm_id": "realm-alston",
+                    "nodes": {
+                        "oracle-core-node": {
+                            "node_id": "oracle-core-node",
+                            "status": "online",
+                            "last_heartbeat_at": "2026-09-03T00:39:12Z",
+                            "capabilities": capabilities,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_client_mode_is_not_a_remote_shell_backdoor(self):
+        result = _runtime_inspect(FakeClientGateway())
+        self.assertFalse(result["supported"])
+        self.assertEqual(result["reason"], "oracle_local_only")
+        self.assertFalse(result["mutation_allowed"])
+        self.assertFalse(result["credential_exposed"])
+
+    def test_projection_is_fixed_and_sanitized(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent-data"
+            self._write_realm(root, ["agentos.one.resolve", "agent.employee.wake.deliver"])
+            core = Path(tmp) / "private-core-path"
+            legacy = Path(tmp) / "private-legacy-path"
+            (core / ".git").mkdir(parents=True)
+            (legacy / ".git").mkdir(parents=True)
+
+            def fake_run(argv, **kwargs):
+                class Result:
+                    returncode = 0
+                    stdout = ""
+                result = Result()
+                if argv[0] == "git":
+                    if "rev-parse" in argv:
+                        result.stdout = "a" * 40 + "\n"
+                    elif "branch" in argv:
+                        result.stdout = "core/integration\n"
+                    elif "status" in argv:
+                        result.stdout = ""
+                elif argv[0] == "systemctl":
+                    result.stdout = "active\n"
+                return result
+
+            with mock.patch("agentos_node.one_runtime_inspect.subprocess.run", side_effect=fake_run):
+                result = inspect_oracle_runtime(
+                    data_root=root,
+                    core_repo_root=core,
+                    legacy_repo_root=legacy,
+                    core_node_id="oracle-core-node",
+                )
+
+            serialized = json.dumps(result)
+            self.assertEqual(result["schema"], "agentos.one-runtime-inspect/v0.1")
+            self.assertFalse(result["mutation_allowed"])
+            self.assertFalse(result["credential_exposed"])
+            self.assertEqual(set(result["services"]), set(FIXED_SERVICES))
+            self.assertTrue(result["realm"]["core_node"]["employee_wake_capable"])
+            self.assertNotIn(str(core), serialized)
+            self.assertNotIn(str(legacy), serialized)
+            self.assertNotIn("ExecStart", serialized)
+            self.assertNotIn("Environment", serialized)
+
+    def test_missing_wake_capability_is_visible_without_mutating_registry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent-data"
+            self._write_realm(root, ["agentos.one.resolve"])
+            with mock.patch("agentos_node.one_runtime_inspect._git_projection", return_value={"present": False, "head_sha": None, "branch": None, "dirty_tracked": None}), mock.patch("agentos_node.one_runtime_inspect._service_state", return_value="missing"):
+                result = inspect_oracle_runtime(data_root=root)
+            self.assertFalse(result["realm"]["core_node"]["employee_wake_capable"])
+            self.assertEqual(result["services"]["core_supervisor"], "missing")
+            self.assertEqual(result["services"]["employee_worker_host"], "missing")
+
+    def test_oracle_stdio_adapter_uses_gateway_data_root_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent-data"
+            self._write_realm(root, [])
+            gateway = FakeOracleGateway(root)
+            with mock.patch("agentos_node.one_mcp_stdio.inspect_oracle_runtime", return_value={"schema": "agentos.one-runtime-inspect/v0.1", "mutation_allowed": False, "credential_exposed": False}) as inspect:
+                result = _runtime_inspect(gateway)
+            inspect.assert_called_once_with(data_root=root, core_node_id="oracle-core-node")
+            self.assertEqual(result["schema"], "agentos.one-runtime-inspect/v0.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relates to #184 and unblocks read-only preflight for #197/#200.

This PR removes the need for a human to copy/paste Oracle shell output for routine runtime inspection. It adds a fixed, sanitized `one_runtime_inspect()` tool to the existing ONE MCP stdio surface.

The tool accepts no command/path/service/unit/credential input. It reports only fixed projections:
- canonical Core source SHA/ref/dirty boolean;
- legacy runtime source SHA/ref/dirty boolean;
- Realm id / registry/fabric presence / core Node registration, heartbeat and advertised capabilities;
- whether the core Node advertises `agent.employee.wake.deliver`;
- fixed service states for Core Supervisor, Employee Worker Host, legacy native Node, and ChatGPT MCP.

Security boundaries:
- Oracle-local read-only only; client mode returns `oracle_local_only`;
- no arbitrary shell/argv/path/service selection;
- no env, unit content, journal, username, token, credential, or raw filesystem path projection;
- `mutation_allowed=false`, `credential_exposed=false`;
- systemctl/git subprocesses are fixed internal probes only.

Fresh branch ONE MCP Safety Guard succeeded on head `c8096491861469a62798fed075183ce1a9e20cb6`. No Oracle service was restarted or deployed, no #50 mutation, and no protected-main publication is implied.