### PR TITLE
Core #117: move Master Floor prehydration below MCP transport

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -9,10 +9,12 @@ on:
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
+      - 'agent_core/experience_runtime.py'
       - 'agentos_node/bootstrap_control.py'
       - 'agentos_node/executor_job_adapter.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/issue117_experience_provider.py'
+      - 'agentos_node/experience_mcp_stdio.py'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/oracle_codex_experience_regression.py'
@@ -36,10 +38,12 @@ on:
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
+      - 'agent_core/experience_runtime.py'
       - 'agentos_node/bootstrap_control.py'
       - 'agentos_node/executor_job_adapter.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/issue117_experience_provider.py'
+      - 'agentos_node/experience_mcp_stdio.py'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/oracle_codex_experience_regression.py'
@@ -127,10 +131,12 @@ jobs:
             agent_core/controller_service.py \
             agent_core/controller_api.py \
             agent_core/control_inbox_bridge.py \
+            agent_core/experience_runtime.py \
             agentos_node/bootstrap_control.py \
             agentos_node/executor_job_adapter.py \
             agentos_node/executor_job_action_relay.py \
             agentos_node/issue117_experience_provider.py \
+            agentos_node/experience_mcp_stdio.py \
             scripts/oracle_codex_experience_regression.py \
             scripts/oracle_codex_experience_regression_entry_v2.py
       - name: Validate governed runtime installers

--- a/agent_core/experience_runtime.py
+++ b/agent_core/experience_runtime.py
@@ -1,0 +1,118 @@
+"""Executor-neutral ONE Experience prehydration runtime.
+
+The Master Experience Floor is an AgentOS responsibility. This module owns the
+bounded pre-executor hydration + receipt semantics so executor launch paths do
+not depend on an MCP transport module. MCP surfaces may delegate here, but the
+minimum floor remains available even when no MCP server is imported or started.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from agent_core.experience_store import hydrate_from_one
+
+RECEIPT_SCHEMA = "agentos.experience-hydration-receipt/v1"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _source_commit() -> str:
+    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
+    if explicit:
+        return explicit
+    return Path(__file__).resolve().parents[1].name
+
+
+def _receipt_path(data_root: Path) -> Path:
+    return Path(
+        os.environ.get(
+            "AGENTOS_EXPERIENCE_HYDRATION_RECEIPT",
+            str(data_root / "runtime" / "experience-hydration-last.json"),
+        )
+    ).expanduser()
+
+
+def _write_receipt(
+    projection: dict[str, Any],
+    *,
+    data_root: Path,
+    surface: str,
+    executor_class: str,
+) -> None:
+    path = _receipt_path(data_root)
+    if path.is_symlink():
+        raise ValueError("Experience hydration receipt path must not be a symlink")
+    payload = {
+        "schema": RECEIPT_SCHEMA,
+        "recorded_at": _utc_now(),
+        "runtime_source_commit": _source_commit(),
+        "source": projection.get("source"),
+        "surface": surface,
+        "executor_class": executor_class,
+        "executor_identity_bound": True,
+        "project_id": projection.get("project_id"),
+        "projection_digest": projection.get("digest"),
+        "experience_ids": list(projection.get("experience_ids") or []),
+        "credential_exposed": False,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def prehydrate_experience(
+    *,
+    project_id: str,
+    active_goal: str,
+    realm: str | None,
+    capabilities: tuple[str, ...] = (),
+    executor: str | None,
+    surface: str,
+    executor_class: str,
+    limit: int = 20,
+    data_root: Path | None = None,
+) -> dict[str, Any]:
+    """Resolve ONE Experience and record an independent bounded receipt."""
+    root = data_root or _data_root()
+    projection = hydrate_from_one(
+        project_id=project_id,
+        active_goal=active_goal,
+        realm=realm,
+        capabilities=capabilities,
+        executor=executor,
+        limit=limit,
+        data_root=root,
+    )
+    projection["surface"] = surface
+    projection["executor_class"] = executor_class
+    projection["executor_identity_bound"] = True
+    projection["credential_exposed"] = False
+    _write_receipt(
+        projection,
+        data_root=root,
+        surface=surface,
+        executor_class=executor_class,
+    )
+    return projection

--- a/agentos_node/experience_mcp_stdio.py
+++ b/agentos_node/experience_mcp_stdio.py
@@ -1,75 +1,19 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-import json
 import os
 from pathlib import Path
-import tempfile
 from typing import Any
 
 from agent_core.experience import ExperienceQuery
-from agent_core.experience_store import discover_from_one, hydrate_from_one
+from agent_core.experience_runtime import prehydrate_experience
+from agent_core.experience_store import discover_from_one
 
 SURFACE = "codex-local"
 EXECUTOR_CLASS = "openai-codex-local"
-RECEIPT_SCHEMA = "agentos.experience-hydration-receipt/v1"
 
 
 def _data_root() -> Path:
     return Path(os.environ.get("AGENT_DATA_ROOT", os.environ.get("AGENTOS_DATA_ROOT", "/home/ubuntu/agent-data"))).expanduser()
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def _source_commit() -> str:
-    explicit = str(os.environ.get("AGENTOS_RUNTIME_SOURCE_COMMIT") or "").strip()
-    if explicit:
-        return explicit
-    return Path(__file__).resolve().parents[1].name
-
-
-def _receipt_path() -> Path:
-    return Path(
-        os.environ.get(
-            "AGENTOS_EXPERIENCE_HYDRATION_RECEIPT",
-            str(_data_root() / "runtime" / "experience-hydration-last.json"),
-        )
-    ).expanduser()
-
-
-def _write_receipt(projection: dict[str, Any]) -> None:
-    path = _receipt_path()
-    if path.is_symlink():
-        raise ValueError("Experience hydration receipt path must not be a symlink")
-    payload = {
-        "schema": RECEIPT_SCHEMA,
-        "recorded_at": _utc_now(),
-        "runtime_source_commit": _source_commit(),
-        "source": projection.get("source"),
-        "surface": SURFACE,
-        "executor_class": EXECUTOR_CLASS,
-        "executor_identity_bound": True,
-        "project_id": projection.get("project_id"),
-        "projection_digest": projection.get("digest"),
-        "experience_ids": list(projection.get("experience_ids") or []),
-        "credential_exposed": False,
-    }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
-    tmp = Path(tmp_name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.chmod(tmp, 0o640)
-        os.replace(tmp, path)
-    finally:
-        if tmp.exists():
-            tmp.unlink()
 
 
 def _project(items: list[dict[str, Any]]) -> dict[str, Any]:
@@ -113,21 +57,17 @@ def one_experience_hydrate(
     executor: str = "codex",
     limit: int = 20,
 ) -> dict[str, Any]:
-    projection = hydrate_from_one(
+    return prehydrate_experience(
         project_id=project_id,
         active_goal=active_goal,
         realm=realm or None,
         capabilities=tuple(capabilities or ()),
         executor=executor or None,
         limit=limit,
+        surface=SURFACE,
+        executor_class=EXECUTOR_CLASS,
         data_root=_data_root(),
     )
-    projection["surface"] = SURFACE
-    projection["executor_class"] = EXECUTOR_CLASS
-    projection["executor_identity_bound"] = True
-    projection["credential_exposed"] = False
-    _write_receipt(projection)
-    return projection
 
 
 def create_server():

--- a/scripts/oracle_codex_experience_regression_entry_v2.py
+++ b/scripts/oracle_codex_experience_regression_entry_v2.py
@@ -6,7 +6,8 @@ feature. Baseline remains a completely fresh Codex process. For the hydrated lan
 AgentOS resolves a bounded ONE Experience projection before launching another fresh
 Codex process, records the independent hydration receipt, and injects only that
 projection into the executor context. Executors may discover more Experience later,
-but the minimum floor must not depend on the model deciding to call a tool.
+but the minimum floor must not depend on the model deciding to call a tool or on
+an MCP transport module being importable.
 """
 from __future__ import annotations
 
