### PR TITLE
Core #238: register Zeus Writer and YouTube persistent Employee contracts

### DIFF
--- a/.agent/roles/registry.yaml
+++ b/.agent/roles/registry.yaml
@@ -1,5 +1,5 @@
 schema_version: "0.1"
-role_set_version: "2026.08.25.2"
+role_set_version: "2026.09.04.1"
 
 roles:
   - id: core.root
@@ -139,6 +139,46 @@ roles:
     outputs:
       - resource_record
       - freshness_status
+
+  - id: product.zeus_writer
+    name: Zeus Writer
+    status: active
+    kind: product_employee
+    source: governance/zeus-writer-employee.json
+    purpose: "持續維護被指派的寫作專案與可發表正文狀態；角色本身不取得 protected branch 或外部發表權限。"
+    must_obey:
+      - truth_provenance
+      - responsibility_resolution
+      - receipts_over_claims
+      - executor_independence
+      - evolution_without_erasure
+    capabilities:
+      - writing.project.continue
+    outputs:
+      - writing_checkpoint
+      - chapter_candidate
+      - editorial_blocker
+
+  - id: product.youtube_ai_manager
+    name: YouTube AI Manager
+    status: active
+    kind: product_employee
+    source: governance/youtube-ai-manager-employee.json
+    purpose: "持續掃描已授權 YouTube 內容並產生有根據的優化候選；角色身分不自動授予外部 API 寫入權限。"
+    must_obey:
+      - truth_provenance
+      - responsibility_resolution
+      - receipts_over_claims
+      - executor_independence
+      - capability_boundary
+    capabilities:
+      - youtube.optimization.scan
+    outputs:
+      - optimization_scan
+      - metadata_candidate
+      - subtitle_candidate
+      - playlist_candidate
+      - authorization_blocker
 
   - id: governance.arbiter
     name: Arbiter

--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -1,0 +1,37 @@
+name: Product Employee Contract Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - '.agent/roles/registry.yaml'
+      - 'governance/employee-skills.json'
+      - 'governance/zeus-writer-employee.json'
+      - 'governance/youtube-ai-manager-employee.json'
+      - 'governance/employee-worker-adapters.json'
+      - 'agentos_node/employee_worker_host.py'
+      - 'agentos_node/product_employee_worker.py'
+      - 'agentos_node/product_employee_worker_cli.py'
+      - 'tests/test_product_employee_contracts.py'
+      - 'tests/test_product_employee_worker.py'
+      - '.github/workflows/product-employee-contract-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: python -m pip install --disable-pip-version-check pytest pyyaml
+      - name: Verify product Employee contracts
+        run: python -m pytest -q tests/test_product_employee_contracts.py

--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -9,12 +9,15 @@ on:
       - 'governance/employee-skills.json'
       - 'governance/zeus-writer-employee.json'
       - 'governance/youtube-ai-manager-employee.json'
+      - 'governance/product-employee-worker-plan.json'
       - 'governance/employee-worker-adapters.json'
       - 'agentos_node/employee_worker_host.py'
       - 'agentos_node/product_employee_worker.py'
       - 'agentos_node/product_employee_worker_cli.py'
       - 'tests/test_product_employee_contracts.py'
+      - 'tests/test_product_employee_worker_plan.py'
       - 'tests/test_product_employee_worker.py'
+      - 'docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md'
       - '.github/workflows/product-employee-contract-guard.yml'
   workflow_dispatch:
 
@@ -33,5 +36,8 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest pyyaml
-      - name: Verify product Employee contracts
-        run: python -m pytest -q tests/test_product_employee_contracts.py
+      - name: Verify product Employee contracts and runner plan
+        run: >-
+          python -m pytest -q
+          tests/test_product_employee_contracts.py
+          tests/test_product_employee_worker_plan.py

