### PR TITLE
Core #240: generalize shared Employee Worker Host for fixed product runners

### DIFF
--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -11,7 +11,9 @@ on:
       - 'governance/youtube-ai-manager-employee.json'
       - 'governance/product-employee-worker-plan.json'
       - 'governance/employee-worker-adapters.json'
+      - 'governance/employee-worker-adapters-v2.json'
       - 'agentos_node/employee_worker_host.py'
+      - 'agentos_node/employee_worker_host_runtime.py'
       - 'agentos_node/product_employee_worker.py'
       - 'agentos_node/product_employee_worker_cli.py'
       - 'tests/test_product_employee_contracts.py'
@@ -36,8 +38,9 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest pyyaml
-      - name: Verify product Employee contracts and runner plan
+      - name: Verify product Employee contracts and bounded runner host
         run: >-
           python -m pytest -q
           tests/test_product_employee_contracts.py
           tests/test_product_employee_worker_plan.py
+          tests/test_product_employee_worker.py

--- a/agentos_node/employee_worker_host_runtime.py
+++ b/agentos_node/employee_worker_host_runtime.py
@@ -1,20 +1,130 @@
 from __future__ import annotations
 
+import json
+import sys
+from pathlib import Path
 from typing import Any
 
-from agentos_node.employee_worker_host import EmployeeWorkerAdapter, EmployeeWorkerHost, WorkerHostCandidate
+from agentos_node.employee_worker_host import (
+    SAFE_CHILD_RESULT_KEYS,
+    EmployeeWorkerAdapter,
+    EmployeeWorkerHost,
+    WorkerHostCandidate,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+V2_ADAPTER_REGISTRY = ROOT / "governance" / "employee-worker-adapters-v2.json"
+V2_REGISTRY_SCHEMA = "agentos.employee-worker-adapters/v2"
+V2_RUNNER_KINDS = {
+    "spec_steward_o3",
+    "zeus_writer_v1",
+    "youtube_ai_manager_scan_v1",
+}
+V2_RESULT_SCHEMAS = {
+    "spec_steward_o3": "agentos.spec-steward-o3-worker-cli-result/v1",
+    "zeus_writer_v1": "agentos.zeus-writer-worker-cli-result/v1",
+    "youtube_ai_manager_scan_v1": "agentos.youtube-ai-manager-scan-worker-cli-result/v1",
+}
+
+
+class ProductEmployeeWorkerAdapterRegistry:
+    """V2 source-controlled registry for fixed bounded Employee runner kinds."""
+
+    def __init__(self, path: str | Path = V2_ADAPTER_REGISTRY) -> None:
+        self.path = Path(path).expanduser().resolve()
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema") != V2_REGISTRY_SCHEMA:
+            raise ValueError("employee_worker_adapter_v2_registry_schema_invalid")
+        raw = payload.get("adapters")
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("employee_worker_adapter_v2_registry_entries_invalid")
+
+        self._adapters: list[EmployeeWorkerAdapter] = []
+        seen_ids: set[str] = set()
+        seen_scopes: set[tuple[str, str]] = set()
+        for entry in raw:
+            if not isinstance(entry, dict):
+                raise ValueError("employee_worker_adapter_v2_shape_invalid")
+            runner_kind = str(entry.get("runner_kind") or "").strip()
+            adapter_id = str(entry.get("adapter_id") or "").strip()
+            employee_id = str(entry.get("employee_id") or "").strip()
+            assignment_id = str(entry.get("assignment_id") or "").strip()
+            status = str(entry.get("status") or "").strip().lower()
+            role_ids = tuple(str(value).strip() for value in (entry.get("role_ids") or []))
+            skill_ids = tuple(str(value).strip() for value in (entry.get("skill_ids") or []))
+            if runner_kind not in V2_RUNNER_KINDS:
+                raise ValueError("employee_worker_adapter_v2_runner_kind_invalid")
+            if status not in {"active", "disabled"}:
+                raise ValueError("employee_worker_adapter_v2_status_invalid")
+            if not adapter_id or not employee_id or not assignment_id or not all(role_ids) or not all(skill_ids):
+                raise ValueError("employee_worker_adapter_v2_scope_invalid")
+            if adapter_id in seen_ids or (employee_id, assignment_id) in seen_scopes:
+                raise ValueError("employee_worker_adapter_v2_duplicate")
+            seen_ids.add(adapter_id)
+            seen_scopes.add((employee_id, assignment_id))
+            self._adapters.append(
+                EmployeeWorkerAdapter(
+                    adapter_id=adapter_id,
+                    status=status,
+                    runner_kind=runner_kind,
+                    employee_id=employee_id,
+                    assignment_id=assignment_id,
+                    role_ids=role_ids,
+                    skill_ids=skill_ids,
+                )
+            )
+
+    def resolve(self, capsule: dict[str, Any]) -> EmployeeWorkerAdapter | None:
+        intent = capsule.get("wake_intent")
+        if not isinstance(intent, dict):
+            return None
+        employee_id = str(capsule.get("employee_id") or "").strip()
+        assignment_id = str(capsule.get("assignment_id") or "").strip()
+        role_ids = set(str(value).strip() for value in (intent.get("role_ids") or []))
+        skill_ids = set(str(value).strip() for value in (intent.get("skill_ids") or []))
+        matches = [
+            adapter
+            for adapter in self._adapters
+            if adapter.status == "active"
+            and adapter.employee_id == employee_id
+            and adapter.assignment_id == assignment_id
+            and set(adapter.role_ids) == role_ids
+            and set(adapter.skill_ids) == skill_ids
+        ]
+        if len(matches) > 1:
+            raise RuntimeError("employee_worker_adapter_v2_resolution_ambiguous")
+        return matches[0] if matches else None
+
+    def projection(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "adapter_id": item.adapter_id,
+                "status": item.status,
+                "runner_kind": item.runner_kind,
+                "employee_id": item.employee_id,
+                "assignment_id": item.assignment_id,
+                "role_ids": list(item.role_ids),
+                "skill_ids": list(item.skill_ids),
+            }
+            for item in self._adapters
+        ]
 
 
 class ExactEmployeeWorkerHost(EmployeeWorkerHost):
