### PR TITLE
Core #117: identify fixed missing prehydration module

### DIFF
--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -10,6 +10,7 @@ but the minimum floor must not depend on the model deciding to call a tool.
 """
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -20,10 +21,29 @@ import tempfile
 from scripts import oracle_codex_experience_regression as regression
 
 
-def _prehydrate() -> dict[str, object]:
-    from agentos_node.experience_mcp_stdio import one_experience_hydrate
+class _PrehydrationDependencyMissing(RuntimeError):
+    def __init__(self, classification: str):
+        super().__init__(classification)
+        self.classification = classification
 
-    return one_experience_hydrate(
+
+def _require_module(name: str, classification: str):
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        raise _PrehydrationDependencyMissing(classification) from None
+
+
+def _prehydrate() -> dict[str, object]:
+    # Fixed canonical import probes make a missing runtime dependency diagnosable
+    # without exposing ModuleNotFoundError.name, paths, or traceback text.
+    _require_module("agent_core.experience", "EXPERIENCE_PREHYDRATION_AGENT_CORE_EXPERIENCE_MISSING")
+    _require_module("agent_core.experience_store", "EXPERIENCE_PREHYDRATION_EXPERIENCE_STORE_MODULE_MISSING")
+    mcp_module = _require_module(
+        "agentos_node.experience_mcp_stdio",
+        "EXPERIENCE_PREHYDRATION_MCP_MODULE_MISSING",
+    )
+    return mcp_module.one_experience_hydrate(
         project_id=regression.PROJECT_ID,
         active_goal=regression.GOAL,
         realm="oracle",
@@ -54,7 +74,9 @@ Otherwise return null. Never infer protected-branch authority.
 
 def _bounded_prehydration_failure(exc: Exception) -> dict[str, object]:
     """Represent pre-executor hydration failure without exposing messages or traces."""
-    if isinstance(exc, FileNotFoundError):
+    if isinstance(exc, _PrehydrationDependencyMissing):
+        classification = exc.classification
+    elif isinstance(exc, FileNotFoundError):
         classification = "EXPERIENCE_PREHYDRATION_STORE_MISSING"
     elif isinstance(exc, PermissionError):
         classification = "EXPERIENCE_PREHYDRATION_PERMISSION_DENIED"


### PR DESCRIPTION
Run #12 narrowed the live blocker to `EXPERIENCE_PREHYDRATION_IMPORT_MISSING`. This patch probes only three fixed canonical module IDs in dependency order before hydration: `agent_core.experience`, `agent_core.experience_store`, and `agentos_node.experience_mcp_stdio`. A failure is converted to a fixed classification for that module; no arbitrary ModuleNotFoundError name, path, traceback, stdout, or stderr is exposed. No deployment or authority surface changes.