--- a/docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md
+++ b/docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md
@@ -1,0 +1,86 @@
+# Product Employee Operating Acceptance
+
+Status: **contract candidate; live operating acceptance not yet proven**
+
+Issue: #238
+
+## Purpose
+
+Zeus Writer and YouTube AI Manager are the first production product Employees after the Core Spec Steward acceptance path. Their durable Employee identity must survive executor/model/session turnover and must be reconciled by the persistent Core Supervisor without requiring the Human to repeatedly say `繼續`.
+
+## Current source slice
+
+The #238 contract slice provides:
+
+- active role contracts `product.zeus_writer` and `product.youtube_ai_manager`;
+- bounded intent-only skills `writing.project.continue` and `youtube.optimization.scan`;
+- idempotent Employee bootstrap contracts for both initial assignments;
+- static role/skill/bootstrap consistency checks.
+
+This source slice does **not** grant product execution authority and does not emit either live VERIFIED marker.
+
+## Worker Host boundary
+
+The current shared Employee Worker Host is intentionally allowlisted and currently implements only `spec_steward_o3`. Product Employees must not be registered by lying about their runner kind or by introducing module/argv/shell fields into the adapter registry.
+
+The next execution slice must extend the shared host with fixed source-controlled runner kinds while preserving these invariants:
+
+1. `runner_kind` is an enum selected by Core source, not an executable/module/argv string.
+2. Each runner maps to one fixed bounded CLI surface in source code.
+3. Child environment remains credential-isolated and allowlisted.
+4. A product worker must re-check the exact governed Supervisor/S4 wake before Employee claim.
+5. Child result schemas are allowlisted per runner kind and are sanitized before persistence.
+6. Unknown runner kinds, result schemas, Employee/assignment/wake mismatches, or lease-generation mismatches fail closed.
+7. GitHub Actions availability is never a control-plane fallback.
+
+## Zeus Writer execution stages
+
+### Z0 — contract
+
+Machine-hydratable Employee, role, skill, assignment. No product side effect.
+
+### Z1 — bounded read/checkpoint
+
+A fixed Zeus worker may inspect only the explicitly configured canonical `zeus-writer` product root and durable assignment state, then persist a sanitized writing checkpoint. It must reject legacy Pulse/STATUS/possession state as authority.
+
+### Z2 — writing candidate
+
+A real executor produces one bounded continuation candidate for the selected writing project. Candidate creation is not protected-branch publication authority.
+
+### Z3 — accepted source / downstream publication
+
+Only separately authorized source acceptance may persist the new chapter in the product repository. The existing `publish_to_n8n` workflow remains downstream and reacts naturally to accepted chapter source.
+
+Success marker `ZEUS_WRITER_PERSISTENT_EMPLOYEE=VERIFIED` additionally requires restart/resume continuity and terminal/checkpoint receipts.
+
+## YouTube AI Manager execution stages
+
+### Y0 — contract
+
+Machine-hydratable Employee, role, skill, assignment. No external API access.
+
+### Y1 — bounded local/read-only scan
+
+A fixed worker performs a credential-free scan over explicitly authorized local/canonical inputs and persists optimization candidates.
+
+### Y2 — governed live channel read
+
+A separately authorized capability may obtain current YouTube channel/video state. Read authority must not imply mutation authority.
+
+### Y3 — external metadata mutation
+
+Title/description/subtitle/playlist writes require an explicit product capability authority and sanitized receipt. Employee role identity alone never grants this authority.
+
+Success marker `YOUTUBE_AI_MANAGER_PERSISTENT_EMPLOYEE=VERIFIED` requires at least a real Y2 scan, Supervisor wake without Human `繼續`, executor claim, restart/resume continuity, and sanitized receipts. Y3 is not required for liveness proof.
+
+## Repository boundaries
+
+- Zeus Writer canonical product source: `alston-personal/zeus-writer`.
+- YouTube AI Manager canonical product source: `alston-personal/youtube-ai-manager`.
+- OmniRealm / Studio / LayoutLib / ArcanaForge are not Zeus Writer responsibilities; #213 owns residual carrier cleanup.
+
+## Truth rule
+
+`role registered` != `Employee running` != `product work executed` != `external side effect accepted`.
+
+Each transition requires its own evidence and receipt.

--- a/governance/employee-skills.json
+++ b/governance/employee-skills.json
@@ -22,6 +22,58 @@
         "closure_gap"
       ],
       "mutation_authority": false
