### PR TITLE
Core #242: run Realm inside explicit agentos group boundary

### DIFF
--- a/scripts/install_realm_fabric_user.sh
+++ b/scripts/install_realm_fabric_user.sh
@@ -22,6 +22,15 @@ if [ "${AGENT_MODE:-CLIENT}" != "CORE" ]; then
   exit 2
 fi
 
+# The Realm reads bounded installed-capability markers from group-protected
+# AgentOS runtime state. Do not rely on the long-lived systemd --user manager's
+# supplemental-group snapshot: a user can be added to agentos after that manager
+# started. Verify membership in account state, then enter the group explicitly
+# for the service process just as the governed Action Relay does.
+command -v sg >/dev/null 2>&1 || { echo "Realm Fabric requires sg for the agentos execution boundary" >&2; exit 3; }
+getent group agentos >/dev/null || { echo "Missing agentos group" >&2; exit 3; }
+id -Gn "$(id -un)" | tr ' ' '\n' | grep -qx agentos || { echo "Realm Fabric service user must belong to agentos group" >&2; exit 3; }
+
 DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
 FABRIC_FILE="$DATA_ROOT/realm/fabric.json"
 REQUESTED_REALM_ID="${AGENTOS_REALM_ID:-}"
@@ -69,7 +78,8 @@ Type=simple
 WorkingDirectory=$LOGIC_ROOT
 EnvironmentFile=$ENV_FILE
 Environment=AGENT_DATA_ROOT=$DATA_ROOT
-ExecStart=$PYTHON_BIN -m agent_core.realm_cli serve --host 127.0.0.1 --port $PORT
+Environment=PYTHONPATH=$LOGIC_ROOT
+ExecStart=/usr/bin/sg agentos -c '$PYTHON_BIN -m agent_core.realm_cli serve --host 127.0.0.1 --port $PORT'
 Restart=always
 RestartSec=5
 StandardOutput=append:$DATA_ROOT/logs/realm-fabric.log
@@ -88,7 +98,7 @@ systemctl --user enable agentos-realm-fabric.service
 systemctl --user restart agentos-realm-fabric.service
 systemctl --user is-active --quiet agentos-realm-fabric.service
 
-# systemd may report the process active before the HTTP listener is ready.
+# systemd may report the wrapper active before the HTTP listener is ready.
 # Accept only after a bounded readiness window; never turn a transient startup
 # race into an unbounded wait or a false-positive health result.
 realm_ready=0
@@ -107,3 +117,4 @@ fi
 echo
 echo "realm_id=$REALM_ID"
 echo "realm_fabric_port=$PORT"
+echo "realm_group_boundary=agentos"

--- a/tests/test_realm_fabric_installer.py
+++ b/tests/test_realm_fabric_installer.py
@@ -27,6 +27,17 @@ class RealmFabricInstallerTests(unittest.TestCase):
         self.assertIn('exit 4', self.text)
         self.assertNotIn('REALM_ID="${AGENTOS_REALM_ID:-realm-primary}"', self.text)
 
+    def test_installer_requires_and_enters_agentos_group_boundary(self):
+        self.assertIn('command -v sg >/dev/null 2>&1', self.text)
+        self.assertIn('getent group agentos >/dev/null', self.text)
+        self.assertIn("grep -qx agentos", self.text)
+        self.assertIn('Environment=PYTHONPATH=$LOGIC_ROOT', self.text)
+        self.assertIn(
+            "ExecStart=/usr/bin/sg agentos -c '$PYTHON_BIN -m agent_core.realm_cli serve --host 127.0.0.1 --port $PORT'",
+            self.text,
+        )
+        self.assertIn('realm_group_boundary=agentos', self.text)
+
     def test_installer_restarts_existing_service_after_unit_update(self):
         daemon_reload = self.text.index('systemctl --user daemon-reload')
         enable = self.text.index('systemctl --user enable agentos-realm-fabric.service')


### PR DESCRIPTION
Live Oracle evidence identified the remaining `node.runtime.converge` self-registration failure.

The deploy SSH shell is a member of group `agentos` (GID 1005), but the long-lived systemd user manager was started before that membership existed. Realm processes spawned by it therefore do not have GID 1005. The installed capability marker lives below an `agentos-node:agentos` directory with mode `2770`; `installed_core_capabilities()` catches the resulting read/traverse OSError and returns an empty capability set. This exactly explains why `oracle-core-node` remained online with fresh heartbeats but only the legacy three capabilities.

This change:
- fail-closes unless `sg` and the `agentos` account group exist and the service user is configured as a member;
- explicitly executes Realm through `sg agentos`, avoiding dependence on stale systemd-user supplemental-group snapshots;
- pins `PYTHONPATH` to the current Core checkout in the unit;
- retains durable Realm identity, explicit restart, and bounded readiness semantics from #248/#249;
- adds regression guards.

No protected `main` mutation. Live acceptance still requires a new exact-SHA Oracle bootstrap and fresh ONE NodeRegistry observation.

Advances #242 and unblocks #238.