### PR TITLE
Core #117: split bounded prehydration exception families

### DIFF
--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -53,13 +53,27 @@ Otherwise return null. Never infer protected-branch authority.
 
 
 def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
-    """Represent pre-executor hydration failure without exposing paths or traces."""
+    """Represent pre-executor hydration failure without exposing messages or traces."""
     if isinstance(exc, FileNotFoundError):
         classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
     elif isinstance(exc, PermissionError):
         classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"
+    elif isinstance(exc, ModuleNotFoundError):
+        classification = "EXPERIENCE_PREHYDRATION_IMPORT_MISSING"
+    elif isinstance(exc, ImportError):
+        classification = "EXPERIENCE_PREHYDRATION_IMPORT_FAILED"
     elif isinstance(exc, ValueError):
         classification = "EXPERIENCE_PREHYDRATION_CONTRACT_INVALID"
+    elif isinstance(exc, TypeError):
+        classification = "EXPERIENCE_PREHYDRATION_TYPE_ERROR"
+    elif isinstance(exc, KeyError):
+        classification = "EXPERIENCE_PREHYDRATION_KEY_ERROR"
+    elif isinstance(exc, AttributeError):
+        classification = "EXPERIENCE_PREHYDRATION_ATTRIBUTE_ERROR"
+    elif isinstance(exc, RuntimeError):
+        classification = "EXPERIENCE_PREHYDRATION_RUNTIME_ERROR"
+    elif isinstance(exc, OSError):
+        classification = "EXPERIENCE_PREHYDRATION_IO_ERROR"
     else:
         classification = "EXPERIENCE_PREHYDRATION_FAILED"
     return {


### PR DESCRIPTION
Run #11 proved AgentOS prehydration is the failing stage but still returned the generic `EXPERIENCE_PREHYDRATION_FAILED`. This patch keeps the same privacy boundary and maps only safe exception families to bounded classifications: missing/import failure, contract/type/key/attribute error, runtime error, I/O error, permission, or store missing. Exception messages, paths, tracebacks, stdout, and stderr remain suppressed. The purpose is purely to identify the failing subsystem on the next exact-generation ONE rollout.