### PR TITLE
Core #238: align YouTube product Employee assignment

### DIFF
--- a/governance/product-employee-worker-plan.json
+++ b/governance/product-employee-worker-plan.json
@@ -19,7 +19,7 @@
     {
       "runner_kind": "youtube_ai_manager_scan_v1",
       "employee_id": "youtube-ai-manager",
-      "assignment_id": "youtube-ai-manager-optimization-v1",
+      "assignment_id": "youtube-ai-manager-scan-v1",
       "role_ids": ["product.youtube_ai_manager"],
       "skill_ids": ["youtube.optimization.scan"],
       "stage": "Y1",

--- a/tests/test_product_employee_worker_plan.py
+++ b/tests/test_product_employee_worker_plan.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 PLAN = ROOT / "governance" / "product-employee-worker-plan.json"
+ZEUS_BOOTSTRAP = ROOT / "governance" / "zeus-writer-employee.json"
+YOUTUBE_BOOTSTRAP = ROOT / "governance" / "youtube-ai-manager-employee.json"
+ADAPTERS = ROOT / "governance" / "employee-worker-adapters-v2.json"
 
 
 def test_product_employee_worker_plan_is_bounded_and_shared_host_only():
@@ -18,6 +21,7 @@ def test_product_employee_worker_plan_is_bounded_and_shared_host_only():
 
     zeus = runners["zeus_writer_v1"]
     assert zeus["employee_id"] == "zeus-writer"
+    assert zeus["assignment_id"] == "zeus-writer-continuation-v1"
     assert zeus["role_ids"] == ["product.zeus_writer"]
     assert zeus["skill_ids"] == ["writing.project.continue"]
     assert zeus["network"] is False
@@ -26,6 +30,7 @@ def test_product_employee_worker_plan_is_bounded_and_shared_host_only():
 
     youtube = runners["youtube_ai_manager_scan_v1"]
     assert youtube["employee_id"] == "youtube-ai-manager"
+    assert youtube["assignment_id"] == "youtube-ai-manager-scan-v1"
     assert youtube["role_ids"] == ["product.youtube_ai_manager"]
     assert youtube["skill_ids"] == ["youtube.optimization.scan"]
     assert youtube["network"] is False
@@ -39,3 +44,26 @@ def test_product_employee_worker_plan_is_bounded_and_shared_host_only():
     assert "one_shared_worker_host_not_daemon_per_role" in payload["invariants"]
     assert "exact_governed_wake_required_before_claim" in payload["invariants"]
     assert "unknown_runner_or_result_schema_fails_closed" in payload["invariants"]
+
+
+def test_product_assignment_ids_match_bootstrap_and_worker_registry_exactly():
+    plan = json.loads(PLAN.read_text(encoding="utf-8"))
+    zeus_bootstrap = json.loads(ZEUS_BOOTSTRAP.read_text(encoding="utf-8"))
+    youtube_bootstrap = json.loads(YOUTUBE_BOOTSTRAP.read_text(encoding="utf-8"))
+    adapters = json.loads(ADAPTERS.read_text(encoding="utf-8"))
+
+    planned = {item["employee_id"]: item for item in plan["runners"]}
+    registered = {item["employee_id"]: item for item in adapters["adapters"]}
+    bootstraps = {
+        "zeus-writer": zeus_bootstrap,
+        "youtube-ai-manager": youtube_bootstrap,
+    }
+
+    for employee_id, bootstrap in bootstraps.items():
+        work_item = bootstrap["initial_work_item"]
+        assert planned[employee_id]["assignment_id"] == work_item["assignment_id"]
+        assert registered[employee_id]["assignment_id"] == work_item["assignment_id"]
+        assert planned[employee_id]["role_ids"] == bootstrap["employee"]["role_ids"]
+        assert registered[employee_id]["role_ids"] == bootstrap["employee"]["role_ids"]
+        assert planned[employee_id]["skill_ids"] == bootstrap["employee"]["skill_ids"]
+        assert registered[employee_id]["skill_ids"] == bootstrap["employee"]["skill_ids"]


### PR DESCRIPTION
Fixes a live-blocking exact-identity drift found before #238 Oracle activation.

`governance/youtube-ai-manager-employee.json` and `governance/employee-worker-adapters-v2.json` both bind the durable assignment to `youtube-ai-manager-scan-v1`, while `governance/product-employee-worker-plan.json` still carried the obsolete `youtube-ai-manager-optimization-v1` value.

This PR:
- aligns the worker plan to `youtube-ai-manager-scan-v1`;
- adds a regression test requiring product plan, bootstrap contract, and V2 adapter registry to agree exactly on assignment, role, and skill identity for both Zeus Writer and YouTube AI Manager.

No live state is mutated by this PR. This must merge before bootstrapping the durable YouTube Employee so an obsolete assignment id never reaches operating state.

Advances #238.