### PR TITLE
Core: give ONE Realm the bounded agentos spool boundary

### DIFF
--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -44,6 +44,10 @@ mkdir -p "$RUNTIME/agentos_node" "$REALM_RUNTIME" "$UNIT_DIR"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
+# Runtime repair must not depend on the mutable checkout being clean or fast-forwardable.
+# Fetch one explicitly allowlisted ref, then materialize only trusted runtime inputs from
+# FETCH_HEAD. When an exact commit is supplied by the bounded bootstrap contract, fail
+# closed unless that allowlisted ref resolves to the same immutable generation.
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
 SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
 if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
@@ -63,6 +67,10 @@ install -m 0664 "$TMPDIR/__init__.py" "$RUNTIME/agentos_node/__init__.py"
 install -m 0664 "$TMPDIR/antigravity_relay.py" "$RUNTIME/agentos_node/antigravity_relay.py"
 install -m 0664 "$TMPDIR/antigravity_relay_worker.py" "$RUNTIME/agentos_node/antigravity_relay_worker.py"
 
+# Realm Server is no longer a tiny hand-curated subset: it imports the runtime
+# controller, legacy compatibility controller, resolve facade and their Core
+# dependencies. Materialize the complete agent_core package from the SAME exact
+# commit so Python dependency closure cannot silently drift behind realm_server.
 rm -rf "$REALM_RUNTIME/agent_core"
 git -C "$REPO" archive "$SOURCE_COMMIT" agent_core | tar -x -C "$REALM_RUNTIME"
 test -f "$REALM_RUNTIME/agent_core/realm_server.py"
@@ -98,6 +106,12 @@ for d in "$SPOOL" "$SPOOL/inbox" "$SPOOL/processing" "$SPOOL/receipts"; do
   chmod 2770 "$d"
 done
 
+# The ubuntu user manager was started before the agentos supplementary-group
+# grant, so its children may not inherit agentos even though /etc/group is
+# correct. Pin the boundary explicitly with `sg agentos` on every relay start.
+# NoNewPrivileges must not be enabled here because it blocks this authorized
+# setgid transition; authority remains bounded by account membership + capsule schema.
+# Provider selection and runtime provenance are explicit; capsules cannot choose either.
 cat > "$UNIT" <<EOF
 [Unit]
 Description=AgentOS Antigravity Relay (ubuntu identity, agentos boundary)
@@ -121,6 +135,9 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
+# Install ONE Realm Fabric as a separate localhost-only Core service. Core code
+# comes from REALM_RUNTIME; bounded Node-side executor dispatch is loaded lazily
+# from the Action Relay worktree, which is pinned to the same SOURCE_COMMIT below.
 (
   cd "$REALM_RUNTIME"
   PYTHONPATH="$REALM_RUNTIME:$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" /usr/bin/python3 -m agent_core.realm_cli init --realm-id realm-alston >/dev/null
@@ -149,6 +166,8 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
+# Do NOT restart Antigravity from inside an Antigravity request. Reload the unit only;
+# the independent Action Relay performs that restart after repair side effects exist.
 systemctl --user daemon-reload
 systemctl --user restart agentos-realm-fabric.service
 systemctl --user enable agentos-realm-fabric.service >/dev/null
@@ -162,6 +181,8 @@ print('antigravity_provider=' + worker.provider)
 PY
 )
 
+# The Action Relay must consume the exact same governed generation selected by
+# this repair. It must not independently fall back to mutable origin/main.
 AGENTOS_REPO="$REPO" \
 AGENTOS_ACTION_RUNTIME_ROOT="$ACTION_RUNTIME" \
 AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
@@ -176,6 +197,8 @@ done
 REALM_HEALTH=$(curl -fsS --max-time 3 http://127.0.0.1:8780/v1/health)
 echo "realm_fabric_health=$REALM_HEALTH"
 
+# Route existence is checked without credentials: current handlers must answer
+# 401 (not 404), proving the selected generation is live without exposing tokens.
 BOOTSTRAP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 'http://127.0.0.1:8780/v1/bootstrap?node_id=vopc5750')
 BENCHMARK_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 -X POST -H 'Content-Type: application/json' --data '{}' http://127.0.0.1:8780/v1/benchmark)
 test "$BOOTSTRAP_CODE" = 401

