### PR TITLE
Ops: reuse N8N_LIVE_N8N_BASE_URL for Oracle deploy host

### DIFF
--- a/.github/workflows/deploy-agentos-core.yml
+++ b/.github/workflows/deploy-agentos-core.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DEPLOY_HOST_SOURCE: ${{ secrets.AGENTOS_DEPLOY_HOST || secrets.N8N_BASE_URL }}
+      DEPLOY_HOST_SOURCE: ${{ secrets.AGENTOS_DEPLOY_HOST || secrets.N8N_LIVE_N8N_BASE_URL || secrets.N8N_BASE_URL }}
       DEPLOY_USER: ${{ secrets.AGENTOS_DEPLOY_USER || secrets.N8N_DEPLOY_USER }}
       DEPLOY_SSH_PORT: ${{ secrets.AGENTOS_DEPLOY_SSH_PORT || secrets.N8N_DEPLOY_SSH_PORT }}
       DEPLOY_ROOT: ${{ vars.AGENTOS_DEPLOY_ROOT }}
@@ -177,9 +177,6 @@ jobs:
               python3 -m pip install -e . || true
               python3 scripts/install_services.py || true
               if [ "$BOOTSTRAP_CONVERGER" = "true" ]; then
-                # A carrier candidate may already have been installed. Remove its
-                # advertisement before restoring the previous Realm generation so
-                # ONE cannot claim a capability whose rollback state is ambiguous.
                 rm -f "$CAPABILITY_MARKER" || true
                 bash scripts/install_realm_fabric_user.sh || true
               fi
@@ -206,7 +203,6 @@ jobs:
           bash -n scripts/install_systemd_user.sh
 
           set -a
-          # shellcheck disable=SC1091
           source .env
           [ -f "$HOME/.agentos.secrets" ] && source "$HOME/.agentos.secrets"
           set +a

--- a/.github/workflows/deploy-agentos-core.yml
+++ b/.github/workflows/deploy-agentos-core.yml
@@ -177,6 +177,9 @@ jobs:
               python3 -m pip install -e . || true
               python3 scripts/install_services.py || true
               if [ "$BOOTSTRAP_CONVERGER" = "true" ]; then
+                # A carrier candidate may already have been installed. Remove its
+                # advertisement before restoring the previous Realm generation so
+                # ONE cannot claim a capability whose rollback state is ambiguous.
                 rm -f "$CAPABILITY_MARKER" || true
                 bash scripts/install_realm_fabric_user.sh || true
               fi
@@ -203,6 +206,7 @@ jobs:
           bash -n scripts/install_systemd_user.sh
 
           set -a
+          # shellcheck disable=SC1091
           source .env
           [ -f "$HOME/.agentos.secrets" ] && source "$HOME/.agentos.secrets"
           set +a


### PR DESCRIPTION
## Why
The governed Oracle bootstrap workflow currently resolves `DEPLOY_HOST_SOURCE` from `AGENTOS_DEPLOY_HOST || N8N_BASE_URL`, but the organization already has the live host secret under `N8N_LIVE_N8N_BASE_URL`. The last manual run failed before SSH with `Missing deployment setting: DEPLOY_HOST_SOURCE`.

## Change
Update only the host fallback expression to:

`AGENTOS_DEPLOY_HOST || N8N_LIVE_N8N_BASE_URL || N8N_BASE_URL`

No secret values are exposed or copied.

## Boundary
- workflow-only change;
- no deployment triggered;
- no runtime code promoted;
- human merge required before re-running the explicit bootstrap.

Relates to #242 / #238.