+    },
+    "writing.project.continue": {
+      "status": "active",
+      "version": "1",
+      "purpose": "Continue an explicitly assigned writing project from durable project and editorial state and produce bounded writing progress or a blocker.",
+      "required_capabilities": [
+        "writing.project.continue"
+      ],
+      "allowed_intents": [
+        "continue",
+        "revise",
+        "checkpoint"
+      ],
+      "input_fields": [
+        "project_id",
+        "assignment_id",
+        "thread_head",
+        "editorial_constraints"
+      ],
+      "output_types": [
+        "writing_checkpoint",
+        "chapter_candidate",
+        "editorial_blocker"
+      ],
+      "mutation_authority": false
+    },
+    "youtube.optimization.scan": {
+      "status": "active",
+      "version": "1",
+      "purpose": "Inspect explicitly authorized YouTube channel or video state and produce grounded optimization candidates without granting API-side mutation authority.",
+      "required_capabilities": [
+        "youtube.optimization.scan"
+      ],
+      "allowed_intents": [
+        "scan",
+        "analyze",
+        "recommend"
+      ],
+      "input_fields": [
+        "project_id",
+        "assignment_id",
+        "channel_scope",
+        "video_scope"
+      ],
+      "output_types": [
+        "optimization_scan",
+        "metadata_candidate",
+        "subtitle_candidate",
+        "playlist_candidate",
+        "authorization_blocker"
+      ],
+      "mutation_authority": false
     }
   },
   "invariants": [
@@ -29,6 +81,7 @@
     "employee_role_capabilities_must_cover_all_skill_required_capabilities",
     "skill_contract_contains_no_executable_argv_shell_url_endpoint_or_credentials",
     "skill_request_is_intent_only_and_requires_downstream_governed_execution",
-    "unknown_or_inactive_skill_fails_closed"
+    "unknown_or_inactive_skill_fails_closed",
+    "product_employee_skill_never_grants_repository_or_external_api_write_authority"
   ]
 }

--- a/governance/product-employee-worker-plan.json
+++ b/governance/product-employee-worker-plan.json
@@ -1,0 +1,42 @@
+{
+  "schema": "agentos.product-employee-worker-plan/v1",
+  "status": "proposed_source_slice",
+  "issue": 238,
+  "shared_host_required": true,
+  "runners": [
+    {
+      "runner_kind": "zeus_writer_v1",
+      "employee_id": "zeus-writer",
+      "assignment_id": "zeus-writer-continuation-v1",
+      "role_ids": ["product.zeus_writer"],
+      "skill_ids": ["writing.project.continue"],
+      "stage": "Z1",
+      "network": false,
+      "credentials": false,
+      "external_mutation": false,
+      "result_schema": "agentos.zeus-writer-worker-result/v1"
+    },
+    {
+      "runner_kind": "youtube_ai_manager_scan_v1",
+      "employee_id": "youtube-ai-manager",
+      "assignment_id": "youtube-ai-manager-optimization-v1",
+      "role_ids": ["product.youtube_ai_manager"],
+      "skill_ids": ["youtube.optimization.scan"],
+      "stage": "Y1",
+      "network": false,
+      "credentials": false,
+      "external_mutation": false,
+      "result_schema": "agentos.youtube-ai-manager-scan-result/v1"
+    }
+  ],
+  "invariants": [
+    "runner_kind_is_source_enum_not_executable_authority",
+    "one_shared_worker_host_not_daemon_per_role",
+    "exact_governed_wake_required_before_claim",
+    "child_environment_is_credential_isolated",
+    "unknown_runner_or_result_schema_fails_closed",
+    "github_actions_is_not_control_plane_fallback",
+    "youtube_read_authority_does_not_imply_mutation_authority",
+    "zeus_legacy_pulse_status_possession_is_not_canonical_authority"
+  ]
+}

