### PR TITLE
Core #242: fixed Oracle runtime converger through Action Relay

### DIFF
--- a/.github/workflows/deploy-agentos-core.yml
+++ b/.github/workflows/deploy-agentos-core.yml
@@ -18,6 +18,16 @@ on:
         required: true
         default: main
         type: string
+      expected_sha:
+        description: Optional exact lowercase 40-char SHA; required for runtime-converger bootstrap
+        required: false
+        default: ''
+        type: string
+      bootstrap_runtime_converger:
+        description: Explicit one-time install of bounded node.runtime.converge carrier (core/integration only)
+        required: false
+        default: false
+        type: boolean
       verify_public_url:
         description: Also verify AGENTOS_CONTROL_PLANE_PUBLIC_URL after local health succeeds
         required: false
@@ -42,6 +52,8 @@ jobs:
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
       DEPLOY_ROOT: ${{ vars.AGENTOS_DEPLOY_ROOT }}
       DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || 'feature/distributed-agentos-runtime' }}
+      EXPECTED_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_sha || '' }}
+      BOOTSTRAP_RUNTIME_CONVERGER: ${{ github.event_name == 'workflow_dispatch' && inputs.bootstrap_runtime_converger || false }}
       VERIFY_PUBLIC_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.verify_public_url || false }}
 
     steps:
@@ -88,6 +100,20 @@ jobs:
           fi
           echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
 
+          if [ "$BOOTSTRAP_RUNTIME_CONVERGER" = "true" ]; then
+            if [ "$DEPLOY_REF" != "core/integration" ]; then
+              echo "Runtime converger bootstrap requires deploy_ref=core/integration" >&2
+              exit 2
+            fi
+            if ! printf '%s' "$EXPECTED_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "Runtime converger bootstrap requires exact lowercase expected_sha" >&2
+              exit 2
+            fi
+          elif [ -n "$EXPECTED_SHA" ] && ! printf '%s' "$EXPECTED_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "expected_sha must be empty or a lowercase 40-character SHA" >&2
+            exit 2
+          fi
+
       - name: Start SSH agent
         id: ssh_agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -132,13 +158,17 @@ jobs:
           set -euo pipefail
           ROOT="${DEPLOY_ROOT:-/home/ubuntu/agentmanager}"
           ssh -o StrictHostKeyChecking=accept-new -p "${DEPLOY_SSH_PORT:-22}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
-            bash -s -- "$ROOT" "$DEPLOY_REF" <<'REMOTE'
+            bash -s -- "$ROOT" "$DEPLOY_REF" "$EXPECTED_SHA" "$BOOTSTRAP_RUNTIME_CONVERGER" <<'REMOTE'
           set -euo pipefail
           ROOT="$1"
           REF="$2"
+          EXPECTED="$3"
+          BOOTSTRAP_CONVERGER="$4"
           cd "$ROOT"
 
           PREVIOUS_SHA="$(git rev-parse HEAD)"
