### PR TITLE
Core #117: promote Experience artifacts to semantic IR v1

### DIFF
--- a/agent_core/experience.py
+++ b/agent_core/experience.py
@@ -1,0 +1,415 @@
+"""Governed ONE Experience IR discovery and hydration primitives.
+
+Experience is a governed projection over canonical state/evidence, not a fourth
+source of truth. The semantic payload is machine-readable Experience IR. Human
+summaries are optional display metadata and are never authoritative.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+
+EXPERIENCE_SCHEMA = "agentos.experience/v1"
+EXPERIENCE_IR_SCHEMA = "agentos.experience-ir/v1"
+EXTRACTION_SCHEMA = "agentos.experience-extraction/v1"
+HYDRATION_SCHEMA = "agentos.experience-hydration/v1"
+ACCEPTED_STATUS = "accepted"
+
+VALID_KINDS = {
+    "decision",
+    "procedure",
+    "heuristic",
+    "failure-pattern",
+    "constraint",
+    "benchmark-pattern",
+}
+VALID_IR_OPS = {
+    "assert",
+    "require",
+    "forbid",
+    "prefer",
+    "avoid",
+    "invoke",
+    "match",
+    "set",
+}
+VALID_VALUE_TYPES = {"symbol", "string", "number", "boolean", "null", "list", "object"}
+_SENSITIVE_KEYS = {
+    "token",
+    "node_token",
+    "access_token",
+    "refresh_token",
+    "authorization",
+    "password",
+    "secret",
+    "claim_secret",
+    "client_secret",
+}
+
+
+class ExperienceContractError(ValueError):
+    """Raised when an Experience artifact violates the contract."""
+
+
+@dataclass(frozen=True)
+class ExperienceQuery:
+    project_id: str
+    realm: str | None = None
+    capabilities: tuple[str, ...] = ()
+    executor: str | None = None
+    limit: int = 20
+
+
+@dataclass(frozen=True)
+class HydrationProjection:
+    schema: str
+    project_id: str
+    active_goal: str
+    experience_ids: tuple[str, ...]
+    items: tuple[Mapping[str, Any], ...]
+    digest: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "project_id": self.project_id,
+            "active_goal": self.active_goal,
+            "experience_ids": list(self.experience_ids),
+            "items": [dict(item) for item in self.items],
+            "digest": self.digest,
+        }
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _string_list(value: Any, field: str, *, required: bool = False) -> tuple[str, ...]:
+    if value is None:
+        if required:
+            raise ExperienceContractError(f"{field} must not be empty")
+        return ()
+    if not isinstance(value, list) or any(not isinstance(v, str) or not v.strip() for v in value):
+        raise ExperienceContractError(f"{field} must be a list of non-empty strings")
+    result = tuple(v.strip() for v in value)
+    if required and not result:
+        raise ExperienceContractError(f"{field} must not be empty")
+    return result
+
+
+def _contains_sensitive(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if str(key).strip().casefold() in _SENSITIVE_KEYS:
+                return True
+            if _contains_sensitive(child):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_sensitive(child) for child in value)
+    return False
+
+
+def _validate_typed_value(value: Any, field: str) -> None:
+    if not isinstance(value, Mapping):
+        raise ExperienceContractError(f"{field} must be an object")
+    value_type = value.get("type")
+    if value_type not in VALID_VALUE_TYPES:
+        raise ExperienceContractError(f"{field}.type is unsupported")
+    if value_type == "null":
+        if value.get("value") is not None:
+            raise ExperienceContractError(f"{field}.value must be null")
+        return
+    if "value" not in value:
+        raise ExperienceContractError(f"{field}.value is required")
+    raw = value["value"]
+    if value_type in {"symbol", "string"} and (not isinstance(raw, str) or not raw.strip()):
+        raise ExperienceContractError(f"{field}.value must be a non-empty string")
+    if value_type == "number" and (not isinstance(raw, (int, float)) or isinstance(raw, bool)):
+        raise ExperienceContractError(f"{field}.value must be a number")
+    if value_type == "boolean" and not isinstance(raw, bool):
+        raise ExperienceContractError(f"{field}.value must be boolean")
+    if value_type == "list" and not isinstance(raw, list):
+        raise ExperienceContractError(f"{field}.value must be a list")
+    if value_type == "object" and not isinstance(raw, Mapping):
+        raise ExperienceContractError(f"{field}.value must be an object")
+
+
+def validate_experience_ir(value: Mapping[str, Any]) -> None:
+    if not isinstance(value, Mapping):
+        raise ExperienceContractError("ir must be an object")
+    if value.get("schema") != EXPERIENCE_IR_SCHEMA:
+        raise ExperienceContractError("unsupported experience IR schema")
+    nodes = value.get("nodes")
+    if not isinstance(nodes, list) or not nodes:
+        raise ExperienceContractError("ir.nodes must be a non-empty list")
+    seen: set[str] = set()
+    for index, node in enumerate(nodes):
+        field = f"ir.nodes[{index}]"
+        if not isinstance(node, Mapping):
+            raise ExperienceContractError(f"{field} must be an object")
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not node_id.strip():
+            raise ExperienceContractError(f"{field}.id must be a non-empty string")
+        if node_id in seen:
+            raise ExperienceContractError(f"duplicate IR node id: {node_id}")
+        seen.add(node_id)
+        if node.get("op") not in VALID_IR_OPS:
+            raise ExperienceContractError(f"{field}.op is unsupported")
+        predicate = node.get("predicate")
+        if not isinstance(predicate, str) or not predicate.strip():
+            raise ExperienceContractError(f"{field}.predicate must be a non-empty string")
+        arguments = node.get("arguments", [])
+        if not isinstance(arguments, list):
+            raise ExperienceContractError(f"{field}.arguments must be a list")
+        for arg_index, argument in enumerate(arguments):
+            _validate_typed_value(argument, f"{field}.arguments[{arg_index}]")
+        if "value" in node:
+            _validate_typed_value(node["value"], f"{field}.value")
+
+    entrypoints = _string_list(value.get("entrypoints"), "ir.entrypoints", required=True)
+    missing = [item for item in entrypoints if item not in seen]
+    if missing:
+        raise ExperienceContractError(f"ir.entrypoints reference missing nodes: {missing}")
+    _string_list(
+        value.get("expected_behavior_dimensions"),
+        "ir.expected_behavior_dimensions",
+        required=True,
+    )
+    if _contains_sensitive(value):
+        raise ExperienceContractError("experience IR contains a sensitive credential field")
+
+
+def validate_experience(artifact: Mapping[str, Any]) -> None:
+    required = {
+        "schema",
+        "experience_id",
+        "project_id",
+        "kind",
+        "ir",
+        "provenance",
+        "authority",
+        "validity",
+    }
+    missing = required.difference(artifact)
+    if missing:
+        raise ExperienceContractError(f"missing required fields: {sorted(missing)}")
+    if artifact["schema"] != EXPERIENCE_SCHEMA:
+        raise ExperienceContractError("unsupported experience schema")
+    for field in ("experience_id", "project_id"):
+        if not isinstance(artifact[field], str) or not artifact[field].strip():
+            raise ExperienceContractError(f"{field} must be a non-empty string")
+    if artifact["kind"] not in VALID_KINDS:
+        raise ExperienceContractError("unsupported experience kind")
+
+    validate_experience_ir(artifact["ir"])
+
+    display = artifact.get("display", {})
+    if not isinstance(display, Mapping):
+        raise ExperienceContractError("display must be an object")
+    summary = display.get("summary")
+    if summary is not None and (not isinstance(summary, str) or not summary.strip()):
+        raise ExperienceContractError("display.summary must be a non-empty string when present")
+
+    provenance = artifact["provenance"]
+    if not isinstance(provenance, Mapping):
+        raise ExperienceContractError("provenance must be an object")
+    _string_list(provenance.get("sources"), "provenance.sources", required=True)
+    _string_list(provenance.get("accepted_evidence", []), "provenance.accepted_evidence")
+    extraction_id = provenance.get("extraction_id")
+    if extraction_id is not None and (not isinstance(extraction_id, str) or not extraction_id.strip()):
+        raise ExperienceContractError("provenance.extraction_id must be a non-empty string when present")
+
+    authority = artifact["authority"]
+    if not isinstance(authority, Mapping) or authority.get("status") not in {
+        "candidate",
+        "accepted",
+        "deprecated",
+        "revoked",
+    }:
+        raise ExperienceContractError("authority.status is invalid")
+    _string_list(authority.get("supersedes", []), "authority.supersedes")
+    _string_list(authority.get("superseded_by", []), "authority.superseded_by")
+
+    validity = artifact["validity"]
+    if not isinstance(validity, Mapping):
+        raise ExperienceContractError("validity must be an object")
+    _string_list(validity.get("conditions", []), "validity.conditions")
+    _string_list(validity.get("invalidated_by", []), "validity.invalidated_by")
+    _string_list(artifact.get("realm_scope", []), "realm_scope")
+    _string_list(artifact.get("capability_scope", []), "capability_scope")
+    _string_list(artifact.get("executor_scope", []), "executor_scope")
+
+    if _contains_sensitive(artifact):
+        raise ExperienceContractError("experience artifact contains a sensitive credential field")
+
+
+def validate_extraction_proposal(proposal: Mapping[str, Any]) -> None:
+    if not isinstance(proposal, Mapping):
+        raise ExperienceContractError("extraction proposal must be an object")
+    if proposal.get("schema") != EXTRACTION_SCHEMA:
+        raise ExperienceContractError("unsupported extraction proposal schema")
+    for field in ("extraction_id", "project_id"):
+        if not isinstance(proposal.get(field), str) or not str(proposal[field]).strip():
+            raise ExperienceContractError(f"{field} must be a non-empty string")
+    origin = proposal.get("origin")
+    if not isinstance(origin, Mapping):
+        raise ExperienceContractError("origin must be an object")
+    if not any(str(origin.get(field) or "").strip() for field in ("node_id", "surface", "executor", "backend")):
+        raise ExperienceContractError("origin must identify at least one trustworthy execution surface field")
+    sources = _string_list(proposal.get("sources"), "sources", required=True)
+    if not sources:
+        raise ExperienceContractError("sources must not be empty")
+    abstraction = proposal.get("abstraction")
+    if not isinstance(abstraction, Mapping):
+        raise ExperienceContractError("abstraction must be an object")
+    _string_list(abstraction.get("generalized_from"), "abstraction.generalized_from", required=True)
+    _string_list(abstraction.get("excluded", []), "abstraction.excluded")
+    candidate = proposal.get("candidate")
+    if not isinstance(candidate, Mapping):
+        raise ExperienceContractError("candidate must be an object")
+    validate_experience(candidate)
+    if candidate["authority"]["status"] != "candidate":
+        raise ExperienceContractError("extraction proposal candidate must not self-authorize acceptance")
+    if candidate["project_id"] != proposal["project_id"]:
+        raise ExperienceContractError("extraction proposal project mismatch")
+    if _contains_sensitive(proposal):
+        raise ExperienceContractError("extraction proposal contains a sensitive credential field")
+
+
+def experience_semantic_digest(artifact: Mapping[str, Any]) -> str:
+    """Hash semantic Experience content, excluding optional human display text."""
+    validate_experience(artifact)
+    semantic = {
+        "schema": artifact["schema"],
+        "experience_id": artifact["experience_id"],
+        "project_id": artifact["project_id"],
+        "kind": artifact["kind"],
+        "realm_scope": list(artifact.get("realm_scope", [])),
+        "capability_scope": list(artifact.get("capability_scope", [])),
+        "executor_scope": list(artifact.get("executor_scope", [])),
+        "ir": artifact["ir"],
+        "validity": artifact["validity"],
+    }
+    return "sha256:" + sha256(_canonical(semantic)).hexdigest()
+
+
+def _scope_matches(scope: Sequence[str], value: str | None) -> bool:
+    return not scope or value is None or value in scope or "*" in scope
+
+
+def _capability_score(scope: Sequence[str], requested: set[str]) -> int:
+    if not scope:
+        return 0
+    if "*" in scope:
+        return 1
+    return len(set(scope).intersection(requested))
+
+
+def discover_experience(
+    artifacts: Iterable[Mapping[str, Any]], query: ExperienceQuery
+) -> list[Mapping[str, Any]]:
+    """Return accepted, current, in-scope Experience ranked deterministically."""
+    if not query.project_id:
+        raise ExperienceContractError("query.project_id must be non-empty")
+    if query.limit < 1:
+        raise ExperienceContractError("query.limit must be positive")
+
+    requested_caps = set(query.capabilities)
+    ranked: list[tuple[tuple[int, int, int, str], Mapping[str, Any]]] = []
+    for artifact in artifacts:
+        validate_experience(artifact)
+        if artifact["project_id"] != query.project_id:
+            continue
+        if artifact["authority"]["status"] != ACCEPTED_STATUS:
+            continue
+        if artifact["authority"].get("superseded_by"):
+            continue
+        if artifact["validity"].get("invalidated_by"):
+            continue
+
+        realms = tuple(artifact.get("realm_scope", []))
+        executors = tuple(artifact.get("executor_scope", []))
+        capabilities = tuple(artifact.get("capability_scope", []))
+        if not _scope_matches(realms, query.realm):
+            continue
+        if not _scope_matches(executors, query.executor):
+            continue
+        if capabilities and requested_caps and not ({"*"} | requested_caps).intersection(capabilities):
+            continue
+
+        score = (
+            1 if query.executor and query.executor in executors else 0,
+            1 if query.realm and query.realm in realms else 0,
+            _capability_score(capabilities, requested_caps),
+            artifact["experience_id"],
+        )
+        ranked.append((score, artifact))
+
+    ranked.sort(key=lambda item: (-item[0][0], -item[0][1], -item[0][2], item[0][3]))
+    return [artifact for _, artifact in ranked[: query.limit]]
+
+
+def hydrate_experience(
+    *, project_id: str, active_goal: str, artifacts: Sequence[Mapping[str, Any]]
+) -> HydrationProjection:
+    """Create an executor-neutral semantic projection from accepted Experience."""
+    if not project_id or not active_goal:
+        raise ExperienceContractError("project_id and active_goal must be non-empty")
+
+    items: list[Mapping[str, Any]] = []
+    ids: list[str] = []
+    for artifact in artifacts:
+        validate_experience(artifact)
+        if artifact["project_id"] != project_id:
+            raise ExperienceContractError("hydration artifact project mismatch")
+        if artifact["authority"]["status"] != ACCEPTED_STATUS:
+            raise ExperienceContractError("hydration accepts only accepted experience")
+        experience_id = artifact["experience_id"]
+        ids.append(experience_id)
+        items.append(
+            {
+                "experience_id": experience_id,
+                "kind": artifact["kind"],
+                "semantic_digest": experience_semantic_digest(artifact),
+                "ir": artifact["ir"],
+                "expected_behavior_dimensions": list(
+                    artifact["ir"]["expected_behavior_dimensions"]
+                ),
+                "provenance": {
+                    "sources": list(artifact["provenance"]["sources"]),
+                    "accepted_evidence": list(
+                        artifact["provenance"].get("accepted_evidence", [])
+                    ),
+                    **(
+                        {"extraction_id": artifact["provenance"]["extraction_id"]}
+                        if artifact["provenance"].get("extraction_id")
+                        else {}
+                    ),
+                },
+            }
+        )
+
+    canonical = {
+        "schema": HYDRATION_SCHEMA,
+        "project_id": project_id,
+        "active_goal": active_goal,
+        "experience_ids": ids,
+        "items": items,
+    }
+    digest = "sha256:" + sha256(_canonical(canonical)).hexdigest()
+    return HydrationProjection(
+        schema=HYDRATION_SCHEMA,
+        project_id=project_id,
+        active_goal=active_goal,
+        experience_ids=tuple(ids),
+        items=tuple(items),
+        digest=digest,
+    )

--- a/agent_core/experience_observation.py
+++ b/agent_core/experience_observation.py
@@ -1,0 +1,112 @@
+"""Compile deterministic observation values from governed Experience IR.
+
+This is an execution/benchmark adapter, not an authority store. The canonical
+learned artifact remains Experience IR. Only explicit IR `set` nodes whose
+predicates are declared in `expected_behavior_dimensions` are projected.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+OBSERVATION_SCHEMA = "agentos.experience-observation-projection/v1"
+
+
+class ExperienceObservationError(ValueError):
+    pass
+
+
+def _typed_value(value: Mapping[str, Any]) -> Any:
+    if not isinstance(value, Mapping) or "type" not in value or "value" not in value:
+        raise ExperienceObservationError("IR set node requires a typed value")
+    value_type = value.get("type")
+    raw = value.get("value")
+    if value_type in {"symbol", "string"}:
+        if not isinstance(raw, str):
+            raise ExperienceObservationError("string/symbol observation must be a string")
+        return raw
+    if value_type == "boolean":
+        if not isinstance(raw, bool):
+            raise ExperienceObservationError("boolean observation must be boolean")
+        return raw
+    if value_type == "number":
+        if not isinstance(raw, (int, float)) or isinstance(raw, bool):
+            raise ExperienceObservationError("number observation must be numeric")
+        return raw
+    if value_type == "null":
+        if raw is not None:
+            raise ExperienceObservationError("null observation must be null")
+        return None
+    if value_type == "list":
+        if not isinstance(raw, list):
+            raise ExperienceObservationError("list observation must be a list")
+        return raw
+    if value_type == "object":
+        if not isinstance(raw, Mapping):
+            raise ExperienceObservationError("object observation must be an object")
+        return dict(raw)
+    raise ExperienceObservationError(f"unsupported typed observation: {value_type}")
+
+
+def compile_experience_observations(
+    hydration: Mapping[str, Any],
+    *,
+    allowed_dimensions: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Compile explicit observation values from hydrated Experience IR.
+
+    Conflicting values fail closed. Missing dimensions are reported rather than
+    guessed. This makes the weak-executor context deterministic without turning
+    display summaries or ad-hoc payloads back into the learned representation.
+    """
+    if not isinstance(hydration, Mapping):
+        raise ExperienceObservationError("hydration must be an object")
+    items = hydration.get("items")
+    if not isinstance(items, list):
+        raise ExperienceObservationError("hydration.items must be a list")
+
+    allowed = set(allowed_dimensions) if allowed_dimensions is not None else None
+    values: dict[str, Any] = {}
+    sources: dict[str, list[str]] = {}
+
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ExperienceObservationError("hydration item must be an object")
+        experience_id = item.get("experience_id")
+        if not isinstance(experience_id, str) or not experience_id:
+            raise ExperienceObservationError("hydration item experience_id is required")
+        dimensions = item.get("expected_behavior_dimensions")
+        ir = item.get("ir")
+        if not isinstance(dimensions, list) or any(not isinstance(d, str) or not d for d in dimensions):
+            raise ExperienceObservationError("expected_behavior_dimensions must be a list of strings")
+        if not isinstance(ir, Mapping) or not isinstance(ir.get("nodes"), list):
+            raise ExperienceObservationError("hydration item IR nodes are required")
+        expected = set(dimensions)
+        for node in ir["nodes"]:
+            if not isinstance(node, Mapping) or node.get("op") != "set":
+                continue
+            predicate = node.get("predicate")
+            if not isinstance(predicate, str) or predicate not in expected:
+                continue
+            if allowed is not None and predicate not in allowed:
+                continue
+            value = _typed_value(node.get("value"))
+            if predicate in values and values[predicate] != value:
+                raise ExperienceObservationError(
+                    f"conflicting Experience IR observation for {predicate}"
+                )
+            values[predicate] = value
+            sources.setdefault(predicate, []).append(experience_id)
+
+    requested = list(allowed_dimensions or ())
+    missing = [dimension for dimension in requested if dimension not in values]
+    return {
+        "schema": OBSERVATION_SCHEMA,
+        "project_id": hydration.get("project_id"),
+        "hydration_digest": hydration.get("digest"),
+        "values": values,
+        "sources": sources,
+        "missing_dimensions": missing,
+        "derived_from_experience_ir": True,
+        "credential_exposed": False,
+    }

--- a/agent_core/experience_regression.py
+++ b/agent_core/experience_regression.py
@@ -1,0 +1,171 @@
+"""Machine-readable before/after and bounded Experience attribution reports."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+DELTA_SCHEMA = "agentos.experience-behavior-delta/v1"
+ATTRIBUTION_SCHEMA = "agentos.experience-attribution/v1"
+
+VALID_DELTAS = {"improved", "unchanged-correct", "unchanged-wrong", "regressed"}
+VALID_ATTRIBUTION = {"direct", "supported", "ambiguous", "no-observed-effect", "negative"}
+
+
+def _normalize_dimensions(value: Mapping[str, Any], *, label: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    out: dict[str, dict[str, Any]] = {}
+    for dimension, result in value.items():
+        if not isinstance(dimension, str) or not dimension:
+            raise ValueError(f"{label} dimension names must be non-empty strings")
+        if not isinstance(result, Mapping) or not isinstance(result.get("pass"), bool):
+            raise ValueError(f"{label}.{dimension} requires boolean pass")
+        out[dimension] = {
+            "value": result.get("value"),
+            "pass": result["pass"],
+        }
+    return out
+
+
+def _candidate_map(hydration: Mapping[str, Any]) -> dict[str, list[str]]:
+    items = hydration.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        raise ValueError("hydration.items must be a list")
+    out: dict[str, list[str]] = {}
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ValueError("hydration item must be an object")
+        experience_id = item.get("experience_id")
+        dimensions = item.get("expected_behavior_dimensions")
+        if not isinstance(experience_id, str) or not experience_id:
+            raise ValueError("hydration item experience_id is required")
+        if not isinstance(dimensions, list) or any(not isinstance(d, str) or not d for d in dimensions):
+            raise ValueError("expected_behavior_dimensions must be a list of strings")
+        for dimension in dimensions:
+            out.setdefault(dimension, []).append(experience_id)
+    return out
+
+
+def _delta(before: bool, after: bool) -> str:
+    if not before and after:
+        return "improved"
+    if before and after:
+        return "unchanged-correct"
+    if not before and not after:
+        return "unchanged-wrong"
+    return "regressed"
+
+
+def build_behavior_delta_report(
+    *,
+    project_id: str,
+    baseline: Mapping[str, Any],
+    hydrated: Mapping[str, Any],
+    hydration_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build per-dimension A/B evidence without claiming item-level causality."""
+    if not project_id:
+        raise ValueError("project_id is required")
+    before = _normalize_dimensions(baseline, label="baseline")
+    after = _normalize_dimensions(hydrated, label="hydrated")
+    if set(before) != set(after):
+        raise ValueError("baseline and hydrated dimensions must match")
+    candidate_map = _candidate_map(hydration_manifest)
+
+    dimensions: dict[str, Any] = {}
+    for dimension in sorted(before):
+        delta = _delta(before[dimension]["pass"], after[dimension]["pass"])
+        dimensions[dimension] = {
+            "baseline": before[dimension],
+            "hydrated": after[dimension],
+            "delta": delta,
+            "candidate_experience_ids": candidate_map.get(dimension, []),
+        }
+    return {
+        "schema": DELTA_SCHEMA,
+        "project_id": project_id,
+        "hydration_digest": hydration_manifest.get("digest"),
+        "experience_ids": list(hydration_manifest.get("experience_ids") or []),
+        "dimensions": dimensions,
+        "regressed_dimensions": [
+            dimension
+            for dimension, result in dimensions.items()
+            if result["delta"] == "regressed"
+        ],
+    }
+
+
+def build_attribution_report(
+    *,
+    project_id: str,
+    full: Mapping[str, Any],
+    ablations: Mapping[str, Mapping[str, Any]],
+    hydration_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build bounded item x dimension attribution from B-minus-Ei runs.
+
+    A single ablation can support attribution but never yields ``direct``. Direct
+    attribution requires stronger repeated/targeted evidence supplied by a future
+    benchmark layer.
+    """
+    if not project_id:
+        raise ValueError("project_id is required")
+    full_dims = _normalize_dimensions(full, label="full")
+    candidates = _candidate_map(hydration_manifest)
+    expected_by_experience: dict[str, set[str]] = {}
+    for dimension, ids in candidates.items():
+        for experience_id in ids:
+            expected_by_experience.setdefault(experience_id, set()).add(dimension)
+
+    matrix: dict[str, dict[str, Any]] = {}
+    for experience_id in sorted(expected_by_experience):
+        raw_ablation = ablations.get(experience_id)
+        if raw_ablation is None:
+            matrix[experience_id] = {
+                dimension: {
+                    "full": full_dims[dimension],
+                    "without_experience": None,
+                    "observed_delta": "not-run",
+                    "confidence": "ambiguous",
+                }
+                for dimension in sorted(expected_by_experience[experience_id])
+                if dimension in full_dims
+            }
+            continue
+        ablated = _normalize_dimensions(raw_ablation, label=f"ablations.{experience_id}")
+        if set(ablated) != set(full_dims):
+            raise ValueError(f"ablation dimensions must match full for {experience_id}")
+        row: dict[str, Any] = {}
+        for dimension in sorted(expected_by_experience[experience_id]):
+            if dimension not in full_dims:
+                continue
+            full_result = full_dims[dimension]
+            without = ablated[dimension]
+            if full_result["pass"] and not without["pass"]:
+                confidence = "supported"
+                observed = "degraded-without"
+            elif not full_result["pass"] and without["pass"]:
+                confidence = "negative"
+                observed = "improved-without"
+            elif full_result == without:
+                confidence = "no-observed-effect"
+                observed = "unchanged"
+            else:
+                confidence = "ambiguous"
+                observed = "changed-but-inconclusive"
+            row[dimension] = {
+                "full": full_result,
+                "without_experience": without,
+                "observed_delta": observed,
+                "confidence": confidence,
+            }
+        matrix[experience_id] = row
+
+    return {
+        "schema": ATTRIBUTION_SCHEMA,
+        "project_id": project_id,
+        "hydration_digest": hydration_manifest.get("digest"),
+        "method": "B-minus-Ei",
+        "causal_claim_bounded": True,
+        "matrix": matrix,
+    }

--- a/agent_core/experience_store.py
+++ b/agent_core/experience_store.py
@@ -1,4 +1,10 @@
-"""ONE-owned Experience artifact persistence for issue #117."""
+"""ONE-owned Experience artifact persistence for issue #117.
+
+Accepted Experience is external ONE data. Repository JSON is a governed
+seed/provenance carrier. Schema migration is explicit and only permitted when the
+installed legacy set byte-semantically matches a repository-approved legacy seed
+and preserves the complete experience_id set.
+"""
 from __future__ import annotations
 
 from contextlib import contextmanager
@@ -13,6 +19,7 @@ from typing import Any, Iterator
 from agent_core.experience import ExperienceQuery, discover_experience, hydrate_experience, validate_experience
 
 SET_SCHEMA = "agentos.experience-set/v1"
+LEGACY_SET_SCHEMA = "agentos.experience-set/v0"
 
 
 def _data_root() -> Path:
@@ -33,6 +40,23 @@ def _canonical_bytes(value: Any) -> bytes:
 
 def digest_set(value: dict[str, Any]) -> str:
     return "sha256:" + sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _artifact_ids(value: dict[str, Any]) -> tuple[str, ...]:
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("experience set artifacts must be a list")
+    ids: list[str] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ValueError("experience artifact must be an object")
+        experience_id = str(artifact.get("experience_id") or "").strip()
+        if not experience_id:
+            raise ValueError("experience artifact id is required")
+        ids.append(experience_id)
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate experience_id")
+    return tuple(ids)
 
 
 def validate_set(value: dict[str, Any], *, project_id: str | None = None) -> dict[str, Any]:
@@ -62,6 +86,17 @@ def validate_set(value: dict[str, Any], *, project_id: str | None = None) -> dic
     return value
 
 
+def _validate_known_legacy(value: dict[str, Any], *, project_id: str) -> dict[str, Any]:
+    if value.get("schema") != LEGACY_SET_SCHEMA:
+        raise ValueError("known migration source must be Experience set v0")
+    if str(value.get("project_id") or "").strip() != project_id:
+        raise ValueError("legacy Experience project mismatch")
+    if value.get("projection_only") is not True:
+        raise ValueError("legacy Experience set must be projection-only")
+    _artifact_ids(value)
+    return value
+
+
 @contextmanager
 def _lock(path: Path) -> Iterator[None]:
     lock = path.with_suffix(path.suffix + ".lock")
@@ -76,6 +111,26 @@ def _lock(path: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+def _atomic_write(target: Path, value: dict[str, Any]) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(_canonical_bytes(value))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, target)
+        dir_fd = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
 def read_experience_set(project_id: str, *, data_root: Path | None = None) -> dict[str, Any]:
     path = experience_path(project_id, data_root=data_root)
     if path.is_symlink():
@@ -85,51 +140,86 @@ def read_experience_set(project_id: str, *, data_root: Path | None = None) -> di
     return validate_set(json.loads(path.read_text(encoding="utf-8")), project_id=project_id)
 
 
-def seed_experience_set(seed_path: Path, *, data_root: Path | None = None) -> dict[str, Any]:
+def seed_experience_set(
+    seed_path: Path,
+    *,
+    data_root: Path | None = None,
+    migrate_from: Path | None = None,
+) -> dict[str, Any]:
     seed_path = Path(seed_path)
     incoming = validate_set(json.loads(seed_path.read_text(encoding="utf-8")))
     project_id = incoming["project_id"]
     target = experience_path(project_id, data_root=data_root)
     incoming_digest = digest_set(incoming)
     target.parent.mkdir(parents=True, exist_ok=True)
+
     with _lock(target):
         if target.is_symlink():
             raise ValueError("experience store path must not be a symlink")
         if target.exists():
-            current = validate_set(json.loads(target.read_text(encoding="utf-8")), project_id=project_id)
-            current_digest = digest_set(current)
-            if current_digest != incoming_digest:
-                raise ValueError("ONE Experience already exists with a different digest; refusing implicit overwrite")
+            raw_current = json.loads(target.read_text(encoding="utf-8"))
+            if raw_current.get("schema") == SET_SCHEMA:
+                current = validate_set(raw_current, project_id=project_id)
+                current_digest = digest_set(current)
+                if current_digest != incoming_digest:
+                    raise ValueError("ONE Experience already exists with a different digest; refusing implicit overwrite")
+                return {
+                    "schema": "agentos.experience-seed-receipt/v1",
+                    "ok": True,
+                    "seeded": False,
+                    "migrated": False,
+                    "project_id": project_id,
+                    "digest": current_digest,
+                    "path": str(target),
+                    "credential_exposed": False,
+                }
+
+            if migrate_from is None:
+                raise ValueError("legacy ONE Experience requires an explicit known migration source")
+            expected_path = Path(migrate_from)
+            expected_legacy = _validate_known_legacy(
+                json.loads(expected_path.read_text(encoding="utf-8")),
+                project_id=project_id,
+            )
+            current_legacy = _validate_known_legacy(raw_current, project_id=project_id)
+            current_digest = digest_set(current_legacy)
+            expected_digest = digest_set(expected_legacy)
+            if current_digest != expected_digest:
+                raise ValueError("installed legacy Experience does not match approved migration source")
+            if set(_artifact_ids(current_legacy)) != set(_artifact_ids(incoming)):
+                raise ValueError("Experience migration would add/drop accepted experience IDs; refusing migration")
+
+            backup = target.with_name(f"accepted.v0.{current_digest.split(':', 1)[1]}.json")
+            if backup.is_symlink():
+                raise ValueError("Experience migration backup path must not be a symlink")
+            if backup.exists():
+                backup_value = json.loads(backup.read_text(encoding="utf-8"))
+                if digest_set(backup_value) != current_digest:
+                    raise ValueError("Experience migration backup exists with unexpected content")
+            else:
+                _atomic_write(backup, current_legacy)
+            _atomic_write(target, incoming)
             return {
                 "schema": "agentos.experience-seed-receipt/v1",
                 "ok": True,
-                "seeded": False,
+                "seeded": True,
+                "migrated": True,
                 "project_id": project_id,
-                "digest": current_digest,
+                "from_schema": LEGACY_SET_SCHEMA,
+                "from_digest": current_digest,
+                "digest": incoming_digest,
+                "backup_path": str(backup),
                 "path": str(target),
                 "credential_exposed": False,
             }
-        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
-        tmp = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(_canonical_bytes(incoming))
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.chmod(tmp, 0o640)
-            os.replace(tmp, target)
-            dir_fd = os.open(target.parent, os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        finally:
-            if tmp.exists():
-                tmp.unlink()
+
+        _atomic_write(target, incoming)
+
     return {
         "schema": "agentos.experience-seed-receipt/v1",
         "ok": True,
         "seeded": True,
+        "migrated": False,
         "project_id": project_id,
         "digest": incoming_digest,
         "path": str(target),

--- a/agent_core/experience_store.py
+++ b/agent_core/experience_store.py
@@ -1,0 +1,168 @@
+"""ONE-owned Experience artifact persistence for issue #117."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Iterator
+
+from agent_core.experience import ExperienceQuery, discover_experience, hydrate_experience, validate_experience
+
+SET_SCHEMA = "agentos.experience-set/v1"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+
+
+def experience_path(project_id: str, *, data_root: Path | None = None) -> Path:
+    project_id = str(project_id or "").strip()
+    if not project_id or "/" in project_id or "\\" in project_id or project_id in {".", ".."}:
+        raise ValueError("invalid project_id")
+    root = data_root or _data_root()
+    return root / "experience" / project_id / "accepted.json"
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def digest_set(value: dict[str, Any]) -> str:
+    return "sha256:" + sha256(_canonical_bytes(value)).hexdigest()
+
+
+def validate_set(value: dict[str, Any], *, project_id: str | None = None) -> dict[str, Any]:
+    if value.get("schema") != SET_SCHEMA:
+        raise ValueError("unsupported experience set schema")
+    actual = str(value.get("project_id") or "").strip()
+    if not actual:
+        raise ValueError("experience set project_id is required")
+    if project_id is not None and actual != project_id:
+        raise ValueError("experience set project mismatch")
+    if value.get("projection_only") is not True:
+        raise ValueError("experience set must declare projection_only=true")
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("experience set artifacts must be a list")
+    seen: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ValueError("experience artifact must be an object")
+        validate_experience(artifact)
+        if artifact["project_id"] != actual:
+            raise ValueError("experience artifact project mismatch")
+        experience_id = artifact["experience_id"]
+        if experience_id in seen:
+            raise ValueError(f"duplicate experience_id: {experience_id}")
+        seen.add(experience_id)
+    return value
+
+
+@contextmanager
+def _lock(path: Path) -> Iterator[None]:
+    lock = path.with_suffix(path.suffix + ".lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    if lock.is_symlink():
+        raise ValueError("experience lock path must not be a symlink")
+    with lock.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def read_experience_set(project_id: str, *, data_root: Path | None = None) -> dict[str, Any]:
+    path = experience_path(project_id, data_root=data_root)
+    if path.is_symlink():
+        raise ValueError("experience store path must not be a symlink")
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return validate_set(json.loads(path.read_text(encoding="utf-8")), project_id=project_id)
+
+
+def seed_experience_set(seed_path: Path, *, data_root: Path | None = None) -> dict[str, Any]:
+    seed_path = Path(seed_path)
+    incoming = validate_set(json.loads(seed_path.read_text(encoding="utf-8")))
+    project_id = incoming["project_id"]
+    target = experience_path(project_id, data_root=data_root)
+    incoming_digest = digest_set(incoming)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with _lock(target):
+        if target.is_symlink():
+            raise ValueError("experience store path must not be a symlink")
+        if target.exists():
+            current = validate_set(json.loads(target.read_text(encoding="utf-8")), project_id=project_id)
+            current_digest = digest_set(current)
+            if current_digest != incoming_digest:
+                raise ValueError("ONE Experience already exists with a different digest; refusing implicit overwrite")
+            return {
+                "schema": "agentos.experience-seed-receipt/v1",
+                "ok": True,
+                "seeded": False,
+                "project_id": project_id,
+                "digest": current_digest,
+                "path": str(target),
+                "credential_exposed": False,
+            }
+        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(_canonical_bytes(incoming))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp, 0o640)
+            os.replace(tmp, target)
+            dir_fd = os.open(target.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+    return {
+        "schema": "agentos.experience-seed-receipt/v1",
+        "ok": True,
+        "seeded": True,
+        "project_id": project_id,
+        "digest": incoming_digest,
+        "path": str(target),
+        "credential_exposed": False,
+    }
+
+
+def discover_from_one(query: ExperienceQuery, *, data_root: Path | None = None) -> list[dict[str, Any]]:
+    value = read_experience_set(query.project_id, data_root=data_root)
+    return [dict(item) for item in discover_experience(value["artifacts"], query)]
+
+
+def hydrate_from_one(
+    *,
+    project_id: str,
+    active_goal: str,
+    realm: str | None = None,
+    capabilities: tuple[str, ...] = (),
+    executor: str | None = None,
+    limit: int = 20,
+    data_root: Path | None = None,
+) -> dict[str, Any]:
+    artifacts = discover_from_one(
+        ExperienceQuery(
+            project_id=project_id,
+            realm=realm,
+            capabilities=capabilities,
+            executor=executor,
+            limit=limit,
+        ),
+        data_root=data_root,
+    )
+    projection = hydrate_experience(project_id=project_id, active_goal=active_goal, artifacts=artifacts).as_dict()
+    projection["source"] = "ONE_EXPERIENCE"
+    projection["credential_exposed"] = False
+    return projection

--- a/agentos_node/experience_mcp_stdio.py
+++ b/agentos_node/experience_mcp_stdio.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from agent_core.experience import ExperienceQuery
+from agent_core.experience_store import discover_from_one, hydrate_from_one
+
+SURFACE = "codex-local"
+EXECUTOR_CLASS = "openai-codex-local"
+RECEIPT_SCHEMA = "agentos.experience-hydration-receipt/v2"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _source_commit() -> str:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    return Path(__file__).resolve().parents[1].name
+
+
+def _receipt_path() -> Path:
+    return Path(
+        os.environ.get(
+            "AGENTOS_EXPERIENCE_HYDRATION_RECEIPT",
+            str(_data_root() / "runtime" / "experience-hydration-last.json"),
+        )
+    ).expanduser()
+
+
+def _write_receipt(projection: dict[str, Any]) -> None:
+    path = _receipt_path()
+    if path.is_symlink():
+        raise ValueError("Experience hydration receipt path must not be a symlink")
+    payload = {
+        "schema": RECEIPT_SCHEMA,
+        "recorded_at": _utc_now(),
+        "runtime_source_commit": _source_commit(),
+        "source": projection.get("source"),
+        "surface": SURFACE,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "project_id": projection.get("project_id"),
+        "projection_digest": projection.get("digest"),
+        "experience_ids": list(projection.get("experience_ids") or []),
+        "semantic_manifest": [
+            {
+                "experience_id": item.get("experience_id"),
+                "semantic_digest": item.get("semantic_digest"),
+                "expected_behavior_dimensions": list(item.get("expected_behavior_dimensions") or []),
+            }
+            for item in (projection.get("items") or [])
+            if isinstance(item, dict)
+        ],
+        "credential_exposed": False,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def _project(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema": "agentos.experience-discovery/v2",
+        "source": "ONE_EXPERIENCE",
+        "surface": SURFACE,
+        "executor_class": EXECUTOR_CLASS,
+        "executor_identity_bound": True,
+        "experience_ids": [item.get("experience_id") for item in items],
+        "items": items,
+        "credential_exposed": False,
+    }
+
+
+def one_experience_discover(
+    project_id: str,
+    realm: str = "oracle",
+    capabilities: list[str] | None = None,
+    executor: str = "codex",
+    limit: int = 20,
+) -> dict[str, Any]:
+    items = discover_from_one(
+        ExperienceQuery(
+            project_id=project_id,
+            realm=realm or None,
+            capabilities=tuple(capabilities or ()),
+            executor=executor or None,
+            limit=limit,
+        ),
+        data_root=_data_root(),
+    )
+    return _project(items)
+
+
+def one_experience_hydrate(
+    project_id: str,
+    active_goal: str,
+    realm: str = "oracle",
+    capabilities: list[str] | None = None,
+    executor: str = "codex",
+    limit: int = 20,
+) -> dict[str, Any]:
+    projection = hydrate_from_one(
+        project_id=project_id,
+        active_goal=active_goal,
+        realm=realm or None,
+        capabilities=tuple(capabilities or ()),
+        executor=executor or None,
+        limit=limit,
+        data_root=_data_root(),
+    )
+    projection["surface"] = SURFACE
+    projection["executor_class"] = EXECUTOR_CLASS
+    projection["executor_identity_bound"] = True
+    projection["credential_exposed"] = False
+    _write_receipt(projection)
+    return projection
+
+
+def create_server():
+    from mcp.server.mcpserver import MCPServer
+
+    server = MCPServer("AgentOS ONE Experience", version="0.2.0")
+    server.tool()(one_experience_discover)
+    server.tool()(one_experience_hydrate)
+    return server
+
+
+def main() -> int:
+    create_server().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ONE_EXPERIENCE_IR.md
+++ b/docs/ONE_EXPERIENCE_IR.md
@@ -1,0 +1,92 @@
+# ONE Experience IR
+
+Status: Core implementation slice for Issue #117. This document does **not** promote general Cognitive IR from Research.
+
+## Decision
+
+ONE Experience is a governed projection/artifact layer over canonical state and accepted evidence. It is not a fourth authority store.
+
+The reusable lesson itself is represented as **Experience IR** (`agentos.experience-ir/v1`). A prose summary is optional display metadata only. Executors hydrate IR, provenance references, semantic digests, and expected benchmark dimensions; they do not depend on a required natural-language summary.
+
+This distinction is intentional:
+
+- Canonical IR (`agentos.ir/v1`) represents current project continuation/state.
+- Experience IR (`agentos.experience-ir/v1`) represents reusable learned constraints, procedures, heuristics, decisions, failure patterns, or benchmark patterns.
+- Experience IR is **not** claimed to be a universal/model-cognitive IR.
+- Accepted evidence and existing governance remain authoritative. A Node/executor may propose Experience but may not self-authorize acceptance.
+
+## Artifact chain
+
+1. **Extraction proposal** (`agentos.experience-extraction/v1`)
+   - identifies origin node/surface/executor/backend where trustworthy;
+   - references canonical source evidence;
+   - records what facts were generalized and what was excluded;
+   - carries a candidate governed Experience artifact;
+   - candidate authority must remain `candidate`.
+
+2. **Governed Experience artifact** (`agentos.experience/v1`)
+   - has stable `experience_id`, project/scope, kind, IR, provenance, authority, and validity;
+   - may have `display.summary`, but display text is non-authoritative and excluded from the semantic digest.
+
+3. **Hydration projection** (`agentos.experience-hydration/v1`)
+   - includes exact Experience IDs;
+   - includes each semantic IR and semantic digest;
+   - maps each Experience item to the behavior dimensions it is expected to influence;
+   - has a stable projection digest.
+
+4. **Behavior delta report** (`agentos.experience-behavior-delta/v1`)
+   - stores baseline/hydrated parsed value and pass state per dimension;
+   - classifies `improved`, `unchanged-correct`, `unchanged-wrong`, or `regressed`;
+   - lists candidate Experience IDs, without claiming item-level causality.
+
+5. **Attribution report** (`agentos.experience-attribution/v1`)
+   - consumes B-minus-Ei ablation runs;
+   - emits an `experience_id × behavior_dimension` matrix;
+   - a single ablation can yield `supported`, `ambiguous`, `no-observed-effect`, or `negative`;
+   - this layer deliberately does not emit `direct` from one stochastic ablation.
+
+## Experience IR v1
+
+An Experience IR contains:
+
+- `nodes`: typed semantic operations;
+- `entrypoints`: the semantic units to project;
+- `expected_behavior_dimensions`: benchmark dimensions that should be observable if the lesson is inherited.
+
+Each node has:
+
+- stable local `id`;
+- `op`: `assert | require | forbid | prefer | avoid | invoke | match | set`;
+- semantic `predicate`;
+- typed `arguments` and optional typed `value`.
+
+This makes an Experience item independently selectable and removable for ablation. The unit of regression is therefore the stable `experience_id`, not a paragraph of prompt text.
+
+## Hash semantics
+
+`experience_semantic_digest()` excludes optional human `display` metadata. Changing wording must not create the illusion of a new learned behavior. Changing IR, scope, kind, validity, project, or identity changes the semantic digest.
+
+The hydration digest is computed over the exact semantic projection delivered to the executor.
+
+## Authority and safety invariants
+
+- only `accepted` Experience may hydrate;
+- superseded or invalidated Experience is not discovered;
+- Experience availability never grants mutation/execution/publication authority;
+- candidate extraction cannot self-authorize acceptance;
+- credential-like keys are rejected recursively from Experience IR/artifacts/proposals;
+- runtime accepted Experience remains ONE-owned data, seeded idempotently and refusing implicit overwrite.
+
+## #117 promotion boundary
+
+This slice provides the contract needed for observable extraction, hydration manifests, before/after diffs, and bounded ablation attribution. It does **not** by itself prove the Master Experience Floor.
+
+Issue #117 remains open until a real fresh executor run persists:
+
+- A: no Experience;
+- B: full accepted Experience IR set;
+- B-minus-Ei/group ablations for material lessons;
+- per-dimension delta;
+- bounded attribution;
+- privacy/authority checks;
+- repeatability evidence where stochasticity matters.

--- a/experience/agentos-core-oracle.seed.json
+++ b/experience/agentos-core-oracle.seed.json
@@ -5,79 +5,166 @@
   "artifacts": [
     {
       "schema": "agentos.experience/v1",
-      "experience_id": "core.workspace-not-continuation-authority.v1",
+      "experience_id": "core.branch-authority.v2",
       "project_id": "agentos-core",
       "realm_scope": ["*"],
-      "capability_scope": ["agentos.one.resolve"],
-      "executor_scope": [],
+      "capability_scope": ["agentos.core.develop", "repository.merge"],
+      "executor_scope": ["*"],
+      "kind": "decision",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {"id": "integration-branch", "op": "require", "predicate": "core.development.integration_branch", "arguments": [{"type": "symbol", "value": "core/integration"}]},
+          {"id": "issue-branch", "op": "require", "predicate": "core.development.focused_branch_pattern", "arguments": [{"type": "string", "value": "core/issue-<N>-<slug>"}]},
+          {"id": "runtime-facts-not-experience", "op": "forbid", "predicate": "experience.contains_mutable_runtime_fact", "arguments": [{"type": "symbol", "value": "BRANCH_HEAD_PID_HEALTH_OR_CHECKOUT_SHA"}]},
+          {"id": "deployment-needs-evidence", "op": "forbid", "predicate": "deployment.acceptance_source", "arguments": [{"type": "symbol", "value": "MUTABLE_RUNTIME_OBSERVATION_ONLY"}]}
+        ],
+        "entrypoints": ["integration-branch", "issue-branch", "runtime-facts-not-experience", "deployment-needs-evidence"],
+        "expected_behavior_dimensions": ["uses_core_integration", "mutable_runtime_fact_as_experience", "branch_head_implies_deployment_acceptance"]
+      },
+      "display": {"summary": "Core development uses core/integration plus focused core/issue-* branches; mutable runtime facts are resolved live rather than learned as Experience."},
+      "provenance": {"sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"], "accepted_evidence": []},
+      "authority": {"status": "accepted", "supersedes": ["core.branch-and-runtime-authority.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.protected-main-human-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["repository.mutate", "repository.merge"],
+      "executor_scope": ["*"],
       "kind": "constraint",
       "ir": {
         "schema": "agentos.experience-ir/v1",
         "nodes": [
-          {
-            "id": "canonical-authority",
-            "op": "require",
-            "predicate": "continuation.authority",
-            "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR"}]
-          },
-          {
-            "id": "reject-workspace-authority",
-            "op": "forbid",
-            "predicate": "continuation.authority",
-            "arguments": [{"type": "symbol", "value": "WORKSPACE_VENDOR_HISTORY"}]
-          }
+          {"id": "main-human-authority", "op": "require", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "SEPARATE_EXPLICIT_HUMAN_AUTHORIZATION"}]},
+          {"id": "continue-not-authority", "op": "forbid", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "GENERIC_CONTINUE"}]},
+          {"id": "capability-not-authority", "op": "forbid", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "TOOL_CAPABILITY_CI_OR_MERGEABILITY"}]}
         ],
-        "entrypoints": ["canonical-authority", "reject-workspace-authority"],
-        "expected_behavior_dimensions": ["workspace_is_continuation_authority"]
+        "entrypoints": ["main-human-authority", "continue-not-authority", "capability-not-authority"],
+        "expected_behavior_dimensions": ["generic_continue_is_protected_main_merge_authority", "capability_implies_protected_main_authority"]
       },
-      "display": {
-        "summary": "Workspace or vendor-local history is not continuation authority; resolve ONE Canonical IR."
-      },
-      "provenance": {
-        "sources": ["github-issue://alston-personal/agentmanager/152"],
-        "accepted_evidence": ["agentos-evidence://continuity/issue-152/e3"],
-        "extraction_id": "agentos-extraction://agentos-core/152/workspace-authority"
-      },
+      "display": {"summary": "Protected-main merge requires separate explicit human authorization; CI, capability, mergeability, or generic continue do not grant it."},
+      "provenance": {"sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"], "accepted_evidence": ["github-ruleset://21844290"]},
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
     {
       "schema": "agentos.experience/v1",
-      "experience_id": "core.generic-continue-not-merge-authority.v1",
+      "experience_id": "core.evidence-scope-and-capability-semantics.v2",
       "project_id": "agentos-core",
       "realm_scope": ["*"],
-      "capability_scope": ["repository.merge"],
-      "executor_scope": [],
+      "capability_scope": ["agentos.one.resolve", "agentos.controller.dispatch", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "heuristic",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {"id": "exact-evidence-path", "op": "require", "predicate": "evidence.claim_path_match", "arguments": [{"type": "boolean", "value": true}]},
+          {"id": "capability-states-distinct", "op": "assert", "predicate": "capability.states_are_distinct", "value": {"type": "list", "value": ["advertised", "transport-routable", "execution-authorized", "successfully-executed"]}},
+          {"id": "dispatch-not-resolve-proof", "op": "forbid", "predicate": "evidence.resolve_proof_source", "arguments": [{"type": "symbol", "value": "CONTROLLER_DISPATCH_ONLY"}]},
+          {"id": "capability-not-execution-authority", "op": "forbid", "predicate": "execution.authority_source", "arguments": [{"type": "symbol", "value": "CAPABILITY_ADVERTISEMENT_ONLY"}]}
+        ],
+        "entrypoints": ["exact-evidence-path", "capability-states-distinct", "dispatch-not-resolve-proof", "capability-not-execution-authority"],
+        "expected_behavior_dimensions": ["evidence_scope_exact", "controller_dispatch_proves_resolve", "capability_implies_execution_authority"]
+      },
+      "display": {"summary": "Evidence must prove the exact claimed path; advertised, routable, authorized, and successfully executed capability states remain distinct."},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"], "accepted_evidence": ["issue-64://controller-service-entered"]},
+      "authority": {"status": "accepted", "supersedes": ["core.evidence-scope-and-capability-semantics.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.discover-before-reinvent.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.capability.discover", "project.resolve"],
+      "executor_scope": ["*"],
+      "kind": "procedure",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {"id": "resolve-project", "op": "invoke", "predicate": "project.resolve_identity"},
+          {"id": "discover-existing", "op": "invoke", "predicate": "project.discover_responsibility_resources_capabilities"},
+          {"id": "reuse-accepted", "op": "prefer", "predicate": "implementation.reuse_accepted_capability"},
+          {"id": "use-owning-core-issue", "op": "require", "predicate": "missing_shared_capability.ownership", "arguments": [{"type": "symbol", "value": "OWNING_CORE_ISSUE"}]},
+          {"id": "implement-after-discovery", "op": "forbid", "predicate": "implementation.parallel_reinvention_before_discovery"}
+        ],
+        "entrypoints": ["resolve-project", "discover-existing", "reuse-accepted", "use-owning-core-issue", "implement-after-discovery"],
+        "expected_behavior_dimensions": ["discovers_existing_capability_before_implementing", "respects_core_ownership"]
+      },
+      "display": {"summary": "Resolve project identity and existing responsibilities/resources/capabilities before creating parallel implementations."},
+      "provenance": {"sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"], "accepted_evidence": []},
+      "authority": {"status": "accepted", "supersedes": ["core.discover-before-reinvent.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.workspace-not-continuation-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve", "project.resolve"],
+      "executor_scope": ["*"],
       "kind": "constraint",
       "ir": {
         "schema": "agentos.experience-ir/v1",
         "nodes": [
-          {
-            "id": "continue-not-authority",
-            "op": "forbid",
-            "predicate": "repository.merge.authorization_source",
-            "arguments": [{"type": "symbol", "value": "GENERIC_CONTINUE"}]
-          },
-          {
-            "id": "require-explicit-authority",
-            "op": "require",
-            "predicate": "repository.merge.authorization_source",
-            "arguments": [{"type": "symbol", "value": "EXPLICIT_CANONICAL_AUTHORITY"}]
-          }
+          {"id": "canonical-authority", "op": "require", "predicate": "continuation.authority", "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR_ACTIVE_POINTER"}]},
+          {"id": "reject-workspace-authority", "op": "forbid", "predicate": "continuation.authority", "arguments": [{"type": "symbol", "value": "IDE_WORKSPACE_GIT_STATUS_LOCAL_TODO_VENDOR_HISTORY_PULSE_OR_MODEL_MEMORY"}]}
         ],
-        "entrypoints": ["continue-not-authority", "require-explicit-authority"],
-        "expected_behavior_dimensions": ["generic_continue_is_merge_authority"]
+        "entrypoints": ["canonical-authority", "reject-workspace-authority"],
+        "expected_behavior_dimensions": ["workspace_is_continuation_authority"]
       },
-      "display": {
-        "summary": "A generic continuation request does not itself authorize repository merge/publication."
-      },
-      "provenance": {
-        "sources": ["github-issue://alston-personal/agentmanager/117"],
-        "accepted_evidence": ["agentos-governance://core/publication-authority"],
-        "extraction_id": "agentos-extraction://agentos-core/117/merge-authority"
-      },
+      "display": {"summary": "Workspace/vendor-local state is not durable continuation authority; resolve ONE Canonical IR selected by the active continuation pointer."},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY_VERIFIED"]},
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.node-executor-boundary.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["executor.dispatch", "executor.liveness", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {"id": "node-executor-distinct", "op": "assert", "predicate": "realm.node_and_executor_are_distinct", "value": {"type": "boolean", "value": true}},
+          {"id": "node-online-not-liveness", "op": "forbid", "predicate": "executor.liveness_proof_source", "arguments": [{"type": "symbol", "value": "NODE_ONLINE_ONLY"}]},
+          {"id": "executor-no-realm-credential-ownership", "op": "forbid", "predicate": "realm.transport_credential_owner", "arguments": [{"type": "symbol", "value": "EXECUTOR_ADAPTER"}]}
+        ],
+        "entrypoints": ["node-executor-distinct", "node-online-not-liveness", "executor-no-realm-credential-ownership"],
+        "expected_behavior_dimensions": ["node_and_executor_are_distinct", "node_online_implies_executor_available", "executor_owns_realm_credentials"]
+      },
+      "display": {"summary": "Nodes are durable Realm/control participants; executors are independent capability providers, so Node online does not prove executor liveness."},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://node-executor-boundary"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "executor.antigravity-relay-liveness.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["oracle"],
+      "capability_scope": ["executor.dispatch", "executor.liveness"],
+      "executor_scope": ["antigravity", "claude"],
+      "kind": "failure-pattern",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {"id": "enqueue-not-liveness", "op": "forbid", "predicate": "executor.liveness_proof_source", "arguments": [{"type": "symbol", "value": "RELAY_ENQUEUE_ONLY"}]},
+          {"id": "fresh-success-required", "op": "require", "predicate": "executor.trusted_workload_precondition", "arguments": [{"type": "symbol", "value": "FRESH_SUCCESSFUL_DETERMINISTIC_LIVENESS_RECEIPT"}]}
+        ],
+        "entrypoints": ["enqueue-not-liveness", "fresh-success-required"],
+        "expected_behavior_dimensions": ["relay_enqueue_proves_executor_liveness", "fresh_liveness_receipt_required"]
+      },
+      "display": {"summary": "Relay enqueue alone does not prove Claude executor liveness; a historical timeout exists, so trust requires a fresh successful deterministic liveness receipt."},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/72"], "accepted_evidence": ["workflow-run://33227123813"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": ["historical failure remains relevant until a newer successful liveness regression supersedes it"], "invalidated_by": []}
     }
   ]
 }

--- a/experience/agentos-core-oracle.seed.json
+++ b/experience/agentos-core-oracle.seed.json
@@ -17,10 +17,11 @@
           {"id": "integration-branch", "op": "require", "predicate": "core.development.integration_branch", "arguments": [{"type": "symbol", "value": "core/integration"}]},
           {"id": "issue-branch", "op": "require", "predicate": "core.development.focused_branch_pattern", "arguments": [{"type": "string", "value": "core/issue-<N>-<slug>"}]},
           {"id": "runtime-facts-not-experience", "op": "forbid", "predicate": "experience.contains_mutable_runtime_fact", "arguments": [{"type": "symbol", "value": "BRANCH_HEAD_PID_HEALTH_OR_CHECKOUT_SHA"}]},
-          {"id": "deployment-needs-evidence", "op": "forbid", "predicate": "deployment.acceptance_source", "arguments": [{"type": "symbol", "value": "MUTABLE_RUNTIME_OBSERVATION_ONLY"}]}
+          {"id": "deployment-needs-evidence", "op": "forbid", "predicate": "deployment.acceptance_source", "arguments": [{"type": "symbol", "value": "MUTABLE_RUNTIME_OBSERVATION_ONLY"}]},
+          {"id": "observe-canonical-branch", "op": "set", "predicate": "canonical_development_branch", "value": {"type": "string", "value": "core/integration"}}
         ],
-        "entrypoints": ["integration-branch", "issue-branch", "runtime-facts-not-experience", "deployment-needs-evidence"],
-        "expected_behavior_dimensions": ["uses_core_integration", "mutable_runtime_fact_as_experience", "branch_head_implies_deployment_acceptance"]
+        "entrypoints": ["integration-branch", "issue-branch", "runtime-facts-not-experience", "deployment-needs-evidence", "observe-canonical-branch"],
+        "expected_behavior_dimensions": ["canonical_development_branch"]
       },
       "display": {"summary": "Core development uses core/integration plus focused core/issue-* branches; mutable runtime facts are resolved live rather than learned as Experience."},
       "provenance": {"sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"], "accepted_evidence": []},
@@ -40,10 +41,11 @@
         "nodes": [
           {"id": "main-human-authority", "op": "require", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "SEPARATE_EXPLICIT_HUMAN_AUTHORIZATION"}]},
           {"id": "continue-not-authority", "op": "forbid", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "GENERIC_CONTINUE"}]},
-          {"id": "capability-not-authority", "op": "forbid", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "TOOL_CAPABILITY_CI_OR_MERGEABILITY"}]}
+          {"id": "capability-not-authority", "op": "forbid", "predicate": "repository.protected_main.merge_authority", "arguments": [{"type": "symbol", "value": "TOOL_CAPABILITY_CI_OR_MERGEABILITY"}]},
+          {"id": "observe-generic-continue", "op": "set", "predicate": "generic_continue_authorizes_main_merge", "value": {"type": "boolean", "value": false}}
         ],
-        "entrypoints": ["main-human-authority", "continue-not-authority", "capability-not-authority"],
-        "expected_behavior_dimensions": ["generic_continue_is_protected_main_merge_authority", "capability_implies_protected_main_authority"]
+        "entrypoints": ["main-human-authority", "continue-not-authority", "capability-not-authority", "observe-generic-continue"],
+        "expected_behavior_dimensions": ["generic_continue_authorizes_main_merge"]
       },
       "display": {"summary": "Protected-main merge requires separate explicit human authorization; CI, capability, mergeability, or generic continue do not grant it."},
       "provenance": {"sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"], "accepted_evidence": ["github-ruleset://21844290"]},
@@ -64,10 +66,11 @@
           {"id": "exact-evidence-path", "op": "require", "predicate": "evidence.claim_path_match", "arguments": [{"type": "boolean", "value": true}]},
           {"id": "capability-states-distinct", "op": "assert", "predicate": "capability.states_are_distinct", "value": {"type": "list", "value": ["advertised", "transport-routable", "execution-authorized", "successfully-executed"]}},
           {"id": "dispatch-not-resolve-proof", "op": "forbid", "predicate": "evidence.resolve_proof_source", "arguments": [{"type": "symbol", "value": "CONTROLLER_DISPATCH_ONLY"}]},
-          {"id": "capability-not-execution-authority", "op": "forbid", "predicate": "execution.authority_source", "arguments": [{"type": "symbol", "value": "CAPABILITY_ADVERTISEMENT_ONLY"}]}
+          {"id": "capability-not-execution-authority", "op": "forbid", "predicate": "execution.authority_source", "arguments": [{"type": "symbol", "value": "CAPABILITY_ADVERTISEMENT_ONLY"}]},
+          {"id": "observe-capability-authority", "op": "set", "predicate": "capability_implies_execution_authority", "value": {"type": "boolean", "value": false}}
         ],
-        "entrypoints": ["exact-evidence-path", "capability-states-distinct", "dispatch-not-resolve-proof", "capability-not-execution-authority"],
-        "expected_behavior_dimensions": ["evidence_scope_exact", "controller_dispatch_proves_resolve", "capability_implies_execution_authority"]
+        "entrypoints": ["exact-evidence-path", "capability-states-distinct", "dispatch-not-resolve-proof", "capability-not-execution-authority", "observe-capability-authority"],
+        "expected_behavior_dimensions": ["capability_implies_execution_authority"]
       },
       "display": {"summary": "Evidence must prove the exact claimed path; advertised, routable, authorized, and successfully executed capability states remain distinct."},
       "provenance": {"sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"], "accepted_evidence": ["issue-64://controller-service-entered"]},
@@ -89,10 +92,11 @@
           {"id": "discover-existing", "op": "invoke", "predicate": "project.discover_responsibility_resources_capabilities"},
           {"id": "reuse-accepted", "op": "prefer", "predicate": "implementation.reuse_accepted_capability"},
           {"id": "use-owning-core-issue", "op": "require", "predicate": "missing_shared_capability.ownership", "arguments": [{"type": "symbol", "value": "OWNING_CORE_ISSUE"}]},
-          {"id": "implement-after-discovery", "op": "forbid", "predicate": "implementation.parallel_reinvention_before_discovery"}
+          {"id": "implement-after-discovery", "op": "forbid", "predicate": "implementation.parallel_reinvention_before_discovery"},
+          {"id": "observe-discovery-order", "op": "set", "predicate": "discovery_before_reimplementation", "value": {"type": "boolean", "value": true}}
         ],
-        "entrypoints": ["resolve-project", "discover-existing", "reuse-accepted", "use-owning-core-issue", "implement-after-discovery"],
-        "expected_behavior_dimensions": ["discovers_existing_capability_before_implementing", "respects_core_ownership"]
+        "entrypoints": ["resolve-project", "discover-existing", "reuse-accepted", "use-owning-core-issue", "implement-after-discovery", "observe-discovery-order"],
+        "expected_behavior_dimensions": ["discovery_before_reimplementation"]
       },
       "display": {"summary": "Resolve project identity and existing responsibilities/resources/capabilities before creating parallel implementations."},
       "provenance": {"sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"], "accepted_evidence": []},
@@ -111,9 +115,10 @@
         "schema": "agentos.experience-ir/v1",
         "nodes": [
           {"id": "canonical-authority", "op": "require", "predicate": "continuation.authority", "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR_ACTIVE_POINTER"}]},
-          {"id": "reject-workspace-authority", "op": "forbid", "predicate": "continuation.authority", "arguments": [{"type": "symbol", "value": "IDE_WORKSPACE_GIT_STATUS_LOCAL_TODO_VENDOR_HISTORY_PULSE_OR_MODEL_MEMORY"}]}
+          {"id": "reject-workspace-authority", "op": "forbid", "predicate": "continuation.authority", "arguments": [{"type": "symbol", "value": "IDE_WORKSPACE_GIT_STATUS_LOCAL_TODO_VENDOR_HISTORY_PULSE_OR_MODEL_MEMORY"}]},
+          {"id": "observe-workspace-authority", "op": "set", "predicate": "workspace_is_continuation_authority", "value": {"type": "boolean", "value": false}}
         ],
-        "entrypoints": ["canonical-authority", "reject-workspace-authority"],
+        "entrypoints": ["canonical-authority", "reject-workspace-authority", "observe-workspace-authority"],
         "expected_behavior_dimensions": ["workspace_is_continuation_authority"]
       },
       "display": {"summary": "Workspace/vendor-local state is not durable continuation authority; resolve ONE Canonical IR selected by the active continuation pointer."},
@@ -134,10 +139,12 @@
         "nodes": [
           {"id": "node-executor-distinct", "op": "assert", "predicate": "realm.node_and_executor_are_distinct", "value": {"type": "boolean", "value": true}},
           {"id": "node-online-not-liveness", "op": "forbid", "predicate": "executor.liveness_proof_source", "arguments": [{"type": "symbol", "value": "NODE_ONLINE_ONLY"}]},
-          {"id": "executor-no-realm-credential-ownership", "op": "forbid", "predicate": "realm.transport_credential_owner", "arguments": [{"type": "symbol", "value": "EXECUTOR_ADAPTER"}]}
+          {"id": "executor-no-realm-credential-ownership", "op": "forbid", "predicate": "realm.transport_credential_owner", "arguments": [{"type": "symbol", "value": "EXECUTOR_ADAPTER"}]},
+          {"id": "observe-node-liveness", "op": "set", "predicate": "node_online_implies_executor_available", "value": {"type": "boolean", "value": false}},
+          {"id": "observe-credential-owner", "op": "set", "predicate": "executor_owns_realm_credentials", "value": {"type": "boolean", "value": false}}
         ],
-        "entrypoints": ["node-executor-distinct", "node-online-not-liveness", "executor-no-realm-credential-ownership"],
-        "expected_behavior_dimensions": ["node_and_executor_are_distinct", "node_online_implies_executor_available", "executor_owns_realm_credentials"]
+        "entrypoints": ["node-executor-distinct", "node-online-not-liveness", "executor-no-realm-credential-ownership", "observe-node-liveness", "observe-credential-owner"],
+        "expected_behavior_dimensions": ["node_online_implies_executor_available", "executor_owns_realm_credentials"]
       },
       "display": {"summary": "Nodes are durable Realm/control participants; executors are independent capability providers, so Node online does not prove executor liveness."},
       "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://node-executor-boundary"]},

--- a/experience/agentos-core-oracle.seed.json
+++ b/experience/agentos-core-oracle.seed.json
@@ -1,0 +1,83 @@
+{
+  "schema": "agentos.experience-set/v1",
+  "project_id": "agentos-core",
+  "projection_only": true,
+  "artifacts": [
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.workspace-not-continuation-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve"],
+      "executor_scope": [],
+      "kind": "constraint",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {
+            "id": "canonical-authority",
+            "op": "require",
+            "predicate": "continuation.authority",
+            "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR"}]
+          },
+          {
+            "id": "reject-workspace-authority",
+            "op": "forbid",
+            "predicate": "continuation.authority",
+            "arguments": [{"type": "symbol", "value": "WORKSPACE_VENDOR_HISTORY"}]
+          }
+        ],
+        "entrypoints": ["canonical-authority", "reject-workspace-authority"],
+        "expected_behavior_dimensions": ["workspace_is_continuation_authority"]
+      },
+      "display": {
+        "summary": "Workspace or vendor-local history is not continuation authority; resolve ONE Canonical IR."
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/152"],
+        "accepted_evidence": ["agentos-evidence://continuity/issue-152/e3"],
+        "extraction_id": "agentos-extraction://agentos-core/152/workspace-authority"
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v1",
+      "experience_id": "core.generic-continue-not-merge-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["repository.merge"],
+      "executor_scope": [],
+      "kind": "constraint",
+      "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [
+          {
+            "id": "continue-not-authority",
+            "op": "forbid",
+            "predicate": "repository.merge.authorization_source",
+            "arguments": [{"type": "symbol", "value": "GENERIC_CONTINUE"}]
+          },
+          {
+            "id": "require-explicit-authority",
+            "op": "require",
+            "predicate": "repository.merge.authorization_source",
+            "arguments": [{"type": "symbol", "value": "EXPLICIT_CANONICAL_AUTHORITY"}]
+          }
+        ],
+        "entrypoints": ["continue-not-authority", "require-explicit-authority"],
+        "expected_behavior_dimensions": ["generic_continue_is_merge_authority"]
+      },
+      "display": {
+        "summary": "A generic continuation request does not itself authorize repository merge/publication."
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/117"],
+        "accepted_evidence": ["agentos-governance://core/publication-authority"],
+        "extraction_id": "agentos-extraction://agentos-core/117/merge-authority"
+      },
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    }
+  ]
+}

--- a/experience/agentos-core-oracle.seed.v0.json
+++ b/experience/agentos-core-oracle.seed.v0.json
@@ -1,0 +1,127 @@
+{
+  "schema": "agentos.experience-set/v0",
+  "project_id": "agentos-core",
+  "projection_only": true,
+  "note": "Approved legacy source retained only for fail-closed v0 to Experience IR v1 migration.",
+  "artifacts": [
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.branch-authority.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.core.develop", "repository.merge"],
+      "executor_scope": ["*"],
+      "kind": "decision",
+      "summary": "Core development uses core/integration plus focused core/issue-* branches; mutable runtime generation/SHA are live state and must be resolved at execution time rather than memorized as Experience.",
+      "payload": {
+        "canonical_development_branch": "core/integration",
+        "issue_branch_pattern": "core/issue-<N>-<slug>",
+        "mutable_runtime_facts_belong_in_experience": false,
+        "rule": "A branch head, PID, checkout HEAD, or health response is not deployment acceptance."
+      },
+      "provenance": {"sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"], "accepted_evidence": []},
+      "authority": {"status": "accepted", "supersedes": ["core.branch-and-runtime-authority.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.protected-main-human-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["repository.mutate", "repository.merge"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "Passing CI, mergeability, review state, tool capability, or generic continue never grants protected-main merge authority; separate explicit human authorization is required.",
+      "payload": {
+        "protected_branch": "main",
+        "required_authority": "separate explicit human authorization",
+        "generic_continue_is_authorization": false,
+        "capability_implies_authority": false
+      },
+      "provenance": {"sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"], "accepted_evidence": ["github-ruleset://21844290"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.evidence-scope-and-capability-semantics.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve", "agentos.controller.dispatch", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "heuristic",
+      "summary": "Evidence must prove the exact claimed path, and capability states must remain distinct: advertised is not routable, routable is not authorized, and authorized is not successful execution.",
+      "payload": {
+        "capability_semantics": ["advertised", "transport-routable", "execution-authorized", "successfully-executed"],
+        "controller_dispatch_proves_resolve": false,
+        "capability_implies_execution_authority": false,
+        "acceptance_rule": "Probe the real target transport/capability path and preserve a receipt."
+      },
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"], "accepted_evidence": ["issue-64://controller-service-entered"]},
+      "authority": {"status": "accepted", "supersedes": ["core.evidence-scope-and-capability-semantics.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.discover-before-reinvent.v2",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.capability.discover", "project.resolve"],
+      "executor_scope": ["*"],
+      "kind": "procedure",
+      "summary": "Resolve existing project responsibility, resources, capabilities, and open Core ownership before creating a parallel implementation or rediscovering AgentOS from source.",
+      "payload": {
+        "procedure": ["resolve project identity", "discover responsibility/resources/capabilities", "reuse accepted capability when present", "file/use the owning Core issue for missing shared capability", "only then implement the missing capability"]
+      },
+      "provenance": {"sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"], "accepted_evidence": []},
+      "authority": {"status": "accepted", "supersedes": ["core.discover-before-reinvent.v1"], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.workspace-not-continuation-authority.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["agentos.one.resolve", "project.resolve"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "IDE workspace, git status, local TODO files, vendor history, Pulse, and local model memory are not durable continuation authority; resolve current continuation from ONE Canonical IR.",
+      "payload": {"workspace_is_continuation_authority": false, "canonical_continuation_authority": "ONE Canonical IR selected by the active continuation pointer"},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY_VERIFIED"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "core.node-executor-boundary.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["*"],
+      "capability_scope": ["executor.dispatch", "executor.liveness", "agentos.capability.discover"],
+      "executor_scope": ["*"],
+      "kind": "constraint",
+      "summary": "A Node is the durable Realm/control participant; executors are independently live capability providers. Node online does not prove executor availability, and executor adapters do not own Realm transport credentials.",
+      "payload": {"node_online_implies_executor_available": false, "executor_owns_realm_credentials": false, "node_and_executor_are_distinct": true},
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://node-executor-boundary"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": [], "invalidated_by": []}
+    },
+    {
+      "schema": "agentos.experience/v0",
+      "experience_id": "executor.antigravity-relay-liveness.v1",
+      "project_id": "agentos-core",
+      "realm_scope": ["oracle"],
+      "capability_scope": ["executor.dispatch", "executor.liveness"],
+      "executor_scope": ["antigravity", "claude"],
+      "kind": "failure-pattern",
+      "summary": "Antigravity relay enqueue does not prove Claude executor liveness. A deterministic no-tool capsule previously timed out at about 180 seconds with returncode 124; future acceptance requires a fresh successful receipt.",
+      "payload": {
+        "historical_failure": {"returncode": 124, "timed_out": true, "stdout_exact_match": false},
+        "recovery_proven": false,
+        "required_regression": "Fresh no-tool deterministic receipt with ok=true, timed_out=false, returncode=0 before trusting executor workloads."
+      },
+      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/72"], "accepted_evidence": ["workflow-run://33227123813"]},
+      "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+      "validity": {"conditions": ["historical failure remains relevant until a newer successful liveness regression supersedes it"], "invalidated_by": []}
+    }
+  ]
+}

--- a/experience/agentos-core-oracle.seed.v0.json
+++ b/experience/agentos-core-oracle.seed.v0.json
@@ -2,7 +2,7 @@
   "schema": "agentos.experience-set/v0",
   "project_id": "agentos-core",
   "projection_only": true,
-  "note": "Approved legacy source retained only for fail-closed v0 to Experience IR v1 migration.",
+  "note": "Seed/provenance carrier for ONE-owned Experience. Runtime discovery reads the accepted set from the AgentOS data layer; newer canonical state and explicit user intent always supersede Experience.",
   "artifacts": [
     {
       "schema": "agentos.experience/v0",
@@ -19,7 +19,10 @@
         "mutable_runtime_facts_belong_in_experience": false,
         "rule": "A branch head, PID, checkout HEAD, or health response is not deployment acceptance."
       },
-      "provenance": {"sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"], "accepted_evidence": []},
+      "provenance": {
+        "sources": ["docs/CORE_BRANCH_MODEL.md", "docs/CORE_DEPLOYMENT_AUTHORITY.md"],
+        "accepted_evidence": []
+      },
       "authority": {"status": "accepted", "supersedes": ["core.branch-and-runtime-authority.v1"], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -38,7 +41,10 @@
         "generic_continue_is_authorization": false,
         "capability_implies_authority": false
       },
-      "provenance": {"sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"], "accepted_evidence": ["github-ruleset://21844290"]},
+      "provenance": {
+        "sources": [".agent/governance/protected_branches.yaml", "docs/governance/decisions/GOV-2026-08-27-001-protected-branch-authority.md"],
+        "accepted_evidence": ["github-ruleset://21844290"]
+      },
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -57,7 +63,10 @@
         "capability_implies_execution_authority": false,
         "acceptance_rule": "Probe the real target transport/capability path and preserve a receipt."
       },
-      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"], "accepted_evidence": ["issue-64://controller-service-entered"]},
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/64", "docs/CURRENT_STATE.md"],
+        "accepted_evidence": ["issue-64://controller-service-entered"]
+      },
       "authority": {"status": "accepted", "supersedes": ["core.evidence-scope-and-capability-semantics.v1"], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -73,7 +82,10 @@
       "payload": {
         "procedure": ["resolve project identity", "discover responsibility/resources/capabilities", "reuse accepted capability when present", "file/use the owning Core issue for missing shared capability", "only then implement the missing capability"]
       },
-      "provenance": {"sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"], "accepted_evidence": []},
+      "provenance": {
+        "sources": ["docs/AGENTOS_NODE.md", "github-issue://alston-personal/agentmanager/137"],
+        "accepted_evidence": []
+      },
       "authority": {"status": "accepted", "supersedes": ["core.discover-before-reinvent.v1"], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -86,8 +98,14 @@
       "executor_scope": ["*"],
       "kind": "constraint",
       "summary": "IDE workspace, git status, local TODO files, vendor history, Pulse, and local model memory are not durable continuation authority; resolve current continuation from ONE Canonical IR.",
-      "payload": {"workspace_is_continuation_authority": false, "canonical_continuation_authority": "ONE Canonical IR selected by the active continuation pointer"},
-      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY_VERIFIED"]},
+      "payload": {
+        "workspace_is_continuation_authority": false,
+        "canonical_continuation_authority": "ONE Canonical IR selected by the active continuation pointer"
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/152"],
+        "accepted_evidence": ["issue-152://E3_GEMINI_ONE_CODEX_EXTENSION_CONTINUITY_VERIFIED"]
+      },
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -100,8 +118,15 @@
       "executor_scope": ["*"],
       "kind": "constraint",
       "summary": "A Node is the durable Realm/control participant; executors are independently live capability providers. Node online does not prove executor availability, and executor adapters do not own Realm transport credentials.",
-      "payload": {"node_online_implies_executor_available": false, "executor_owns_realm_credentials": false, "node_and_executor_are_distinct": true},
-      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/152"], "accepted_evidence": ["issue-152://node-executor-boundary"]},
+      "payload": {
+        "node_online_implies_executor_available": false,
+        "executor_owns_realm_credentials": false,
+        "node_and_executor_are_distinct": true
+      },
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/152"],
+        "accepted_evidence": ["issue-152://node-executor-boundary"]
+      },
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": [], "invalidated_by": []}
     },
@@ -119,7 +144,10 @@
         "recovery_proven": false,
         "required_regression": "Fresh no-tool deterministic receipt with ok=true, timed_out=false, returncode=0 before trusting executor workloads."
       },
-      "provenance": {"sources": ["github-issue://alston-personal/agentmanager/72"], "accepted_evidence": ["workflow-run://33227123813"]},
+      "provenance": {
+        "sources": ["github-issue://alston-personal/agentmanager/72"],
+        "accepted_evidence": ["workflow-run://33227123813"]
+      },
       "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
       "validity": {"conditions": ["historical failure remains relevant until a newer successful liveness regression supersedes it"], "invalidated_by": []}
     }

--- a/schemas/agentos-experience-v1.schema.json
+++ b/schemas/agentos-experience-v1.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentos.local/schemas/agentos-experience-v1.schema.json",
+  "title": "AgentOS Governed Experience v1",
+  "type": "object",
+  "required": ["schema", "experience_id", "project_id", "kind", "ir", "provenance", "authority", "validity"],
+  "properties": {
+    "schema": {"const": "agentos.experience/v1"},
+    "experience_id": {"type": "string", "minLength": 1},
+    "project_id": {"type": "string", "minLength": 1},
+    "realm_scope": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "capability_scope": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "executor_scope": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "kind": {"enum": ["decision", "procedure", "heuristic", "failure-pattern", "constraint", "benchmark-pattern"]},
+    "ir": {"$ref": "#/$defs/experienceIr"},
+    "display": {
+      "type": "object",
+      "properties": {"summary": {"type": "string", "minLength": 1}},
+      "additionalProperties": true
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["sources"],
+      "properties": {
+        "sources": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "accepted_evidence": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "extraction_id": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "authority": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"enum": ["candidate", "accepted", "deprecated", "revoked"]},
+        "supersedes": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "superseded_by": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      },
+      "additionalProperties": false
+    },
+    "validity": {
+      "type": "object",
+      "properties": {
+        "conditions": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "invalidated_by": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "typedValue": {
+      "type": "object",
+      "required": ["type", "value"],
+      "properties": {
+        "type": {"enum": ["symbol", "string", "number", "boolean", "null", "list", "object"]},
+        "value": {}
+      },
+      "additionalProperties": false
+    },
+    "experienceIr": {
+      "type": "object",
+      "required": ["schema", "nodes", "entrypoints", "expected_behavior_dimensions"],
+      "properties": {
+        "schema": {"const": "agentos.experience-ir/v1"},
+        "nodes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "op", "predicate"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "op": {"enum": ["assert", "require", "forbid", "prefer", "avoid", "invoke", "match", "set"]},
+              "predicate": {"type": "string", "minLength": 1},
+              "arguments": {"type": "array", "items": {"$ref": "#/$defs/typedValue"}},
+              "value": {"$ref": "#/$defs/typedValue"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "entrypoints": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "expected_behavior_dimensions": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -9,6 +9,7 @@ benchmark vocabulary; display summaries are never used as learned authority.
 """
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -20,10 +21,39 @@ from agent_core.experience_observation import compile_experience_observations
 from scripts import oracle_codex_experience_regression as regression
 
 
-def _prehydrate() -> dict[str, object]:
-    from agentos_node.experience_mcp_stdio import one_experience_hydrate
+class _PrehydrationDependencyMissing(RuntimeError):
+    def __init__(self, classification: str):
+        super().__init__(classification)
+        self.classification = classification
 
-    return one_experience_hydrate(
+
+def _require_module(name: str, classification: str):
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        raise _PrehydrationDependencyMissing(classification) from None
+
+
+def _prehydrate() -> dict[str, object]:
+    # Fixed canonical probes identify which runtime dependency is missing without
+    # exposing ModuleNotFoundError.name, local paths, or traceback text.
+    _require_module(
+        "agent_core.experience",
+        "EXPERIENCE_PREHYDRATION_AGENT_CORE_EXPERIENCE_MISSING",
+    )
+    _require_module(
+        "agent_core.experience_store",
+        "EXPERIENCE_PREHYDRATION_EXPERIENCE_STORE_MODULE_MISSING",
+    )
+    _require_module(
+        "agent_core.experience_observation",
+        "EXPERIENCE_PREHYDRATION_OBSERVATION_MODULE_MISSING",
+    )
+    mcp_module = _require_module(
+        "agentos_node.experience_mcp_stdio",
+        "EXPERIENCE_PREHYDRATION_MCP_MODULE_MISSING",
+    )
+    return mcp_module.one_experience_hydrate(
         project_id=regression.PROJECT_ID,
         active_goal=regression.GOAL,
         realm="oracle",
@@ -63,7 +93,9 @@ If a key is listed in missing_dimensions, return null for that key. Never infer 
 
 def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
     """Represent pre-executor hydration failure without exposing messages or traces."""
-    if isinstance(exc, FileNotFoundError):
+    if isinstance(exc, _PrehydrationDependencyMissing):
+        classification = exc.classification
+    elif isinstance(exc, FileNotFoundError):
         classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
     elif isinstance(exc, PermissionError):
         classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -62,13 +62,27 @@ If a key is listed in missing_dimensions, return null for that key. Never infer 
 
 
 def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
-    """Represent pre-executor hydration failure without exposing paths or traces."""
+    """Represent pre-executor hydration failure without exposing messages or traces."""
     if isinstance(exc, FileNotFoundError):
         classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
     elif isinstance(exc, PermissionError):
         classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    elif isinstance(exc, ModuleNotFoundError):
+        classification = "EXPERIENCE_PREHYDRATION_IMPORT_MISSING"
+    elif isinstance(exc, ImportError):
+        classification = "EXPERIENCE_PREHYDRATION_IMPORT_FAILED"
     elif isinstance(exc, ValueError):
         classification = "EXPERIENCE_PREHYDRATION_CONTRACT_INVALID"
+    elif isinstance(exc, TypeError):
+        classification = "EXPERIENCE_PREHYDRATION_TYPE_ERROR"
+    elif isinstance(exc, KeyError):
+        classification = "EXPERIENCE_PREHYDRATION_KEY_ERROR"
+    elif isinstance(exc, AttributeError):
+        classification = "EXPERIENCE_PREHYDRATION_ATTRIBUTE_ERROR"
+    elif isinstance(exc, RuntimeError):
+        classification = "EXPERIENCE_PREHYDRATION_RUNTIME_ERROR"
+    elif isinstance(exc, OSError):
+        classification = "EXPERIENCE_PREHYDRATION_IO_ERROR"
     else:
         classification = "EXPERIENCE_PREHYDRATION_FAILED"
     return {

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -61,11 +61,35 @@ If a key is listed in missing_dimensions, return null for that key. Never infer 
 """
 
 
+def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
+    """Represent pre-executor hydration failure without exposing paths or traces."""
+    if isinstance(exc, FileNotFoundError):
+        classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
+    elif isinstance(exc, PermissionError):
+        classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    elif isinstance(exc, ValueError):
+        classification = "EXPERIENCE_PREHYDRATION_CONTRACT_INVALID"
+    else:
+        classification = "EXPERIENCE_PREHYDRATION_FAILED"
+    return {
+        "returncode": 78,
+        "timed_out": False,
+        "stdout": "",
+        "stderr_tail": "",
+        "argv_family": "agentos pre-executor hydration (Codex not launched)",
+        "prehydration_failed": True,
+        "prehydration_classification": classification,
+    }
+
+
 def run_codex(exe: Path, *, hydrated: bool, timeout: int) -> dict[str, object]:
     prompt = regression.prompt(hydrated=False)
     if hydrated:
-        projection = _prehydrate()
-        prompt = _hydrated_prompt(projection)
+        try:
+            projection = _prehydrate()
+            prompt = _hydrated_prompt(projection)
+        except Exception as exc:
+            return _bounded_prehydration_failure(exc)
     argv = [
         str(exe),
         "exec",
@@ -122,6 +146,11 @@ def _fixed_classification(payload: dict[str, object]) -> str:
     baseline_run = baseline.get("run") if isinstance(baseline.get("run"), dict) else {}
     hydrated_run = hydrated.get("run") if isinstance(hydrated.get("run"), dict) else {}
 
+    if hydrated_run.get("prehydration_failed") is True:
+        bounded = hydrated_run.get("prehydration_classification")
+        if isinstance(bounded, str) and bounded.startswith("EXPERIENCE_PREHYDRATION_"):
+            return bounded
+        return "EXPERIENCE_PREHYDRATION_FAILED"
     if baseline_run.get("timed_out") is True:
         return "EXPERIENCE_BASELINE_CODEX_TIMEOUT"
     if hydrated_run.get("timed_out") is True:

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""AgentOS-prehydrated #117 Codex Experience IR regression entry.
+
+The Master Experience Floor is an AgentOS guarantee, not an executor-discretion
+feature. Baseline remains a completely fresh Codex process. For the hydrated lane,
+AgentOS resolves bounded ONE Experience IR before launching another fresh Codex.
+A deterministic adapter compiles only explicit IR observation nodes into the
+benchmark vocabulary; display summaries are never used as learned authority.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from agent_core.experience_observation import compile_experience_observations
+from scripts import oracle_codex_experience_regression as regression
+
+
+def _prehydrate() -> dict[str, object]:
+    from agentos_node.experience_mcp_stdio import one_experience_hydrate
+
+    return one_experience_hydrate(
+        project_id=regression.PROJECT_ID,
+        active_goal=regression.GOAL,
+        realm="oracle",
+        executor="codex",
+        capabilities=regression.CAPABILITIES,
+    )
+
+
+def _hydrated_prompt(projection: dict[str, object]) -> str:
+    observations = compile_experience_observations(
+        projection,
+        allowed_dimensions=regression.DIMENSIONS,
+    )
+    return f"""You are a completely fresh Codex executor with no prior AgentOS Core session history.
+Project identity: {regression.PROJECT_ID}
+Current goal: {regression.GOAL}
+
+AgentOS has already hydrated bounded ONE Experience IR before executor launch.
+The IR is the learned source. AgentOS deterministically compiled its explicit observation nodes into
+ONE_EXPERIENCE_OBSERVATIONS below for this benchmark. Do not use display summaries as authority.
+Do not inspect workspace files, git, network, prior sessions, local TODO/status files, or any other source.
+Do not call tools for this benchmark.
+
+ONE_EXPERIENCE_OBSERVATIONS:
+{json.dumps(observations, ensure_ascii=False, sort_keys=True)}
+
+ONE_EXPERIENCE_IR_PROJECTION:
+{json.dumps(projection, ensure_ascii=False, sort_keys=True)}
+
+This is a controlled Experience-transfer benchmark, not a repository task. Do not modify anything.
+Return exactly one JSON object and nothing else with these keys:
+{json.dumps(list(regression.DIMENSIONS))}
+For each key, use the exact value in ONE_EXPERIENCE_OBSERVATIONS.values when present.
+If a key is listed in missing_dimensions, return null for that key. Never infer protected-branch authority.
+"""
+
+
+def run_codex(exe: Path, *, hydrated: bool, timeout: int) -> dict[str, object]:
+    prompt = regression.prompt(hydrated=False)
+    if hydrated:
+        projection = _prehydrate()
+        prompt = _hydrated_prompt(projection)
+    argv = [
+        str(exe),
+        "exec",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--color",
+        "never",
+        prompt,
+    ]
+    with tempfile.TemporaryDirectory(
+        prefix=f"agentos-exp117-codex-{'hydrated' if hydrated else 'baseline'}-"
+    ) as tmp:
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=tmp,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, "CI": "1"},
+                check=False,
+            )
+            return {
+                "returncode": proc.returncode,
+                "timed_out": False,
+                "stdout": proc.stdout[-12000:],
+                "stderr_tail": proc.stderr[-3000:],
+                "argv_family": "codex exec --sandbox read-only (AgentOS prehydrated Experience IR)",
+            }
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "returncode": None,
+                "timed_out": True,
+                "stdout": (exc.stdout or "")[-12000:] if isinstance(exc.stdout, str) else "",
+                "stderr_tail": (exc.stderr or "")[-3000:] if isinstance(exc.stderr, str) else "",
+                "argv_family": "codex exec --sandbox read-only (AgentOS prehydrated Experience IR)",
+            }
+
+
+def _output_arg() -> Path | None:
+    for index, value in enumerate(sys.argv[:-1]):
+        if value == "--output":
+            return Path(sys.argv[index + 1])
+    return None
+
+
+def _fixed_classification(payload: dict[str, object]) -> str:
+    checks = payload.get("checks") if isinstance(payload.get("checks"), dict) else {}
+    baseline = payload.get("baseline") if isinstance(payload.get("baseline"), dict) else {}
+    hydrated = payload.get("hydrated") if isinstance(payload.get("hydrated"), dict) else {}
+    baseline_run = baseline.get("run") if isinstance(baseline.get("run"), dict) else {}
+    hydrated_run = hydrated.get("run") if isinstance(hydrated.get("run"), dict) else {}
+
+    if baseline_run.get("timed_out") is True:
+        return "EXPERIENCE_BASELINE_CODEX_TIMEOUT"
+    if hydrated_run.get("timed_out") is True:
+        return "EXPERIENCE_HYDRATED_CODEX_TIMEOUT"
+    if baseline_run.get("returncode") != 0:
+        return "EXPERIENCE_BASELINE_CODEX_RUNTIME_FAILED"
+    if hydrated_run.get("returncode") != 0:
+        return "EXPERIENCE_HYDRATED_CODEX_RUNTIME_FAILED"
+    if checks.get("hydration_receipt_ok") is not True:
+        return "EXPERIENCE_AGENTOS_PREHYDRATION_NOT_OBSERVED"
+    if payload.get("verdict") != "PASS":
+        return "EXPERIENCE_MASTER_FLOOR_NOT_MET"
+    return "EXPERIENCE_REGRESSION_PASS"
+
+
+def _correct_method_evidence(path: Path | None) -> None:
+    if path is None or not path.is_file():
+        return
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    method = payload.get("method")
+    if isinstance(method, dict):
+        method["baseline"] = (
+            "fresh Codex process + empty cwd; no AgentOS Experience projection is supplied; "
+            "unchanged hydration receipt independently proves non-access"
+        )
+        method["hydrated"] = (
+            "AgentOS pre-executor hydration from governed ONE Experience IR + independent receipt; "
+            "explicit IR observation nodes are deterministically compiled before a fresh Codex process"
+        )
+    payload["config_override_used"] = False
+    payload["hydration_delivery"] = "agentos-pre-executor-experience-ir"
+    payload["experience_representation"] = "agentos.experience-ir/v1"
+    payload["observation_projection"] = "derived-from-explicit-ir-set-nodes"
+    payload["executor_tool_call_required_for_floor"] = False
+    payload["classification"] = _fixed_classification(payload)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    regression.run_codex = run_codex
+    rc = regression.main()
+    _correct_method_evidence(_output_arg())
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agent_core.experience_store import seed_experience_set
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed accepted Experience IR into the ONE data layer")
+    parser.add_argument("--seed", default="experience/agentos-core-oracle.seed.json")
+    parser.add_argument(
+        "--migrate-from",
+        default="experience/agentos-core-oracle.seed.v0.json",
+        help="approved legacy seed used only to verify a fail-closed v0 -> v1 migration",
+    )
+    args = parser.parse_args()
+    migrate_from = Path(args.migrate_from).resolve() if args.migrate_from else None
+    receipt = seed_experience_set(
+        Path(args.seed).resolve(),
+        migrate_from=migrate_from,
+    )
+    print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_experience_ir.py
+++ b/tests/test_experience_ir.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from agent_core.experience import (
+    ExperienceContractError,
+    ExperienceQuery,
+    discover_experience,
+    experience_semantic_digest,
+    hydrate_experience,
+    validate_extraction_proposal,
+)
+
+
+def artifact(experience_id: str, *, status: str = "accepted"):
+    return {
+        "schema": "agentos.experience/v1",
+        "experience_id": experience_id,
+        "project_id": "agentos-core",
+        "realm_scope": ["oracle"],
+        "capability_scope": ["agentos.one.resolve"],
+        "executor_scope": [],
+        "kind": "constraint",
+        "ir": {
+            "schema": "agentos.experience-ir/v1",
+            "nodes": [
+                {
+                    "id": "authority",
+                    "op": "require",
+                    "predicate": "continuation.authority",
+                    "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR"}],
+                },
+                {
+                    "id": "workspace",
+                    "op": "forbid",
+                    "predicate": "continuation.authority",
+                    "arguments": [{"type": "symbol", "value": "WORKSPACE_VENDOR_HISTORY"}],
+                },
+            ],
+            "entrypoints": ["authority", "workspace"],
+            "expected_behavior_dimensions": ["workspace_is_continuation_authority"],
+        },
+        "display": {"summary": f"Human label for {experience_id}"},
+        "provenance": {
+            "sources": ["issue://152"],
+            "accepted_evidence": ["evidence://continuity/e3"],
+            "extraction_id": "extract://152/authority",
+        },
+        "authority": {
+            "status": status,
+            "supersedes": [],
+            "superseded_by": [],
+        },
+        "validity": {"conditions": [], "invalidated_by": []},
+    }
+
+
+def test_summary_is_optional_and_non_authoritative():
+    item = artifact("authority.v1")
+    first = experience_semantic_digest(item)
+    item["display"]["summary"] = "A completely different human explanation"
+    second = experience_semantic_digest(item)
+    assert first == second
+
+    del item["display"]
+    third = experience_semantic_digest(item)
+    assert first == third
+
+
+def test_semantic_change_changes_digest():
+    item = artifact("authority.v1")
+    first = experience_semantic_digest(item)
+    item["ir"]["nodes"][0]["arguments"][0]["value"] = "WORKSPACE_VENDOR_HISTORY"
+    assert experience_semantic_digest(item) != first
+
+
+def test_hydration_contains_ir_and_expected_dimensions_not_summary_payload():
+    item = artifact("authority.v1")
+    projection = hydrate_experience(
+        project_id="agentos-core",
+        active_goal="continue Core integration",
+        artifacts=[item],
+    ).as_dict()
+    hydrated = projection["items"][0]
+    assert hydrated["experience_id"] == "authority.v1"
+    assert hydrated["ir"]["schema"] == "agentos.experience-ir/v1"
+    assert hydrated["expected_behavior_dimensions"] == ["workspace_is_continuation_authority"]
+    assert "summary" not in hydrated
+    assert "payload" not in hydrated
+
+
+def test_discovery_filters_candidates_and_preserves_scope():
+    accepted = artifact("accepted")
+    candidate = artifact("candidate", status="candidate")
+    result = discover_experience(
+        [candidate, accepted],
+        ExperienceQuery(
+            project_id="agentos-core",
+            realm="oracle",
+            capabilities=("agentos.one.resolve",),
+            executor="codex",
+        ),
+    )
+    assert [item["experience_id"] for item in result] == ["accepted"]
+
+
+def test_rejects_sensitive_ir():
+    item = artifact("bad")
+    item["ir"]["nodes"][0]["value"] = {
+        "type": "object",
+        "value": {"token": "must-not-enter-experience"},
+    }
+    with pytest.raises(ExperienceContractError, match="sensitive credential"):
+        experience_semantic_digest(item)
+
+
+def test_extraction_proposal_cannot_self_authorize():
+    candidate = artifact("candidate", status="candidate")
+    proposal = {
+        "schema": "agentos.experience-extraction/v1",
+        "extraction_id": "extract-1",
+        "project_id": "agentos-core",
+        "origin": {"node_id": "oracle", "surface": "codex"},
+        "sources": ["issue://152", "receipt://e3"],
+        "abstraction": {
+            "generalized_from": ["canonical continuation authority evidence"],
+            "excluded": ["vendor-local workspace history"],
+        },
+        "candidate": candidate,
+    }
+    validate_extraction_proposal(proposal)
+    accepted = deepcopy(proposal)
+    accepted["candidate"]["authority"]["status"] = "accepted"
+    with pytest.raises(ExperienceContractError, match="must not self-authorize"):
+        validate_extraction_proposal(accepted)

--- a/tests/test_experience_mcp_ir.py
+++ b/tests/test_experience_mcp_ir.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+
+from agentos_node import experience_mcp_stdio as mcp
+
+
+def test_hydration_receipt_records_manifest_without_ir_body(tmp_path, monkeypatch):
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setenv("AGENTOS_EXPERIENCE_HYDRATION_RECEIPT", str(receipt))
+    monkeypatch.setenv("AGENTOS_RUNTIME_SOURCE_COMMIT", "test-sha")
+    projection = {
+        "source": "ONE_EXPERIENCE",
+        "project_id": "agentos-core",
+        "digest": "sha256:projection",
+        "experience_ids": ["x.v1"],
+        "items": [{
+            "experience_id": "x.v1",
+            "semantic_digest": "sha256:item",
+            "expected_behavior_dimensions": ["governance"],
+            "ir": {"schema": "agentos.experience-ir/v1", "nodes": [{"secret-free": True}]},
+        }],
+    }
+    mcp._write_receipt(projection)
+    stored = json.loads(receipt.read_text(encoding="utf-8"))
+    assert stored["schema"] == "agentos.experience-hydration-receipt/v2"
+    assert stored["semantic_manifest"] == [{
+        "experience_id": "x.v1",
+        "semantic_digest": "sha256:item",
+        "expected_behavior_dimensions": ["governance"],
+    }]
+    assert "ir" not in stored["semantic_manifest"][0]
+    assert stored["credential_exposed"] is False

--- a/tests/test_experience_observation_ir.py
+++ b/tests/test_experience_observation_ir.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_core.experience_observation import (
+    ExperienceObservationError,
+    compile_experience_observations,
+)
+
+
+def _item(experience_id: str, predicate: str, value, value_type: str = "boolean"):
+    return {
+        "experience_id": experience_id,
+        "expected_behavior_dimensions": [predicate],
+        "ir": {
+            "schema": "agentos.experience-ir/v1",
+            "nodes": [
+                {
+                    "id": "observation",
+                    "op": "set",
+                    "predicate": predicate,
+                    "value": {"type": value_type, "value": value},
+                }
+            ],
+        },
+    }
+
+
+def test_compile_observations_uses_explicit_ir_set_nodes_only():
+    hydration = {
+        "project_id": "agentos-core",
+        "digest": "sha256:test",
+        "items": [
+            _item("branch.v1", "canonical_development_branch", "core/integration", "string"),
+            _item("authority.v1", "generic_continue_authorizes_main_merge", False),
+        ],
+    }
+    result = compile_experience_observations(
+        hydration,
+        allowed_dimensions=(
+            "canonical_development_branch",
+            "generic_continue_authorizes_main_merge",
+        ),
+    )
+    assert result["values"] == {
+        "canonical_development_branch": "core/integration",
+        "generic_continue_authorizes_main_merge": False,
+    }
+    assert result["sources"]["canonical_development_branch"] == ["branch.v1"]
+    assert result["missing_dimensions"] == []
+    assert result["derived_from_experience_ir"] is True
+
+
+def test_compile_observations_reports_missing_without_guessing():
+    hydration = {"project_id": "agentos-core", "items": []}
+    result = compile_experience_observations(
+        hydration,
+        allowed_dimensions=("workspace_is_continuation_authority",),
+    )
+    assert result["values"] == {}
+    assert result["missing_dimensions"] == ["workspace_is_continuation_authority"]
+
+
+def test_compile_observations_rejects_conflicting_experience():
+    hydration = {
+        "project_id": "agentos-core",
+        "items": [
+            _item("a.v1", "workspace_is_continuation_authority", False),
+            _item("b.v1", "workspace_is_continuation_authority", True),
+        ],
+    }
+    with pytest.raises(ExperienceObservationError, match="conflicting"):
+        compile_experience_observations(hydration)

--- a/tests/test_experience_regression_ir.py
+++ b/tests/test_experience_regression_ir.py
@@ -1,0 +1,78 @@
+from agent_core.experience_regression import (
+    build_attribution_report,
+    build_behavior_delta_report,
+)
+
+
+MANIFEST = {
+    "schema": "agentos.experience-hydration/v1",
+    "digest": "sha256:test",
+    "experience_ids": ["authority.v1", "governance.v1"],
+    "items": [
+        {
+            "experience_id": "authority.v1",
+            "expected_behavior_dimensions": ["workspace_is_continuation_authority"],
+        },
+        {
+            "experience_id": "governance.v1",
+            "expected_behavior_dimensions": ["generic_continue_is_merge_authority"],
+        },
+    ],
+}
+
+
+def test_behavior_delta_reports_before_after_and_candidates():
+    baseline = {
+        "workspace_is_continuation_authority": {"value": None, "pass": False},
+        "generic_continue_is_merge_authority": {"value": False, "pass": True},
+    }
+    hydrated = {
+        "workspace_is_continuation_authority": {"value": False, "pass": True},
+        "generic_continue_is_merge_authority": {"value": False, "pass": True},
+    }
+    report = build_behavior_delta_report(
+        project_id="agentos-core",
+        baseline=baseline,
+        hydrated=hydrated,
+        hydration_manifest=MANIFEST,
+    )
+    assert report["dimensions"]["workspace_is_continuation_authority"]["delta"] == "improved"
+    assert report["dimensions"]["workspace_is_continuation_authority"]["candidate_experience_ids"] == ["authority.v1"]
+    assert report["dimensions"]["generic_continue_is_merge_authority"]["delta"] == "unchanged-correct"
+    assert report["regressed_dimensions"] == []
+
+
+def test_behavior_delta_flags_regression():
+    baseline = {"governance": {"value": True, "pass": True}}
+    hydrated = {"governance": {"value": False, "pass": False}}
+    report = build_behavior_delta_report(
+        project_id="agentos-core",
+        baseline=baseline,
+        hydrated=hydrated,
+        hydration_manifest={"items": [], "experience_ids": [], "digest": "sha256:none"},
+    )
+    assert report["regressed_dimensions"] == ["governance"]
+
+
+def test_ablation_supports_but_does_not_overclaim_causality():
+    full = {
+        "workspace_is_continuation_authority": {"value": False, "pass": True},
+        "generic_continue_is_merge_authority": {"value": False, "pass": True},
+    }
+    ablations = {
+        "authority.v1": {
+            "workspace_is_continuation_authority": {"value": None, "pass": False},
+            "generic_continue_is_merge_authority": {"value": False, "pass": True},
+        }
+    }
+    report = build_attribution_report(
+        project_id="agentos-core",
+        full=full,
+        ablations=ablations,
+        hydration_manifest=MANIFEST,
+    )
+    cell = report["matrix"]["authority.v1"]["workspace_is_continuation_authority"]
+    assert cell["observed_delta"] == "degraded-without"
+    assert cell["confidence"] == "supported"
+    assert report["matrix"]["governance.v1"]["generic_continue_is_merge_authority"]["confidence"] == "ambiguous"
+    assert report["causal_claim_bounded"] is True

--- a/tests/test_experience_store_ir.py
+++ b/tests/test_experience_store_ir.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from agent_core.experience_store import hydrate_from_one, read_experience_set, seed_experience_set
+from agent_core.experience_store import experience_path, hydrate_from_one, read_experience_set, seed_experience_set
 
 
 ARTIFACT = {
@@ -52,11 +52,26 @@ class ExperienceStoreTests(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
+    def _legacy(self, experience_id: str = ARTIFACT["experience_id"]):
+        return {
+            "schema": "agentos.experience-set/v0",
+            "project_id": "agentos-core",
+            "projection_only": True,
+            "artifacts": [{
+                "schema": "agentos.experience/v0",
+                "experience_id": experience_id,
+                "project_id": "agentos-core",
+                "summary": "legacy display payload",
+                "payload": {"workspace_is_continuation_authority": False},
+            }],
+        }
+
     def test_seed_is_idempotent_and_runtime_reads_data_layer(self):
         first = seed_experience_set(self.seed, data_root=self.root / "data")
         second = seed_experience_set(self.seed, data_root=self.root / "data")
         self.assertTrue(first["seeded"])
         self.assertFalse(second["seeded"])
+        self.assertFalse(second["migrated"])
         stored = read_experience_set("agentos-core", data_root=self.root / "data")
         self.assertEqual(stored["artifacts"][0]["experience_id"], ARTIFACT["experience_id"])
 
@@ -68,6 +83,47 @@ class ExperienceStoreTests(unittest.TestCase):
         other.write_text(json.dumps(changed), encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "different digest"):
             seed_experience_set(other, data_root=self.root / "data")
+
+    def test_legacy_store_requires_explicit_migration_source(self):
+        target = experience_path("agentos-core", data_root=self.root / "data")
+        target.parent.mkdir(parents=True)
+        target.write_text(json.dumps(self._legacy()), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "explicit known migration source"):
+            seed_experience_set(self.seed, data_root=self.root / "data")
+
+    def test_known_legacy_migrates_only_when_ids_are_preserved(self):
+        target = experience_path("agentos-core", data_root=self.root / "data")
+        target.parent.mkdir(parents=True)
+        legacy = self._legacy()
+        target.write_text(json.dumps(legacy), encoding="utf-8")
+        known = self.root / "known-v0.json"
+        known.write_text(json.dumps(legacy), encoding="utf-8")
+
+        receipt = seed_experience_set(
+            self.seed,
+            data_root=self.root / "data",
+            migrate_from=known,
+        )
+        self.assertTrue(receipt["migrated"])
+        self.assertTrue(Path(receipt["backup_path"]).is_file())
+        self.assertEqual(read_experience_set("agentos-core", data_root=self.root / "data")["schema"], "agentos.experience-set/v1")
+
+    def test_unknown_legacy_or_id_loss_fails_closed(self):
+        target = experience_path("agentos-core", data_root=self.root / "data")
+        target.parent.mkdir(parents=True)
+        target.write_text(json.dumps(self._legacy()), encoding="utf-8")
+        wrong_known = self.root / "wrong-v0.json"
+        wrong = self._legacy()
+        wrong["artifacts"][0]["payload"]["extra"] = True
+        wrong_known.write_text(json.dumps(wrong), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "does not match approved migration source"):
+            seed_experience_set(self.seed, data_root=self.root / "data", migrate_from=wrong_known)
+
+        target.write_text(json.dumps(self._legacy("legacy.other-id")), encoding="utf-8")
+        known = self.root / "known-other-v0.json"
+        known.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "add/drop accepted experience IDs"):
+            seed_experience_set(self.seed, data_root=self.root / "data", migrate_from=known)
 
     def test_hydration_comes_from_one_store_as_ir(self):
         seed_experience_set(self.seed, data_root=self.root / "data")

--- a/tests/test_experience_store_ir.py
+++ b/tests/test_experience_store_ir.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from agent_core.experience_store import hydrate_from_one, read_experience_set, seed_experience_set
+
+
+ARTIFACT = {
+    "schema": "agentos.experience/v1",
+    "experience_id": "core.workspace-not-continuation-authority.v1",
+    "project_id": "agentos-core",
+    "realm_scope": ["oracle"],
+    "capability_scope": ["agentos.one.resolve"],
+    "executor_scope": [],
+    "kind": "constraint",
+    "ir": {
+        "schema": "agentos.experience-ir/v1",
+        "nodes": [{
+            "id": "authority",
+            "op": "require",
+            "predicate": "continuation.authority",
+            "arguments": [{"type": "symbol", "value": "ONE_CANONICAL_IR"}],
+        }],
+        "entrypoints": ["authority"],
+        "expected_behavior_dimensions": ["workspace_is_continuation_authority"],
+    },
+    "provenance": {
+        "sources": ["issue://152"],
+        "accepted_evidence": ["receipt://e3"],
+        "extraction_id": "extract://152/authority",
+    },
+    "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+    "validity": {"conditions": [], "invalidated_by": []},
+}
+
+
+class ExperienceStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.seed = self.root / "seed.json"
+        self.seed.write_text(json.dumps({
+            "schema": "agentos.experience-set/v1",
+            "project_id": "agentos-core",
+            "projection_only": True,
+            "artifacts": [ARTIFACT],
+        }), encoding="utf-8")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_seed_is_idempotent_and_runtime_reads_data_layer(self):
+        first = seed_experience_set(self.seed, data_root=self.root / "data")
+        second = seed_experience_set(self.seed, data_root=self.root / "data")
+        self.assertTrue(first["seeded"])
+        self.assertFalse(second["seeded"])
+        stored = read_experience_set("agentos-core", data_root=self.root / "data")
+        self.assertEqual(stored["artifacts"][0]["experience_id"], ARTIFACT["experience_id"])
+
+    def test_existing_different_semantic_set_fails_closed(self):
+        seed_experience_set(self.seed, data_root=self.root / "data")
+        changed = json.loads(self.seed.read_text(encoding="utf-8"))
+        changed["artifacts"][0]["ir"]["nodes"][0]["arguments"][0]["value"] = "WORKSPACE_VENDOR_HISTORY"
+        other = self.root / "other.json"
+        other.write_text(json.dumps(changed), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "different digest"):
+            seed_experience_set(other, data_root=self.root / "data")
+
+    def test_hydration_comes_from_one_store_as_ir(self):
+        seed_experience_set(self.seed, data_root=self.root / "data")
+        result = hydrate_from_one(
+            project_id="agentos-core",
+            active_goal="continue safely",
+            realm="oracle",
+            capabilities=("agentos.one.resolve",),
+            executor="codex",
+            data_root=self.root / "data",
+        )
+        self.assertEqual(result["source"], "ONE_EXPERIENCE")
+        self.assertEqual(result["experience_ids"], [ARTIFACT["experience_id"]])
+        self.assertEqual(result["items"][0]["ir"]["schema"], "agentos.experience-ir/v1")
+        self.assertFalse(result["credential_exposed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 from agent_core.executor_job_contract import canonical_experience_regression_request
+from agent_core.experience_observation import compile_experience_observations
 from agentos_node.executor_job_adapter import ExecutorJobProviderRegistry, execute_registered_executor_job
 from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _write_runtime(root: Path, *, codex_available: bool = True, credential_exposed: bool = False) -> None:
@@ -44,6 +49,15 @@ def _write_runtime(root: Path, *, codex_available: bool = True, credential_expos
         "raise SystemExit(0)\n",
         encoding="utf-8",
     )
+
+
+def _load_entry_v2():
+    path = ROOT / "scripts" / "oracle_codex_experience_regression_entry_v2.py"
+    spec = importlib.util.spec_from_file_location("_issue117_entry_v2_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_provider_is_not_registered_when_issue117_is_absent(tmp_path: Path) -> None:
@@ -108,3 +122,82 @@ def test_provider_credential_boundary_violation_is_forced_to_failure(tmp_path: P
     assert receipt["successful"] is False
     assert receipt["credential_exposed"] is False
     assert receipt["classification"] == "PROVIDER_CREDENTIAL_BOUNDARY_VIOLATION"
+
+
+def test_v2_classifies_agentos_pre_hydration_and_floor_failures() -> None:
+    entry = _load_entry_v2()
+    payload = {
+        "baseline": {"run": {"returncode": 0, "timed_out": False}},
+        "hydrated": {"run": {"returncode": 0, "timed_out": False}},
+        "checks": {"hydration_receipt_ok": False},
+        "verdict": "FAIL",
+    }
+    assert entry._fixed_classification(payload) == "EXPERIENCE_AGENTOS_PREHYDRATION_NOT_OBSERVED"
+
+    payload["checks"]["hydration_receipt_ok"] = True
+    assert entry._fixed_classification(payload) == "EXPERIENCE_MASTER_FLOOR_NOT_MET"
+
+    payload["verdict"] = "PASS"
+    assert entry._fixed_classification(payload) == "EXPERIENCE_REGRESSION_PASS"
+
+
+def test_v2_prehydration_failure_is_bounded_and_preserves_evidence_path() -> None:
+    entry = _load_entry_v2()
+    failure = entry._bounded_prehydration_failure(PermissionError("/private/secret/path"))
+    assert failure["returncode"] == 78
+    assert failure["prehydration_failed"] is True
+    assert failure["prehydration_classification"] == "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    assert failure["stdout"] == ""
+    assert failure["stderr_tail"] == ""
+    assert "/private/secret/path" not in str(failure)
+
+    payload = {
+        "baseline": {"run": {"returncode": 0, "timed_out": False}},
+        "hydrated": {"run": failure},
+        "checks": {"hydration_receipt_ok": False},
+        "verdict": "FAIL",
+    }
+    assert entry._fixed_classification(payload) == "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+
+
+def test_v2_hydrated_prompt_is_compiled_from_experience_ir_without_tool_discretion() -> None:
+    entry = _load_entry_v2()
+    projection = {
+        "schema": "agentos.experience-hydration/v1",
+        "source": "ONE_EXPERIENCE",
+        "project_id": "agentos-core",
+        "digest": "sha256:test",
+        "experience_ids": ["core.branch-authority.v2"],
+        "items": [{
+            "experience_id": "core.branch-authority.v2",
+            "semantic_digest": "sha256:item",
+            "expected_behavior_dimensions": ["canonical_development_branch"],
+            "ir": {
+                "schema": "agentos.experience-ir/v1",
+                "nodes": [{
+                    "id": "observe-canonical-branch",
+                    "op": "set",
+                    "predicate": "canonical_development_branch",
+                    "value": {"type": "string", "value": "core/integration"},
+                }],
+                "entrypoints": ["observe-canonical-branch"],
+                "expected_behavior_dimensions": ["canonical_development_branch"],
+            },
+        }],
+        "credential_exposed": False,
+    }
+    observations = compile_experience_observations(
+        projection,
+        allowed_dimensions=entry.regression.DIMENSIONS,
+    )
+    assert observations["values"]["canonical_development_branch"] == "core/integration"
+    assert "canonical_development_branch" not in observations["missing_dimensions"]
+
+    prompt = entry._hydrated_prompt(projection)
+    assert "ONE_EXPERIENCE_OBSERVATIONS" in prompt
+    assert "ONE_EXPERIENCE_IR_PROJECTION" in prompt
+    assert "agentos.experience-ir/v1" in prompt
+    assert '\"canonical_development_branch\": \"core/integration\"' in prompt
+    assert "Do not call tools for this benchmark" in prompt
+    assert "must call agentos-experience" not in prompt
+    assert "token" not in prompt.lower()


### PR DESCRIPTION
## Scope

Refresh Issue #117 on top of current `core/integration` and replace the stale prose-centric Experience v0 contract with a machine-operable Experience IR substrate.

This PR intentionally does **not** claim that general Cognitive IR is production-ready and does **not** close #117. It provides the contract required by the upgraded acceptance gate before rerunning the live Codex A/B + ablation experiment.

## Key changes

- add `agentos.experience/v1` governed artifacts with required `agentos.experience-ir/v1` semantic content;
- make `display.summary` optional/non-authoritative;
- exclude human display text from `experience_semantic_digest()`;
- add typed IR nodes, stable entrypoints, and `expected_behavior_dimensions`;
- add `agentos.experience-extraction/v1` validation; extraction candidates cannot self-authorize acceptance;
- add ONE-owned `agentos.experience-set/v1` store with idempotent seed/fail-closed overwrite semantics;
- hydrate exact semantic IR + per-item digest + expected behavior dimensions;
- add hydration receipt v2 semantic manifest without copying IR bodies into the receipt;
- add per-dimension before/after delta report;
- add bounded `B-minus-Ei` attribution report and deliberately avoid claiming `direct` causality from a single stochastic ablation;
- add seed examples for `workspace-not-continuation-authority` and `generic-continue-not-merge-authority`;
- document the boundary between Canonical IR, Experience IR, and still-Research general Cognitive IR.

## Why this replaces the old #119 design

The old candidate required natural-language `summary` and hydrated `summary + payload`. That is useful for presentation but not a stable semantic unit for exact hydration manifests, item-level removal, semantic hashing, or attribution. The upgraded #117 gate requires those properties.

## Validation

Isolated local contract suite for this slice: **13/13 PASS**.

Important: this is contract/unit evidence only. Master Experience Floor remains unverified until fresh real-executor A/B + B-minus-Ei evidence is persisted.

Refs #117
Supersedes design direction in #119; do not merge #119 wholesale.