-    """Deployment surface that pins one host cycle to one exact wake capsule.
+    """One shared credential-isolated host for exact fixed Employee runner kinds.
 
-    `EmployeeWorkerHost` owns the durable dispatch ledger and crash/UNKNOWN
-    semantics. This wrapper makes the selected wake immutable for the duration of
-    one child launch and passes the exact wake identity to the bounded adapter CLI.
+    The underlying EmployeeWorkerHost still owns the durable dispatch ledger,
+    crash/UNKNOWN semantics and allowlisted child environment. This wrapper only
+    expands source-controlled runner selection and pins one exact wake per launch.
     """
 
     def __init__(self, **kwargs: Any) -> None:
+        # Base initialization intentionally uses the existing v1 Spec Steward registry
+        # so all original validation and host setup remain unchanged. Runtime selection
+        # is then replaced with the stricter v2 fixed-runner registry.
         super().__init__(**kwargs)
+        self.registry = ProductEmployeeWorkerAdapterRegistry()
         self._pinned_candidate: WorkerHostCandidate | None = None
 
     def _candidates(self) -> list[WorkerHostCandidate]:
@@ -29,7 +139,29 @@ class ExactEmployeeWorkerHost(EmployeeWorkerHost):
         candidate = self._pinned_candidate
         if candidate is None:
             raise RuntimeError("employee_worker_exact_candidate_missing")
-        command = super()._child_command(adapter)
+        if adapter.runner_kind == "spec_steward_o3":
+            command = EmployeeWorkerHost._child_command(self, adapter)
+        elif adapter.runner_kind in {"zeus_writer_v1", "youtube_ai_manager_scan_v1"}:
+            command = [
+                sys.executable,
+                "-m",
+                "agentos_node.product_employee_worker_cli",
+                "--runner-kind",
+                adapter.runner_kind,
+                "--runtime-root",
+                str(self.runtime_root),
+                "--wake-root",
+                str(self.wake_root),
+                "--worker-state-root",
+                str(self.worker_state_root),
+                "--node-id",
+                self.node_id,
+                "--lease-seconds",
+                str(self.lease_seconds),
+                "--once",
+            ]
+        else:
+            raise RuntimeError("employee_worker_runner_kind_unimplemented")
         command.extend(
             [
                 "--wake-id",
@@ -39,6 +171,29 @@ class ExactEmployeeWorkerHost(EmployeeWorkerHost):
             ]
         )
         return command
+
+    def _parse_child_result(self, stdout: str) -> dict[str, Any] | None:
+        candidate = self._pinned_candidate
+        if candidate is None:
+            return None
+        lines = [line.strip() for line in str(stdout or "").splitlines() if line.strip()]
+        if not lines:
+            return None
+        try:
+            payload = json.loads(lines[-1])
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict) or set(payload) - SAFE_CHILD_RESULT_KEYS:
+            return None
+        if payload.get("schema") != V2_RESULT_SCHEMAS.get(candidate.adapter.runner_kind):
+            return None
+        if payload.get("credential_exposed") is not False:
+            return None
+        if payload.get("session_identity_exposed") is not False:
+            return None
+        if payload.get("verified_marker_emitted") is not False:
+            return None
+        return payload
 
     def process_one(self) -> dict[str, Any] | None:
         self._pinned_candidate = None

--- a/agentos_node/product_employee_worker.py
+++ b/agentos_node/product_employee_worker.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_core.core_supervisor import RECONCILE_INTENT_SCHEMA
+from agent_core.core_supervisor_delivery import DELIVERY_STATE_SCHEMA
+from agent_core.core_supervisor_service import INTENT_RECORD_SCHEMA
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+
+EXPECTED_AUTHORITY_POLICY = "core-supervisor-employee-wake-v1"
+EXPECTED_TRANSPORT = "one_direct"
+ELIGIBLE_PRECLAIM_DELIVERY_STATES = {"awaiting_claim"}
+SUPPORTED_PRODUCT_RUNNERS = {
+    "zeus_writer_v1": {
+        "employee_id": "zeus-writer",
+        "assignment_id": "zeus-writer-continuation-v1",
+        "role_ids": {"product.zeus_writer"},
+        "skill_ids": {"writing.project.continue"},
+    },
+    "youtube_ai_manager_scan_v1": {
+        "employee_id": "youtube-ai-manager",
+        "assignment_id": "youtube-ai-manager-scan-v1",
+        "role_ids": {"product.youtube_ai_manager"},
+        "skill_ids": {"youtube.optimization.scan"},
+    },
+}
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("product_employee_worker_evidence_invalid")
+    return payload
+
+
+def _same_wake(left: Any, right: Any) -> bool:
+    return isinstance(left, dict) and isinstance(right, dict) and left == right
+
+
+def _require_runner_scope(runner_kind: str, capsule: dict[str, Any]) -> dict[str, Any]:
+    scope = SUPPORTED_PRODUCT_RUNNERS.get(str(runner_kind or "").strip())
+    if scope is None:
+        raise PermissionError("product_employee_runner_kind_not_allowed")
+    wake = capsule.get("wake_intent")
+    if not isinstance(wake, dict):
+        raise PermissionError("product_employee_worker_wake_missing")
+    if capsule.get("employee_id") != scope["employee_id"] or capsule.get("assignment_id") != scope["assignment_id"]:
+        raise PermissionError("product_employee_worker_scope_mismatch")
+    if set(wake.get("role_ids") or []) != scope["role_ids"]:
+        raise PermissionError("product_employee_worker_role_scope_mismatch")
+    if set(wake.get("skill_ids") or []) != scope["skill_ids"]:
+        raise PermissionError("product_employee_worker_skill_scope_mismatch")
+    return scope
+
+
+def require_governed_product_delivery(
+    runtime_root: str | Path,
+    runner_kind: str,
+    capsule: dict[str, Any],
+) -> dict[str, Any]:
+    """Bind one product wake to one exact Supervisor/S4 delivery before claim."""
+    _require_runner_scope(runner_kind, capsule)
+    root = Path(runtime_root).expanduser().resolve()
+    wake = capsule.get("wake_intent")
+    deliveries = root / "supervisor" / "deliveries"
+    intents = root / "supervisor" / "intents"
+    if not deliveries.is_dir() or not intents.is_dir():
+        raise PermissionError("product_employee_worker_governed_delivery_missing")
+
+    matches: list[dict[str, Any]] = []
+    for path in sorted(deliveries.glob("reconcile_*.json")):
+        try:
+            delivery = _read(path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not delivery or delivery.get("schema") != DELIVERY_STATE_SCHEMA:
+            continue
+        if delivery.get("status") not in ELIGIBLE_PRECLAIM_DELIVERY_STATES:
+            continue
+        if delivery.get("employee_id") != capsule.get("employee_id"):
+            continue
+        if delivery.get("assignment_id") != capsule.get("assignment_id"):
+            continue
+        if delivery.get("wake_id") != capsule.get("wake_id"):
+            continue
+        if delivery.get("transport") != EXPECTED_TRANSPORT:
+            continue
+        if delivery.get("authority_policy_id") != EXPECTED_AUTHORITY_POLICY:
+            continue
+        if delivery.get("capability") != WAKE_CAPABILITY:
+            continue
+        if delivery.get("dispatch_performed") is not True:
+            continue
+        if delivery.get("node_id") != capsule.get("node_id"):
+            continue
+        if delivery.get("presence_id") != capsule.get("presence_id"):
+            continue
+        if int(delivery.get("presence_generation") or 0) != int(capsule.get("presence_generation") or 0):
+            continue
+        if not delivery.get("task_id") or not delivery.get("wake_attempt_id"):
+            continue
+
+        reconcile_id = str(delivery.get("reconcile_id") or "").strip()
+        if not reconcile_id or path.stem != reconcile_id:
+            continue
+        try:
+            record = _read(intents / f"{reconcile_id}.json")
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not record or record.get("schema") != INTENT_RECORD_SCHEMA:
+            continue
+        if record.get("reconcile_id") != reconcile_id or record.get("state") != "planned":
+            continue
+        if record.get("dispatch_performed") is not False:
+            continue
+        intent = record.get("intent")
+        if not isinstance(intent, dict) or intent.get("schema") != RECONCILE_INTENT_SCHEMA:
+            continue
+        if intent.get("kind") != "employee_wake":
+            continue
+        if intent.get("employee_id") != capsule.get("employee_id"):
+            continue
+        if intent.get("assignment_id") != capsule.get("assignment_id"):
+            continue
+        if intent.get("authority_boundary") != "observe_and_select_only":
+            continue
+        if any(
+            intent.get(key) != "unbound"
+            for key in ("node_selection", "executor_selection", "transport_selection", "capability_authority")
+        ):
+            continue
+        if intent.get("credential_exposed") is not False:
+            continue
+        if not _same_wake(intent.get("wake_intent"), wake):
+            continue
+        matches.append(delivery)
+
+    if len(matches) != 1:
+        raise PermissionError(
+            "product_employee_worker_governed_delivery_ambiguous"
+            if len(matches) > 1
+            else "product_employee_worker_governed_delivery_missing"
+        )
+    return matches[0]
+
+
+@dataclass(slots=True)
+class ProductWorkerState:
+    status: str
+    runner_kind: str
+    employee_id: str
+    assignment_id: str
+    wake_id: str
+    presence_generation: int
+    lease_generation: int
+    thread_head: str
+    error_code: str | None = None
+    executor_provider: str = "unbound"
+    executor_model: str = ""
+
+
+class GovernedProductEmployeeWorker:
+    """No-network product Employee worker used to prove the governed wake/claim boundary.
+
+    v1 intentionally performs only a deterministic dry-run checkpoint. Product repository
+    writes, publication, YouTube API reads/writes, credentials, network and arbitrary
+    executable selection remain outside this worker's authority.
+    """
+
+    def __init__(
+        self,
+        *,
+        runtime_root: str | Path,
+        wake_root: str | Path,
+        worker_state_root: str | Path,
+        node_id: str,
+        runner_kind: str,
+        lease_seconds: int = 60,
+    ) -> None:
+        self.runtime_root = Path(runtime_root).expanduser().resolve()
+        self.wake_root = Path(wake_root).expanduser().resolve()
+        self.worker_state_root = Path(worker_state_root).expanduser().resolve()
+        self.node_id = str(node_id or "").strip()
+        self.runner_kind = str(runner_kind or "").strip()
+        self.lease_seconds = int(lease_seconds)
+        if self.runner_kind not in SUPPORTED_PRODUCT_RUNNERS:
+            raise ValueError("product_employee_runner_kind_not_allowed")
+        if not self.node_id:
+            raise ValueError("product_employee_node_id_required")
+
+    def _capsules(self) -> list[tuple[Path, dict[str, Any]]]:
+        scope = SUPPORTED_PRODUCT_RUNNERS[self.runner_kind]
+        root = self.wake_root / scope["employee_id"]
+        result: list[tuple[Path, dict[str, Any]]] = []
+        if not root.is_dir():
+            return result
+        for path in sorted(root.glob("*.json")):
+            try:
+                payload = _read(path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            if not payload or payload.get("node_id") != self.node_id:
+                continue
+            try:
+                _require_runner_scope(self.runner_kind, payload)
+            except PermissionError:
+                continue
+            result.append((path, payload))
+        return result
+
+    def process_exact(self, *, wake_id: str, presence_generation: int) -> ProductWorkerState | None:
+        wake = str(wake_id or "").strip()
+        generation = int(presence_generation)
+        matches = [
+            item
+            for item in self._capsules()
+            if str(item[1].get("wake_id") or "") == wake
+            and int(item[1].get("presence_generation") or 0) == generation
+        ]
+        if len(matches) > 1:
+            raise RuntimeError("product_employee_worker_exact_wake_ambiguous")
+        if not matches:
+            return None
+        _, capsule = matches[0]
+        require_governed_product_delivery(self.runtime_root, self.runner_kind, capsule)
+
+        runtime = EmployeeRuntime(self.runtime_root)
+        lifecycle = EmployeeLifecycle(runtime)
+        employee_id = str(capsule["employee_id"])
+        assignment_id = str(capsule["assignment_id"])
+        lease_id = f"product-{self.runner_kind}-{wake}-{generation}"
+        lease = lifecycle.claim(
+            assignment_id,
+            employee_id,
+            lease_id,
+            lease_seconds=self.lease_seconds,
+        )
+        expected = int(capsule.get("expected_lease_generation") or 0)
+        if lease.generation != expected:
+            return ProductWorkerState(
+                status="unknown",
+                runner_kind=self.runner_kind,
+                employee_id=employee_id,
+                assignment_id=assignment_id,
+                wake_id=wake,
+                presence_generation=generation,
+                lease_generation=lease.generation,
+                thread_head=lease.thread_head,
+                error_code="product_employee_worker_lease_generation_mismatch",
+            )
+
+        thread_head = f"product-worker:{self.runner_kind}:dry-run:{wake}:p{generation}:l{lease.generation}"
+        lease = lifecycle.checkpoint(assignment_id, lease_id, thread_head)
+        employee = runtime.get_employee(employee_id)
+        return ProductWorkerState(
+            status="checkpointed",
+            runner_kind=self.runner_kind,
+            employee_id=employee_id,
+            assignment_id=assignment_id,
+            wake_id=wake,
+            presence_generation=generation,
+            lease_generation=lease.generation,
+            thread_head=lease.thread_head,
+            executor_provider=employee.executor.provider,
+            executor_model=employee.executor.model,
+        )

--- a/agentos_node/product_employee_worker_cli.py
+++ b/agentos_node/product_employee_worker_cli.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from agentos_node.product_employee_worker import GovernedProductEmployeeWorker, SUPPORTED_PRODUCT_RUNNERS
+
+RESULT_SCHEMAS = {
+    "zeus_writer_v1": "agentos.zeus-writer-worker-cli-result/v1",
+    "youtube_ai_manager_scan_v1": "agentos.youtube-ai-manager-scan-worker-cli-result/v1",
+}
+
+
+def _absolute_path(value: str, field: str) -> str:
+    path = Path(str(value or "").strip()).expanduser()
+    if not path.is_absolute():
+        raise argparse.ArgumentTypeError(f"{field}_must_be_absolute")
+    return str(path.resolve())
+
+
+def _positive_int(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("positive_integer_required") from exc
+    if number < 1:
+        raise argparse.ArgumentTypeError("positive_integer_required")
+    return number
+
+
+def _safe_output(runner_kind: str, state: Any) -> dict[str, Any]:
+    schema = RESULT_SCHEMAS[runner_kind]
+    if state is None:
+        return {
+            "schema": schema,
+            "status": "idle",
+            "work_performed": False,
+            "credential_exposed": False,
+            "session_identity_exposed": False,
+            "verified_marker_emitted": False,
+        }
+    return {
+        "schema": schema,
+        "status": state.status,
+        "work_performed": state.status in {"checkpointed", "completed", "unknown"},
+        "employee_id": state.employee_id,
+        "assignment_id": state.assignment_id,
+        "wake_id": state.wake_id,
+        "presence_generation": state.presence_generation,
+        "lease_generation": state.lease_generation,
+        "thread_head": state.thread_head,
+        "error_code": state.error_code,
+        "executor_provider": state.executor_provider,
+        "executor_model": state.executor_model,
+        "credential_exposed": False,
+        "session_identity_exposed": False,
+        "verified_marker_emitted": False,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agentos-product-employee-worker",
+        description="Run one fixed governed product Employee dry-run checkpoint. No product mutation authority is granted.",
+    )
+    parser.add_argument("--runner-kind", required=True, choices=sorted(SUPPORTED_PRODUCT_RUNNERS))
+    parser.add_argument("--runtime-root", required=True, type=lambda value: _absolute_path(value, "runtime_root"))
+    parser.add_argument("--wake-root", required=True, type=lambda value: _absolute_path(value, "wake_root"))
+    parser.add_argument("--worker-state-root", required=True, type=lambda value: _absolute_path(value, "worker_state_root"))
+    parser.add_argument("--node-id", required=True)
+    parser.add_argument("--lease-seconds", type=int, default=60)
+    parser.add_argument("--wake-id", required=True)
+    parser.add_argument("--presence-generation", required=True, type=_positive_int)
+    parser.add_argument("--once", action="store_true", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    worker = GovernedProductEmployeeWorker(
+        runtime_root=args.runtime_root,
+        wake_root=args.wake_root,
+        worker_state_root=args.worker_state_root,
+        node_id=args.node_id,
+        runner_kind=args.runner_kind,
+        lease_seconds=args.lease_seconds,
+    )
+    state = worker.process_exact(
+        wake_id=args.wake_id,
+        presence_generation=args.presence_generation,
+    )
+    print(json.dumps(_safe_output(args.runner_kind, state), ensure_ascii=False, sort_keys=True))
+    if state is None or state.status in {"checkpointed", "completed"}:
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/governance/employee-worker-adapters-v2.json
+++ b/governance/employee-worker-adapters-v2.json
@@ -1,0 +1,38 @@
+{
+  "schema": "agentos.employee-worker-adapters/v2",
+  "adapters": [
+    {
+      "adapter_id": "spec-steward-o3",
+      "status": "active",
+      "runner_kind": "spec_steward_o3",
+      "employee_id": "agentos-spec-steward",
+      "assignment_id": "spec-steward-o3-acceptance-v1",
+      "role_ids": ["governance.spec_steward"],
+      "skill_ids": ["spec.audit"]
+    },
+    {
+      "adapter_id": "zeus-writer-v1",
+      "status": "active",
+      "runner_kind": "zeus_writer_v1",
+      "employee_id": "zeus-writer",
+      "assignment_id": "zeus-writer-continuation-v1",
+      "role_ids": ["product.zeus_writer"],
+      "skill_ids": ["writing.project.continue"]
+    },
+    {
+      "adapter_id": "youtube-ai-manager-scan-v1",
+      "status": "active",
+      "runner_kind": "youtube_ai_manager_scan_v1",
+      "employee_id": "youtube-ai-manager",
+      "assignment_id": "youtube-ai-manager-scan-v1",
+      "role_ids": ["product.youtube_ai_manager"],
+      "skill_ids": ["youtube.optimization.scan"]
+    }
+  ],
+  "invariants": [
+    "runner_kind_is_source_controlled_enum_not_executable_authority",
+    "one_shared_host_process_for_all_employee_runners",
+    "unknown_runner_kind_fails_closed",
+    "product_runners_start_without_network_or_product_credentials"
+  ]
+}

--- a/tests/test_product_employee_worker.py
+++ b/tests/test_product_employee_worker.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos_node.employee_worker_host import WorkerHostCandidate
+from agentos_node.employee_worker_host_runtime import (
+    ExactEmployeeWorkerHost,
+    ProductEmployeeWorkerAdapterRegistry,
+)
+from agentos_node.product_employee_worker import _require_runner_scope
+
+
+def _capsule(employee_id: str, assignment_id: str, role_id: str, skill_id: str) -> dict:
+    return {
+        "schema": "agentos.employee-wake-delivery/v1",
+        "wake_id": "wake-1",
+        "employee_id": employee_id,
+        "assignment_id": assignment_id,
+        "node_id": "oracle-core-node",
+        "presence_id": "presence-1",
+        "presence_generation": 1,
+        "expected_lease_generation": 1,
+        "digest": "digest",
+        "wake_intent": {
+            "role_ids": [role_id],
+            "skill_ids": [skill_id],
+        },
+        "employee_wake_route": {},
+    }
+
+
+def test_v2_registry_resolves_only_exact_product_scope() -> None:
+    registry = ProductEmployeeWorkerAdapterRegistry()
+    zeus = _capsule(
+        "zeus-writer",
+        "zeus-writer-continuation-v1",
+        "product.zeus_writer",
+        "writing.project.continue",
+    )
+    adapter = registry.resolve(zeus)
+    assert adapter is not None
+    assert adapter.runner_kind == "zeus_writer_v1"
+
+    foreign = dict(zeus)
+    foreign["wake_intent"] = dict(zeus["wake_intent"])
+    foreign["wake_intent"]["role_ids"] = ["product.youtube_ai_manager"]
+    assert registry.resolve(foreign) is None
+
+
+def test_product_runner_scope_is_fail_closed() -> None:
+    youtube = _capsule(
+        "youtube-ai-manager",
+        "youtube-ai-manager-scan-v1",
+        "product.youtube_ai_manager",
+        "youtube.optimization.scan",
+    )
+    scope = _require_runner_scope("youtube_ai_manager_scan_v1", youtube)
+    assert scope["employee_id"] == "youtube-ai-manager"
+
+    with pytest.raises(PermissionError, match="runner_kind_not_allowed"):
+        _require_runner_scope("arbitrary_shell", youtube)
+
+
+def test_exact_shared_host_maps_product_runner_to_fixed_cli(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    wake_root = tmp_path / "wake"
+    host_root = tmp_path / "host"
+    worker_root = tmp_path / "worker"
+    for path in (runtime_root, wake_root, host_root, worker_root):
+        path.mkdir()
+
+    host = ExactEmployeeWorkerHost(
+        runtime_root=runtime_root,
+        wake_root=wake_root,
+        host_state_root=host_root,
+        worker_state_root=worker_root,
+        node_id="oracle-core-node",
+    )
+    capsule = _capsule(
+        "zeus-writer",
+        "zeus-writer-continuation-v1",
+        "product.zeus_writer",
+        "writing.project.continue",
+    )
+    adapter = host.registry.resolve(capsule)
+    assert adapter is not None
+    host._pinned_candidate = WorkerHostCandidate(  # noqa: SLF001 - exact-host boundary test
+        path=Path("wake.json"),
+        capsule=capsule,
+        adapter=adapter,
+    )
+    command = host._child_command(adapter)  # noqa: SLF001
+    joined = " ".join(command)
+    assert "agentos_node.product_employee_worker_cli" in joined
+    assert "--runner-kind zeus_writer_v1" in joined
+    assert "--wake-id wake-1" in joined
+    assert "--presence-generation 1" in joined
+    assert "shell" not in joined
+
+
+def test_shared_host_accepts_only_runner_specific_result_schema(tmp_path: Path) -> None:
+    roots = [tmp_path / name for name in ("runtime", "wake", "host", "worker")]
+    for path in roots:
+        path.mkdir()
+    host = ExactEmployeeWorkerHost(
+        runtime_root=roots[0],
+        wake_root=roots[1],
+        host_state_root=roots[2],
+        worker_state_root=roots[3],
+        node_id="oracle-core-node",
+    )
+    capsule = _capsule(
+        "youtube-ai-manager",
+        "youtube-ai-manager-scan-v1",
+        "product.youtube_ai_manager",
+        "youtube.optimization.scan",
+    )
+    adapter = host.registry.resolve(capsule)
+    assert adapter is not None
+    host._pinned_candidate = WorkerHostCandidate(Path("wake.json"), capsule, adapter)  # noqa: SLF001
+    good = {
+        "schema": "agentos.youtube-ai-manager-scan-worker-cli-result/v1",
+        "status": "checkpointed",
+        "work_performed": True,
+        "employee_id": "youtube-ai-manager",
+        "assignment_id": "youtube-ai-manager-scan-v1",
+        "wake_id": "wake-1",
+        "presence_generation": 1,
+        "lease_generation": 1,
+        "thread_head": "dry-run",
+        "error_code": None,
+        "executor_provider": "unbound",
+        "executor_model": "",
+        "credential_exposed": False,
+        "session_identity_exposed": False,
+        "verified_marker_emitted": False,
+    }
+    assert host._parse_child_result(json.dumps(good)) is not None  # noqa: SLF001
+    good["schema"] = "agentos.zeus-writer-worker-cli-result/v1"
+    assert host._parse_child_result(json.dumps(good)) is None  # noqa: SLF001


### PR DESCRIPTION
## Scope

Extend the existing shared credential-isolated Employee Worker Host to support the first two production product Employee runner kinds from #238 while preserving the existing Spec Steward path and fail-closed authority model.

## Adds
- `governance/employee-worker-adapters-v2.json` with exactly three source-controlled runner kinds: `spec_steward_o3`, `zeus_writer_v1`, `youtube_ai_manager_scan_v1`;
- `agentos_node/product_employee_worker.py`: generic governed product wake/claim boundary that re-checks exact Supervisor/S4 `awaiting_claim` evidence before lifecycle claim;
- `agentos_node/product_employee_worker_cli.py`: fixed CLI surface with runner-specific sanitized result schemas;
- `ExactEmployeeWorkerHost` v2 registry/dispatch mapping in the existing shared host runtime wrapper;
- regression tests for exact role/skill/assignment resolution, unknown-runner fail closed, fixed CLI mapping, and runner-specific result schema isolation;
- Product Employee guard now runs the bounded Worker Host tests.

## Security / authority invariants
- one shared Worker Host process; no per-role daemon;
- runner kind is a source-controlled enum, never executable/module/argv authority;
- product child process still inherits the existing allowlisted credential-isolated environment;
- exact wake id + presence generation stay pinned through host selection and child invocation;
- product worker re-checks the immutable Supervisor reconcile intent and one_direct delivery ledger before claim;
- v1 product runners perform only a deterministic dry-run lifecycle checkpoint;
- no product repo mutation, protected-branch publication, network, GitHub credential, ONE credential, YouTube credential, or YouTube API mutation authority;
- wrong runner, Employee, assignment, role, skill, result schema, wake or lease generation fails closed/unknown;
- static/source CI cannot emit product VERIFIED markers;
- GitHub Actions remains CI/evidence only, not control plane.

## Acceptance status

This PR proves the shared wake → fixed bounded product worker source boundary. It does **not** claim live Oracle deployment or real Zeus writing / YouTube channel scanning. Those remain live acceptance work under #238 after source guards pass and the governed runtime is deployed.

Relates to #151, #197, #200, #215, #238, #240.