@@ -35,20 +36,20 @@ def _require_module(name: str, classification: str):
 
 
 def _prehydrate() -> dict[str, object]:
-    # Fixed canonical import probes make a missing runtime dependency diagnosable
-    # without exposing ModuleNotFoundError.name, paths, or traceback text.
-    _require_module("agent_core.experience", "EXPERIENCE_PREHYDRATION_AGENT_CORE_EXPERIENCE_MISSING")
-    _require_module("agent_core.experience_store", "EXPERIENCE_PREHYDRATION_EXPERIENCE_STORE_MODULE_MISSING")
-    mcp_module = _require_module(
-        "agentos_node.experience_mcp_stdio",
-        "EXPERIENCE_PREHYDRATION_MCP_MODULE_MISSING",
+    # Master Floor uses the executor-neutral Core primitive. MCP is an optional
+    # discovery surface and is deliberately not part of this minimum guarantee.
+    runtime = _require_module(
+        "agent_core.experience_runtime",
+        "EXPERIENCE_PREHYDRATION_CORE_RUNTIME_MISSING",
     )
-    return mcp_module.one_experience_hydrate(
+    return runtime.prehydrate_experience(
         project_id=regression.PROJECT_ID,
         active_goal=regression.GOAL,
         realm="oracle",
         executor="codex",
-        capabilities=regression.CAPABILITIES,
+        capabilities=tuple(regression.CAPABILITIES),
+        surface="codex-local",
+        executor_class="openai-codex-local",
     )
 
 
@@ -204,11 +205,11 @@ def _correct_method_evidence(path: Path | None) -> None:
             "unchanged hydration receipt independently proves non-access"
         )
         method["hydrated"] = (
-            "AgentOS pre-executor hydration from ONE Experience + independent receipt, followed by a fresh "
+            "AgentOS Core pre-executor hydration from ONE Experience + independent receipt, followed by a fresh "
             "Codex process receiving only the bounded projection as context"
         )
     payload["config_override_used"] = False
-    payload["hydration_delivery"] = "agentos-pre-executor-projection"
+    payload["hydration_delivery"] = "agentos-core-pre-executor-projection"
     payload["executor_tool_call_required_for_floor"] = False
     payload["classification"] = _fixed_classification(payload)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Live evidence
Run #13 (`33708632408`) proved Core Experience + Store imports succeed but prehydration fails at the `agentos_node.experience_mcp_stdio` transport module (`EXPERIENCE_PREHYDRATION_MCP_MODULE_MISSING`). The exact commit contains that file, so the minimum Experience floor is unnecessarily coupled to an MCP transport/package boundary.

## Architectural fix
- add `agent_core.experience_runtime.prehydrate_experience` as the executor-neutral Core primitive for ONE Experience hydration + independent receipt
- #117 pre-executor Master Floor calls this Core primitive directly
- MCP `one_experience_hydrate` delegates to the same primitive rather than owning duplicate receipt semantics
- no executor tool call is required for the minimum floor
- no shell/argv/env/credential authority is added
- Bounded Guard now treats the Core hydration primitive and MCP adapter as governed runtime inputs and compiles them

This preserves MCP as an optional discovery surface while making the Master Experience Floor an AgentOS/Core guarantee.