--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -44,10 +44,6 @@ mkdir -p "$RUNTIME/agentos_node" "$REALM_RUNTIME" "$UNIT_DIR"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Runtime repair must not depend on the mutable checkout being clean or fast-forwardable.
-# Fetch one explicitly allowlisted ref, then materialize only trusted runtime inputs from
-# FETCH_HEAD. When an exact commit is supplied by the bounded bootstrap contract, fail
-# closed unless that allowlisted ref resolves to the same immutable generation.
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
 SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
 if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
@@ -67,10 +63,6 @@ install -m 0664 "$TMPDIR/__init__.py" "$RUNTIME/agentos_node/__init__.py"
 install -m 0664 "$TMPDIR/antigravity_relay.py" "$RUNTIME/agentos_node/antigravity_relay.py"
 install -m 0664 "$TMPDIR/antigravity_relay_worker.py" "$RUNTIME/agentos_node/antigravity_relay_worker.py"
 
-# Realm Server is no longer a tiny hand-curated subset: it imports the runtime
-# controller, legacy compatibility controller, resolve facade and their Core
-# dependencies. Materialize the complete agent_core package from the SAME exact
-# commit so Python dependency closure cannot silently drift behind realm_server.
 rm -rf "$REALM_RUNTIME/agent_core"
 git -C "$REPO" archive "$SOURCE_COMMIT" agent_core | tar -x -C "$REALM_RUNTIME"
 test -f "$REALM_RUNTIME/agent_core/realm_server.py"
@@ -106,12 +98,6 @@ for d in "$SPOOL" "$SPOOL/inbox" "$SPOOL/processing" "$SPOOL/receipts"; do
   chmod 2770 "$d"
 done
 
-# The ubuntu user manager was started before the agentos supplementary-group
-# grant, so its children may not inherit agentos even though /etc/group is
-# correct. Pin the boundary explicitly with `sg agentos` on every relay start.
-# NoNewPrivileges must not be enabled here because it blocks this authorized
-# setgid transition; authority remains bounded by account membership + capsule schema.
-# Provider selection and runtime provenance are explicit; capsules cannot choose either.
 cat > "$UNIT" <<EOF
 [Unit]
 Description=AgentOS Antigravity Relay (ubuntu identity, agentos boundary)
@@ -135,16 +121,13 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
-# Install ONE Realm Fabric as a separate localhost-only Core service. Core code
-# comes from REALM_RUNTIME; bounded Node-side executor dispatch is loaded lazily
-# from the Action Relay worktree, which is pinned to the same SOURCE_COMMIT below.
 (
   cd "$REALM_RUNTIME"
   PYTHONPATH="$REALM_RUNTIME:$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" /usr/bin/python3 -m agent_core.realm_cli init --realm-id realm-alston >/dev/null
 )
 cat > "$REALM_UNIT" <<EOF
 [Unit]
-Description=AgentOS ONE Realm Fabric (ubuntu Core identity)
+Description=AgentOS ONE Realm Fabric (ubuntu Core identity, agentos boundary)
 After=network.target
 
 [Service]
@@ -153,7 +136,11 @@ WorkingDirectory=$REALM_RUNTIME
 Environment=PYTHONPATH=$REALM_RUNTIME:$ACTION_RUNTIME
 Environment=AGENT_DATA_ROOT=$DATA_ROOT
 UMask=0007
-ExecStart=/usr/bin/python3 -m agent_core.realm_cli serve --host 127.0.0.1 --port 8780
+# ONE dispatches only bounded semantic executor jobs, but that still requires
+# access to the shared Action Relay spool. The long-lived ubuntu user manager
+# predates the agentos supplementary-group grant, so establish the already-
+# authorized group boundary explicitly without sudo or broader filesystem mode.
+ExecStart=/usr/bin/sg agentos -c '/usr/bin/python3 -m agent_core.realm_cli serve --host 127.0.0.1 --port 8780'
 Restart=always
 RestartSec=3
 PrivateTmp=true
@@ -162,8 +149,6 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
-# Do NOT restart Antigravity from inside an Antigravity request. Reload the unit only;
-# the independent Action Relay performs that restart after repair side effects exist.
 systemctl --user daemon-reload
 systemctl --user restart agentos-realm-fabric.service
 systemctl --user enable agentos-realm-fabric.service >/dev/null
@@ -177,8 +162,6 @@ print('antigravity_provider=' + worker.provider)
 PY
 )
 
-# The Action Relay must consume the exact same governed generation selected by
-# this repair. It must not independently fall back to mutable origin/main.
 AGENTOS_REPO="$REPO" \
 AGENTOS_ACTION_RUNTIME_ROOT="$ACTION_RUNTIME" \
 AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
