### PR TITLE
Core #242: restart Realm after unit update and preserve durable identity

### DIFF
--- a/.github/workflows/realm-fabric-installer-guard.yml
+++ b/.github/workflows/realm-fabric-installer-guard.yml
@@ -1,0 +1,23 @@
+name: Realm Fabric Installer Guard
+
+on:
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - "scripts/install_realm_fabric_user.sh"
+      - "tests/test_realm_fabric_installer.py"
+      - ".github/workflows/realm-fabric-installer-guard.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate installer shell
+        run: bash -n scripts/install_realm_fabric_user.sh
+      - name: Run Realm installer regression tests
+        run: python3 -m unittest tests.test_realm_fabric_installer

--- a/docs/CORE_242_REALM_RESTART_FIX.md
+++ b/docs/CORE_242_REALM_RESTART_FIX.md
@@ -1,0 +1,14 @@
+# Core #242 Realm restart root cause
+
+Live Oracle bootstrap evidence on 2026-09-04 showed that the bounded runtime-converge carrier and capability marker installed successfully at exact `core/integration` source, while the durable `oracle-core-node` manifest remained on the old capability set.
+
+The root cause was systemd activation semantics in `scripts/install_realm_fabric_user.sh`: after rewriting the user unit, the installer used `systemctl --user enable --now agentos-realm-fabric.service`. When the service was already active, that did not replace the running Python process. The old process therefore kept its old in-memory Core manifest and never projected the newly installed `node.runtime.converge` capability.
+
+The same live bootstrap also exposed a Realm identity migration hazard: Oracle already belongs to durable Realm `realm-alston`, while `AGENTOS_REALM_ID` is unset in the host `.env`. Falling back to `realm-primary` during reinstall is incorrect. Existing durable `realm/fabric.json` identity is authoritative; an explicit conflicting environment value must fail closed.
+
+The fix therefore requires both invariants:
+
+1. Existing durable Realm identity is preserved unless no Realm exists yet. An explicit conflicting `AGENTOS_REALM_ID` is rejected.
+2. After writing the systemd unit, the installer performs `daemon-reload`, `enable`, explicit `restart`, `is-active`, and health verification. `enable --now` alone is not accepted as a restart guarantee.
+
+This document is source evidence only. Live `node.runtime.converge` acceptance remains dependent on a successful Oracle bootstrap and fresh ONE NodeRegistry observation.

--- a/scripts/install_realm_fabric_user.sh
+++ b/scripts/install_realm_fabric_user.sh
@@ -23,11 +23,38 @@ if [ "${AGENT_MODE:-CLIENT}" != "CORE" ]; then
 fi
 
 DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
-REALM_ID="${AGENTOS_REALM_ID:-realm-primary}"
+FABRIC_FILE="$DATA_ROOT/realm/fabric.json"
+REQUESTED_REALM_ID="${AGENTOS_REALM_ID:-}"
 PORT="${AGENTOS_REALM_FABRIC_PORT:-8780}"
 PYTHON_BIN="$LOGIC_ROOT/venv/bin/python3"
 if [ ! -x "$PYTHON_BIN" ]; then PYTHON_BIN="$LOGIC_ROOT/.venv/bin/python3"; fi
 if [ ! -x "$PYTHON_BIN" ]; then PYTHON_BIN="$(command -v python3)"; fi
+
+# Existing durable Realm identity is authoritative. A missing AGENTOS_REALM_ID
+# must never silently replace an enrolled Realm with the historical
+# "realm-primary" default. An explicit conflicting value is a fail-closed
+# configuration error rather than permission to rewrite fabric identity.
+if [ -f "$FABRIC_FILE" ]; then
+  EXISTING_REALM_ID="$(python3 - "$FABRIC_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+realm_id = str(payload.get("realm_id") or "").strip()
+if not realm_id:
+    raise SystemExit(2)
+print(realm_id)
+PY
+)"
+  if [ -n "$REQUESTED_REALM_ID" ] && [ "$REQUESTED_REALM_ID" != "$EXISTING_REALM_ID" ]; then
+    echo "Configured AGENTOS_REALM_ID does not match existing Realm fabric" >&2
+    exit 4
+  fi
+  REALM_ID="$EXISTING_REALM_ID"
+else
+  REALM_ID="${REQUESTED_REALM_ID:-realm-primary}"
+fi
 
 mkdir -p "$USER_SYSTEMD_DIR" "$DATA_ROOT/logs"
 AGENT_DATA_ROOT="$DATA_ROOT" "$PYTHON_BIN" -m agent_core.realm_cli init --realm-id "$REALM_ID"
