### PR TITLE
Core #238: reconcile fixed runtime on current generation

### DIFF
--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -149,7 +149,13 @@ def _safe_failure(request: Mapping[str, Any], classification: str, *, previous: 
 
 
 def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -> dict[str, Any]:
-    """Converge the Oracle Core checkout to an exact current core/integration head."""
+    """Converge exact source and reconcile its fixed operating profile.
+
+    Source equality is not operating-profile equality.  Even when HEAD already
+    equals the requested generation, the source-owned installer sequence is
+    replayed idempotently so stopped services or missing host-local profile state
+    cannot survive a successful convergence receipt.
+    """
     canonical = validate_runtime_converge_request(request).as_payload()
     previous: str | None = None
     try:
@@ -158,7 +164,7 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
         return _safe_failure(canonical, str(exc))
 
     if idempotent:
-        healthy = _health()
+        reconciled = _install_fixed_runtime(repo)
         return {
             "request_id": canonical["request_id"],
             "node_id": canonical["node_id"],
@@ -167,10 +173,10 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
             "source_commit": canonical["source_commit"],
             "previous_commit": previous,
             "resulting_commit": previous,
-            "health": "passed" if healthy else "failed",
+            "health": "passed" if reconciled else "failed",
             "rollback": "not_needed",
-            "status": "completed" if healthy else "failed",
-            "classification": "ALREADY_CONVERGED" if healthy else "CURRENT_GENERATION_UNHEALTHY",
+            "status": "completed" if reconciled else "failed",
+            "classification": "CURRENT_GENERATION_RECONCILED" if reconciled else "CURRENT_GENERATION_RECONCILE_FAILED",
             "idempotent": True,
             "credential_exposed": False,
             "observed_at": _utc_now(),

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -59,6 +59,30 @@ def test_fixed_runtime_install_converges_product_employee_profile_after_realm(mo
     ]
 
 
+def test_current_generation_still_reconciles_fixed_runtime(monkeypatch, tmp_path):
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True))
+    installs = []
+    monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: installs.append(repo) or True)
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert installs == [tmp_path]
+    assert result["classification"] == "CURRENT_GENERATION_RECONCILED"
+    assert result["status"] == "completed"
+    assert result["health"] == "passed"
+    assert result["idempotent"] is True
+    assert result["resulting_commit"] == SHA
+
+
+def test_current_generation_reconcile_failure_is_not_reported_healthy(monkeypatch, tmp_path):
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True))
+    monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: False)
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert result["classification"] == "CURRENT_GENERATION_RECONCILE_FAILED"
+    assert result["status"] == "failed"
+    assert result["health"] == "failed"
+    assert result["idempotent"] is True
+    assert result["rollback"] == "not_needed"
+
+
 def test_preflight_refuses_dirty_checkout(monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
 


### PR DESCRIPTION
Fixes a convergence semantic gap exposed by live #238 activation: source equality is not operating-profile equality.

Previously, `node.runtime.converge` returned `ALREADY_CONVERGED` whenever HEAD already matched the requested exact `core/integration` SHA, without replaying the source-owned fixed installer sequence. That allows stopped services or missing host-local profile state to survive a successful convergence receipt.

This change makes the current-generation path replay `_install_fixed_runtime()` idempotently. Success is reported as `CURRENT_GENERATION_RECONCILED`; failure is fail-closed as `CURRENT_GENERATION_RECONCILE_FAILED`. Source identity remains idempotent and unchanged.

No caller authority changes: repository/ref/SHA remain the only typed inputs; executable names, argv, paths, services and installer ordering remain fixed source-owned code. Existing generic carrier field rejection remains intact.

Refs #238