### PR TITLE
Core: prove live executor dispatch through ONE

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -10,6 +10,8 @@ on:
       - core/integration
     paths:
       - '.github/workflows/oracle-exact-generation-executor-job-rollout.yml'
+      - 'agent_core/controller_service.py'
+      - 'agent_core/realm_server.py'
       - 'agentos_node/bootstrap_control.py'
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/install_action_relay_user.sh'
@@ -76,50 +78,33 @@ jobs:
           import json, os, sys
           from datetime import datetime, timezone
           from pathlib import Path
-
-          path = Path(sys.argv[1])
-          request_id = sys.argv[2]
-          sha = sys.argv[3]
-          params={"source_commit": sha}
+          path = Path(sys.argv[1]); request_id = sys.argv[2]; sha = sys.argv[3]
           payload = {
               "schema": "agentos.bootstrap-request/v1",
               "request_id": request_id,
               "action": "agentos.transport.repair",
               "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-              "params": params,
-              "authority": {
-                  "source": "github-actions",
-                  "target_user": "ubuntu",
-                  "arbitrary_shell": False,
-              },
+              "params": {"source_commit": sha},
+              "authority": {"source": "github-actions", "target_user": "ubuntu", "arbitrary_shell": False},
           }
           tmp = path.with_suffix(path.suffix + ".tmp")
           tmp.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-          os.chmod(tmp, 0o644)
-          tmp.replace(path)
-          os.chmod(path, 0o644)
+          os.chmod(tmp, 0o644); tmp.replace(path); os.chmod(path, 0o644)
           PY
 
-          for i in $(seq 1 360); do
-            [ -f "$RECEIPT" ] && break
-            sleep 1
-          done
+          for i in $(seq 1 360); do [ -f "$RECEIPT" ] && break; sleep 1; done
           test -f "$RECEIPT" || { echo 'exact_generation_bootstrap_receipt=TIMEOUT'; exit 3; }
 
           python3 - "$RECEIPT" "$GITHUB_SHA" <<'PY'
           import json, sys
-          receipt = json.load(open(sys.argv[1], encoding="utf-8"))
-          expected = sys.argv[2]
+          receipt = json.load(open(sys.argv[1], encoding="utf-8")); expected = sys.argv[2]
           assert receipt.get("schema") == "agentos.bootstrap-receipt/v1", receipt
           assert receipt.get("action") == "agentos.transport.repair", receipt
           assert receipt.get("executor_user") == "ubuntu", receipt
           assert receipt.get("executor_uid") == 1001, receipt
           assert receipt.get("source_commit") == expected, receipt
           assert receipt.get("ok") is True, receipt
-          text = "\n".join(
-              str(step.get("stdout", "")) + "\n" + str(step.get("stderr", ""))
-              for step in receipt.get("steps", [])
-          )
+          text = "\n".join(str(s.get("stdout", "")) + "\n" + str(s.get("stderr", "")) for s in receipt.get("steps", []))
           assert "antigravity_repair=PASS" in text, text[-12000:]
           assert "agentos_source_ref=core/integration" in text, text[-12000:]
           assert f"agentos_source_commit={expected}" in text, text[-12000:]
@@ -128,65 +113,79 @@ jobs:
           print("exact_generation_transport_repair=PASS")
           print("action_relay_exact_generation=PASS")
           PY
-          # AGENTOS_REF=core/integration is fixed by bootstrap_control for exact repairs;
-          # the request itself cannot select or widen the runtime source lane.
 
-      - name: Submit real bounded executor job and collect sanitized action receipt
+      - name: Submit through ONE and collect bounded executor receipt
         shell: bash
         run: |
           set -euo pipefail
           RUNTIME=/home/ubuntu/.local/share/agentos/action-runtime
           ACTION_ROOT=/home/ubuntu/agent-data/runtime/action-relay
+          REQUEST="$RUNNER_TEMP/one-executor-job-request.json"
+          SUBMISSION="$RUNNER_TEMP/one-executor-job-submission.json"
           EVIDENCE="$RUNNER_TEMP/executor-job-live-receipt.json"
 
-          # The canonical worktree is ubuntu-owned by design while this workflow
-          # runs as agentos-node. Trust only this one path for this one command;
-          # do not mutate global Git safe.directory configuration.
           test "$(git -c safe.directory="$RUNTIME" -C "$RUNTIME" rev-parse HEAD)" = "$GITHUB_SHA"
           grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_REF=core/integration" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
           grep -q "AGENTOS_ACTION_RUNTIME_SOURCE_COMMIT=$GITHUB_SHA" /home/ubuntu/.config/systemd/user/agentos-action-relay.service
+          curl -fsS --max-time 3 http://127.0.0.1:8780/v1/health >/dev/null
 
-          PYTHONPATH="$RUNTIME" python3 - "$ACTION_ROOT" "$EVIDENCE" <<'PY'
-          import json, sys, time
+          PYTHONPATH="$RUNTIME" python3 - "$REQUEST" <<'PY'
+          import json, sys
           from pathlib import Path
           from agent_core.executor_job_contract import canonical_experience_regression_request
+          payload = {
+              "schema": "agentos.controller-dispatch/v0.1",
+              "node_id": "oracle-core-node",
+              "action": "agentos.executor.job",
+              "payload": canonical_experience_regression_request(),
+          }
+          Path(sys.argv[1]).write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+          PY
+
+          curl -fsS --max-time 10 \
+            -H 'Content-Type: application/json' \
+            --data-binary "@$REQUEST" \
+            http://127.0.0.1:8780/v1/controller/dispatch > "$SUBMISSION"
+
+          PYTHONPATH="$RUNTIME" python3 - "$ACTION_ROOT" "$SUBMISSION" "$EVIDENCE" <<'PY'
+          import json, sys, time
+          from pathlib import Path
           from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
 