@@ -52,8 +79,14 @@ StandardError=append:$DATA_ROOT/logs/realm-fabric.log
 WantedBy=default.target
 EOF
 
+# Writing a new unit while the service is already active does not replace the
+# running Python process. enable --now alone therefore leaves stale code and a
+# stale Core manifest in memory. Always reload, enable, then explicitly restart
+# so the process re-reads the exact deployed checkout before acceptance.
 systemctl --user daemon-reload
-systemctl --user enable --now agentos-realm-fabric.service
+systemctl --user enable agentos-realm-fabric.service
+systemctl --user restart agentos-realm-fabric.service
+systemctl --user is-active --quiet agentos-realm-fabric.service
 curl -fsS --max-time 5 "http://127.0.0.1:$PORT/v1/health"
 echo
 echo "realm_id=$REALM_ID"

--- a/tests/test_realm_fabric_installer.py
+++ b/tests/test_realm_fabric_installer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install_realm_fabric_user.sh"
+
+
+class RealmFabricInstallerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = INSTALLER.read_text(encoding="utf-8")
+
+    def test_existing_durable_realm_identity_is_preserved(self):
+        self.assertIn('FABRIC_FILE="$DATA_ROOT/realm/fabric.json"', self.text)
+        self.assertIn('REQUESTED_REALM_ID="${AGENTOS_REALM_ID:-}"', self.text)
+        self.assertIn('if [ -f "$FABRIC_FILE" ]; then', self.text)
+        self.assertIn('REALM_ID="$EXISTING_REALM_ID"', self.text)
+        self.assertIn('REALM_ID="${REQUESTED_REALM_ID:-realm-primary}"', self.text)
+
+    def test_explicit_conflicting_realm_identity_fails_closed(self):
+        self.assertIn(
+            'if [ -n "$REQUESTED_REALM_ID" ] && [ "$REQUESTED_REALM_ID" != "$EXISTING_REALM_ID" ]; then',
+            self.text,
+        )
+        self.assertIn('exit 4', self.text)
+        self.assertNotIn('REALM_ID="${AGENTOS_REALM_ID:-realm-primary}"', self.text)
+
+    def test_installer_restarts_existing_service_after_unit_update(self):
+        daemon_reload = self.text.index('systemctl --user daemon-reload')
+        enable = self.text.index('systemctl --user enable agentos-realm-fabric.service')
+        restart = self.text.index('systemctl --user restart agentos-realm-fabric.service')
+        active = self.text.index('systemctl --user is-active --quiet agentos-realm-fabric.service')
+        self.assertLess(daemon_reload, enable)
+        self.assertLess(enable, restart)
+        self.assertLess(restart, active)
+        self.assertNotIn('enable --now agentos-realm-fabric.service', self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes the live Oracle bootstrap failure observed under #242.

Live evidence showed the bounded Action Relay and `node.runtime.converge` capability marker installed successfully, but `oracle-core-node` continued advertising the old capability set because the Realm process never restarted. `systemctl --user enable --now` does not replace an already-active service after its unit/source generation changes.

This change:
- preserves existing durable Realm identity from `agent-data/realm/fabric.json` when `AGENTOS_REALM_ID` is unset;
- fails closed if an explicit `AGENTOS_REALM_ID` conflicts with the durable Realm;
- replaces `enable --now` with `daemon-reload` → `enable` → explicit `restart` → `is-active` → health verification;
- adds regression tests and a dedicated PR guard;
- records the live root cause as source evidence only.

No protected `main` mutation. Live `node.runtime.converge` acceptance remains pending a successful exact-SHA Oracle bootstrap and ONE NodeRegistry verification.

Closes no issue by itself; advances #242 and gates #238.