### PR TITLE
Core #117: expose bounded hydration failure classification

### DIFF
--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -2,12 +2,15 @@
 """Compatibility entry for #117 Codex Experience regression.
 
 Codex has had multiple config-merge regressions around partial `-c mcp_servers.*`
-overrides.  The #117 benchmark does not need to mutate/partially shadow the MCP
+overrides. The #117 benchmark does not need to mutate/partially shadow the MCP
 transport at all: baseline access is proven absent by the hydration receipt, while
 the hydrated process must produce a new receipt.
 
 This entry reuses the v1 scorer/evidence contract but replaces only the process
-launcher so both fresh processes load the complete installed Codex config.
+launcher so both fresh processes load the complete installed Codex config. It also
+projects only a fixed failure classification from local execution evidence so ONE
+can distinguish transport/runtime failure from a true Experience-quality failure
+without exposing stdout, stderr, prompts, paths, or credentials.
 """
 from __future__ import annotations
 
@@ -71,6 +74,31 @@ def _output_arg() -> Path | None:
     return None
 
 
+def _fixed_classification(payload: dict[str, object]) -> str:
+    checks = payload.get("checks") if isinstance(payload.get("checks"), dict) else {}
+    baseline = payload.get("baseline") if isinstance(payload.get("baseline"), dict) else {}
+    hydrated = payload.get("hydrated") if isinstance(payload.get("hydrated"), dict) else {}
+    baseline_run = baseline.get("run") if isinstance(baseline.get("run"), dict) else {}
+    hydrated_run = hydrated.get("run") if isinstance(hydrated.get("run"), dict) else {}
+
+    if baseline_run.get("timed_out") is True:
+        return "EXPERIENCE_BASELINE_CODEX_TIMEOUT"
+    if hydrated_run.get("timed_out") is True:
+        return "EXPERIENCE_HYDRATED_CODEX_TIMEOUT"
+    if baseline_run.get("returncode") != 0:
+        return "EXPERIENCE_BASELINE_CODEX_RUNTIME_FAILED"
+    if hydrated_run.get("returncode") != 0:
+        stderr = str(hydrated_run.get("stderr_tail") or "").casefold()
+        if "mcp" in stderr or "tool" in stderr or "transport" in stderr:
+            return "EXPERIENCE_HYDRATED_MCP_RUNTIME_FAILED"
+        return "EXPERIENCE_HYDRATED_CODEX_RUNTIME_FAILED"
+    if checks.get("hydration_receipt_ok") is not True:
+        return "EXPERIENCE_HYDRATION_TOOL_NOT_OBSERVED"
+    if payload.get("verdict") != "PASS":
+        return "EXPERIENCE_MASTER_FLOOR_NOT_MET"
+    return "EXPERIENCE_REGRESSION_PASS"
+
+
 def _correct_method_evidence(path: Path | None) -> None:
     if path is None or not path.is_file():
         return
@@ -90,6 +118,7 @@ def _correct_method_evidence(path: Path | None) -> None:
         "The MCP server definition may be visible to the baseline harness, but no Experience payload is accepted "
         "unless the hydration tool is called; an unchanged receipt is an acceptance requirement."
     )
+    payload["classification"] = _fixed_classification(payload)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 from agent_core.executor_job_contract import canonical_experience_regression_request
 from agentos_node.executor_job_adapter import ExecutorJobProviderRegistry, execute_registered_executor_job
 from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _write_runtime(root: Path, *, codex_available: bool = True, credential_exposed: bool = False) -> None:
@@ -44,6 +48,15 @@ def _write_runtime(root: Path, *, codex_available: bool = True, credential_expos
         "raise SystemExit(0)\n",
         encoding="utf-8",
     )
+
+
+def _load_entry_v2():
+    path = ROOT / "scripts" / "oracle_codex_experience_regression_entry_v2.py"
+    spec = importlib.util.spec_from_file_location("_issue117_entry_v2_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_provider_is_not_registered_when_issue117_is_absent(tmp_path: Path) -> None:
@@ -108,3 +121,23 @@ def test_provider_credential_boundary_violation_is_forced_to_failure(tmp_path: P
     assert receipt["successful"] is False
     assert receipt["credential_exposed"] is False
     assert receipt["classification"] == "PROVIDER_CREDENTIAL_BOUNDARY_VIOLATION"
+
+
+def test_v2_projects_only_fixed_hydration_failure_classes() -> None:
+    entry = _load_entry_v2()
+    payload = {
+        "baseline": {"run": {"returncode": 0, "timed_out": False}},
+        "hydrated": {"run": {"returncode": 0, "timed_out": False, "stderr_tail": "PRIVATE"}},
+        "checks": {"hydration_receipt_ok": False},
+        "verdict": "FAIL",
+    }
+    assert entry._fixed_classification(payload) == "EXPERIENCE_HYDRATION_TOOL_NOT_OBSERVED"
+
+    payload["hydrated"]["run"]["returncode"] = 1
+    payload["hydrated"]["run"]["stderr_tail"] = "MCP transport failed at /private/path"
+    assert entry._fixed_classification(payload) == "EXPERIENCE_HYDRATED_MCP_RUNTIME_FAILED"
+    assert "/private/path" not in entry._fixed_classification(payload)
+
+    payload["hydrated"]["run"] = {"returncode": 0, "timed_out": False}
+    payload["checks"]["hydration_receipt_ok"] = True
+    assert entry._fixed_classification(payload) == "EXPERIENCE_MASTER_FLOOR_NOT_MET"


### PR DESCRIPTION
## Why
Run `33706253883` proves exact-generation Experience seed + MCP config installation succeeds, but the live ONE job still returns `hydration_receipt_ok=false`. The current sanitized result collapses all causes into `EXPERIENCE_REGRESSION_FAILED`.

## Change
The existing v2 #117 entrypoint now derives one fixed classification from local evidence only:
- baseline/hydrated Codex timeout
- baseline Codex runtime failure
- hydrated MCP/runtime failure
- hydration tool not observed
- Master Experience Floor not met
- PASS

No stderr/stdout/prompt/path is returned. MCP-related stderr is only used locally as a boolean classifier and is never projected. Provider and generic receipt boundaries remain unchanged.

This is diagnostic narrowing, not a benchmark/scoring change.