-          root = Path(sys.argv[1])
-          evidence = Path(sys.argv[2])
-          dispatcher = ActionRelayExecutorJobDispatcher(root)
-          submission = dispatcher.submit(
-              node_id="oracle-action-relay",
-              request=canonical_experience_regression_request(),
-          )
-          job_id = submission["job_id"]
+          root = Path(sys.argv[1]); submission_path = Path(sys.argv[2]); evidence = Path(sys.argv[3])
+          submission = json.loads(submission_path.read_text(encoding="utf-8"))
+          assert submission.get("schema") == "agentos.executor-job-submission/v1", submission
+          assert submission.get("ok") is True, submission
+          assert submission.get("node_id") == "oracle-core-node", submission
+          assert submission.get("job_type") == "experience.regression", submission
+          assert submission.get("credential_exposed") is False, submission
+          job_id = str(submission.get("job_id") or "")
           assert job_id.startswith("action-"), submission
+          assert submission.get("task_id") == job_id, submission
+
           receipt_path = root / "receipts" / f"{job_id}.json"
           for _ in range(500):
-              if receipt_path.is_file():
-                  break
+              if receipt_path.is_file(): break
               time.sleep(1)
           else:
               raise SystemExit("executor job action receipt timeout")
 
+          dispatcher = ActionRelayExecutorJobDispatcher(root)
           receipt = dispatcher.inspect(job_id)
           assert isinstance(receipt, dict), receipt
           assert receipt.get("job_id") == job_id, receipt
           assert receipt.get("job_type") == "experience.regression", receipt
           assert receipt.get("project_id") == "agentos-core", receipt
           assert receipt.get("credential_exposed") is False, receipt
-          safe = {
-              key: receipt.get(key)
-              for key in (
-                  "schema", "job_id", "job_type", "project_id", "executor_class",
-                  "capability", "executor_available", "routable", "authorized",
-                  "successful", "credential_exposed", "experiment_id", "verdict",
-                  "baseline_score", "hydrated_score", "uplift",
-                  "hydration_receipt_ok", "classification",
-              )
-              if key in receipt
-          }
+          safe = {key: receipt.get(key) for key in (
+              "schema", "job_id", "job_type", "project_id", "executor_class", "capability",
+              "executor_available", "routable", "authorized", "successful", "credential_exposed",
+              "experiment_id", "verdict", "baseline_score", "hydrated_score", "uplift",
+              "hydration_receipt_ok", "classification",
+          ) if key in receipt}
+          safe["one_controller_entered"] = True
           evidence.write_text(json.dumps(safe, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+          print("one_controller_dispatch=PASS")
           print("executor_job_transport_receipt=PASS")
           print("executor_job_id=" + job_id)
           print("executor_job_classification=" + str(receipt.get("classification")))

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -30,8 +30,8 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
     def test_rollout_is_integration_only_and_never_writes_main(self):
         text = _text(WORKFLOW)
         self.assertIn('branches:\n      - core/integration', text)
-        self.assertIn('params={"source_commit": sha}', text)
-        self.assertIn('AGENTOS_REF=core/integration', text)
+        self.assertIn('"params": {"source_commit": sha}', text)
+        self.assertIn('agentos_source_ref=core/integration', text)
         self.assertNotIn('git push', text)
         self.assertNotIn('HEAD:main', text)
         self.assertNotIn('origin/main', text)
@@ -41,10 +41,23 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
         self.assertIn('git -c safe.directory="$RUNTIME" -C "$RUNTIME" rev-parse HEAD', text)
         self.assertNotIn('git config --global --add safe.directory', text)
 
+    def test_live_submission_enters_one_controller_before_action_relay(self):
+        text = _text(WORKFLOW)
+        self.assertIn('http://127.0.0.1:8780/v1/controller/dispatch', text)
+        self.assertIn('"schema": "agentos.controller-dispatch/v0.1"', text)
+        self.assertIn('"node_id": "oracle-core-node"', text)
+        self.assertIn('"action": "agentos.executor.job"', text)
+        self.assertIn('assert submission.get("schema") == "agentos.executor-job-submission/v1"', text)
+        self.assertIn('assert submission.get("task_id") == job_id', text)
+        self.assertIn('one_controller_dispatch=PASS', text)
+        submit_section = text.split('Submit through ONE and collect bounded executor receipt', 1)[1]
+        self.assertNotIn('dispatcher.submit(', submit_section)
+
     def test_rollout_records_bounded_executor_job_receipt_without_requiring_workload_success(self):
         text = _text(WORKFLOW)
         self.assertIn('canonical_experience_regression_request', text)
         self.assertIn('ActionRelayExecutorJobDispatcher', text)
+        self.assertIn('dispatcher.inspect(job_id)', text)
         self.assertIn('credential_exposed', text)
         self.assertIn('executor_job_transport_receipt=PASS', text)
         self.assertIn('actions/upload-artifact@v4', text)


### PR DESCRIPTION
## Goal
Upgrade the live proof from direct Action Relay submission to the real ONE control-plane path.

## Change
- canonical rollout now submits the fixed `experience.regression` job via localhost ONE `POST /v1/controller/dispatch`
- requires ONE to return the bounded `agentos.executor-job-submission/v1` with an opaque `action-*` id
- confirms controller compatibility alias `task_id == job_id`
- only after ONE submission succeeds does the smoke inspect the existing sanitized Action Relay receipt
- no new API surface is added solely for testing
- workload success remains optional until #117 is integrated into the same immutable generation

## Truth boundary
Passing this PR's live rollout proves `ONE controller -> bounded executor transport -> sanitized receipt`. It does not claim #117's regression workload itself is available or successful yet.