@@ -193,8 +176,6 @@ done
 REALM_HEALTH=$(curl -fsS --max-time 3 http://127.0.0.1:8780/v1/health)
 echo "realm_fabric_health=$REALM_HEALTH"
 
-# Route existence is checked without credentials: current handlers must answer
-# 401 (not 404), proving the selected generation is live without exposing tokens.
 BOOTSTRAP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 'http://127.0.0.1:8780/v1/bootstrap?node_id=vopc5750')
 BENCHMARK_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 -X POST -H 'Content-Type: application/json' --data '{}' http://127.0.0.1:8780/v1/benchmark)
 test "$BOOTSTRAP_CODE" = 401
@@ -213,6 +194,7 @@ echo "action_relay_install=PASS"
 echo "action_relay_source_generation_pinned=PASS"
 echo "realm_fabric_install=PASS"
 echo "realm_fabric_runtime_closure=PASS"
+echo "realm_fabric_group_context=agentos"
 echo "realm_fabric_device_flow=PASS"
 echo "realm_fabric_bootstrap_route=PASS"
 echo "realm_fabric_benchmark_route=PASS"

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -16,6 +16,8 @@ class AntigravityRepairContractTests(unittest.TestCase):
         text = _text(SCRIPT)
         self.assertIn('SOURCE_REF="${AGENTOS_REF:-main}"', text)
         self.assertIn('EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"', text)
+        # core/integration is the governed integration generation. Development
+        # worker branches remain excluded from the runtime repair allowlist.
         self.assertIn('main|core/integration|feature/realm-node-fabric-readiness', text)
         self.assertNotIn('core/issue-194-bounded-executor-jobs)', text)
         self.assertIn('git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"', text)

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -16,8 +16,6 @@ class AntigravityRepairContractTests(unittest.TestCase):
         text = _text(SCRIPT)
         self.assertIn('SOURCE_REF="${AGENTOS_REF:-main}"', text)
         self.assertIn('EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"', text)
-        # core/integration is the governed integration generation. Development
-        # worker branches remain excluded from the runtime repair allowlist.
         self.assertIn('main|core/integration|feature/realm-node-fabric-readiness', text)
         self.assertNotIn('core/issue-194-bounded-executor-jobs)', text)
         self.assertIn('git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"', text)
@@ -48,6 +46,15 @@ class AntigravityRepairContractTests(unittest.TestCase):
         unit_section = text.split('cat > "$UNIT" <<EOF', 1)[1].split('EOF', 1)[0]
         self.assertNotIn('NoNewPrivileges=true', unit_section)
         self.assertIn('UMask=0007', unit_section)
+
+    def test_realm_boundary_uses_authorized_agentos_group_for_bounded_executor_dispatch(self):
+        text = _text(SCRIPT)
+        realm_section = text.split('cat > "$REALM_UNIT" <<EOF', 1)[1].split('EOF', 1)[0]
+        self.assertIn("ExecStart=/usr/bin/sg agentos -c '/usr/bin/python3 -m agent_core.realm_cli serve --host 127.0.0.1 --port 8780'", realm_section)
+        self.assertIn('Environment=PYTHONPATH=$REALM_RUNTIME:$ACTION_RUNTIME', realm_section)
+        self.assertIn('UMask=0007', realm_section)
+        self.assertNotIn('NoNewPrivileges=true', realm_section)
+        self.assertIn('realm_fabric_group_context=agentos', text)
 
     def test_relay_provider_is_explicit_allowlisted_and_not_capsule_controlled(self):
         text = _text(SCRIPT)


### PR DESCRIPTION
Rebased/transplanted onto current `core/integration` after concurrent Core #184 landed.

## Live failure evidence
ONE-routed rollout run `33703329067` completed exact-generation repair, but `POST /v1/controller/dispatch` returned 401 because the handler mapped an internal `PermissionError`: the long-lived ubuntu Realm service did not inherit the `agentos` supplementary group required to enter the governed Action Relay spool.

## Fix
- Realm remains ubuntu and localhost-only
- Realm service starts through `/usr/bin/sg agentos`
- no sudo, no world-writable fallback, no widened job schema
- same-generation Action Relay runtime remains on PYTHONPATH
- regression guard requires this group boundary

The change is transplanted on top of `9432a5ac...` so Core #184 is preserved intact.