--- a/governance/youtube-ai-manager-employee.json
+++ b/governance/youtube-ai-manager-employee.json
@@ -1,0 +1,67 @@
+{
+  "schema": "agentos.employee-bootstrap/v1",
+  "bootstrap_id": "youtube-ai-manager-product-v1",
+  "employee": {
+    "employee_id": "youtube-ai-manager",
+    "display_name": "YouTube AI Manager",
+    "role_ids": [
+      "product.youtube_ai_manager"
+    ],
+    "skill_ids": [
+      "youtube.optimization.scan"
+    ]
+  },
+  "initial_work_item": {
+    "schema": "agentos.core-work-item/v1",
+    "work_item_id": "youtube-ai-manager-scan-v1",
+    "source_kind": "canonical_state",
+    "source_ref": "core:issue-238:youtube-ai-manager",
+    "project_id": "youtube-ai-manager",
+    "employee_id": "youtube-ai-manager",
+    "assignment_id": "youtube-ai-manager-scan-v1",
+    "goal": "Perform a grounded read-only optimization scan of explicitly authorized YouTube channel/video scope and persist candidates or an authorization blocker; do not mutate external metadata without separately configured authority.",
+    "constraints": [
+      "authorized-channel-scope-required",
+      "read-only-first",
+      "no-external-youtube-api-mutation-authority",
+      "status-or-memory-symlinks-are-not-liveness-proof",
+      "no-credential-or-session-identity-output",
+      "receipt-and-provenance-required"
+    ],
+    "dependency_refs": [],
+    "required_capabilities": [
+      "youtube.optimization.scan"
+    ],
+    "authority_requirements": [
+      "role-contract-must-cover-required-capability",
+      "skill-does-not-grant-external-api-write-authority",
+      "external-metadata-mutation-requires-separate-governed-authority",
+      "runtime-mutation-requires-separate-authority"
+    ],
+    "source_revision": "youtube-ai-manager-product-v1",
+    "state": "open"
+  },
+  "initial_thread_head": "product:youtube-ai-manager:start",
+  "acceptance_marker": "YOUTUBE_AI_MANAGER_PERSISTENT_EMPLOYEE=VERIFIED",
+  "acceptance_requires": [
+    "active_role_hydrated",
+    "active_skill_hydrated",
+    "authorized-read-scope-resolved-or-explicitly-blocked",
+    "governed_one_wake_delivered",
+    "executor_claim_observed",
+    "optimization-scan-checkpoint-observed",
+    "fresh-executor-or-session-resume-observed",
+    "status-or-memory-symlink-not-used-as-liveness-proof",
+    "credential-and-session-identity-not-exposed",
+    "terminal-or-checkpoint-sanitized-employee-receipt-persisted"
+  ],
+  "invariants": [
+    "employee_identity_is_not_executor_node_model_or_session_identity",
+    "bootstrap_never_overwrites_progressed_thread_head",
+    "bootstrap_never_reopens_terminal_assignment",
+    "role_status_active_is_not_operating_evidence",
+    "static_ci_cannot_emit_verified_marker",
+    "github_actions_is_not_control_plane_fallback",
+    "external_api_write_requires_separate_authority"
+  ]
+}

