### PR TITLE
Core #238: activate governed product Employee runtime on Oracle

### DIFF
--- a/.agent/scripts/agentos-employee-wake-node.service
+++ b/.agent/scripts/agentos-employee-wake-node.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AgentOS Oracle Product Employee Wake Node
+After=network.target agentos-realm-fabric.service
+Requires=agentos-realm-fabric.service
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu/agentmanager
+EnvironmentFile=/home/ubuntu/agentmanager/.env
+ExecStart=/usr/bin/python3 -m agentos_node.employee_wake_node --data-root /home/ubuntu/agent-data --config /home/ubuntu/agent-data/employee-wake-node/client.json --wake-root /home/ubuntu/agent-data/employee-wakes --runtime-root /home/ubuntu/agent-data/employee-runtime run
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -12,13 +12,18 @@ on:
       - 'governance/product-employee-worker-plan.json'
       - 'governance/employee-worker-adapters.json'
       - 'governance/employee-worker-adapters-v2.json'
+      - '.agent/scripts/agentos-employee-wake-node.service'
+      - 'agentos_node/employee_wake_node.py'
       - 'agentos_node/employee_worker_host.py'
       - 'agentos_node/employee_worker_host_runtime.py'
       - 'agentos_node/product_employee_worker.py'
       - 'agentos_node/product_employee_worker_cli.py'
+      - 'scripts/bootstrap_product_employees.py'
+      - 'scripts/activate_product_employees_oracle.sh'
       - 'tests/test_product_employee_contracts.py'
       - 'tests/test_product_employee_worker_plan.py'
       - 'tests/test_product_employee_worker.py'
+      - 'tests/test_product_employee_activation.py'
       - 'docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md'
       - '.github/workflows/product-employee-contract-guard.yml'
   workflow_dispatch:
@@ -38,9 +43,10 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest pyyaml
-      - name: Verify product Employee contracts and bounded runner host
+      - name: Verify product Employee contracts, bounded runner host, and activation boundary
         run: >-
           python -m pytest -q
           tests/test_product_employee_contracts.py
           tests/test_product_employee_worker_plan.py
           tests/test_product_employee_worker.py
+          tests/test_product_employee_activation.py