+          DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
+          CAPABILITY_MARKER="$DATA_ROOT/runtime/action-relay/capabilities.json"
           rollback() {
             rc=$?
             if [ "$rc" -ne 0 ]; then
@@ -146,6 +176,13 @@ jobs:
               git checkout --detach "$PREVIOUS_SHA" || true
               python3 -m pip install -e . || true
               python3 scripts/install_services.py || true
+              if [ "$BOOTSTRAP_CONVERGER" = "true" ]; then
+                # A carrier candidate may already have been installed. Remove its
+                # advertisement before restoring the previous Realm generation so
+                # ONE cannot claim a capability whose rollback state is ambiguous.
+                rm -f "$CAPABILITY_MARKER" || true
+                bash scripts/install_realm_fabric_user.sh || true
+              fi
               curl -fsS http://127.0.0.1:8765/health || true
             fi
             exit "$rc"
@@ -154,6 +191,14 @@ jobs:
 
           git fetch --prune origin "$REF"
           TARGET_SHA="$(git rev-parse FETCH_HEAD)"
+          if [ -n "$EXPECTED" ] && [ "$TARGET_SHA" != "$EXPECTED" ]; then
+            echo "Refusing deployment: expected SHA does not equal current ref head" >&2
+            exit 2
+          fi
+          if [ "$BOOTSTRAP_CONVERGER" = "true" ]; then
+            [ "$REF" = "core/integration" ] || { echo "Converger bootstrap ref mismatch" >&2; exit 2; }
+            [ "$TARGET_SHA" = "$EXPECTED" ] || { echo "Converger bootstrap exact-SHA mismatch" >&2; exit 2; }
+          fi
           echo "Deploying $TARGET_SHA from $REF (previous $PREVIOUS_SHA)"
           git checkout --detach "$TARGET_SHA"
 
@@ -185,8 +230,12 @@ jobs:
           echo
           systemctl --user --no-pager --full status agentos-control-plane.service | head -n 30
 
-          mkdir -p "${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}/runtime"
-          printf '%s\n' "$PREVIOUS_SHA" > "${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}/runtime/previous-agentos-core-sha"
+          if [ "$BOOTSTRAP_CONVERGER" = "true" ]; then
+            bash scripts/bootstrap_runtime_converger_oracle.sh "$REF" "$TARGET_SHA"
+          fi
+
+          mkdir -p "$DATA_ROOT/runtime"
+          printf '%s\n' "$PREVIOUS_SHA" > "$DATA_ROOT/runtime/previous-agentos-core-sha"
           trap - EXIT
           REMOTE
 
@@ -251,4 +300,5 @@ jobs:
           echo "Target host: ${DEPLOY_HOST:-unresolved}"
           echo "Target ref: ${DEPLOY_REF}"
           echo "Stable checkout: ${DEPLOY_ROOT:-/home/ubuntu/agentmanager}"
+          echo "Runtime converger bootstrap requested: ${BOOTSTRAP_RUNTIME_CONVERGER}"
           echo "Public verification requested: ${VERIFY_PUBLIC_URL}"

--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -7,7 +7,11 @@ on:
     paths:
       - 'governance/runtime-converge.json'
       - 'agent_core/runtime_converge_contract.py'
+      - 'agent_core/controller_service.py'
+      - 'agentos_node/runtime_converge_action_relay.py'
+      - 'agentos_node/executor_job_action_relay.py'
       - 'tests/test_runtime_converge_contract.py'
+      - 'tests/test_runtime_converge_action_relay.py'
       - '.github/workflows/runtime-converge-contract-guard.yml'
   workflow_dispatch:
 
@@ -26,5 +30,8 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest
-      - name: Verify bounded runtime converge contract
-        run: python -m pytest -q tests/test_runtime_converge_contract.py
+      - name: Verify bounded runtime converge contract and fixed relay
+        run: >-
+          python -m pytest -q
+          tests/test_runtime_converge_contract.py
+          tests/test_runtime_converge_action_relay.py

--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -7,11 +7,15 @@ on:
     paths:
       - 'governance/runtime-converge.json'
       - 'agent_core/runtime_converge_contract.py'
+      - 'agent_core/runtime_converge_capability.py'
       - 'agent_core/controller_service.py'
+      - 'agent_core/realm_server.py'
       - 'agentos_node/runtime_converge_action_relay.py'
       - 'agentos_node/executor_job_action_relay.py'
+      - 'scripts/install_action_relay_user.sh'
       - 'tests/test_runtime_converge_contract.py'
       - 'tests/test_runtime_converge_action_relay.py'
+      - 'tests/test_runtime_converge_capability.py'
       - '.github/workflows/runtime-converge-contract-guard.yml'
   workflow_dispatch:
 
@@ -35,3 +39,4 @@ jobs:
           python -m pytest -q
           tests/test_runtime_converge_contract.py
           tests/test_runtime_converge_action_relay.py
+          tests/test_runtime_converge_capability.py

--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -13,9 +13,12 @@ on:
       - 'agentos_node/runtime_converge_action_relay.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'scripts/install_action_relay_user.sh'
+      - 'scripts/bootstrap_runtime_converger_oracle.sh'
+      - '.github/workflows/deploy-agentos-core.yml'
       - 'tests/test_runtime_converge_contract.py'
       - 'tests/test_runtime_converge_action_relay.py'
       - 'tests/test_runtime_converge_capability.py'
+      - 'tests/test_runtime_converge_bootstrap_contract.py'
       - '.github/workflows/runtime-converge-contract-guard.yml'
   workflow_dispatch:
 
@@ -40,3 +43,4 @@ jobs:
           tests/test_runtime_converge_contract.py
           tests/test_runtime_converge_action_relay.py
           tests/test_runtime_converge_capability.py
+          tests/test_runtime_converge_bootstrap_contract.py

--- a/agent_core/controller_service.py
+++ b/agent_core/controller_service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from agent_core.executor_job_contract import validate_executor_job
 from agent_core.realm_fabric import RealmFabricStore
+from agent_core.runtime_converge_contract import SCHEMA as RUNTIME_CONVERGE_SCHEMA, validate_runtime_converge_request
 
 
 def _utc_now() -> str:
@@ -15,27 +16,35 @@ def _utc_now() -> str:
 class ControllerService:
     """Governed ONE control-plane dispatcher for Node actions.
 
-    This service preserves the accepted #64 controller-dispatch contract. Newer
-    privileged controller/runtime APIs live in agent_core.controller_api.
-
-    #194 adds exactly one typed local-executor branch. It does not turn the
-    compatibility controller into a generic command router.
+    Typed privileged actions use fixed semantic adapters. Ordinary Node actions
+    still follow the accepted #64 queue contract. No privileged branch expands
+    into generic shell/argv authority.
     """
 
     REQUEST_SCHEMA = 'agentos.controller-dispatch/v0.1'
     RECEIPT_SCHEMA = 'agentos.controller-dispatch-receipt/v0.1'
     EXECUTOR_JOB_ACTION = 'agentos.executor.job'
     EXECUTOR_JOB_NODE = 'oracle-core-node'
+    RUNTIME_CONVERGE_ACTION = 'node.runtime.converge'
+    RUNTIME_CONVERGE_NODE = 'oracle-core-node'
 
-    def __init__(self, fabric: RealmFabricStore, executor_job_dispatcher: Any | None = None):
+    def __init__(self, fabric: RealmFabricStore, executor_job_dispatcher: Any | None = None,
+                 runtime_converge_dispatcher: Any | None = None):
         self.fabric = fabric
         self._executor_job_dispatcher = executor_job_dispatcher
+        self._runtime_converge_dispatcher = runtime_converge_dispatcher
 
     def _executor_dispatcher(self):
         if self._executor_job_dispatcher is None:
             from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
             self._executor_job_dispatcher = ActionRelayExecutorJobDispatcher()
         return self._executor_job_dispatcher
+
+    def _runtime_dispatcher(self):
+        if self._runtime_converge_dispatcher is None:
+            from agentos_node.runtime_converge_action_relay import ActionRelayRuntimeConvergeDispatcher
+            self._runtime_converge_dispatcher = ActionRelayRuntimeConvergeDispatcher()
+        return self._runtime_converge_dispatcher
 
     def _node_for_dispatch(self, node_id: str) -> dict[str, Any]:
         node_map = self.fabric.node_registry.node_map()
@@ -56,15 +65,35 @@ class ControllerService:
         if node_id != self.EXECUTOR_JOB_NODE:
             raise ValueError(f'executor job is not routable to target node: {node_id}')
         submission = dict(self._executor_dispatcher().submit(node_id=node_id, request=payload))
-        # #50's hardened bridge historically calls the returned opaque id
-        # ``task_id``. Preserve that field name as a compatibility alias only;
-        # both values are the SAME Action Relay capsule/job ID. The caller's
-        # incoming ctl_* hint never becomes execution identity.
         job_id = str(submission.get('job_id') or '')
         if not job_id:
             raise RuntimeError('executor-job dispatcher returned no job_id')
         submission['task_id'] = job_id
         return submission
+
+    def _dispatch_runtime_converge(self, *, node_id: str, task_hint: str,
+                                   payload: dict[str, Any], passthrough: dict[str, Any]) -> dict[str, Any]:
+        if payload:
+            raise ValueError('runtime converge does not accept generic payload')
+        allowed = {'repository', 'source_ref', 'source_commit'}
+        unexpected = set(passthrough) - allowed
+        if unexpected:
+            raise ValueError(f'unexpected runtime-converge controller fields: {sorted(unexpected)}')
+        if set(passthrough) != allowed:
+            raise ValueError('runtime converge requires repository, source_ref, and source_commit')
+        if node_id != self.RUNTIME_CONVERGE_NODE:
+            raise ValueError(f'runtime converge is not routable to target node: {node_id}')
+        request_id = task_hint or ('ctl-' + uuid.uuid4().hex)
+        canonical = {
+            'schema': RUNTIME_CONVERGE_SCHEMA,
+            'request_id': request_id,
+            'node_id': node_id,
+            'repository': passthrough['repository'],
+            'source_ref': passthrough['source_ref'],
+            'source_commit': passthrough['source_commit'],
+        }
+        validate_runtime_converge_request(canonical)
+        return dict(self._runtime_dispatcher().submit(request=canonical))
 
     def dispatch(self, request: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(request, dict):
@@ -91,17 +120,19 @@ class ControllerService:
         passthrough = {key: value for key, value in request.items() if key not in reserved}
 
         if action == self.EXECUTOR_JOB_ACTION:
-            # A legacy ctl_* task_id may arrive from #50. It is deliberately
-            # ignored and cannot select/reuse the Action Relay capsule ID.
-            return self._dispatch_executor_job(
-                node_id=node_id,
-                payload=payload,
-                passthrough=passthrough,
-            )
+            return self._dispatch_executor_job(node_id=node_id, payload=payload, passthrough=passthrough)
 
         advertised = {str(x) for x in (node.get('capabilities') or []) if str(x)}
         if action not in advertised:
             raise ValueError(f'target node does not advertise capability: {action}')
+
+        if action == self.RUNTIME_CONVERGE_ACTION:
+            return self._dispatch_runtime_converge(
+                node_id=node_id,
+                task_hint=str(request.get('task_id') or '').strip(),
+                payload=payload,
+                passthrough=passthrough,
+            )
 
         task_id = str(request.get('task_id') or ('task-' + uuid.uuid4().hex))
         task = {

--- a/agent_core/realm_server.py
+++ b/agent_core/realm_server.py
@@ -19,6 +19,7 @@ from agent_core.node_bootstrap import bootstrap_snapshot, record_join_regression
 from agent_core.node_registry import NodeRegistry
 from agent_core.realm_fabric import RealmFabricStore
 from agent_core.resolve_facade import resolve_continuation
+from agent_core.runtime_converge_capability import installed_core_capabilities
 
 
 def _utc_now() -> str:
@@ -30,6 +31,8 @@ def _core_node_manifest(realm_id: str) -> dict[str, Any]:
     if not node_id:
         raise ValueError('AGENTOS_CORE_NODE_ID cannot be empty')
     tools = {name: bool(shutil.which(name)) for name in ('git', 'python3', 'curl', 'systemctl')}
+    capabilities = ['agentos.governance.read', 'agentos.one.resolve', 'agentos.realm.fabric']
+    capabilities.extend(capability for capability in installed_core_capabilities() if capability not in capabilities)
     return {
         'schema': 'agentos.node-manifest/v0.1',
         'realm_id': realm_id,
@@ -38,7 +41,7 @@ def _core_node_manifest(realm_id: str) -> dict[str, Any]:
         'hostname': socket.gethostname(),
         'platform': platform.system(),
         'platform_release': platform.release(),
-        'capabilities': ['agentos.governance.read', 'agentos.one.resolve', 'agentos.realm.fabric'],
+        'capabilities': capabilities,
         'tool_presence': tools,
         'surface_inventory': {'surfaces': []},
         'observed_at': _utc_now(),

--- a/agent_core/runtime_converge_capability.py
+++ b/agent_core/runtime_converge_capability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -10,9 +11,17 @@ MARKER_SCHEMA = "agentos.action-relay-capabilities/v1"
 MARKER_ACTION = "agentos.runtime.converge"
 NODE_CAPABILITY = "node.runtime.converge"
 ALLOWED_SOURCE_REF = "core/integration"
-DEFAULT_MARKER = Path("/home/ubuntu/agent-data/runtime/action-relay/capabilities.json")
 EXPECTED_ACTIONS = {"agentos.executor.job", MARKER_ACTION}
 EXPECTED_NODE_CAPABILITIES = {NODE_CAPABILITY}
+
+
+def default_marker_path() -> Path:
+    data_root = Path(
+        os.environ.get("AGENT_DATA_ROOT")
+        or os.environ.get("AGENT_DATA_DIR")
+        or (Path.home() / "agent-data")
+    )
+    return data_root / "runtime" / "action-relay" / "capabilities.json"
 
 
 def validate_installed_marker(payload: Any) -> dict[str, Any] | None:
@@ -40,8 +49,8 @@ def validate_installed_marker(payload: Any) -> dict[str, Any] | None:
     }
 
 
-def installed_core_capabilities(marker_path: str | Path = DEFAULT_MARKER) -> list[str]:
-    path = Path(marker_path)
+def installed_core_capabilities(marker_path: str | Path | None = None) -> list[str]:
+    path = Path(marker_path) if marker_path is not None else default_marker_path()
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeError):

--- a/agent_core/runtime_converge_capability.py
+++ b/agent_core/runtime_converge_capability.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+MARKER_SCHEMA = "agentos.action-relay-capabilities/v1"
+MARKER_ACTION = "agentos.runtime.converge"
+NODE_CAPABILITY = "node.runtime.converge"
+ALLOWED_SOURCE_REF = "core/integration"
+DEFAULT_MARKER = Path("/home/ubuntu/agent-data/runtime/action-relay/capabilities.json")
+EXPECTED_ACTIONS = {"agentos.executor.job", MARKER_ACTION}
+EXPECTED_NODE_CAPABILITIES = {NODE_CAPABILITY}
+
+
+def validate_installed_marker(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema") != MARKER_SCHEMA:
+        return None
+    if payload.get("source_ref") != ALLOWED_SOURCE_REF:
+        return None
+    source_commit = str(payload.get("source_commit") or "")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        return None
+
+    actions = payload.get("actions")
+    capabilities = payload.get("node_capabilities")
+    if not isinstance(actions, list) or set(actions) != EXPECTED_ACTIONS:
+        return None
+    if not isinstance(capabilities, list) or set(capabilities) != EXPECTED_NODE_CAPABILITIES:
+        return None
+    return {
+        "source_ref": ALLOWED_SOURCE_REF,
+        "source_commit": source_commit,
+        "actions": sorted(EXPECTED_ACTIONS),
+        "node_capabilities": sorted(EXPECTED_NODE_CAPABILITIES),
+    }
+
+
+def installed_core_capabilities(marker_path: str | Path = DEFAULT_MARKER) -> list[str]:
+    path = Path(marker_path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError):
+        return []
+    marker = validate_installed_marker(payload)
+    if marker is None:
+        return []
+    return list(marker["node_capabilities"])

--- a/agentos_node/executor_job_action_relay.py
+++ b/agentos_node/executor_job_action_relay.py
@@ -1,8 +1,8 @@
 """Bounded executor-job extension for the existing ubuntu Action Relay.
 
 This module deliberately reuses ``agentos_node.action_relay`` and its spool,
-digest, at-most-once, quarantine, and ubuntu-owned worker boundary. It adds one
-fixed semantic action only; no generic shell or argv surface is introduced.
+digest, at-most-once, quarantine, and ubuntu-owned worker boundary. It loads
+fixed semantic actions only; no generic shell or argv surface is introduced.
 """
 from __future__ import annotations
 
@@ -26,14 +26,10 @@ ACTION = "agentos.executor.job"
 DEFAULT_ROOT = Path("/home/ubuntu/agent-data/runtime/action-relay")
 _REQUEST_FIELDS = ("job_type", "project_id", "executor_class", "workload_ref", "authority")
 
-# Cross-slice integration is conditional by construction. #194 remains usable
-# without #117; once both are present in the same immutable runtime generation,
-# the trusted provider becomes available without a second daemon or model input.
 ISSUE117_PROVIDER_REGISTERED = register_issue117_provider_if_available()
 
 
 def _request_projection(request: Mapping[str, Any]) -> dict[str, Any]:
-    """Persist only semantic identity fields, never transport-reserved fields."""
     validate_executor_job(request)
     return {key: request[key] for key in _REQUEST_FIELDS}
 
@@ -54,16 +50,18 @@ def _execute(params: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("executor-job relay accepts only a canonical request object")
     request = dict(params["request"])
     validate_executor_job(request)
-    # ActionRelay owns receipt schema/capsule/action/timestamps. Persist only
-    # fixed job identity plus the adapter's already-sanitized semantic result.
     return {**_request_projection(request), **run_registered_executor_job(request=request)}
 
 
-# Trusted-process registration. Importing this module extends the same fixed
-# Action Relay ACTIONS table used by both producer and ubuntu worker process.
 if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
     raise RuntimeError("executor-job Action Relay action already registered differently")
 ACTIONS[ACTION] = _execute
+
+# Load the independently typed #242 converger into the SAME fixed Action Relay
+# process. This import is intentionally after executor-job registration so the
+# service entrypoint remains backwards compatible while gaining no generic
+# execution surface.
+from agentos_node import runtime_converge_action_relay as _runtime_converge_action_relay  # noqa: E402,F401
 
 
 class ActionRelayExecutorJobDispatcher:
@@ -138,7 +136,7 @@ class ActionRelayExecutorJobDispatcher:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the original Action Relay worker with the fixed job action loaded."""
+    """Run the original Action Relay worker with all fixed actions loaded."""
     return action_relay_main(argv)
 
 

--- a/agentos_node/executor_job_action_relay.py
+++ b/agentos_node/executor_job_action_relay.py
@@ -57,15 +57,16 @@ if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
     raise RuntimeError("executor-job Action Relay action already registered differently")
 ACTIONS[ACTION] = _execute
 
-# Load the independently typed #242 converger into the SAME fixed Action Relay
-# process. This import is intentionally after executor-job registration so the
-# service entrypoint remains backwards compatible while gaining no generic
-# execution surface.
 from agentos_node import runtime_converge_action_relay as _runtime_converge_action_relay  # noqa: E402,F401
 
 
 class ActionRelayExecutorJobDispatcher:
-    """Submit/inspect bounded jobs through the existing Action Relay spool."""
+    """Submit/inspect fixed semantic work through the shared Action Relay spool.
+
+    ``inspect`` remains the historical controller receipt facade. It now routes
+    runtime-converge receipts by their persisted semantic action before applying
+    executor-job projection, so action-* IDs remain unambiguous.
+    """
 
     def __init__(self, root: str | Path = DEFAULT_ROOT):
         self.root = Path(root)
@@ -106,10 +107,12 @@ class ActionRelayExecutorJobDispatcher:
 
     def inspect(self, job_id: str) -> dict[str, Any] | None:
         job_id = validate_executor_job_id(job_id)
-        request = self._recover_request(job_id)
         receipt = self.client.receipt(job_id)
+        if receipt is not None and receipt.get("action") == _runtime_converge_action_relay.ACTION:
+            return _runtime_converge_action_relay.ActionRelayRuntimeConvergeDispatcher(self.root).inspect(job_id)
         if receipt is None:
             return None
+        request = self._recover_request(job_id)
         if request is None:
             raise RuntimeError("executor-job request provenance unavailable")
         if receipt.get("action") not in (None, ACTION):
@@ -136,7 +139,6 @@ class ActionRelayExecutorJobDispatcher:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the original Action Relay worker with all fixed actions loaded."""
     return action_relay_main(argv)
 
 

--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -8,7 +8,6 @@ service names and installer sequence are fixed here.
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import urllib.request
@@ -150,7 +149,7 @@ def _safe_failure(request: Mapping[str, Any], classification: str, *, previous: 
 
 def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -> dict[str, Any]:
     """Converge the Oracle Core checkout to an exact current core/integration head."""
-    canonical = validate_runtime_converge_request(request)
+    canonical = validate_runtime_converge_request(request).as_payload()
     previous: str | None = None
     try:
         previous, idempotent = _preflight(repo, canonical)
@@ -197,8 +196,6 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
             "observed_at": _utc_now(),
         }
 
-    # Failed target health/install. Restore exactly the previous accepted checkout
-    # and re-run the same fixed installers. No mutable ref and no caller code.
     rollback_checkout = bool(previous) and _checkout_exact(repo, previous)
     rollback_health = rollback_checkout and _install_fixed_runtime(repo)
     if rollback_health:
@@ -222,9 +219,6 @@ def _execute(params: dict[str, Any]) -> dict[str, Any]:
     if set(params) != {"request"} or not isinstance(params.get("request"), dict):
         raise ValueError("runtime-converge relay accepts only a canonical request object")
     result = converge_runtime(dict(params["request"]))
-    # A fixed allowlist is persisted to the Action Relay receipt. Subprocess
-    # stdout/stderr, filesystem paths, service environment and credentials never
-    # become relay result data.
     return {key: result.get(key) for key in SAFE_RESULT_FIELDS}
 
 
@@ -239,7 +233,7 @@ class ActionRelayRuntimeConvergeDispatcher:
         self.client = ActionRelayClient(self.root)
 
     def submit(self, *, request: Mapping[str, Any]) -> dict[str, Any]:
-        canonical = validate_runtime_converge_request(request)
+        canonical = validate_runtime_converge_request(request).as_payload()
         capsule = self.client.submit(ACTION, {"request": canonical})
         return {
             "schema": "agentos.runtime-converge-submission/v1",

--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -1,0 +1,284 @@
+"""Bounded Oracle Core runtime convergence through the existing Action Relay.
+
+The external capability is ``node.runtime.converge``.  The relay action below is
+an implementation detail owned by the trusted ubuntu worker.  Callers provide
+only the canonical typed request; executable names, argv, paths, environment,
+service names and installer sequence are fixed here.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from agent_core.runtime_converge_contract import validate_runtime_converge_request
+from agentos_node.action_relay import ACTIONS, ActionRelayClient
+
+
+ACTION = "agentos.runtime.converge"
+DEFAULT_RELAY_ROOT = Path("/home/ubuntu/agent-data/runtime/action-relay")
+DEFAULT_REPO = Path("/home/ubuntu/agentmanager")
+CAPABILITY_MARKER = DEFAULT_RELAY_ROOT / "capabilities.json"
+ALLOWED_ORIGIN_RE = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+    r"alston-personal/agentmanager(?:\.git)?/?$"
+)
+SAFE_RESULT_FIELDS = (
+    "request_id",
+    "node_id",
+    "repository",
+    "source_ref",
+    "source_commit",
+    "previous_commit",
+    "resulting_commit",
+    "health",
+    "rollback",
+    "status",
+    "classification",
+    "idempotent",
+    "credential_exposed",
+    "observed_at",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _run(argv: list[str], *, cwd: Path, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    """Run one trusted, source-owned command. Caller data never supplies argv."""
+    return subprocess.run(
+        argv,
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _git(repo: Path, *args: str, timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return _run(["git", *args], cwd=repo, timeout=timeout)
+
+
+def _git_value(repo: Path, *args: str) -> str:
+    result = _git(repo, *args)
+    if result.returncode != 0:
+        raise RuntimeError("git_preflight_failed")
+    return result.stdout.strip()
+
+
+def _health() -> bool:
+    for unit in ("agentos-realm-fabric.service", "agentos-core-supervisor.service"):
+        result = _run(["systemctl", "--user", "is-active", "--quiet", unit], cwd=DEFAULT_REPO, timeout=20)
+        if result.returncode != 0:
+            return False
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:8780/v1/health", timeout=5) as response:
+            if response.status != 200:
+                return False
+            payload = json.loads(response.read().decode("utf-8"))
+            return isinstance(payload, dict) and payload.get("ok") is True
+    except Exception:
+        return False
+
+
+def _install_fixed_runtime(repo: Path) -> bool:
+    """Install only source-owned, fixed Core surfaces; never caller-selected code."""
+    steps = (
+        (["python3", "scripts/install_services.py"], 240),
+        (["bash", "scripts/install_realm_fabric_user.sh"], 120),
+    )
+    for argv, timeout in steps:
+        result = _run(argv, cwd=repo, timeout=timeout)
+        if result.returncode != 0:
+            return False
+    return _health()
+
+
+def _checkout_exact(repo: Path, commit: str) -> bool:
+    result = _git(repo, "checkout", "--detach", "--force", commit)
+    return result.returncode == 0 and _git_value(repo, "rev-parse", "HEAD") == commit
+
+
+def _preflight(repo: Path, request: Mapping[str, Any]) -> tuple[str, bool]:
+    if not repo.is_dir() or not (repo / ".git").exists():
+        raise RuntimeError("repo_unavailable")
+    origin = _git_value(repo, "remote", "get-url", "origin")
+    if not ALLOWED_ORIGIN_RE.fullmatch(origin):
+        raise RuntimeError("repository_origin_not_allowed")
+    dirty = _git_value(repo, "status", "--porcelain", "--untracked-files=no")
+    if dirty:
+        raise RuntimeError("tracked_checkout_dirty")
+
+    previous = _git_value(repo, "rev-parse", "HEAD")
+    source_ref = str(request["source_ref"])
+    source_commit = str(request["source_commit"])
+    fetched = _git(repo, "fetch", "--no-tags", "origin", source_ref)
+    if fetched.returncode != 0:
+        raise RuntimeError("source_fetch_failed")
+    observed_head = _git_value(repo, "rev-parse", "FETCH_HEAD")
+    if observed_head != source_commit:
+        raise RuntimeError("exact_source_head_mismatch")
+    return previous, previous == source_commit
+
+
+def _safe_failure(request: Mapping[str, Any], classification: str, *, previous: str | None = None,
+                  rollback: str = "not_attempted", resulting: str | None = None) -> dict[str, Any]:
+    return {
+        "request_id": request["request_id"],
+        "node_id": request["node_id"],
+        "repository": request["repository"],
+        "source_ref": request["source_ref"],
+        "source_commit": request["source_commit"],
+        "previous_commit": previous,
+        "resulting_commit": resulting,
+        "health": "failed",
+        "rollback": rollback,
+        "status": "failed",
+        "classification": classification,
+        "idempotent": False,
+        "credential_exposed": False,
+        "observed_at": _utc_now(),
+    }
+
+
+def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -> dict[str, Any]:
+    """Converge the Oracle Core checkout to an exact current core/integration head."""
+    canonical = validate_runtime_converge_request(request)
+    previous: str | None = None
+    try:
+        previous, idempotent = _preflight(repo, canonical)
+    except RuntimeError as exc:
+        return _safe_failure(canonical, str(exc))
+
+    if idempotent:
+        healthy = _health()
+        return {
+            "request_id": canonical["request_id"],
+            "node_id": canonical["node_id"],
+            "repository": canonical["repository"],
+            "source_ref": canonical["source_ref"],
+            "source_commit": canonical["source_commit"],
+            "previous_commit": previous,
+            "resulting_commit": previous,
+            "health": "passed" if healthy else "failed",
+            "rollback": "not_needed",
+            "status": "completed" if healthy else "failed",
+            "classification": "ALREADY_CONVERGED" if healthy else "CURRENT_GENERATION_UNHEALTHY",
+            "idempotent": True,
+            "credential_exposed": False,
+            "observed_at": _utc_now(),
+        }
+
+    if not _checkout_exact(repo, canonical["source_commit"]):
+        return _safe_failure(canonical, "target_checkout_failed", previous=previous)
+
+    if _install_fixed_runtime(repo):
+        return {
+            "request_id": canonical["request_id"],
+            "node_id": canonical["node_id"],
+            "repository": canonical["repository"],
+            "source_ref": canonical["source_ref"],
+            "source_commit": canonical["source_commit"],
+            "previous_commit": previous,
+            "resulting_commit": canonical["source_commit"],
+            "health": "passed",
+            "rollback": "not_needed",
+            "status": "completed",
+            "classification": "CONVERGED",
+            "idempotent": False,
+            "credential_exposed": False,
+            "observed_at": _utc_now(),
+        }
+
+    # Failed target health/install. Restore exactly the previous accepted checkout
+    # and re-run the same fixed installers. No mutable ref and no caller code.
+    rollback_checkout = bool(previous) and _checkout_exact(repo, previous)
+    rollback_health = rollback_checkout and _install_fixed_runtime(repo)
+    if rollback_health:
+        return _safe_failure(
+            canonical,
+            "TARGET_HEALTH_FAILED_ROLLED_BACK",
+            previous=previous,
+            rollback="completed",
+            resulting=previous,
+        )
+    return _safe_failure(
+        canonical,
+        "ROLLBACK_OUTCOME_UNKNOWN",
+        previous=previous,
+        rollback="unknown",
+        resulting=None,
+    )
+
+
+def _execute(params: dict[str, Any]) -> dict[str, Any]:
+    if set(params) != {"request"} or not isinstance(params.get("request"), dict):
+        raise ValueError("runtime-converge relay accepts only a canonical request object")
+    result = converge_runtime(dict(params["request"]))
+    # A fixed allowlist is persisted to the Action Relay receipt. Subprocess
+    # stdout/stderr, filesystem paths, service environment and credentials never
+    # become relay result data.
+    return {key: result.get(key) for key in SAFE_RESULT_FIELDS}
+
+
+if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
+    raise RuntimeError("runtime-converge Action Relay action already registered differently")
+ACTIONS[ACTION] = _execute
+
+
+class ActionRelayRuntimeConvergeDispatcher:
+    def __init__(self, root: str | Path = DEFAULT_RELAY_ROOT):
+        self.root = Path(root)
+        self.client = ActionRelayClient(self.root)
+
+    def submit(self, *, request: Mapping[str, Any]) -> dict[str, Any]:
+        canonical = validate_runtime_converge_request(request)
+        capsule = self.client.submit(ACTION, {"request": canonical})
+        return {
+            "schema": "agentos.runtime-converge-submission/v1",
+            "ok": True,
+            "action": "node.runtime.converge",
+            "task_id": str(capsule["capsule_id"]),
+            "request_id": canonical["request_id"],
+            "node_id": canonical["node_id"],
+            "source_ref": canonical["source_ref"],
+            "source_commit": canonical["source_commit"],
+            "state": "queued",
+        }
+
+    def inspect(self, task_id: str) -> dict[str, Any] | None:
+        receipt = self.client.receipt(str(task_id))
+        if receipt is None:
+            return None
+        if receipt.get("action") != ACTION:
+            raise RuntimeError("runtime_converge_receipt_action_mismatch")
+        projected = {key: receipt.get(key) for key in SAFE_RESULT_FIELDS if key in receipt}
+        projected.update({
+            "schema": "agentos.runtime-converge-receipt/v1",
+            "ok": projected.get("status") == "completed",
+            "action": "node.runtime.converge",
+            "task_id": str(task_id),
+        })
+        if receipt.get("outcome") == "unknown":
+            projected.update({"ok": False, "status": "unknown", "classification": "EXECUTION_OUTCOME_UNKNOWN"})
+        return projected
+
+
+def capability_marker_payload(*, source_ref: str, source_commit: str) -> dict[str, Any]:
+    if source_ref != "core/integration" or not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("invalid Action Relay capability provenance")
+    return {
+        "schema": "agentos.action-relay-capabilities/v1",
+        "actions": ["agentos.executor.job", ACTION],
+        "node_capabilities": ["node.runtime.converge"],
+        "source_ref": source_ref,
+        "source_commit": source_commit,
+        "observed_at": _utc_now(),
+    }

--- a/scripts/bootstrap_runtime_converger_oracle.sh
+++ b/scripts/bootstrap_runtime_converger_oracle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: bootstrap must run as ubuntu" >&2
+  exit 2
+fi
+
+SOURCE_REF="${1:-}"
+SOURCE_COMMIT="${2:-}"
+REPO="${AGENTOS_REPO:-$HOME/agentmanager}"
+DATA="${AGENT_DATA_ROOT:-$HOME/agent-data}"
+MARKER="$DATA/runtime/action-relay/capabilities.json"
+
+if [ "$SOURCE_REF" != "core/integration" ]; then
+  echo "ERROR: bootstrap source_ref must be core/integration" >&2
+  exit 4
+fi
+if ! printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "ERROR: bootstrap source_commit must be a lowercase 40-character git SHA" >&2
+  exit 4
+fi
+
+test -d "$REPO/.git" || { echo "ERROR: canonical repo missing" >&2; exit 2; }
+cd "$REPO"
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  echo "ERROR: refusing bootstrap with tracked local changes" >&2
+  exit 2
+fi
+CURRENT="$(git rev-parse HEAD)"
+if [ "$CURRENT" != "$SOURCE_COMMIT" ]; then
+  echo "ERROR: canonical checkout must already be detached at requested exact SHA" >&2
+  exit 4
+fi
+
+git fetch --no-tags origin "$SOURCE_REF"
+FETCHED="$(git rev-parse FETCH_HEAD)"
+if [ "$FETCHED" != "$SOURCE_COMMIT" ]; then
+  echo "ERROR: requested SHA is not the current permitted source-ref head" >&2
+  exit 4
+fi
+
+# The bootstrap carrier is explicit/manual only. The installer receives an exact
+# immutable generation and cannot choose another ref or silently drift.
+AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
+AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT" \
+bash scripts/install_action_relay_user.sh
+
+python3 - "$MARKER" "$SOURCE_COMMIT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+expected = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+assert payload.get("schema") == "agentos.action-relay-capabilities/v1"
+assert payload.get("source_ref") == "core/integration"
+assert payload.get("source_commit") == expected
+assert set(payload.get("actions") or []) == {"agentos.executor.job", "agentos.runtime.converge"}
+assert payload.get("node_capabilities") == ["node.runtime.converge"]
+PY
+
+# Restart ONE from the same exact checkout so its Core manifest projects the
+# installed marker. This does not grant steady-state authority to this script.
+bash scripts/install_realm_fabric_user.sh
+systemctl --user is-active --quiet agentos-action-relay.service
+systemctl --user is-active --quiet agentos-realm-fabric.service
+curl -fsS --max-time 5 http://127.0.0.1:8780/v1/health >/dev/null
+
+# Local source-level proof that the manifest now sees the installed marker.
+AGENT_DATA_ROOT="$DATA" python3 - <<'PY'
+from agent_core.realm_server import _core_node_manifest
+manifest = _core_node_manifest("bootstrap-proof")
+assert "node.runtime.converge" in set(manifest.get("capabilities") or [])
+PY
+
+echo "runtime_converger_bootstrap=PASS"
+echo "runtime_converger_source_ref=$SOURCE_REF"
+echo "runtime_converger_source_commit=$SOURCE_COMMIT"
+echo "runtime_converger_capability=node.runtime.converge"

--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -11,6 +11,7 @@ DATA="${AGENT_DATA_ROOT:-$HOME/agent-data}"
 RUNTIME_ROOT="${AGENTOS_ACTION_RUNTIME_ROOT:-$HOME/.local/share/agentos/action-runtime}"
 LEGACY_RUNTIME_ROOT="${RUNTIME_ROOT}.legacy-pre-worktree"
 RELAY_ROOT="$DATA/runtime/action-relay"
+CAPABILITY_MARKER="$RELAY_ROOT/capabilities.json"
 UNIT_DIR="$HOME/.config/systemd/user"
 UNIT="$UNIT_DIR/agentos-action-relay.service"
 SOURCE_REF="${AGENTOS_ACTION_SOURCE_REF:-main}"
@@ -107,10 +108,14 @@ echo "action_relay_runtime_worktree=PASS"
   cd "$RUNTIME_ROOT"
   PYTHONPATH="$RUNTIME_ROOT" python3 - <<'PY'
 from agentos_node.executor_job_action_relay import ACTION, ACTIONS
+from agentos_node.runtime_converge_action_relay import ACTION as CONVERGE_ACTION
 assert ACTION == 'agentos.executor.job'
+assert CONVERGE_ACTION == 'agentos.runtime.converge'
 assert ACTION in ACTIONS
+assert CONVERGE_ACTION in ACTIONS
 print('action_runtime_import=ok')
 print('executor_job_action_loaded=PASS')
+print('runtime_converge_action_loaded=PASS')
 print('actions='+','.join(sorted(ACTIONS)))
 PY
 )
@@ -155,14 +160,38 @@ done
 
 systemctl --user --no-pager --full status agentos-action-relay.service || true
 if [ "$stable" -lt 3 ]; then
+  rm -f "$CAPABILITY_MARKER"
   echo '=== ACTION RELAY STARTUP JOURNAL ===' >&2
   journalctl --user -u agentos-action-relay.service -n 80 --no-pager >&2 || true
   echo 'action_relay_install=FAIL' >&2
   exit 4
 fi
 
+# Capability availability is installed-state evidence, not a source-code claim.
+# Publish only after the exact immutable runtime imports both fixed semantic
+# actions and the worker demonstrates stable liveness. The marker contains no
+# credentials, executable path, argv, environment or mutable authority.
+PYTHONPATH="$RUNTIME_ROOT" python3 - "$CAPABILITY_MARKER" "$SOURCE_REF" "$SOURCE_COMMIT" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+from agentos_node.runtime_converge_action_relay import capability_marker_payload
+
+path = Path(sys.argv[1])
+payload = capability_marker_payload(source_ref=sys.argv[2], source_commit=sys.argv[3])
+tmp = path.with_suffix('.tmp')
+tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+os.chmod(tmp, 0o640)
+tmp.replace(path)
+PY
+chgrp agentos "$CAPABILITY_MARKER"
+
 echo "action_relay_install=PASS"
 echo "action_relay_executor_job_extension=PASS"
+echo "action_relay_runtime_converge_extension=PASS"
+echo "action_relay_capability_marker=PASS"
 echo "action_relay_group_context=agentos"
 echo "action_relay_user_bus=ubuntu:/run/user/1001/bus"
 echo "action_relay_stable_liveness=PASS"

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent_core.controller_service import ControllerService
+from agent_core.runtime_converge_contract import ALLOWED_REPOSITORY, SCHEMA
+from agentos_node import runtime_converge_action_relay as relay
+
+
+SHA = "a" * 40
+PREVIOUS = "b" * 40
+
+
+def request(**overrides):
+    payload = {
+        "schema": SCHEMA,
+        "request_id": "ctl_runtime_1",
+        "node_id": "oracle-core-node",
+        "repository": ALLOWED_REPOSITORY,
+        "source_ref": "core/integration",
+        "source_commit": SHA,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class Proc(SimpleNamespace):
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+def test_relay_registers_fixed_semantic_action_without_generic_carrier():
+    assert relay.ACTION == "agentos.runtime.converge"
+    assert relay.ACTION in relay.ACTIONS
+    assert "shell.exec" not in relay.ACTIONS
+    assert "argv" not in relay.SAFE_RESULT_FIELDS
+    assert "stdout" not in relay.SAFE_RESULT_FIELDS
+    assert "stderr" not in relay.SAFE_RESULT_FIELDS
+
+
+def test_preflight_refuses_dirty_checkout(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+
+    def fake_git_value(repo, *args):
+        if args[:3] == ("remote", "get-url", "origin"):
+            return "https://github.com/alston-personal/agentmanager.git"
+        if args[:2] == ("status", "--porcelain"):
+            return " M agent_core/realm_server.py"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(relay, "_git_value", fake_git_value)
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert result["status"] == "failed"
+    assert result["classification"] == "tracked_checkout_dirty"
+    assert result["credential_exposed"] is False
+
+
+def test_preflight_refuses_requested_sha_that_is_not_exact_ref_head(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+
+    def fake_git_value(repo, *args):
+        if args[:3] == ("remote", "get-url", "origin"):
+            return "git@github.com:alston-personal/agentmanager.git"
+        if args[:2] == ("status", "--porcelain"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return PREVIOUS
+        if args == ("rev-parse", "FETCH_HEAD"):
+            return "c" * 40
+        raise AssertionError(args)
+
+    monkeypatch.setattr(relay, "_git_value", fake_git_value)
+    monkeypatch.setattr(relay, "_git", lambda *a, **k: Proc(returncode=0, stdout=""))
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert result["classification"] == "exact_source_head_mismatch"
+
+
+def test_health_failure_rolls_back_exact_previous_generation(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False))
+    checkouts = []
+    monkeypatch.setattr(relay, "_checkout_exact", lambda repo, sha: checkouts.append(sha) or True)
+    outcomes = iter([False, True])
+    monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: next(outcomes))
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert checkouts == [SHA, PREVIOUS]
+    assert result["classification"] == "TARGET_HEALTH_FAILED_ROLLED_BACK"
+    assert result["rollback"] == "completed"
+    assert result["resulting_commit"] == PREVIOUS
+
+
+def test_rollback_ambiguity_is_unknown_and_not_success(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False))
+    monkeypatch.setattr(relay, "_checkout_exact", lambda repo, sha: True)
+    monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: False)
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert result["classification"] == "ROLLBACK_OUTCOME_UNKNOWN"
+    assert result["rollback"] == "unknown"
+    assert result["status"] == "failed"
+
+
+class NodeRegistry:
+    def node_map(self):
+        return {"nodes": [{"node_id": "oracle-core-node", "status": "online", "capabilities": ["node.runtime.converge"]}]}
+
+
+class Fabric:
+    node_registry = NodeRegistry()
+
+    def queue_task(self, *args, **kwargs):
+        raise AssertionError("runtime converge must not enter generic Node task queue")
+
+
+class RuntimeDispatcher:
+    def __init__(self):
+        self.seen = None
+
+    def submit(self, *, request):
+        self.seen = request
+        return {"ok": True, "action": "node.runtime.converge", "task_id": "action-123", "state": "queued"}
+
+
+def test_controller_routes_typed_converge_to_fixed_relay_not_node_queue():
+    dispatcher = RuntimeDispatcher()
+    controller = ControllerService(Fabric(), runtime_converge_dispatcher=dispatcher)
+    result = controller.dispatch({
+        "node_id": "oracle-core-node",
+        "task_id": "ctl_runtime_1",
+        "action": "node.runtime.converge",
+        "repository": ALLOWED_REPOSITORY,
+        "source_ref": "core/integration",
+        "source_commit": SHA,
+    })
+    assert result["task_id"] == "action-123"
+    assert dispatcher.seen["request_id"] == "ctl_runtime_1"
+    assert set(dispatcher.seen) == {"schema", "request_id", "node_id", "repository", "source_ref", "source_commit"}
+
+
+@pytest.mark.parametrize("field", ["shell", "argv", "command", "module", "token", "environment"])
+def test_controller_rejects_execution_carrier_fields(field):
+    controller = ControllerService(Fabric(), runtime_converge_dispatcher=RuntimeDispatcher())
+    body = {
+        "node_id": "oracle-core-node",
+        "action": "node.runtime.converge",
+        "repository": ALLOWED_REPOSITORY,
+        "source_ref": "core/integration",
+        "source_commit": SHA,
+        field: "forbidden",
+    }
+    with pytest.raises(ValueError):
+        controller.dispatch(body)

--- a/tests/test_runtime_converge_bootstrap_contract.py
+++ b/tests/test_runtime_converge_bootstrap_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BOOTSTRAP = ROOT / "scripts" / "bootstrap_runtime_converger_oracle.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-agentos-core.yml"
+
+
+def test_bootstrap_is_exact_ref_exact_sha_and_clean_tree_only():
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    assert 'SOURCE_REF="${1:-}"' in text
+    assert 'SOURCE_COMMIT="${2:-}"' in text
+    assert '[ "$SOURCE_REF" != "core/integration" ]' in text
+    assert "^[0-9a-f]{40}$" in text
+    assert 'git status --porcelain --untracked-files=no' in text
+    assert 'CURRENT="$(git rev-parse HEAD)"' in text
+    assert 'FETCHED="$(git rev-parse FETCH_HEAD)"' in text
+    assert '[ "$FETCHED" != "$SOURCE_COMMIT" ]' in text
+
+
+def test_bootstrap_uses_fixed_installers_and_verifies_installed_marker():
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    assert 'AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF"' in text
+    assert 'AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT"' in text
+    assert "bash scripts/install_action_relay_user.sh" in text
+    assert "agentos.action-relay-capabilities/v1" in text
+    assert 'bash scripts/install_realm_fabric_user.sh' in text
+    assert 'systemctl --user is-active --quiet agentos-action-relay.service' in text
+    assert 'systemctl --user is-active --quiet agentos-realm-fabric.service' in text
+    assert 'curl -fsS --max-time 5 http://127.0.0.1:8780/v1/health' in text
+    assert '"node.runtime.converge" in set(manifest.get("capabilities") or [])' in text
+
+
+def test_bootstrap_has_no_generic_execution_inputs():
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    forbidden = ("$3", "$4", "eval ", "bash -c", "sh -c", "--command", "--argv", "--module", "--executable")
+    for token in forbidden:
+        assert token not in text
+
+
+def test_existing_manual_deploy_workflow_requires_explicit_opt_in_and_exact_sha():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "bootstrap_runtime_converger:" in text
+    assert "default: false" in text
+    assert "expected_sha:" in text
+    assert 'Runtime converger bootstrap requires deploy_ref=core/integration' in text
+    assert 'Runtime converger bootstrap requires exact lowercase expected_sha' in text
+    assert '[ "$TARGET_SHA" = "$EXPECTED" ]' in text
+    assert 'bash scripts/bootstrap_runtime_converger_oracle.sh "$REF" "$TARGET_SHA"' in text
+
+
+def test_failed_bootstrap_revokes_advertisement_before_realm_restore():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    marker_remove = text.index('rm -f "$CAPABILITY_MARKER"')
+    realm_restore = text.index('bash scripts/install_realm_fabric_user.sh || true')
+    assert marker_remove < realm_restore
+    assert "ONE cannot claim a capability whose rollback state is ambiguous" in text

--- a/tests/test_runtime_converge_capability.py
+++ b/tests/test_runtime_converge_capability.py
@@ -9,6 +9,7 @@ from agent_core.runtime_converge_capability import (
     MARKER_ACTION,
     MARKER_SCHEMA,
     NODE_CAPABILITY,
+    default_marker_path,
     installed_core_capabilities,
     validate_installed_marker,
 )
@@ -37,6 +38,15 @@ def test_valid_installed_marker_advertises_only_runtime_converge(tmp_path: Path)
     validated = validate_installed_marker(marker())
     assert validated is not None
     assert validated["source_commit"] == SHA
+
+
+def test_default_marker_follows_runtime_data_root(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AGENT_DATA_ROOT", str(tmp_path))
+    path = tmp_path / "runtime" / "action-relay" / "capabilities.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(marker()), encoding="utf-8")
+    assert default_marker_path() == path
+    assert installed_core_capabilities() == [NODE_CAPABILITY]
 
 
 def test_missing_corrupt_or_wrong_provenance_marker_fails_closed(tmp_path: Path):

--- a/tests/test_runtime_converge_capability.py
+++ b/tests/test_runtime_converge_capability.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_core import realm_server
+from agent_core.runtime_converge_capability import (
+    ALLOWED_SOURCE_REF,
+    MARKER_ACTION,
+    MARKER_SCHEMA,
+    NODE_CAPABILITY,
+    installed_core_capabilities,
+    validate_installed_marker,
+)
+
+
+SHA = "a" * 40
+
+
+def marker(**overrides):
+    payload = {
+        "schema": MARKER_SCHEMA,
+        "actions": ["agentos.executor.job", MARKER_ACTION],
+        "node_capabilities": [NODE_CAPABILITY],
+        "source_ref": ALLOWED_SOURCE_REF,
+        "source_commit": SHA,
+        "observed_at": "2026-09-04T03:00:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_valid_installed_marker_advertises_only_runtime_converge(tmp_path: Path):
+    path = tmp_path / "capabilities.json"
+    path.write_text(json.dumps(marker()), encoding="utf-8")
+    assert installed_core_capabilities(path) == [NODE_CAPABILITY]
+    validated = validate_installed_marker(marker())
+    assert validated is not None
+    assert validated["source_commit"] == SHA
+
+
+def test_missing_corrupt_or_wrong_provenance_marker_fails_closed(tmp_path: Path):
+    missing = tmp_path / "missing.json"
+    assert installed_core_capabilities(missing) == []
+
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("not-json", encoding="utf-8")
+    assert installed_core_capabilities(corrupt) == []
+
+    cases = [
+        marker(schema="wrong"),
+        marker(source_ref="main"),
+        marker(source_commit="abc"),
+        marker(actions=["agentos.executor.job"]),
+        marker(actions=["agentos.executor.job", MARKER_ACTION, "shell.exec"]),
+        marker(node_capabilities=[NODE_CAPABILITY, "shell.exec"]),
+    ]
+    for payload in cases:
+        assert validate_installed_marker(payload) is None
+
+
+def test_core_manifest_does_not_claim_source_only_capability(monkeypatch):
+    monkeypatch.setattr(realm_server, "installed_core_capabilities", lambda: [])
+    manifest = realm_server._core_node_manifest("realm-test")
+    assert NODE_CAPABILITY not in manifest["capabilities"]
+
+
+def test_core_manifest_advertises_only_after_installed_marker(monkeypatch):
+    monkeypatch.setattr(realm_server, "installed_core_capabilities", lambda: [NODE_CAPABILITY])
+    manifest = realm_server._core_node_manifest("realm-test")
+    assert manifest["capabilities"].count(NODE_CAPABILITY) == 1
+
+
+def test_installer_publishes_marker_only_after_stable_liveness():
+    text = (Path(__file__).resolve().parent.parent / "scripts" / "install_action_relay_user.sh").read_text(encoding="utf-8")
+    stable_gate = text.index('if [ "$stable" -lt 3 ]')
+    marker_write = text.index('capability_marker_payload')
+    assert stable_gate < marker_write
+    assert 'rm -f "$CAPABILITY_MARKER"' in text
+    assert "runtime_converge_action_loaded=PASS" in text


### PR DESCRIPTION
## Scope
Second source slice for #242. Replace the legacy `node.runtime.converge -> shell.exec` carrier with a fixed semantic Action Relay action, installed-state capability advertisement, and an explicit exact-SHA Oracle bootstrap path.

## Adds
- Fixed `agentos.runtime.converge` Action Relay action on the existing ubuntu-owned relay; no second daemon.
- Typed compatibility-controller routing for external `node.runtime.converge`; never queued as generic Node shell work.
- Exact `core/integration` SHA validation, clean tracked checkout, fixed installers, health check, exact previous-SHA rollback, `unknown` on ambiguous rollback.
- Sanitized `action-*` receipt routing shared with executor jobs.
- Installed Action Relay capability marker written only after exact runtime import + stable liveness; failed startup removes marker.
- Fail-closed installed marker validator and `oracle-core-node` advertisement only from validated marker.
- Runtime marker path follows `AGENT_DATA_ROOT`/`AGENT_DATA_DIR`; no hard-coded false advertisement on alternate data roots.
- Explicit `scripts/bootstrap_runtime_converger_oracle.sh` requiring ubuntu + `core/integration` + lowercase exact SHA + clean checkout + current ref-head equality.
- Existing `deploy-agentos-core.yml` retains manual SSH/preflight/rollback and adds opt-in `bootstrap_runtime_converger=false` plus required exact SHA when enabled.
- Failed bootstrap revokes the converge capability marker before restoring the previous Realm generation, so ambiguous carrier state is not advertised.

## Security boundary
Caller cannot choose executable, argv, shell, module, cwd, filesystem path, service, installer or environment. Capability availability is not inferred from source presence. GitHub Actions is bootstrap-only and is not the steady-state control plane.

## CI evidence at head `c5be4306f208d759ffde2a2d08bd9de0f1a9c9b8`
- Runtime Converge Contract Guard: PASS
- Bounded Executor Job Guard: PASS
- AgentOS Control Inbox Contract: PASS
- AgentOS Readiness Repair Contract: PASS

## Remaining live acceptance
- Perform one explicit manual Oracle bootstrap for the merged `core/integration` exact SHA.
- Confirm restarted ONE manifest advertises `node.runtime.converge` from the installed marker.
- Send fresh #50 -> ONE typed converge for the accepted exact SHA and obtain a terminal sanitized receipt.
- Repeat the same SHA and prove idempotence.

No live deployment or VERIFIED marker is claimed by this PR.

Relates to #242, #238, #179, #194.