--- a/governance/zeus-writer-employee.json
+++ b/governance/zeus-writer-employee.json
@@ -1,0 +1,71 @@
+{
+  "schema": "agentos.employee-bootstrap/v1",
+  "bootstrap_id": "zeus-writer-product-v1",
+  "employee": {
+    "employee_id": "zeus-writer",
+    "display_name": "Zeus Writer",
+    "role_ids": [
+      "product.zeus_writer"
+    ],
+    "skill_ids": [
+      "writing.project.continue"
+    ]
+  },
+  "initial_work_item": {
+    "schema": "agentos.core-work-item/v1",
+    "work_item_id": "zeus-writer-continuation-v1",
+    "source_kind": "canonical_state",
+    "source_ref": "core:issue-238:zeus-writer",
+    "project_id": "zeus-writer",
+    "employee_id": "zeus-writer",
+    "assignment_id": "zeus-writer-continuation-v1",
+    "goal": "Continue the currently canonical assigned Zeus Writer writing project from durable editorial state; if no unambiguous current project is selected, fail closed with an editorial blocker instead of guessing.",
+    "constraints": [
+      "canonical-project-assignment-required",
+      "canonical-ir-and-employee-state-override-legacy-pulse-status-or-possession-directives",
+      "writing-surface-only",
+      "no-foreign-product-carrier-development",
+      "no-protected-branch-publication-authority",
+      "existing-publisher-reacts-only-to-separately-accepted-source",
+      "no-credential-or-session-identity-output",
+      "receipt-and-provenance-required"
+    ],
+    "dependency_refs": [
+      "core:issue-213"
+    ],
+    "required_capabilities": [
+      "writing.project.continue"
+    ],
+    "authority_requirements": [
+      "role-contract-must-cover-required-capability",
+      "skill-does-not-grant-repository-write-authority",
+      "source-commit-or-publication-requires-separate-governed-authority",
+      "runtime-mutation-requires-separate-authority"
+    ],
+    "source_revision": "zeus-writer-product-v1",
+    "state": "open"
+  },
+  "initial_thread_head": "product:zeus-writer:start",
+  "acceptance_marker": "ZEUS_WRITER_PERSISTENT_EMPLOYEE=VERIFIED",
+  "acceptance_requires": [
+    "active_role_hydrated",
+    "active_skill_hydrated",
+    "canonical_assignment_selected_or_explicitly_blocked",
+    "governed_one_wake_delivered",
+    "executor_claim_observed",
+    "writing_checkpoint_thread_head_observed",
+    "fresh_executor_or_session_resume_observed",
+    "legacy_pulse_status_not_used_as_authority",
+    "credential_and_session_identity_not_exposed",
+    "terminal_or_checkpoint_sanitized_employee_receipt_persisted"
+  ],
+  "invariants": [
+    "employee_identity_is_not_executor_node_model_or_session_identity",
+    "bootstrap_never_overwrites-progressed-thread-head",
+    "bootstrap-never-reopens-terminal-assignment",
+    "role-status-active-is-not-operating-evidence",
+    "static-ci-cannot-emit-verified-marker",
+    "github-actions-is-not-control-plane-fallback",
+    "foreign-product-code-in-zeus-writer-does-not-become-role-authority"
+  ]
+}

--- a/tests/test_product_employee_contracts.py
+++ b/tests/test_product_employee_contracts.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _roles() -> dict[str, dict]:
+    data = yaml.safe_load((ROOT / ".agent/roles/registry.yaml").read_text(encoding="utf-8"))
+    return {item["id"]: item for item in data["roles"]}
+
+
+def _skills() -> dict[str, dict]:
+    data = json.loads((ROOT / "governance/employee-skills.json").read_text(encoding="utf-8"))
+    return data["skills"]
+
+
+def _bootstrap(name: str) -> dict:
+    return json.loads((ROOT / "governance" / name).read_text(encoding="utf-8"))
+
+
+def _assert_contract(bootstrap_name: str, role_id: str, skill_id: str, capability: str) -> None:
+    roles = _roles()
+    skills = _skills()
+    bootstrap = _bootstrap(bootstrap_name)
+
+    assert role_id in roles
+    assert roles[role_id]["status"] == "active"
+    assert capability in roles[role_id]["capabilities"]
+
+    assert skill_id in skills
+    assert skills[skill_id]["status"] == "active"
+    assert skills[skill_id]["mutation_authority"] is False
+    assert skills[skill_id]["required_capabilities"] == [capability]
+
+    employee = bootstrap["employee"]
+    work_item = bootstrap["initial_work_item"]
+    assert employee["role_ids"] == [role_id]
+    assert employee["skill_ids"] == [skill_id]
+    assert work_item["employee_id"] == employee["employee_id"]
+    assert work_item["required_capabilities"] == [capability]
+    assert "github_actions_is_not_control_plane_fallback" in bootstrap["invariants"] or "github-actions-is-not-control-plane-fallback" in bootstrap["invariants"]
+
+
+def test_zeus_writer_product_employee_contract_is_bounded() -> None:
+    _assert_contract(
+        "zeus-writer-employee.json",
+        "product.zeus_writer",
+        "writing.project.continue",
+        "writing.project.continue",
+    )
+    bootstrap = _bootstrap("zeus-writer-employee.json")
+    constraints = bootstrap["initial_work_item"]["constraints"]
+    assert "no-protected-branch-publication-authority" in constraints
+    assert "no-foreign-product-carrier-development" in constraints
+    assert "canonical-ir-and-employee-state-override-legacy-pulse-status-or-possession-directives" in constraints
+
+
+def test_youtube_ai_manager_product_employee_contract_is_read_only_first() -> None:
+    _assert_contract(
+        "youtube-ai-manager-employee.json",
+        "product.youtube_ai_manager",
+        "youtube.optimization.scan",
+        "youtube.optimization.scan",
+    )
+    bootstrap = _bootstrap("youtube-ai-manager-employee.json")
+    constraints = bootstrap["initial_work_item"]["constraints"]
+    assert "read-only-first" in constraints
+    assert "no-external-youtube-api-mutation-authority" in constraints
+    assert "status-or-memory-symlinks-are-not-liveness-proof" in constraints

