### PR TITLE
Core #242: wait for restarted Realm readiness before acceptance

### DIFF
--- a/scripts/install_realm_fabric_user.sh
+++ b/scripts/install_realm_fabric_user.sh
@@ -87,7 +87,23 @@ systemctl --user daemon-reload
 systemctl --user enable agentos-realm-fabric.service
 systemctl --user restart agentos-realm-fabric.service
 systemctl --user is-active --quiet agentos-realm-fabric.service
-curl -fsS --max-time 5 "http://127.0.0.1:$PORT/v1/health"
+
+# systemd may report the process active before the HTTP listener is ready.
+# Accept only after a bounded readiness window; never turn a transient startup
+# race into an unbounded wait or a false-positive health result.
+realm_ready=0
+for _ in $(seq 1 10); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/v1/health"; then
+    realm_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "$realm_ready" -ne 1 ]; then
+  echo "Realm Fabric did not become healthy after restart" >&2
+  exit 4
+fi
+
 echo
 echo "realm_id=$REALM_ID"
 echo "realm_fabric_port=$PORT"

--- a/tests/test_realm_fabric_installer.py
+++ b/tests/test_realm_fabric_installer.py
@@ -37,6 +37,15 @@ class RealmFabricInstallerTests(unittest.TestCase):
         self.assertLess(restart, active)
         self.assertNotIn('enable --now agentos-realm-fabric.service', self.text)
 
+    def test_restarted_service_uses_bounded_health_readiness_window(self):
+        self.assertIn('realm_ready=0', self.text)
+        self.assertIn('for _ in $(seq 1 10); do', self.text)
+        self.assertIn('curl -fsS --max-time 2 "http://127.0.0.1:$PORT/v1/health"', self.text)
+        self.assertIn('sleep 1', self.text)
+        self.assertIn('if [ "$realm_ready" -ne 1 ]; then', self.text)
+        self.assertIn('Realm Fabric did not become healthy after restart', self.text)
+        self.assertIn('exit 4', self.text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #248. Live Oracle bootstrap at merged source `dcb4930...` proved the Realm is now explicitly restarted, but the installer immediately curls port 8780 after `systemctl restart`; systemd reports the process active before the HTTP listener is ready, producing a transient connection-refused and unnecessary rollback.

This follow-up adds a bounded readiness retry only. Acceptance remains fail-closed if the Realm does not become healthy within the fixed window. No authority or capability gate is weakened.

Also note: an accidental temporary doc write to `core/integration` was immediately reverted before this branch was created; the source tree was restored before this PR work continued.