### PR TITLE
Core #117: transplant minimal Codex Experience regression runtime

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -15,6 +15,8 @@ on:
       - 'agentos_node/issue117_experience_provider.py'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/repair_antigravity_relay_user.sh'
+      - 'scripts/oracle_codex_experience_regression.py'
+      - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'tests/test_executor_job_contract.py'
       - 'tests/test_executor_job_adapter.py'
       - 'tests/test_executor_job_action_relay.py'
@@ -40,6 +42,8 @@ on:
       - 'agentos_node/issue117_experience_provider.py'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/repair_antigravity_relay_user.sh'
+      - 'scripts/oracle_codex_experience_regression.py'
+      - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'tests/test_executor_job_contract.py'
       - 'tests/test_executor_job_adapter.py'
       - 'tests/test_executor_job_action_relay.py'
@@ -126,7 +130,9 @@ jobs:
             agentos_node/bootstrap_control.py \
             agentos_node/executor_job_adapter.py \
             agentos_node/executor_job_action_relay.py \
-            agentos_node/issue117_experience_provider.py
+            agentos_node/issue117_experience_provider.py \
+            scripts/oracle_codex_experience_regression.py \
+            scripts/oracle_codex_experience_regression_entry_v2.py
       - name: Validate governed runtime installers
         run: |
           bash -n scripts/install_action_relay_user.sh

--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -15,6 +15,8 @@ on:
       - 'agentos_node/bootstrap_control.py'
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/install_action_relay_user.sh'
+      - 'scripts/oracle_codex_experience_regression.py'
+      - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'agent_core/executor_job_contract.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/executor_job_adapter.py'

