### PR TITLE
Core #117: preserve bounded evidence when prehydration fails

### DIFF
--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -52,10 +52,34 @@ Otherwise return null. Never infer protected-branch authority.
 """
 
 
+def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
+    """Represent pre-executor hydration failure without exposing paths or traces."""
+    if isinstance(exc, FileNotFoundError):
+        classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
+    elif isinstance(exc, PermissionError):
+        classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    elif isinstance(exc, ValueError):
+        classification = "EXPERIENCE_PREHYDRATION_CONTRACT_INVALID"
+    else:
+        classification = "EXPERIENCE_PREHYDRATION_FAILED"
+    return {
+        "returncode": 78,
+        "timed_out": False,
+        "stdout": "",
+        "stderr_tail": "",
+        "argv_family": "agentos pre-executor hydration (Codex not launched)",
+        "prehydration_failed": True,
+        "prehydration_classification": classification,
+    }
+
+
 def run_codex(exe: Path, *, hydrated: bool, timeout: int) -> dict[str, object]:
     prompt = regression.prompt(hydrated=False)
     if hydrated:
-        projection = _prehydrate()
+        try:
+            projection = _prehydrate()
+        except Exception as exc:
+            return _bounded_prehydration_failure(exc)
         prompt = _hydrated_prompt(projection)
     argv = [
         str(exe),
@@ -113,6 +137,11 @@ def _fixed_classification(payload: dict[str, object]) -> str:
     baseline_run = baseline.get("run") if isinstance(baseline.get("run"), dict) else {}
     hydrated_run = hydrated.get("run") if isinstance(hydrated.get("run"), dict) else {}
 
+    if hydrated_run.get("prehydration_failed") is True:
+        bounded = hydrated_run.get("prehydration_classification")
+        if isinstance(bounded, str) and bounded.startswith("EXPERIENCE_PREHYDRATION_"):
+            return bounded
+        return "EXPERIENCE_PREHYDRATION_FAILED"
     if baseline_run.get("timed_out") is True:
         return "EXPERIENCE_BASELINE_CODEX_TIMEOUT"
     if hydrated_run.get("timed_out") is True:

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -140,6 +140,25 @@ def test_v2_classifies_agentos_pre_hydration_and_floor_failures() -> None:
     assert entry._fixed_classification(payload) == "EXPERIENCE_REGRESSION_PASS"
 
 
+def test_v2_prehydration_failure_is_bounded_and_preserves_evidence_path() -> None:
+    entry = _load_entry_v2()
+    failure = entry._bounded_prehydration_failure(PermissionError("/private/secret/path"))
+    assert failure["returncode"] == 78
+    assert failure["prehydration_failed"] is True
+    assert failure["prehydration_classification"] == "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    assert failure["stdout"] == ""
+    assert failure["stderr_tail"] == ""
+    assert "/private/secret/path" not in str(failure)
+
+    payload = {
+        "baseline": {"run": {"returncode": 0, "timed_out": False}},
+        "hydrated": {"run": failure},
+        "checks": {"hydration_receipt_ok": False},
+        "verdict": "FAIL",
+    }
+    assert entry._fixed_classification(payload) == "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+
+
 def test_v2_hydrated_prompt_uses_supplied_projection_without_requiring_tool_call() -> None:
     entry = _load_entry_v2()
     projection = {


### PR DESCRIPTION
## Live failure evidence
Exact-generation rollout run `33706849997` on `5b656aa9...` reached ONE -> bounded executor -> #117 v2 prehydration, but returned `EXPERIENCE_REGRESSION_EVIDENCE_MISSING`. The v2 entrypoint can raise inside AgentOS `_prehydrate()` before the base harness writes its evidence file, so the provider loses the actual failure stage.

## Fix
- catch pre-executor hydration exceptions inside the v2 benchmark boundary
- do not expose exception text, paths, tracebacks, stdout, or stderr
- represent only bounded classifications: store missing, permission denied, contract invalid, or generic prehydration failure
- return a synthetic nonzero hydrated-lane run so the base harness still writes canonical `agentos.experience-regression/v1` evidence
- prioritize the bounded prehydration classification in the v2 evidence correction
- add regression coverage proving private exception paths do not cross the evidence boundary

This does not weaken the Master Experience Floor or convert a hydration failure into success; it only preserves diagnosable governed evidence.