### PR TITLE
Core #117: install exact-generation Experience MCP runtime

### DIFF
--- a/agent_core/experience.py
+++ b/agent_core/experience.py
@@ -1,0 +1,230 @@
+"""Governed ONE Experience discovery/hydration primitives.
+
+Experience is a projection over canonical state/evidence, not a fourth source of
+truth. This module intentionally performs deterministic filtering/projection only;
+it does not grant execution authority and it does not ingest raw conversation text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+
+EXPERIENCE_SCHEMA = "agentos.experience/v0"
+ACCEPTED_STATUS = "accepted"
+VALID_KINDS = {
+    "decision",
+    "procedure",
+    "heuristic",
+    "failure-pattern",
+    "constraint",
+    "benchmark-pattern",
+}
+
+
+class ExperienceContractError(ValueError):
+    """Raised when an experience artifact violates the v0 contract."""
+
+
+@dataclass(frozen=True)
+class ExperienceQuery:
+    project_id: str
+    realm: str | None = None
+    capabilities: tuple[str, ...] = ()
+    executor: str | None = None
+    limit: int = 20
+
+
+@dataclass(frozen=True)
+class HydrationProjection:
+    schema: str
+    project_id: str
+    active_goal: str
+    experience_ids: tuple[str, ...]
+    items: tuple[Mapping[str, Any], ...]
+    digest: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "project_id": self.project_id,
+            "active_goal": self.active_goal,
+            "experience_ids": list(self.experience_ids),
+            "items": [dict(item) for item in self.items],
+            "digest": self.digest,
+        }
+
+
+def _string_list(value: Any, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or any(not isinstance(v, str) or not v for v in value):
+        raise ExperienceContractError(f"{field} must be a list of non-empty strings")
+    return tuple(value)
+
+
+def validate_experience(artifact: Mapping[str, Any]) -> None:
+    required = {
+        "schema",
+        "experience_id",
+        "project_id",
+        "kind",
+        "summary",
+        "payload",
+        "provenance",
+        "authority",
+        "validity",
+    }
+    missing = required.difference(artifact)
+    if missing:
+        raise ExperienceContractError(f"missing required fields: {sorted(missing)}")
+    if artifact["schema"] != EXPERIENCE_SCHEMA:
+        raise ExperienceContractError("unsupported experience schema")
+    for field in ("experience_id", "project_id", "summary"):
+        if not isinstance(artifact[field], str) or not artifact[field].strip():
+            raise ExperienceContractError(f"{field} must be a non-empty string")
+    if artifact["kind"] not in VALID_KINDS:
+        raise ExperienceContractError("unsupported experience kind")
+    if not isinstance(artifact["payload"], Mapping):
+        raise ExperienceContractError("payload must be an object")
+
+    provenance = artifact["provenance"]
+    if not isinstance(provenance, Mapping):
+        raise ExperienceContractError("provenance must be an object")
+    sources = _string_list(provenance.get("sources"), "provenance.sources")
+    if not sources:
+        raise ExperienceContractError("provenance.sources must not be empty")
+    _string_list(provenance.get("accepted_evidence", []), "provenance.accepted_evidence")
+
+    authority = artifact["authority"]
+    if not isinstance(authority, Mapping) or authority.get("status") not in {
+        "candidate",
+        "accepted",
+        "deprecated",
+        "revoked",
+    }:
+        raise ExperienceContractError("authority.status is invalid")
+    _string_list(authority.get("supersedes", []), "authority.supersedes")
+    _string_list(authority.get("superseded_by", []), "authority.superseded_by")
+
+    validity = artifact["validity"]
+    if not isinstance(validity, Mapping):
+        raise ExperienceContractError("validity must be an object")
+    _string_list(validity.get("conditions", []), "validity.conditions")
+    _string_list(validity.get("invalidated_by", []), "validity.invalidated_by")
+    _string_list(artifact.get("realm_scope", []), "realm_scope")
+    _string_list(artifact.get("capability_scope", []), "capability_scope")
+    _string_list(artifact.get("executor_scope", []), "executor_scope")
+
+
+def _scope_matches(scope: Sequence[str], value: str | None) -> bool:
+    return not scope or value is None or value in scope or "*" in scope
+
+
+def _capability_score(scope: Sequence[str], requested: set[str]) -> int:
+    if not scope:
+        return 0
+    if "*" in scope:
+        return 1
+    return len(set(scope).intersection(requested))
+
+
+def discover_experience(
+    artifacts: Iterable[Mapping[str, Any]], query: ExperienceQuery
+) -> list[Mapping[str, Any]]:
+    """Return accepted, in-scope experience ranked deterministically.
+
+    Discovery is intentionally authority-neutral: it only returns knowledge
+    artifacts. Mutation/execution authority must be resolved elsewhere.
+    """
+    if not query.project_id:
+        raise ExperienceContractError("query.project_id must be non-empty")
+    if query.limit < 1:
+        raise ExperienceContractError("query.limit must be positive")
+
+    requested_caps = set(query.capabilities)
+    ranked: list[tuple[tuple[int, int, int, str], Mapping[str, Any]]] = []
+    for artifact in artifacts:
+        validate_experience(artifact)
+        if artifact["project_id"] != query.project_id:
+            continue
+        if artifact["authority"]["status"] != ACCEPTED_STATUS:
+            continue
+        if artifact["authority"].get("superseded_by"):
+            continue
+        if artifact["validity"].get("invalidated_by"):
+            continue
+
+        realms = tuple(artifact.get("realm_scope", []))
+        executors = tuple(artifact.get("executor_scope", []))
+        capabilities = tuple(artifact.get("capability_scope", []))
+        if not _scope_matches(realms, query.realm):
+            continue
+        if not _scope_matches(executors, query.executor):
+            continue
+        if capabilities and requested_caps and not ({"*"} | requested_caps).intersection(capabilities):
+            continue
+
+        # Prefer exact executor/realm scope and capability overlap; tie-break by ID.
+        score = (
+            1 if query.executor and query.executor in executors else 0,
+            1 if query.realm and query.realm in realms else 0,
+            _capability_score(capabilities, requested_caps),
+            artifact["experience_id"],
+        )
+        ranked.append((score, artifact))
+
+    ranked.sort(key=lambda item: (-item[0][0], -item[0][1], -item[0][2], item[0][3]))
+    return [artifact for _, artifact in ranked[: query.limit]]
+
+
+def hydrate_experience(
+    *, project_id: str, active_goal: str, artifacts: Sequence[Mapping[str, Any]]
+) -> HydrationProjection:
+    """Create a bounded executor-neutral projection from discovered experience."""
+    if not project_id or not active_goal:
+        raise ExperienceContractError("project_id and active_goal must be non-empty")
+
+    items: list[Mapping[str, Any]] = []
+    ids: list[str] = []
+    for artifact in artifacts:
+        validate_experience(artifact)
+        if artifact["project_id"] != project_id:
+            raise ExperienceContractError("hydration artifact project mismatch")
+        if artifact["authority"]["status"] != ACCEPTED_STATUS:
+            raise ExperienceContractError("hydration accepts only accepted experience")
+        ids.append(artifact["experience_id"])
+        items.append(
+            {
+                "experience_id": artifact["experience_id"],
+                "kind": artifact["kind"],
+                "summary": artifact["summary"],
+                "payload": artifact["payload"],
+                "provenance": {
+                    "sources": list(artifact["provenance"]["sources"]),
+                    "accepted_evidence": list(artifact["provenance"].get("accepted_evidence", [])),
+                },
+            }
+        )
+
+    canonical = {
+        "schema": "agentos.experience-hydration/v0",
+        "project_id": project_id,
+        "active_goal": active_goal,
+        "experience_ids": ids,
+        "items": items,
+    }
+    digest = sha256(
+        json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return HydrationProjection(
+        schema="agentos.experience-hydration/v0",
+        project_id=project_id,
+        active_goal=active_goal,
+        experience_ids=tuple(ids),
+        items=tuple(items),
+        digest=digest,
+    )

--- a/agent_core/experience_store.py
+++ b/agent_core/experience_store.py
@@ -1,0 +1,173 @@
+"""ONE-owned Experience artifact persistence for issue #117.
+
+Repository JSON is only a seed/provenance carrier. Runtime discovery and hydration
+must read the accepted set from the AgentOS data layer so Experience is external to
+an individual executor/session and is not silently coupled to a checkout.
+"""
+from __future__ import annotations
+
+import fcntl
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Iterator
+from contextlib import contextmanager
+
+from agent_core.experience import ExperienceQuery, discover_experience, hydrate_experience, validate_experience
+
+SET_SCHEMA = "agentos.experience-set/v0"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+
+
+def experience_path(project_id: str, *, data_root: Path | None = None) -> Path:
+    project_id = str(project_id or "").strip()
+    if not project_id or "/" in project_id or "\\" in project_id or project_id in {".", ".."}:
+        raise ValueError("invalid project_id")
+    root = data_root or _data_root()
+    return root / "experience" / project_id / "accepted.json"
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def digest_set(value: dict[str, Any]) -> str:
+    return "sha256:" + sha256(_canonical_bytes(value)).hexdigest()
+
+
+def validate_set(value: dict[str, Any], *, project_id: str | None = None) -> dict[str, Any]:
+    if value.get("schema") != SET_SCHEMA:
+        raise ValueError("unsupported experience set schema")
+    actual = str(value.get("project_id") or "").strip()
+    if not actual:
+        raise ValueError("experience set project_id is required")
+    if project_id is not None and actual != project_id:
+        raise ValueError("experience set project mismatch")
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("experience set artifacts must be a list")
+    seen: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ValueError("experience artifact must be an object")
+        validate_experience(artifact)
+        if artifact["project_id"] != actual:
+            raise ValueError("experience artifact project mismatch")
+        experience_id = artifact["experience_id"]
+        if experience_id in seen:
+            raise ValueError(f"duplicate experience_id: {experience_id}")
+        seen.add(experience_id)
+    return value
+
+
+@contextmanager
+def _lock(path: Path) -> Iterator[None]:
+    lock = path.with_suffix(path.suffix + ".lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    if lock.is_symlink():
+        raise ValueError("experience lock path must not be a symlink")
+    with lock.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def read_experience_set(project_id: str, *, data_root: Path | None = None) -> dict[str, Any]:
+    path = experience_path(project_id, data_root=data_root)
+    if path.is_symlink():
+        raise ValueError("experience store path must not be a symlink")
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return validate_set(json.loads(path.read_text(encoding="utf-8")), project_id=project_id)
+
+
+def seed_experience_set(seed_path: Path, *, data_root: Path | None = None) -> dict[str, Any]:
+    seed_path = Path(seed_path)
+    incoming = validate_set(json.loads(seed_path.read_text(encoding="utf-8")))
+    project_id = incoming["project_id"]
+    target = experience_path(project_id, data_root=data_root)
+    incoming_digest = digest_set(incoming)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with _lock(target):
+        if target.is_symlink():
+            raise ValueError("experience store path must not be a symlink")
+        if target.exists():
+            current = validate_set(json.loads(target.read_text(encoding="utf-8")), project_id=project_id)
+            current_digest = digest_set(current)
+            if current_digest != incoming_digest:
+                raise ValueError(
+                    "ONE Experience already exists with a different digest; refusing implicit overwrite"
+                )
+            return {
+                "schema": "agentos.experience-seed-receipt/v1",
+                "ok": True,
+                "seeded": False,
+                "project_id": project_id,
+                "digest": current_digest,
+                "path": str(target),
+                "credential_exposed": False,
+            }
+        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(_canonical_bytes(incoming))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp, 0o640)
+            os.replace(tmp, target)
+            dir_fd = os.open(target.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+    return {
+        "schema": "agentos.experience-seed-receipt/v1",
+        "ok": True,
+        "seeded": True,
+        "project_id": project_id,
+        "digest": incoming_digest,
+        "path": str(target),
+        "credential_exposed": False,
+    }
+
+
+def discover_from_one(query: ExperienceQuery, *, data_root: Path | None = None) -> list[dict[str, Any]]:
+    value = read_experience_set(query.project_id, data_root=data_root)
+    return [dict(item) for item in discover_experience(value["artifacts"], query)]
+
+
+def hydrate_from_one(
+    *,
+    project_id: str,
+    active_goal: str,
+    realm: str | None = None,
+    capabilities: tuple[str, ...] = (),
+    executor: str | None = None,
+    limit: int = 20,
+    data_root: Path | None = None,
+) -> dict[str, Any]:
+    artifacts = discover_from_one(
+        ExperienceQuery(
+            project_id=project_id,
+            realm=realm,
+            capabilities=capabilities,
+            executor=executor,
+            limit=limit,
+        ),
+        data_root=data_root,
+    )
+    projection = hydrate_experience(project_id=project_id, active_goal=active_goal, artifacts=artifacts).as_dict()
+    projection["source"] = "ONE_EXPERIENCE"
+    projection["credential_exposed"] = False
+    return projection

--- a/agentos_node/experience_mcp_stdio.py
+++ b/agentos_node/experience_mcp_stdio.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from agent_core.experience import ExperienceQuery
+from agent_core.experience_store import discover_from_one, hydrate_from_one
+
+SURFACE = "codex-local"
+EXECUTOR_CLASS = "openai-codex-local"
+RECEIPT_SCHEMA = "agentos.experience-hydration-receipt/v1"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _source_commit() -> str:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    return Path(__file__).resolve().parents[1].name
+
+
+def _receipt_path() -> Path:
+    return Path(
+        os.environ.get(
+            "AGENTOS_EXPERIENCE_HYDRATION_RECEIPT",
+            str(_data_root() / "runtime" / "experience-hydration-last.json"),
+        )
+    ).expanduser()
+
+
+def _write_receipt(projection: dict[str, Any]) -> None:
+    path = _receipt_path()
+    if path.is_symlink():
+        raise ValueError("Experience hydration receipt path must not be a symlink")
+    payload = {
+        "schema": RECEIPT_SCHEMA,
+        "recorded_at": _utc_now(),
+        "runtime_source_commit": _source_commit(),
+        "source": projection.get("source"),
+        "surface": SURFACE,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "project_id": projection.get("project_id"),
+        "projection_digest": projection.get("digest"),
+        "experience_ids": list(projection.get("experience_ids") or []),
+        "credential_exposed": False,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def _project(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema": "agentos.experience-discovery/v1",
+        "source": "ONE_EXPERIENCE",
+        "surface": SURFACE,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "experience_ids": [item.get("experience_id") for item in items],
+        "items": items,
+        "credential_exposed": False,
+    }
+
+
+def one_experience_discover(
+    project_id: str,
+    realm: str = "oracle",
+    capabilities: list[str] | None = None,
+    executor: str = "codex",
+    limit: int = 20,
+) -> dict[str, Any]:
+    items = discover_from_one(
+        ExperienceQuery(
+            project_id=project_id,
+            realm=realm or None,
+            capabilities=tuple(capabilities or ()),
+            executor=executor or None,
+            limit=limit,
+        ),
+        data_root=_data_root(),
+    )
+    return _project(items)
+
+
+def one_experience_hydrate(
+    project_id: str,
+    active_goal: str,
+    realm: str = "oracle",
+    capabilities: list[str] | None = None,
+    executor: str = "codex",
+    limit: int = 20,
+) -> dict[str, Any]:
+    projection = hydrate_from_one(
+        project_id=project_id,
+        active_goal=active_goal,
+        realm=realm or None,
+        capabilities=tuple(capabilities or ()),
+        executor=executor or None,
+        limit=limit,
+        data_root=_data_root(),
+    )
+    projection["surface"] = SURFACE
+    projection["executor_class"] = EXECUTOR_CLASS
+    projection["executor_identity_bound"] = True
+    projection["credential_exposed"] = False
+    _write_receipt(projection)
+    return projection
+
+
+def create_server():
+    from mcp.server.mcpserver import MCPServer
+
+    server = MCPServer("AgentOS ONE Experience", version="0.1.0")
+    server.tool()(one_experience_discover)
+    server.tool()(one_experience_hydrate)
+    return server
+
+
+def main() -> int:
+    create_server().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experience/agentos-core-oracle.seed.json
+++ b/experience/agentos-core-oracle.seed.json
@@ -1,0 +1,155 @@
+{
+  "schema": "agentos.experience-set/v0",
+  "project_id": "agentos-core",
+  "projection_only": true,
+  "note": "Seed/provenance carrier for ONE-owned Experience. Runtime discovery reads the accepted set from the AgentOS data layer; newer canonical state and explicit user intent always supersede Experience.",
+  "artifacts": [
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.branch-authority.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.core.develop", "repository.merge"],
+      "executor_scope": ["*"],
+      "kind": "decision",
+      "summary": "Core development uses core/integration plus focused core/issue-* branches; mutable runtime generation/SHA are live state and must be resolved at execution time rather than memorized as Experience.",
+      "payload": {
+        "canonical_development_branch": "core/integration",
+        "issue_branch_pattern": "core/issue-<N>-<slug>",
+        "mutable_runtime_facts_belong_in_experience": false,
+        "rule": "A branch head, PID, checkout HEAD, or health response is not deployment acceptance."
+      },
+      "provenance": {
+        "sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"],
+        "accepted_evidence": []
+      },
+      "authority": {"status": "accepted", "supersedes": ["core.branch-and-runtime-authority.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.protected-main-human-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["repository.mutate", "repository.merge"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "Passing CI, mergeability, review state, tool capability, or generic continue never grants protected-main merge authority; separate explicit human authorization is required.",
+      "payload": {
+        "protected_branch": "main",
+        "required_authority": "separate explicit human authorization",
+        "generic_continue_is_authorization": false,
+        "capability_implies_authority": false
+      },
+      "provenance": {
+        "sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"],
+        "accepted_evidence": ["github-ruleset://21844290"]
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.evidence-scope-and-capability-semantics.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve", "agentos.controller.dispatch", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "heuristic",
+      "summary": "Evidence must prove the exact claimed path, and capability states must remain distinct: advertised is not routable, routable is not authorized, and authorized is not successful execution.",
+      "payload": {
+        "capability_semantics": ["advertised", "transport-routable", "execution-authorized", "successfully-executed"],
+        "controller_dispatch_proves_resolve": false,
+        "capability_implies_execution_authority": false,
+        "acceptance_rule": "Probe the real target transport/capability path and preserve a receipt."
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"],
+        "accepted_evidence": ["issue-64://controller-service-entered"]
+      },
+      "authority": {"status": "accepted", "supersedes": ["core.evidence-scope-and-capability-semantics.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.discover-before-reinvent.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.capability.discover", "project.resolve"],
+      "executor_scope": ["*"],
+      "kind": "procedure",
+      "summary": "Resolve existing project responsibility, resources, capabilities, and open Core ownership before creating a parallel implementation or rediscovering AgentOS from source.",
+      "payload": {
+        "procedure": ["resolve project identity", "discover responsibility/resources/capabilities", "reuse accepted capability when present", "file/use the owning Core issue for missing shared capability", "only then implement the missing capability"]
+      },
+      "provenance": {
+        "sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"],
+        "accepted_evidence": []
+      },
+      "authority": {"status": "accepted", "supersedes": ["core.discover-before-reinvent.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.workspace-not-continuation-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve", "project.resolve"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "IDE workspace, git status, local TODO files, vendor history, Pulse, and local model memory are not durable continuation authority; resolve current continuation from ONE Canonical IR.",
+      "payload": {
+        "workspace_is_continuation_authority": false,
+        "canonical_continuation_authority": "ONE Canonical IR selected by the active continuation pointer"
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/152"],
+        "accepted_evidence": ["issue-152://E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY_VERIFIED"]
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.node-executor-boundary.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["executor.dispatch", "executor.liveness", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "A Node is the durable Realm/control participant; executors are independently live capability providers. Node online does not prove executor availability, and executor adapters do not own Realm transport credentials.",
+      "payload": {
+        "node_online_implies_executor_available": false,
+        "executor_owns_realm_credentials": false,
+        "node_and_executor_are_distinct": true
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/152"],
+        "accepted_evidence": ["issue-152://node-executor-boundary"]
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "executor.antigravity-relay-liveness.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["oracle"],
+      "capability_scope": ["executor.dispatch", "executor.liveness"],
+      "executor_scope": ["antigravity", "claude"],
+      "kind": "failure-pattern",
+      "summary": "Antigravity relay enqueue does not prove Claude executor liveness. A deterministic no-tool capsule previously timed out at about 180 seconds with returncode 124; future acceptance requires a fresh successful receipt.",
+      "payload": {
+        "historical_failure": {"returncode": 124, "timed_out": true, "stdout_exact_match": false},
+        "recovery_proven": false,
+        "required_regression": "Fresh no-tool deterministic receipt with ok=true, timed_out=false, returncode=0 before trusting executor workloads."
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/72"],
+        "accepted_evidence": ["workflow-run://33227123813"]
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": ["historical failure remains relevant until a newer successful liveness regression supersedes it"], "invalidated_by": []}
+    }
+  ]
+}

--- a/scripts/install_codex_experience_mcp_oracle.py
+++ b/scripts/install_codex_experience_mcp_oracle.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import venv
+
+MCP_PACKAGE = "mcp>=2,<3"
+CONFIG_START = "# AGENTOS_EXPERIENCE_MCP_START"
+CONFIG_END = "# AGENTOS_EXPERIENCE_MCP_END"
+SERVER = "agentos-experience"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", "/home/ubuntu/agent-data")).expanduser()
+
+
+def codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser()
+
+
+def ensure_python() -> Path:
+    shared = Path.home() / ".local" / "share" / "agentos" / "one-mcp" / "venv" / "bin" / "python"
+    if shared.is_file():
+        probe = subprocess.run([str(shared), "-c", "from mcp.server.mcpserver import MCPServer"], capture_output=True)
+        if probe.returncode == 0:
+            return shared
+    root = Path.home() / ".local" / "share" / "agentos" / "experience-mcp" / "venv"
+    python = root / "bin" / "python"
+    if not python.is_file():
+        root.parent.mkdir(parents=True, exist_ok=True)
+        venv.EnvBuilder(with_pip=True, clear=False).create(root)
+    probe = subprocess.run([str(python), "-c", "from mcp.server.mcpserver import MCPServer"], capture_output=True)
+    if probe.returncode != 0:
+        install = subprocess.run(
+            [str(python), "-m", "pip", "install", "--disable-pip-version-check", MCP_PACKAGE],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if install.returncode != 0:
+            raise RuntimeError("failed to install MCP SDK: " + (install.stderr or install.stdout)[-3000:])
+    return python
+
+
+def _toml(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def block(python: Path) -> str:
+    root = repo_root()
+    return "\n".join([
+        CONFIG_START,
+        f'[mcp_servers."{SERVER}"]',
+        f"command = {_toml(str(python))}",
+        'args = ["-m", "agentos_node.experience_mcp_stdio"]',
+        f"cwd = {_toml(str(root))}",
+        "enabled = true",
+        "",
+        f'[mcp_servers."{SERVER}".env]',
+        f"PYTHONPATH = {_toml(str(root))}",
+        f"AGENT_DATA_ROOT = {_toml(str(data_root()))}",
+        CONFIG_END,
+    ])
+
+
+def replace_block(existing: str, new_block: str) -> str:
+    if CONFIG_START in existing or CONFIG_END in existing:
+        if CONFIG_START not in existing or CONFIG_END not in existing:
+            raise ValueError("partial managed Experience MCP block found")
+        before, rest = existing.split(CONFIG_START, 1)
+        _, after = rest.split(CONFIG_END, 1)
+        return before.rstrip() + "\n\n" + new_block.strip() + "\n" + after.lstrip()
+    unmanaged_keys = (f'[mcp_servers."{SERVER}"]', f"[mcp_servers.{SERVER}]")
+    if any(key in existing for key in unmanaged_keys):
+        raise ValueError("unmanaged agentos-experience MCP entry exists; refusing overwrite")
+    return (existing.rstrip() + "\n\n" if existing.strip() else "") + new_block.strip() + "\n"
+
+
+def main() -> int:
+    if os.name == "nt":
+        raise RuntimeError("Oracle-local Experience MCP installer requires Linux")
+    required = data_root() / "experience" / "agentos-core" / "accepted.json"
+    if not required.is_file():
+        raise FileNotFoundError(f"ONE Experience store missing: {required}")
+    python = ensure_python()
+    home = codex_home()
+    config = home / "config.toml"
+    existing = config.read_text(encoding="utf-8") if config.exists() else ""
+    updated = replace_block(existing, block(python))
+    home.mkdir(parents=True, exist_ok=True)
+    tmp = config.with_suffix(".toml.agentos-experience.tmp")
+    tmp.write_text(updated, encoding="utf-8")
+    tmp.replace(config)
+    print(json.dumps({
+        "schema": "agentos.codex-experience-mcp-install/v1",
+        "ok": True,
+        "server": SERVER,
+        "config_path": str(config),
+        "experience_path": str(required),
+        "canonical_ir_copied": False,
+        "experience_body_copied_to_config": False,
+        "credential_in_config": False,
+        "reload_required": False,
+    }, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -19,6 +19,7 @@ UNIT_DIR="/home/ubuntu/.config/systemd/user"
 UNIT="$UNIT_DIR/agentos-antigravity-relay.service"
 REALM_UNIT="$UNIT_DIR/agentos-realm-fabric.service"
 MANIFEST="$RUNTIME/runtime-provenance.json"
+CODEX_CONFIG="/home/ubuntu/.codex/config.toml"
 
 case "$SOURCE_REF" in
   main|core/integration|feature/realm-node-fabric-readiness) ;;
@@ -188,6 +189,42 @@ AGENTOS_ACTION_RUNTIME_ROOT="$ACTION_RUNTIME" \
 AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
 AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT" \
 bash "$TMPDIR/install_action_relay_user.sh"
+
+# #117 Experience hydration is an executor-local, read-only cognitive input. Keep
+# its code and Codex MCP configuration on the SAME immutable Action Runtime used
+# by the bounded executor provider. Existing accepted Experience is never silently
+# replaced: the seed helper refuses a digest mismatch and therefore fails closed.
+for required in \
+  agent_core/experience.py \
+  agent_core/experience_store.py \
+  agentos_node/experience_mcp_stdio.py \
+  scripts/seed_one_experience.py \
+  scripts/install_codex_experience_mcp_oracle.py \
+  experience/agentos-core-oracle.seed.json; do
+  test -f "$ACTION_RUNTIME/$required" || { echo "ERROR: Experience runtime input missing: $required" >&2; exit 8; }
+done
+PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" python3 -m py_compile \
+  "$ACTION_RUNTIME/agent_core/experience.py" \
+  "$ACTION_RUNTIME/agent_core/experience_store.py" \
+  "$ACTION_RUNTIME/agentos_node/experience_mcp_stdio.py" \
+  "$ACTION_RUNTIME/scripts/seed_one_experience.py" \
+  "$ACTION_RUNTIME/scripts/install_codex_experience_mcp_oracle.py"
+(
+  cd "$ACTION_RUNTIME"
+  PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" \
+    python3 scripts/seed_one_experience.py --seed experience/agentos-core-oracle.seed.json >/dev/null
+  echo "one_experience_seed=PASS"
+  PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" \
+    python3 scripts/install_codex_experience_mcp_oracle.py >/dev/null
+  echo "codex_experience_mcp_install=PASS"
+)
+test -f "$CODEX_CONFIG"
+grep -Fq '# AGENTOS_EXPERIENCE_MCP_START' "$CODEX_CONFIG"
+grep -Fq '[mcp_servers."agentos-experience"]' "$CODEX_CONFIG"
+grep -Fq "cwd = \"$ACTION_RUNTIME\"" "$CODEX_CONFIG"
+grep -Fq "PYTHONPATH = \"$ACTION_RUNTIME\"" "$CODEX_CONFIG"
+echo "codex_experience_mcp_exact_runtime=PASS"
+
 systemctl --user is-active --quiet agentos-action-relay.service
 systemctl --user is-active --quiet agentos-realm-fabric.service
 for i in $(seq 1 20); do
@@ -215,6 +252,9 @@ echo "antigravity_runtime_manifest=$MANIFEST"
 echo "antigravity_restart_pending=YES"
 echo "action_relay_install=PASS"
 echo "action_relay_source_generation_pinned=PASS"
+echo "one_experience_seed=PASS"
+echo "codex_experience_mcp_install=PASS"
+echo "codex_experience_mcp_exact_runtime=PASS"
 echo "realm_fabric_install=PASS"
 echo "realm_fabric_runtime_closure=PASS"
 echo "realm_fabric_group_context=agentos"

--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agent_core.experience_store import seed_experience_set
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed accepted Experience into the ONE data layer")
+    parser.add_argument("--seed", default="experience/agentos-core-oracle.seed.json")
+    args = parser.parse_args()
+    receipt = seed_experience_set(Path(args.seed).resolve())
+    print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -86,6 +86,27 @@ class AntigravityRepairContractTests(unittest.TestCase):
         self.assertIn('bash "$TMPDIR/install_action_relay_user.sh"', text)
         self.assertIn('action_relay_source_generation_pinned=PASS', text)
 
+    def test_experience_mcp_is_seeded_and_installed_from_exact_action_runtime(self):
+        text = _text(SCRIPT)
+        for path in (
+            'agent_core/experience.py',
+            'agent_core/experience_store.py',
+            'agentos_node/experience_mcp_stdio.py',
+            'scripts/seed_one_experience.py',
+            'scripts/install_codex_experience_mcp_oracle.py',
+            'experience/agentos-core-oracle.seed.json',
+        ):
+            self.assertIn(path, text)
+        self.assertIn('cd "$ACTION_RUNTIME"', text)
+        self.assertIn('python3 scripts/seed_one_experience.py --seed experience/agentos-core-oracle.seed.json', text)
+        self.assertIn('python3 scripts/install_codex_experience_mcp_oracle.py', text)
+        self.assertIn('grep -Fq "cwd = \\"$ACTION_RUNTIME\\"" "$CODEX_CONFIG"', text)
+        self.assertIn('grep -Fq "PYTHONPATH = \\"$ACTION_RUNTIME\\"" "$CODEX_CONFIG"', text)
+        self.assertIn('one_experience_seed=PASS', text)
+        self.assertIn('codex_experience_mcp_install=PASS', text)
+        self.assertIn('codex_experience_mcp_exact_runtime=PASS', text)
+        self.assertNotIn('AGENTOS_EXPERIENCE_MCP_ALLOW_OVERWRITE', text)
+
     def test_action_relay_installer_preserves_correct_foreign_owned_shared_boundary(self):
         text = _text(ACTION_INSTALLER)
         self.assertIn('ensure_shared_dir()', text)


### PR DESCRIPTION
## Live evidence
Canonical ONE rollout run `33705771574` reached the real #117 Codex workload with `executor_available=true`, `routable=true`, `authorized=true`, but produced:
- baseline score `0.8571428571`
- hydrated score `0.0`
- uplift `-0.8571428571`
- `hydration_receipt_ok=false`
- classification `EXPERIENCE_REGRESSION_FAILED`

This isolates the remaining blocker to Codex `agentos-experience` MCP hydration/config rather than ONE transport or executor discovery.

## Change
Transplant the existing #117 Experience runtime closure unchanged:
- `agent_core/experience.py`
- `agent_core/experience_store.py`
- `agentos_node/experience_mcp_stdio.py`
- `scripts/seed_one_experience.py`
- `scripts/install_codex_experience_mcp_oracle.py`
- `experience/agentos-core-oracle.seed.json`

Exact repair now, after creating the immutable Action Runtime:
1. verifies those inputs exist in the same runtime generation;
2. idempotently seeds accepted ONE Experience (digest mismatch fails closed);
3. installs the Codex MCP from that exact Action Runtime;
4. verifies managed Codex config `cwd` and `PYTHONPATH` point to the exact Action Runtime;
5. emits bounded PASS markers without printing config or credentials.

No generic command surface is added and the benchmark/scorer is unchanged.