### PR TITLE
Core #238: converge product Employee operating profile with Core runtime

### DIFF
--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -92,6 +92,7 @@ def _install_fixed_runtime(repo: Path) -> bool:
     steps = (
         (["python3", "scripts/install_services.py"], 240),
         (["bash", "scripts/install_realm_fabric_user.sh"], 120),
+        (["bash", "scripts/activate_product_employees_oracle.sh"], 240),
     )
     for argv, timeout in steps:
         result = _run(argv, cwd=repo, timeout=timeout)

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -42,6 +42,23 @@ def test_relay_registers_fixed_semantic_action_without_generic_carrier():
     assert "stderr" not in relay.SAFE_RESULT_FIELDS
 
 
+def test_fixed_runtime_install_converges_product_employee_profile_after_realm(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(argv, *, cwd, timeout=180):
+        calls.append((list(argv), cwd, timeout))
+        return Proc(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(relay, "_run", fake_run)
+    monkeypatch.setattr(relay, "_health", lambda: True)
+    assert relay._install_fixed_runtime(tmp_path) is True
+    assert calls == [
+        (["python3", "scripts/install_services.py"], tmp_path, 240),
+        (["bash", "scripts/install_realm_fabric_user.sh"], tmp_path, 120),
+        (["bash", "scripts/activate_product_employees_oracle.sh"], tmp_path, 240),
+    ]
+
+
 def test_preflight_refuses_dirty_checkout(monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
 


### PR DESCRIPTION
Makes the already accepted #238 Oracle product Employee activation profile part of the existing fixed `node.runtime.converge` installer sequence.

The externally callable authority does not change: callers still provide only the exact canonical repository/ref/SHA request. Executable names, argv, paths, service names, and install ordering remain source-owned and fixed.

Fixed install order:
1. Core services
2. existing Realm fabric
3. governed product Employee activation profile

The third step activates the dedicated wake-only Node, Supervisor `one_direct`, shared Employee Worker Host, and idempotent durable Zeus Writer / YouTube AI Manager bootstrap. It does not emit live VERIFIED markers.

Tests pin the exact fixed command sequence and retain the existing rejection of caller-provided shell/argv/command/module/token/environment fields.

This also makes future Core convergence repair the product Employee operating profile rather than relying on a one-off deployment carrier.

Refs #238