### PR TITLE
Core #242: define bounded Oracle runtime converge contract

### DIFF
--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -1,0 +1,30 @@
+name: Runtime Converge Contract Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'governance/runtime-converge.json'
+      - 'agent_core/runtime_converge_contract.py'
+      - 'tests/test_runtime_converge_contract.py'
+      - '.github/workflows/runtime-converge-contract-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: python -m pip install --disable-pip-version-check pytest
+      - name: Verify bounded runtime converge contract
+        run: python -m pytest -q tests/test_runtime_converge_contract.py

--- a/agent_core/runtime_converge_contract.py
+++ b/agent_core/runtime_converge_contract.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+SCHEMA = "agentos.runtime-converge-request/v1"
+CAPABILITY = "node.runtime.converge"
+ALLOWED_NODE_IDS = {"oracle-core-node"}
+ALLOWED_REPOSITORY = "alston-personal/agentmanager"
+ALLOWED_SOURCE_REFS = {"core/integration"}
+REQUEST_FIELDS = {"schema", "request_id", "node_id", "repository", "source_ref", "source_commit"}
+FORBIDDEN_KEYS = {
+    "argv",
+    "command",
+    "credentials",
+    "environment",
+    "executable",
+    "module",
+    "password",
+    "script",
+    "shell",
+    "token",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeConvergeRequest:
+    request_id: str
+    node_id: str
+    repository: str
+    source_ref: str
+    source_commit: str
+
+    def as_payload(self) -> dict[str, str]:
+        return {
+            "schema": SCHEMA,
+            "request_id": self.request_id,
+            "node_id": self.node_id,
+            "repository": self.repository,
+            "source_ref": self.source_ref,
+            "source_commit": self.source_commit,
+        }
+
+
+def _safe_id(value: Any, field: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 256 or text in {".", ".."} or any(ch in text for ch in "/\\\0"):
+        raise ValueError(f"invalid_runtime_converge_{field}")
+    return text
+
+
+def validate_runtime_converge_request(payload: Any) -> RuntimeConvergeRequest:
+    if not isinstance(payload, dict):
+        raise ValueError("runtime_converge_request_must_be_object")
+    keys = set(payload)
+    if keys != REQUEST_FIELDS:
+        forbidden = sorted(keys & FORBIDDEN_KEYS)
+        if forbidden:
+            raise ValueError(f"runtime_converge_forbidden_fields:{','.join(forbidden)}")
+        raise ValueError("runtime_converge_request_shape_invalid")
+    if payload.get("schema") != SCHEMA:
+        raise ValueError("runtime_converge_schema_invalid")
+
+    request_id = _safe_id(payload.get("request_id"), "request_id")
+    node_id = _safe_id(payload.get("node_id"), "node_id")
+    repository = str(payload.get("repository") or "").strip()
+    source_ref = str(payload.get("source_ref") or "").strip()
+    source_commit = str(payload.get("source_commit") or "").strip()
+
+    if node_id not in ALLOWED_NODE_IDS:
+        raise ValueError("runtime_converge_node_not_allowed")
+    if repository != ALLOWED_REPOSITORY:
+        raise ValueError("runtime_converge_repository_not_allowed")
+    if source_ref not in ALLOWED_SOURCE_REFS:
+        raise ValueError("runtime_converge_source_ref_not_allowed")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("runtime_converge_source_commit_invalid")
+
+    return RuntimeConvergeRequest(
+        request_id=request_id,
+        node_id=node_id,
+        repository=repository,
+        source_ref=source_ref,
+        source_commit=source_commit,
+    )

--- a/governance/runtime-converge.json
+++ b/governance/runtime-converge.json
@@ -1,0 +1,47 @@
+{
+  "schema": "agentos.runtime-converge-policy/v1",
+  "capability": "node.runtime.converge",
+  "target_node_ids": ["oracle-core-node"],
+  "allowed_repository": "alston-personal/agentmanager",
+  "allowed_source_refs": ["core/integration"],
+  "require_exact_commit": true,
+  "require_clean_tracked_checkout": true,
+  "require_health_check": true,
+  "rollback_on_failed_health": true,
+  "ambiguous_state": "unknown_no_blind_retry",
+  "bootstrap_authority": "explicit_manual_deploy_only",
+  "steady_state_transport": "one_direct",
+  "forbidden_request_fields": [
+    "argv",
+    "command",
+    "credentials",
+    "environment",
+    "executable",
+    "module",
+    "password",
+    "script",
+    "shell",
+    "token"
+  ],
+  "receipt_fields": [
+    "request_id",
+    "node_id",
+    "source_ref",
+    "source_commit",
+    "previous_commit",
+    "resulting_commit",
+    "health",
+    "rollback",
+    "status",
+    "observed_at"
+  ],
+  "invariants": [
+    "capability_availability_does_not_grant_authority",
+    "no_generic_shell_or_argv",
+    "no_credential_readback",
+    "no_protected_main_mutation",
+    "github_actions_is_not_steady_state_control_plane",
+    "one_failure_does_not_expand_authority",
+    "ambiguous_external_side_effect_is_unknown"
+  ]
+}

--- a/tests/test_runtime_converge_contract.py
+++ b/tests/test_runtime_converge_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_core.runtime_converge_contract import (
+    ALLOWED_REPOSITORY,
+    CAPABILITY,
+    SCHEMA,
+    validate_runtime_converge_request,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+POLICY = ROOT / "governance" / "runtime-converge.json"
+SHA = "45e63abc3e806ecc0547f93330584e1e387e0757"
+
+
+def request(**overrides):
+    payload = {
+        "schema": SCHEMA,
+        "request_id": "runtime-converge-test-1",
+        "node_id": "oracle-core-node",
+        "repository": ALLOWED_REPOSITORY,
+        "source_ref": "core/integration",
+        "source_commit": SHA,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_policy_is_fail_closed_and_one_direct():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    assert policy["capability"] == CAPABILITY
+    assert policy["target_node_ids"] == ["oracle-core-node"]
+    assert policy["allowed_repository"] == ALLOWED_REPOSITORY
+    assert policy["allowed_source_refs"] == ["core/integration"]
+    assert policy["require_exact_commit"] is True
+    assert policy["require_clean_tracked_checkout"] is True
+    assert policy["require_health_check"] is True
+    assert policy["rollback_on_failed_health"] is True
+    assert policy["steady_state_transport"] == "one_direct"
+    assert policy["ambiguous_state"] == "unknown_no_blind_retry"
+    assert "github_actions_is_not_steady_state_control_plane" in policy["invariants"]
+
+
+def test_valid_request_is_normalized_without_execution_carrier():
+    validated = validate_runtime_converge_request(request())
+    assert validated.node_id == "oracle-core-node"
+    assert validated.repository == ALLOWED_REPOSITORY
+    assert validated.source_ref == "core/integration"
+    assert validated.source_commit == SHA
+    assert set(validated.as_payload()) == {
+        "schema", "request_id", "node_id", "repository", "source_ref", "source_commit"
+    }
+
+
+@pytest.mark.parametrize("field", ["shell", "script", "argv", "module", "executable", "command", "token", "credentials", "environment"])
+def test_execution_and_credential_fields_fail_closed(field):
+    with pytest.raises(ValueError, match="runtime_converge_forbidden_fields"):
+        validate_runtime_converge_request(request(**{field: "forbidden"}))
+
+
+def test_wrong_node_repo_ref_or_sha_fail_closed():
+    cases = [
+        (request(node_id="vopc5750"), "node_not_allowed"),
+        (request(repository="alston-personal/zeus-writer"), "repository_not_allowed"),
+        (request(source_ref="main"), "source_ref_not_allowed"),
+        (request(source_commit="abc"), "source_commit_invalid"),
+        (request(source_commit=SHA.upper()), "source_commit_invalid"),
+    ]
+    for payload, message in cases:
+        with pytest.raises(ValueError, match=message):
+            validate_runtime_converge_request(payload)
+
+
+def test_extra_unknown_field_fails_closed():
+    with pytest.raises(ValueError, match="request_shape_invalid"):
+        validate_runtime_converge_request(request(auto_converge=False))


### PR DESCRIPTION
## Scope
First source slice for #242. Recover the useful intent of the legacy Runtime OTA path without restoring its old `shell.exec` + embedded PowerShell carrier.

## Adds
- `governance/runtime-converge.json`: explicit steady-state ONE converge policy;
- `agent_core/runtime_converge_contract.py`: typed, fail-closed request contract pinned to `oracle-core-node`, `alston-personal/agentmanager`, `core/integration`, and an exact lowercase 40-char SHA;
- regression tests and hosted guard.

## Explicitly forbidden
- executable/module/argv/shell/script/command injection;
- credentials/token/environment fields;
- `main` as a source ref;
- arbitrary repository or arbitrary Node targeting;
- GitHub Actions as steady-state control-plane fallback.

## Legacy extraction note
The 2026-08-28 Golden Path implementation did have `runtime_ota.py` and `realm.runtime.rollout`, but `node.runtime.converge` was translated into `shell.exec` with embedded PowerShell. This PR deliberately does not restore that carrier. The next slice will bind this typed contract to a fixed Node-local converger with clean-tree/exact-SHA/health/rollback receipts.

## Live evidence
Fresh #50 probes on 2026-09-04 proved `oracle-core-node` currently advertises neither `node.runtime.converge` nor `realm.runtime.rollout`; both were rejected by ONE before dispatch. Therefore no live deployment/VERIFIED claim is made here.

Relates to #238, #242, #179 and legacy Golden Path OTA work.