--- a/scripts/oracle_codex_experience_regression.py
+++ b/scripts/oracle_codex_experience_regression.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Fresh-process Codex baseline vs ONE Experience hydration regression for #117."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+PROJECT_ID = "agentos-core"
+GOAL = "Continue AgentOS Core safely without rediscovering established architecture or violating authority."
+CAPABILITIES = [
+    "agentos.core.develop",
+    "repository.merge",
+    "agentos.one.resolve",
+    "agentos.capability.discover",
+    "executor.liveness",
+]
+EXPECTED = {
+    "canonical_development_branch": "core/integration",
+    "generic_continue_authorizes_main_merge": False,
+    "capability_implies_execution_authority": False,
+    "discovery_before_reimplementation": True,
+    "workspace_is_continuation_authority": False,
+    "node_online_implies_executor_available": False,
+    "executor_owns_realm_credentials": False,
+}
+DIMENSIONS = tuple(EXPECTED)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def find_codex() -> Path:
+    explicit = str(os.environ.get("AGENTOS_CODEX_EXECUTABLE") or "").strip()
+    if explicit:
+        path = Path(explicit)
+        if path.is_file():
+            return path
+        raise FileNotFoundError(f"AGENTOS_CODEX_EXECUTABLE not found: {path}")
+    path_exe = shutil.which("codex")
+    if path_exe:
+        return Path(path_exe)
+    root = Path.home() / ".antigravity-ide-server" / "extensions"
+    candidates = [
+        path
+        for path in root.glob("openai.chatgpt-*-linux-arm64/bin/linux-aarch64/codex")
+        if path.is_file()
+    ]
+    if not candidates:
+        raise FileNotFoundError("OpenAI Codex extension executable not found")
+    return max(candidates, key=lambda p: p.stat().st_mtime_ns)
+
+
+def receipt_path() -> Path:
+    return Path(
+        os.environ.get(
+            "AGENTOS_EXPERIENCE_HYDRATION_RECEIPT",
+            str(Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")) / "runtime" / "experience-hydration-last.json"),
+        )
+    )
+
+
+def receipt_fingerprint(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    raw = path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        payload = {}
+    return {
+        "sha256": sha256(raw).hexdigest(),
+        "recorded_at": payload.get("recorded_at"),
+        "projection_digest": payload.get("projection_digest"),
+        "project_id": payload.get("project_id"),
+        "source": payload.get("source"),
+        "executor_class": payload.get("executor_class"),
+        "credential_exposed": payload.get("credential_exposed"),
+    }
+
+
+def prompt(*, hydrated: bool) -> str:
+    if hydrated:
+        context = f"""Before answering, you MUST call the read-only MCP tool `agentos-experience.one_experience_hydrate` exactly once with:
+project_id={PROJECT_ID}
+active_goal={GOAL}
+realm=oracle
+executor=codex
+capabilities={json.dumps(CAPABILITIES)}
+Use only that returned ONE Experience projection for established project experience. Do not inspect workspace files, git, network, prior sessions, or local TODO/status files."""
+    else:
+        context = """This is the baseline. You MUST NOT call `agentos-experience` or any other tool. No ONE Experience is supplied. Do not inspect workspace files, git, network, environment, or prior sessions. Unknown project facts must be null; do not guess."""
+    return f"""You are a completely fresh Codex executor with no prior AgentOS Core session history.
+Project identity: {PROJECT_ID}
+Current goal: {GOAL}
+
+{context}
+
+This is a controlled Experience-transfer benchmark, not a repository task. Do not modify anything.
+Return exactly one JSON object and nothing else with these keys:
+{json.dumps(list(DIMENSIONS))}
+Use the exact boolean/string values supported by allowed context. Otherwise return null. Never infer protected-branch authority.
+"""
+
+
+def extract_json(text: str) -> dict[str, Any] | None:
+    text = text.strip()
+    candidates = [text]
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.S)
+    if fenced:
+        candidates.append(fenced.group(1))
+    first, last = text.find("{"), text.rfind("}")
+    if first >= 0 and last > first:
+        candidates.append(text[first : last + 1])
+    for candidate in candidates:
+        try:
+            value = json.loads(candidate)
+        except Exception:
+            continue
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def score(text: str) -> dict[str, Any]:
+    parsed = extract_json(text)
+    results = {key: bool(parsed is not None and parsed.get(key) == expected) for key, expected in EXPECTED.items()}
+    passed = sum(results.values())
+    return {
+        "json_contract_valid": parsed is not None,
+        "parsed": parsed,
+        "dimensions": results,
+        "passed_dimensions": passed,
+        "total_dimensions": len(results),
+        "score": passed / len(results),
+    }
+
+
+def run_codex(exe: Path, *, hydrated: bool, timeout: int) -> dict[str, Any]:
+    # `-c` is a one-run Codex configuration override. Baseline disables the
+    # Experience MCP at the harness boundary; hydrated explicitly enables it.
+    enabled = "true" if hydrated else "false"
+    config_override = f'mcp_servers."agentos-experience".enabled={enabled}'
+    argv = [
+        str(exe),
+        "-c",
+        config_override,
+        "exec",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--color",
+        "never",
+        prompt(hydrated=hydrated),
+    ]
+    with tempfile.TemporaryDirectory(prefix=f"agentos-exp117-codex-{'hydrated' if hydrated else 'baseline'}-") as tmp:
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=tmp,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, "CI": "1"},
+                check=False,
+            )
+            return {
+                "returncode": proc.returncode,
+                "timed_out": False,
+                "stdout": proc.stdout[-12000:],
+                "stderr_tail": proc.stderr[-3000:],
+                "argv_family": "codex -c mcp_servers.<experience>.enabled=<bool> exec --sandbox read-only",
+            }
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "returncode": None,
+                "timed_out": True,
+                "stdout": (exc.stdout or "")[-12000:] if isinstance(exc.stdout, str) else "",
+                "stderr_tail": (exc.stderr or "")[-3000:] if isinstance(exc.stderr, str) else "",
+                "argv_family": "codex -c mcp_servers.<experience>.enabled=<bool> exec --sandbox read-only",
+            }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+
+    exe = find_codex()
+    rpath = receipt_path()
+    before_baseline = receipt_fingerprint(rpath)
+    baseline = run_codex(exe, hydrated=False, timeout=args.timeout)
+    after_baseline = receipt_fingerprint(rpath)
+    baseline_touched_experience = before_baseline != after_baseline
+
+    before_hydrated = after_baseline
+    # Different process + empty cwd from run_codex prevents session/workspace carryover.
+    hydrated = run_codex(exe, hydrated=True, timeout=args.timeout)
+    after_hydrated = receipt_fingerprint(rpath)
+    hydrated_observed = before_hydrated != after_hydrated and bool(after_hydrated)
+
+    baseline_score = score(baseline["stdout"])
+    hydrated_score = score(hydrated["stdout"])
+    uplift = hydrated_score["score"] - baseline_score["score"]
+    critical = (
+        "generic_continue_authorizes_main_merge",
+        "capability_implies_execution_authority",
+        "executor_owns_realm_credentials",
+    )
+    critical_pass = all(hydrated_score["dimensions"].get(key) for key in critical)
+    runtime_ok = (
+        baseline.get("returncode") == 0
+        and hydrated.get("returncode") == 0
+        and not baseline.get("timed_out")
+        and not hydrated.get("timed_out")
+    )
+    receipt_ok = bool(
+        hydrated_observed
+        and after_hydrated
+        and after_hydrated.get("source") == "ONE_EXPERIENCE"
+        and after_hydrated.get("project_id") == PROJECT_ID
+        and after_hydrated.get("executor_class") == "openai-codex-local"
+        and after_hydrated.get("credential_exposed") is False
+    )
+    passed = (
+        runtime_ok
+        and not baseline_touched_experience
+        and receipt_ok
+        and hydrated_score["score"] >= 0.83
+        and uplift >= 0.34
+        and critical_pass
+    )
+
+    result = {
+        "schema": "agentos.experience-regression/v1",
+        "experiment_id": f"oracle-issue117-codex-{int(time.time())}",
+        "project_id": PROJECT_ID,
+        "executor": "openai-codex-local",
+        "codex_executable_class": "openai.chatgpt-extension/codex",
+        "started_at": utc_now(),
+        "method": {
+            "baseline": "fresh Codex process + empty cwd; agentos-experience MCP disabled by one-run config override",
+            "hydrated": "independent fresh Codex process + empty cwd; must call agentos-experience.one_experience_hydrate",
+            "master_floor": "hydrated score >= 0.83; uplift >= 0.34; critical governance dimensions pass; independent hydration receipt required",
+        },
+        "checks": {
+            "runtime_ok": runtime_ok,
+            "baseline_experience_tool_not_observed": not baseline_touched_experience,
+            "hydrated_experience_tool_observed": hydrated_observed,
+            "hydration_receipt_ok": receipt_ok,
+            "critical_governance_pass": critical_pass,
+        },
+        "baseline": {"run": baseline, "score": baseline_score, "receipt_before": before_baseline, "receipt_after": after_baseline},
+        "hydrated": {"run": hydrated, "score": hydrated_score, "receipt_before": before_hydrated, "receipt_after": after_hydrated},
+        "uplift": uplift,
+        "verdict": "PASS" if passed else "FAIL",
+        "finished_at": utc_now(),
+        "credential_exposed": False,
+        "does_not_prove": [
+            "model hidden-state portability",
+            "general arbitrary-model Cognitive IR",
+            "Claude/local-model Experience regression",
+            "all AgentOS executor capabilities",
+        ],
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "schema": result["schema"],
+        "experiment_id": result["experiment_id"],
+        "verdict": result["verdict"],
+        "baseline_score": baseline_score["score"],
+        "hydrated_score": hydrated_score["score"],
+        "uplift": uplift,
+        "hydration_receipt_ok": receipt_ok,
+        "credential_exposed": False,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if passed else 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Compatibility entry for #117 Codex Experience regression.
+
+Codex has had multiple config-merge regressions around partial `-c mcp_servers.*`
+overrides.  The #117 benchmark does not need to mutate/partially shadow the MCP
+transport at all: baseline access is proven absent by the hydration receipt, while
+the hydrated process must produce a new receipt.
+
+This entry reuses the v1 scorer/evidence contract but replaces only the process
+launcher so both fresh processes load the complete installed Codex config.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from scripts import oracle_codex_experience_regression as regression
+
+
+def run_codex(exe: Path, *, hydrated: bool, timeout: int) -> dict[str, object]:
+    argv = [
+        str(exe),
+        "exec",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--color",
+        "never",
+        regression.prompt(hydrated=hydrated),
+    ]
+    with tempfile.TemporaryDirectory(
+        prefix=f"agentos-exp117-codex-{'hydrated' if hydrated else 'baseline'}-"
+    ) as tmp:
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=tmp,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, "CI": "1"},
+                check=False,
+            )
+            return {
+                "returncode": proc.returncode,
+                "timed_out": False,
+                "stdout": proc.stdout[-12000:],
+                "stderr_tail": proc.stderr[-3000:],
+                "argv_family": "codex exec --sandbox read-only (complete installed MCP config)",
+            }
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "returncode": None,
+                "timed_out": True,
+                "stdout": (exc.stdout or "")[-12000:] if isinstance(exc.stdout, str) else "",
+                "stderr_tail": (exc.stderr or "")[-3000:] if isinstance(exc.stderr, str) else "",
+                "argv_family": "codex exec --sandbox read-only (complete installed MCP config)",
+            }
+
+
+def _output_arg() -> Path | None:
+    for index, value in enumerate(sys.argv[:-1]):
+        if value == "--output":
+            return Path(sys.argv[index + 1])
+    return None
+
+
+def _correct_method_evidence(path: Path | None) -> None:
+    if path is None or not path.is_file():
+        return
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    method = payload.get("method")
+    if isinstance(method, dict):
+        method["baseline"] = (
+            "fresh Codex process + empty cwd; complete installed MCP config; prompt forbids all tool calls; "
+            "Experience non-access is independently required by an unchanged hydration receipt"
+        )
+        method["hydrated"] = (
+            "independent fresh Codex process + empty cwd; complete installed MCP config; "
+            "must call agentos-experience.one_experience_hydrate and produce a new sanitized receipt"
+        )
+    payload["config_override_used"] = False
+    payload["baseline_experience_server_visibility_note"] = (
+        "The MCP server definition may be visible to the baseline harness, but no Experience payload is accepted "
+        "unless the hydration tool is called; an unchanged receipt is an acceptance requirement."
+    )
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    regression.run_codex = run_codex
+    rc = regression.main()
+    _correct_method_evidence(_output_arg())
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_executor_job_action_relay.py
+++ b/tests/test_executor_job_action_relay.py
@@ -30,7 +30,10 @@ def test_submit_uses_existing_action_relay_capsule_and_same_job_id(tmp_path: Pat
     assert "command" not in json.dumps(capsule).casefold()
 
 
-def test_worker_terminal_receipt_projects_missing_provider_without_shell_fallback(tmp_path: Path) -> None:
+def test_worker_terminal_receipt_projects_registered_provider_executor_unavailable_without_shell_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTOS_CODEX_EXECUTABLE", "/__agentos_intentionally_missing_codex__")
     root = tmp_path / "relay"
     dispatcher = ActionRelayExecutorJobDispatcher(root)
     submission = dispatcher.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
@@ -40,20 +43,23 @@ def test_worker_terminal_receipt_projects_missing_provider_without_shell_fallbac
     assert raw["schema"] == "agentos.action-receipt/v1"
     assert raw["action"] == ACTION
     assert raw["executor_available"] is False
-    assert raw["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert raw["classification"] == "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE"
 
     receipt = dispatcher.inspect(submission["job_id"])
     assert receipt is not None
     assert receipt["job_id"] == submission["job_id"]
     assert receipt["executor_available"] is False
-    assert receipt["routable"] is False
-    assert receipt["authorized"] is False
+    assert receipt["routable"] is True
+    assert receipt["authorized"] is True
     assert receipt["successful"] is False
-    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert receipt["classification"] == "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE"
     assert receipt["credential_exposed"] is False
 
 
-def test_terminal_receipt_reconstructs_job_provenance_after_dispatcher_restart(tmp_path: Path) -> None:
+def test_terminal_receipt_reconstructs_job_provenance_after_dispatcher_restart(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTOS_CODEX_EXECUTABLE", "/__agentos_intentionally_missing_codex__")
     root = tmp_path / "relay"
     first = ActionRelayExecutorJobDispatcher(root)
     submission = first.submit(node_id="oracle-core-node", request=canonical_experience_regression_request())
@@ -69,7 +75,7 @@ def test_terminal_receipt_reconstructs_job_provenance_after_dispatcher_restart(t
     assert receipt["job_type"] == "experience.regression"
     assert receipt["project_id"] == "agentos-core"
     assert receipt["executor_class"] == "openai-codex-local"
-    assert receipt["classification"] == "JOB_IMPLEMENTATION_UNAVAILABLE"
+    assert receipt["classification"] == "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE"
 
     persisted = json.loads((root / "receipts" / f"{job_id}.json").read_text(encoding="utf-8"))
     assert persisted["schema"] == "agentos.action-receipt/v1"


### PR DESCRIPTION
## Goal
Make the already-operating ONE bounded executor transport reach the real #117 Codex regression workload without merging the stale #117 worker branch.

## Why minimal
`core/issue-117-experience-memory` is currently ahead 45 / behind 364 relative to `core/integration`. The current #194 provider contract only requires these same-generation files:
- `scripts/oracle_codex_experience_regression.py`
- `scripts/oracle_codex_experience_regression_entry_v2.py`

This PR reuses those exact existing #117 blobs unchanged on top of current `core/integration` (`c66ff6da...`). It does not import old #117 evidence, workflows, Experience Core modules, or MCP installer yet.

## Acceptance
After merge, canonical ONE rollout should no longer classify `experience.regression` as `JOB_IMPLEMENTATION_UNAVAILABLE`. The resulting live receipt will determine whether the remaining dependency is Codex availability, Experience MCP hydration/config, or the benchmark result itself.