--- a/agentos_node/employee_wake_node.py
+++ b/agentos_node/employee_wake_node.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import socket
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_presence import EmployeePresenceRegistry, WAKE_CAPABILITY
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+from agentos_node.employee_wake_inbox import deliver_employee_wake
+from agentos_node.thin_client_transport import ClientConfig, ThinClientTransport
+
+NODE_ID = "oracle-employee-wake-node"
+EMPLOYEE_IDS = ("zeus-writer", "youtube-ai-manager")
+NODE_RECEIPT_SCHEMA = "agentos.node-receipt/v0.1"
+
+
+def _utc_now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class EmployeeWakeOnlyClient:
+    """Least-privilege ONE client: authenticated wake delivery and nothing else."""
+
+    def __init__(self, realm_id: str, node_id: str, wake_root: Path) -> None:
+        if node_id != NODE_ID:
+            raise ValueError("employee_wake_node_id_not_allowed")
+        self.realm_id = str(realm_id or "").strip()
+        self.node_id = node_id
+        self.wake_root = Path(wake_root).expanduser().resolve()
+        if not self.realm_id:
+            raise ValueError("employee_wake_realm_id_required")
+
+    def capability_manifest(self) -> dict[str, Any]:
+        return {
+            "schema": "agentos.node-manifest/v0.1",
+            "realm_id": self.realm_id,
+            "node_id": self.node_id,
+            "role": "client",
+            "hostname": socket.gethostname(),
+            "platform": platform.system(),
+            "platform_release": platform.release(),
+            "observed_at": _utc_now(),
+            "capabilities": [WAKE_CAPABILITY],
+            "tool_presence": {},
+            "surface_inventory": {"surfaces": []},
+            "workspace_roots": {"readable": [], "writable": []},
+        }
+
+    def heartbeat(self) -> dict[str, Any]:
+        manifest = self.capability_manifest()
+        return {
+            "schema": "agentos.node-heartbeat/v0.1",
+            "realm_id": self.realm_id,
+            "node_id": self.node_id,
+            "role": "client",
+            "status": "online",
+            "observed_at": _utc_now(),
+            "capability_count": 1,
+            "surface_count": 0,
+            "manifest": manifest,
+        }
+
+    def execute(self, task: dict[str, Any]) -> dict[str, Any]:
+        started = _utc_now()
+        receipt: dict[str, Any] = {
+            "schema": NODE_RECEIPT_SCHEMA,
+            "realm_id": self.realm_id,
+            "node_id": self.node_id,
+            "task_id": task.get("task_id"),
+            "action": task.get("action"),
+            "started_at": started,
+            "completed_at": None,
+            "ok": False,
+            "cognition_ids_used": [],
+        }
+        try:
+            if task.get("schema") != "agentos.node-task/v0.1":
+                raise ValueError("invalid task schema")
+            if task.get("action") != WAKE_CAPABILITY:
+                raise PermissionError("employee_wake_node_action_not_allowed")
+            receipt.update(deliver_employee_wake(task, self.wake_root, expected_node_id=self.node_id))
+            receipt["ok"] = True
+        except Exception as exc:
+            receipt["error"] = f"{type(exc).__name__}: {exc}"
+        receipt["completed_at"] = _utc_now()
+        receipt["credential_exposed"] = False
+        receipt["executor_invoked"] = False
+        return receipt
+
+
+def _build_transport(config: ClientConfig, wake_root: Path) -> ThinClientTransport:
+    return ThinClientTransport(EmployeeWakeOnlyClient(config.realm_id, config.node_id, wake_root), config)
+
+
+def bootstrap_local_enrollment(*, data_root: Path, config_path: Path, wake_root: Path) -> ClientConfig:
+    data_root = Path(data_root).expanduser().resolve()
+    config_path = Path(config_path).expanduser().resolve()
+    wake_root = Path(wake_root).expanduser().resolve()
+    registry = NodeRegistry(data_root / "realm" / "nodes.json")
+    fabric = RealmFabricStore(data_root / "realm" / "fabric.json", node_registry=registry)
+    realm = fabric.load()
+    realm_id = str(realm.get("realm_id") or "").strip()
+    if not realm_id:
+        raise RuntimeError("employee_wake_realm_not_initialized")
+
+    if config_path.exists():
+        config = ClientConfig.load(config_path)
+        if config.realm_id != realm_id or config.node_id != NODE_ID or config.one_url.rstrip("/") != "http://127.0.0.1:8780":
+            raise RuntimeError("employee_wake_existing_config_mismatch")
+        fabric.authenticate(config.node_id, config.node_token)
+        return config
+
+    existing = (realm.get("nodes") or {}).get(NODE_ID)
+    if existing and not existing.get("revoked_at"):
+        raise RuntimeError("employee_wake_node_enrolled_without_local_config")
+
+    client = EmployeeWakeOnlyClient(realm_id, NODE_ID, wake_root)
+    invite = fabric.create_invite(expires_minutes=5, label="core-238-product-employee-wake-node")
+    result = fabric.enroll(invite_id=str(invite["invite_id"]), code=str(invite["code"]), manifest=client.capability_manifest())
+    config = ClientConfig(
+        one_url="http://127.0.0.1:8780",
+        realm_id=realm_id,
+        node_id=NODE_ID,
+        node_token=str(result["node_token"]),
+        poll_seconds=2.0,
+    )
+    config.save(config_path)
+    return config
+
+
+def _bind_presences(*, runtime: EmployeeRuntime, registry: NodeRegistry, node_id: str, presence_id: str) -> EmployeePresenceRegistry:
+    presence = EmployeePresenceRegistry(runtime, registry)
+    for employee_id in EMPLOYEE_IDS:
+        existing = presence.get(employee_id)
+        presence.bind(
+            employee_id,
+            node_id,
+            presence_id,
+            ttl_seconds=120,
+            supersede_presence_id=existing.presence_id if existing else None,
+        )
+    return presence
+
+
+def run_daemon(*, data_root: Path, config_path: Path, wake_root: Path, runtime_root: Path, once: bool = False) -> int:
+    data_root = Path(data_root).expanduser().resolve()
+    config = ClientConfig.load(config_path)
+    if config.node_id != NODE_ID:
+        raise RuntimeError("employee_wake_node_config_identity_mismatch")
+    wake_root.mkdir(parents=True, exist_ok=True)
+    runtime = EmployeeRuntime(Path(runtime_root).expanduser().resolve())
+    for employee_id in EMPLOYEE_IDS:
+        runtime.get_employee(employee_id)
+    registry = NodeRegistry(data_root / "realm" / "nodes.json")
+    transport = _build_transport(config, wake_root)
+    presence_id = "presence-" + uuid.uuid4().hex
+
+    # Heartbeat Node first so presence eligibility is independently observable.
+    transport.heartbeat()
+    presences = _bind_presences(runtime=runtime, registry=registry, node_id=NODE_ID, presence_id=presence_id)
+
+    while True:
+        transport.run_once()
+        for employee_id in EMPLOYEE_IDS:
+            presences.heartbeat(employee_id, presence_id, ttl_seconds=120)
+        if once:
+            return 0
+        time.sleep(max(1.0, float(config.poll_seconds)))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agentos-employee-wake-node")
+    parser.add_argument("--data-root", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--wake-root", type=Path, required=True)
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("bootstrap")
+    p_run = sub.add_parser("run")
+    p_run.add_argument("--once", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "bootstrap":
+        args.wake_root.expanduser().resolve().mkdir(parents=True, exist_ok=True)
+        config = bootstrap_local_enrollment(data_root=args.data_root, config_path=args.config, wake_root=args.wake_root)
+        print(json.dumps({
+            "schema": "agentos.employee-wake-node-bootstrap/v1",
+            "ok": True,
+            "node_id": config.node_id,
+            "realm_id": config.realm_id,
+            "capabilities": [WAKE_CAPABILITY],
+            "credential_exposed": False,
+        }, sort_keys=True))
+        return 0
+    return run_daemon(
+        data_root=args.data_root,
+        config_path=args.config,
+        wake_root=args.wake_root,
+        runtime_root=args.runtime_root,
+        once=args.once,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/activate_product_employees_oracle.sh
+++ b/scripts/activate_product_employees_oracle.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$ROOT/.env"
+USER_SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+WAKE_UNIT_SRC="$ROOT/.agent/scripts/agentos-employee-wake-node.service"
+WAKE_UNIT_DST="$USER_SYSTEMD_DIR/agentos-employee-wake-node.service"
+WAKE_NODE_ID="oracle-employee-wake-node"
+
+[ -f "$ENV_FILE" ] || { echo "Missing $ENV_FILE" >&2; exit 2; }
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+[ -f "$HOME/.agentos.secrets" ] && source "$HOME/.agentos.secrets"
+set +a
+
+[ "${AGENT_MODE:-CLIENT}" = "CORE" ] || { echo "Product Employee activation requires AGENT_MODE=CORE" >&2; exit 2; }
+DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
+case "$DATA_ROOT" in /*) ;; *) echo "AGENT_DATA_ROOT must be absolute" >&2; exit 2;; esac
+[ -f "$DATA_ROOT/realm/fabric.json" ] || { echo "Missing existing Realm fabric" >&2; exit 2; }
+[ -f "$DATA_ROOT/realm/nodes.json" ] || { echo "Missing existing Node registry" >&2; exit 2; }
+[ -f "$WAKE_UNIT_SRC" ] || { echo "Missing wake node service asset" >&2; exit 2; }
+
+RUNTIME_ROOT="$DATA_ROOT/employee-runtime"
+WAKE_ROOT="$DATA_ROOT/employee-wakes"
+WAKE_NODE_ROOT="$DATA_ROOT/employee-wake-node"
+WAKE_CONFIG="$WAKE_NODE_ROOT/client.json"
+HOST_STATE_ROOT="$DATA_ROOT/employee-worker-host"
+WORKER_STATE_ROOT="$DATA_ROOT/employee-worker-state"
+mkdir -p "$RUNTIME_ROOT" "$WAKE_ROOT" "$WAKE_NODE_ROOT" "$HOST_STATE_ROOT" "$WORKER_STATE_ROOT" "$USER_SYSTEMD_DIR"
+chmod 700 "$WAKE_NODE_ROOT"
+
+PYTHON_BIN="$ROOT/.venv/bin/python3"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="$(command -v python3)"
+
+PYTHONPATH="$ROOT" "$PYTHON_BIN" "$ROOT/scripts/bootstrap_product_employees.py" --runtime-root "$RUNTIME_ROOT"
+PYTHONPATH="$ROOT" "$PYTHON_BIN" -m agentos_node.employee_wake_node \
+  --data-root "$DATA_ROOT" \
+  --config "$WAKE_CONFIG" \
+  --wake-root "$WAKE_ROOT" \
+  --runtime-root "$RUNTIME_ROOT" \
+  bootstrap
+[ -f "$WAKE_CONFIG" ] || { echo "Wake node config was not created" >&2; exit 2; }
+chmod 600 "$WAKE_CONFIG"
+
+# Install Supervisor one_direct and the existing shared Worker Host through their
+# canonical installer. These flags are fixed by this activation profile and do
+# not provide executable/argv/product authority.
+AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1 \
+AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE=1 \
+AGENTOS_EMPLOYEE_WAKE_ROOT="$WAKE_ROOT" \
+AGENTOS_EMPLOYEE_WORKER_NODE_ID="$WAKE_NODE_ID" \
+AGENTOS_EMPLOYEE_WORKER_HOST_STATE_ROOT="$HOST_STATE_ROOT" \
+AGENTOS_EMPLOYEE_WORKER_STATE_ROOT="$WORKER_STATE_ROOT" \
+  bash "$ROOT/scripts/install_systemd_user.sh"
+
+# Render the fixed wake-only Node unit for this checkout/data root. No token is
+# embedded in the unit or EnvironmentFile; the daemon reads the 0600 ClientConfig.
+"$PYTHON_BIN" - "$WAKE_UNIT_SRC" "$WAKE_UNIT_DST" "$ROOT" "$DATA_ROOT" "$PYTHON_BIN" <<'PY'
+from pathlib import Path
+import sys
+src, dst, root, data_root, python_bin = sys.argv[1:]
+text = Path(src).read_text(encoding="utf-8")
+text = text.replace("/home/ubuntu/agentmanager", root)
+text = text.replace("/home/ubuntu/agent-data", data_root)
+text = text.replace("/usr/bin/python3", python_bin)
+Path(dst).write_text(text, encoding="utf-8")
+PY
+
+systemctl --user daemon-reload
+systemctl --user enable agentos-employee-wake-node.service >/dev/null
+systemctl --user restart agentos-employee-wake-node.service
+systemctl --user is-active --quiet agentos-employee-wake-node.service
+systemctl --user is-active --quiet agentos-core-supervisor.service
+systemctl --user is-active --quiet agentos-employee-worker-host.service
+
+# The wake Node must become eligible before acceptance. Presence and work claims
+# are created by the daemon/Supervisor; this bootstrap does not synthesize them.
+ready=0
+for _ in $(seq 1 10); do
+  if PYTHONPATH="$ROOT" "$PYTHON_BIN" - "$DATA_ROOT/realm/nodes.json" <<'PY'
+import json, sys
+from pathlib import Path
+p=Path(sys.argv[1])
+d=json.loads(p.read_text())
+nodes=d.get('nodes') or {}
+node=nodes.get('oracle-employee-wake-node') if isinstance(nodes, dict) else None
+raise SystemExit(0 if isinstance(node,dict) and node.get('status') == 'online' and node.get('capabilities') == ['agent.employee.wake.deliver'] else 1)
+PY
+  then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "Wake node did not advertise exact bounded capability" >&2; exit 4; }
+
+echo "product_employee_activation=PASS"
+echo "wake_node_id=$WAKE_NODE_ID"
+echo "wake_capability=agent.employee.wake.deliver"
+echo "supervisor_delivery=one_direct"
+echo "worker_host=active"
+echo "verified_marker_emitted=false"

--- a/scripts/bootstrap_product_employees.py
+++ b/scripts/bootstrap_product_employees.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from agent_core.employee_runtime import EmployeeRuntime
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATHS = (
+    ROOT / "governance" / "zeus-writer-employee.json",
+    ROOT / "governance" / "youtube-ai-manager-employee.json",
+)
+TERMINAL_STATES = {"blocked", "handoff", "completed", "cancelled"}
+
+
+def _load_contract(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != "agentos.employee-bootstrap/v1":
+        raise ValueError(f"invalid_product_employee_bootstrap:{path.name}")
+    return payload
+
+
+def _exact_list(value: Any) -> list[str]:
+    return [str(item) for item in (value or [])]
+
+
+def bootstrap_contract(runtime: EmployeeRuntime, contract: dict[str, Any]) -> dict[str, Any]:
+    employee_spec = dict(contract["employee"])
+    work = dict(contract["initial_work_item"])
+    employee_id = str(employee_spec["employee_id"])
+    assignment_id = str(work["assignment_id"])
+    initial_head = str(contract["initial_thread_head"])
+    expected_roles = _exact_list(employee_spec.get("role_ids"))
+    expected_skills = _exact_list(employee_spec.get("skill_ids"))
+    expected_constraints = _exact_list(work.get("constraints"))
+
+    employee_created = False
+    try:
+        employee = runtime.get_employee(employee_id)
+    except FileNotFoundError:
+        employee = runtime.create_employee(
+            employee_id,
+            str(employee_spec.get("display_name") or employee_id),
+            role_ids=expected_roles,
+            skill_ids=expected_skills,
+        )
+        employee_created = True
+    else:
+        if employee.display_name != str(employee_spec.get("display_name") or employee_id):
+            raise RuntimeError(f"product_employee_display_name_mismatch:{employee_id}")
+        if employee.role_ids != expected_roles:
+            raise RuntimeError(f"product_employee_role_mismatch:{employee_id}")
+        if employee.skill_ids != expected_skills:
+            raise RuntimeError(f"product_employee_skill_mismatch:{employee_id}")
+
+    assignment_created = False
+    try:
+        assignment = runtime.get_assignment(assignment_id)
+    except FileNotFoundError:
+        assignment = runtime.create_assignment(
+            assignment_id,
+            employee_id,
+            str(work["goal"]),
+            thread_head=initial_head,
+            constraints=expected_constraints,
+        )
+        assignment_created = True
+    else:
+        if assignment.employee_id != employee_id:
+            raise RuntimeError(f"product_assignment_employee_mismatch:{assignment_id}")
+        if assignment.goal != str(work["goal"]):
+            raise RuntimeError(f"product_assignment_goal_mismatch:{assignment_id}")
+        if assignment.constraints != expected_constraints:
+            raise RuntimeError(f"product_assignment_constraints_mismatch:{assignment_id}")
+        # Existing state is authoritative. Never reopen a terminal assignment and
+        # never replace a progressed durable thread head with the bootstrap head.
+        if assignment.state in TERMINAL_STATES:
+            return {
+                "employee_id": employee_id,
+                "assignment_id": assignment_id,
+                "employee_created": employee_created,
+                "assignment_created": False,
+                "assignment_state": assignment.state,
+                "thread_head": assignment.thread_head,
+                "terminal_preserved": True,
+                "progress_preserved": assignment.thread_head != initial_head,
+            }
+
+    return {
+        "employee_id": employee_id,
+        "assignment_id": assignment_id,
+        "employee_created": employee_created,
+        "assignment_created": assignment_created,
+        "assignment_state": assignment.state,
+        "thread_head": assignment.thread_head,
+        "terminal_preserved": False,
+        "progress_preserved": (not assignment_created and assignment.thread_head != initial_head),
+    }
+
+
+def bootstrap_all(runtime_root: Path) -> dict[str, Any]:
+    runtime = EmployeeRuntime(runtime_root)
+    results = [bootstrap_contract(runtime, _load_contract(path)) for path in CONTRACT_PATHS]
+    receipt = {
+        "schema": "agentos.product-employee-bootstrap-receipt/v1",
+        "ok": True,
+        "runtime_root": str(runtime.root),
+        "employees": results,
+        "executor_bound": False,
+        "credential_exposed": False,
+        "verified_marker_emitted": False,
+    }
+    receipt_path = runtime.root / "bootstrap" / "product-employees-v1.json"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return receipt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="bootstrap-product-employees")
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    args = parser.parse_args(argv)
+    root = args.runtime_root.expanduser()
+    if not root.is_absolute():
+        raise SystemExit("runtime root must be absolute")
+    receipt = bootstrap_all(root.resolve())
+    # Sanitized: no Employee memory, token, provider/model or session identity.
+    print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_product_employee_activation.py
+++ b/tests/test_product_employee_activation.py
@@ -2,11 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from agent_core.employee_runtime import EmployeeRuntime
 from agent_core.node_registry import NodeRegistry
@@ -56,7 +52,6 @@ def test_local_wake_enrollment_is_idempotent_and_credential_file_is_private(tmp_
     registry = NodeRegistry(data_root / "realm" / "nodes.json")
     fabric = RealmFabricStore(data_root / "realm" / "fabric.json", node_registry=registry)
     fabric.initialize_realm("realm-test")
-    registry.initialize_realm("realm-test")
     config_path = data_root / "employee-wake-node" / "client.json"
     wake_root = data_root / "employee-wakes"
 
@@ -68,6 +63,9 @@ def test_local_wake_enrollment_is_idempotent_and_credential_file_is_private(tmp_
     stored = fabric.load()
     assert NODE_ID in stored["nodes"]
     assert first.node_token not in json.dumps(stored)
+    node_map = registry.node_map()
+    wake_node = next(node for node in node_map["nodes"] if node["node_id"] == NODE_ID)
+    assert wake_node["capabilities"] == ["agent.employee.wake.deliver"]
 
 
 def test_product_employee_bootstrap_is_idempotent_and_preserves_progress(tmp_path: Path):

--- a/tests/test_product_employee_activation.py
+++ b/tests/test_product_employee_activation.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+from agentos_node.employee_wake_node import (
+    EMPLOYEE_IDS,
+    NODE_ID,
+    EmployeeWakeOnlyClient,
+    bootstrap_local_enrollment,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP_PATH = ROOT / "scripts" / "bootstrap_product_employees.py"
+ACTIVATE = ROOT / "scripts" / "activate_product_employees_oracle.sh"
+WAKE_UNIT = ROOT / ".agent" / "scripts" / "agentos-employee-wake-node.service"
+
+spec = importlib.util.spec_from_file_location("bootstrap_product_employees", BOOTSTRAP_PATH)
+assert spec and spec.loader
+bootstrap_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bootstrap_mod)
+
+
+def test_wake_only_client_advertises_exactly_one_capability(tmp_path: Path):
+    client = EmployeeWakeOnlyClient("realm-test", NODE_ID, tmp_path / "wakes")
+    manifest = client.capability_manifest()
+    assert manifest["capabilities"] == ["agent.employee.wake.deliver"]
+    assert manifest["workspace_roots"] == {"readable": [], "writable": []}
+    assert manifest["tool_presence"] == {}
+
+
+def test_wake_only_client_rejects_non_wake_action(tmp_path: Path):
+    client = EmployeeWakeOnlyClient("realm-test", NODE_ID, tmp_path / "wakes")
+    receipt = client.execute({
+        "schema": "agentos.node-task/v0.1",
+        "task_id": "task-1",
+        "action": "shell.exec",
+    })
+    assert receipt["ok"] is False
+    assert "action_not_allowed" in receipt["error"]
+    assert receipt["credential_exposed"] is False
+    assert receipt["executor_invoked"] is False
+
+
+def test_local_wake_enrollment_is_idempotent_and_credential_file_is_private(tmp_path: Path, monkeypatch):
+    data_root = tmp_path / "data"
+    monkeypatch.setenv("AGENT_DATA_ROOT", str(data_root))
+    registry = NodeRegistry(data_root / "realm" / "nodes.json")
+    fabric = RealmFabricStore(data_root / "realm" / "fabric.json", node_registry=registry)
+    fabric.initialize_realm("realm-test")
+    registry.initialize_realm("realm-test")
+    config_path = data_root / "employee-wake-node" / "client.json"
+    wake_root = data_root / "employee-wakes"
+
+    first = bootstrap_local_enrollment(data_root=data_root, config_path=config_path, wake_root=wake_root)
+    second = bootstrap_local_enrollment(data_root=data_root, config_path=config_path, wake_root=wake_root)
+    assert first.node_id == second.node_id == NODE_ID
+    assert first.node_token == second.node_token
+    assert (config_path.stat().st_mode & 0o777) == 0o600
+    stored = fabric.load()
+    assert NODE_ID in stored["nodes"]
+    assert first.node_token not in json.dumps(stored)
+
+
+def test_product_employee_bootstrap_is_idempotent_and_preserves_progress(tmp_path: Path):
+    runtime_root = tmp_path / "employee-runtime"
+    first = bootstrap_mod.bootstrap_all(runtime_root)
+    assert first["ok"] is True
+    runtime = EmployeeRuntime(runtime_root)
+    assert {runtime.get_employee(e).agent_id for e in EMPLOYEE_IDS} == set(EMPLOYEE_IDS)
+    runtime.update_assignment("zeus-writer-continuation-v1", thread_head="product:zeus-writer:progress-1")
+
+    second = bootstrap_mod.bootstrap_all(runtime_root)
+    zeus = next(x for x in second["employees"] if x["employee_id"] == "zeus-writer")
+    assert zeus["employee_created"] is False
+    assert zeus["assignment_created"] is False
+    assert zeus["progress_preserved"] is True
+    assert runtime.get_assignment("zeus-writer-continuation-v1").thread_head == "product:zeus-writer:progress-1"
+
+
+def test_product_employee_bootstrap_never_reopens_terminal_assignment(tmp_path: Path):
+    runtime_root = tmp_path / "employee-runtime"
+    bootstrap_mod.bootstrap_all(runtime_root)
+    runtime = EmployeeRuntime(runtime_root)
+    runtime.update_assignment("youtube-ai-manager-scan-v1", state="completed", thread_head="product:youtube-ai-manager:done")
+    receipt = bootstrap_mod.bootstrap_all(runtime_root)
+    youtube = next(x for x in receipt["employees"] if x["employee_id"] == "youtube-ai-manager")
+    assert youtube["terminal_preserved"] is True
+    assert runtime.get_assignment("youtube-ai-manager-scan-v1").state == "completed"
+
+
+def test_activation_assets_are_fixed_and_do_not_emit_verified_markers():
+    shell = ACTIVATE.read_text(encoding="utf-8")
+    unit = WAKE_UNIT.read_text(encoding="utf-8")
+    assert 'WAKE_NODE_ID="oracle-employee-wake-node"' in shell
+    assert 'AGENTOS_CORE_SUPERVISOR_ENABLE_ONE_DIRECT=1' in shell
+    assert 'AGENTOS_CORE_EMPLOYEE_WORKER_HOST_ENABLE=1' in shell
+    assert 'verified_marker_emitted=false' in shell
+    assert "shell.exec" not in unit
+    assert "youtube" not in unit.casefold()
+    assert "zeus" not in unit.casefold()
+    assert "employee_wake_node" in unit


### PR DESCRIPTION
Implements the canonical activation slice for #238 without expanding product or external mutation authority.

Scope:
- add a fixed wake-only Oracle ThinClient that advertises only `agent.employee.wake.deliver`
- persist only bounded wake capsules; never select/start an executor in the wake carrier
- maintain Zeus Writer and YouTube AI Manager Employee presence on the wake-only node
- add idempotent durable product Employee bootstrap from the two canonical governance contracts
- preserve progressed thread heads and terminal assignments
- add a fixed Oracle activation installer for Supervisor one_direct + shared Employee Worker Host + wake-only node
- add regression coverage and wire it into Product Employee Contract Guard

Fences:
- no protected `main` mutation
- no generic shell/argv authority
- no product credentials in the wake node
- no GitHub Actions control-plane fallback
- no `VERIFIED` marker emitted by source/static CI
- live acceptance still requires Oracle activation + governed ONE wake + Worker Host claim/checkpoint + turnover/resume evidence

Refs #238