### PR TITLE
Core #242: require live Core self-registration in bootstrap acceptance

### DIFF
--- a/scripts/bootstrap_runtime_converger_oracle.sh
+++ b/scripts/bootstrap_runtime_converger_oracle.sh
@@ -68,14 +68,45 @@ systemctl --user is-active --quiet agentos-action-relay.service
 systemctl --user is-active --quiet agentos-realm-fabric.service
 curl -fsS --max-time 5 http://127.0.0.1:8780/v1/health >/dev/null
 
-# Local source-level proof that the manifest now sees the installed marker.
+# Local source-level proof that the manifest sees the installed marker.
 AGENT_DATA_ROOT="$DATA" python3 - <<'PY'
 from agent_core.realm_server import _core_node_manifest
 manifest = _core_node_manifest("bootstrap-proof")
 assert "node.runtime.converge" in set(manifest.get("capabilities") or [])
 PY
 
+# Operating proof: the restarted Realm process must have persisted its own Core
+# manifest + heartbeat into the durable Node Registry. Source presence alone is
+# not acceptance. Retry briefly only for process-start scheduling; never mutate
+# the registry from this bootstrap proof.
+registered=0
+for _ in $(seq 1 10); do
+  if AGENT_DATA_ROOT="$DATA" python3 - <<'PY'
+from agent_core.node_registry import NodeRegistry
+
+node_map = NodeRegistry().node_map()
+matches = [n for n in node_map.get("nodes", []) if n.get("node_id") == "oracle-core-node"]
+assert len(matches) == 1
+node = matches[0]
+assert node.get("status") == "online"
+assert "node.runtime.converge" in set(node.get("capabilities") or [])
+assert node.get("heartbeat_age_seconds") is not None
+assert node.get("heartbeat_age_seconds") <= node.get("heartbeat_stale_after_seconds", 30)
+PY
+  then
+    registered=1
+    break
+  fi
+  sleep 1
+done
+if [ "$registered" -ne 1 ]; then
+  rm -f "$MARKER"
+  echo "ERROR: restarted Realm did not self-register oracle-core-node with live bounded converge capability" >&2
+  exit 4
+fi
+
 echo "runtime_converger_bootstrap=PASS"
 echo "runtime_converger_source_ref=$SOURCE_REF"
 echo "runtime_converger_source_commit=$SOURCE_COMMIT"
 echo "runtime_converger_capability=node.runtime.converge"
+echo "runtime_converger_core_node_registration=PASS"

--- a/tests/test_runtime_converge_bootstrap_contract.py
+++ b/tests/test_runtime_converge_bootstrap_contract.py
@@ -33,6 +33,26 @@ def test_bootstrap_uses_fixed_installers_and_verifies_installed_marker():
     assert '"node.runtime.converge" in set(manifest.get("capabilities") or [])' in text
 
 
+def test_bootstrap_requires_operating_core_self_registration_without_registry_mutation():
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    assert "from agent_core.node_registry import NodeRegistry" in text
+    assert 'n.get("node_id") == "oracle-core-node"' in text
+    assert 'node.get("status") == "online"' in text
+    assert '"node.runtime.converge" in set(node.get("capabilities") or [])' in text
+    assert 'node.get("heartbeat_age_seconds") <= node.get("heartbeat_stale_after_seconds", 30)' in text
+    assert 'runtime_converger_core_node_registration=PASS' in text
+    assert "register_manifest(" not in text
+    assert "record_heartbeat(" not in text
+
+
+def test_failed_live_registration_revokes_capability_marker():
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    failure_gate = text.index('if [ "$registered" -ne 1 ]')
+    marker_remove = text.index('rm -f "$MARKER"', failure_gate)
+    failure_exit = text.index('exit 4', failure_gate)
+    assert failure_gate < marker_remove < failure_exit
+
+
 def test_bootstrap_has_no_generic_execution_inputs():
     text = BOOTSTRAP.read_text(encoding="utf-8")
     forbidden = ("$3", "$4", "eval ", "bash -c", "sh -c", "--command", "--argv", "--module", "--executable")


### PR DESCRIPTION
## Scope
Follow-up to #244 after live #50 evidence showed `oracle-core-node` currently absent from the running ONE registry.

## Change
Strengthen the explicit one-time Oracle bootstrap acceptance:
- after installing the exact Action Relay carrier and restarting Realm, require durable `NodeRegistry` to contain exactly one `oracle-core-node`;
- require node status `online` with a fresh heartbeat;
- require installed-only `node.runtime.converge` capability on that live node;
- bootstrap proof is read-only against the registry and must not call `register_manifest` or `record_heartbeat` itself;
- if live self-registration does not appear, remove the capability marker and fail the bootstrap.

This closes the gap between source-level `_core_node_manifest()` proof and actual operating self-registration.

No live deployment or VERIFIED claim. Relates to #242 / #238.