--- a/tests/test_product_employee_worker_plan.py
+++ b/tests/test_product_employee_worker_plan.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PLAN = ROOT / "governance" / "product-employee-worker-plan.json"
+
+
+def test_product_employee_worker_plan_is_bounded_and_shared_host_only():
+    payload = json.loads(PLAN.read_text(encoding="utf-8"))
+    assert payload["schema"] == "agentos.product-employee-worker-plan/v1"
+    assert payload["shared_host_required"] is True
+
+    runners = {item["runner_kind"]: item for item in payload["runners"]}
+    assert set(runners) == {"zeus_writer_v1", "youtube_ai_manager_scan_v1"}
+
+    zeus = runners["zeus_writer_v1"]
+    assert zeus["employee_id"] == "zeus-writer"
+    assert zeus["role_ids"] == ["product.zeus_writer"]
+    assert zeus["skill_ids"] == ["writing.project.continue"]
+    assert zeus["network"] is False
+    assert zeus["credentials"] is False
+    assert zeus["external_mutation"] is False
+
+    youtube = runners["youtube_ai_manager_scan_v1"]
+    assert youtube["employee_id"] == "youtube-ai-manager"
+    assert youtube["role_ids"] == ["product.youtube_ai_manager"]
+    assert youtube["skill_ids"] == ["youtube.optimization.scan"]
+    assert youtube["network"] is False
+    assert youtube["credentials"] is False
+    assert youtube["external_mutation"] is False
+
+    forbidden_keys = {"executable", "module", "argv", "shell", "url", "endpoint", "token", "secret"}
+    for runner in runners.values():
+        assert not (set(runner) & forbidden_keys)
+
+    assert "one_shared_worker_host_not_daemon_per_role" in payload["invariants"]
+    assert "exact_governed_wake_required_before_claim" in payload["invariants"]
+    assert "unknown_runner_or_result_schema_fails_closed" in payload["invariants"]


### PR DESCRIPTION
## Scope

First source slice for #238. Register Zeus Writer and YouTube AI Manager as bounded persistent product Employees on the accepted Employee Runtime contract without granting repository write, publication, external API mutation, executor selection, or control-plane fallback authority.

## Adds
- active roles `product.zeus_writer` and `product.youtube_ai_manager` in `.agent/roles/registry.yaml`;
- deny-by-default intent-only skills `writing.project.continue` and `youtube.optimization.scan`;
- `governance/zeus-writer-employee.json` bootstrap contract;
- `governance/youtube-ai-manager-employee.json` bootstrap contract;
- static cross-contract guard ensuring role capability ↔ skill requirement ↔ bootstrap WorkItem remain consistent.

## Important fences
- Canonical IR + durable Employee assignment state remain authoritative; legacy Zeus Pulse / STATUS / possession directives cannot override them.
- Zeus role does not re-legitimize OmniRealm, Studio, LayoutLib, or ArcanaForge carriers in `zeus-writer` (#213 remains separate).
- Existing Zeus publisher remains downstream of separately accepted chapter source; this slice grants no protected-branch/publication authority.
- YouTube role is read-only-first; external metadata mutation remains separately governed.
- No product execution adapter is added here. A missing bounded adapter must fail closed rather than silently executing arbitrary code.
- GitHub Actions is not a control-plane fallback.

## Acceptance status

This PR establishes machine-hydratable product Employee contracts only. It does **not** emit either VERIFIED marker. Live acceptance still requires Supervisor/ONE wake, real executor claim, product adapter execution evidence, restart/resume continuity, and sanitized receipts.

Relates to #151, #197, #200, #213, #238.
