### PR TITLE
Core #238: self-heal Action Relay runtime generation drift

### DIFF
--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -14,11 +14,14 @@ on:
       - 'agentos_node/executor_job_action_relay.py'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/bootstrap_runtime_converger_oracle.sh'
+      - 'scripts/reconcile_action_relay_runtime.py'
+      - 'scripts/maintenance.py'
       - '.github/workflows/deploy-agentos-core.yml'
       - 'tests/test_runtime_converge_contract.py'
       - 'tests/test_runtime_converge_action_relay.py'
       - 'tests/test_runtime_converge_capability.py'
       - 'tests/test_runtime_converge_bootstrap_contract.py'
+      - 'tests/test_action_relay_generation_reconcile.py'
       - '.github/workflows/runtime-converge-contract-guard.yml'
   workflow_dispatch:
 
@@ -37,10 +40,11 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest
-      - name: Verify bounded runtime converge contract and fixed relay
+      - name: Verify bounded runtime converge contract, fixed relay, and generation reconciliation
         run: >-
           python -m pytest -q
           tests/test_runtime_converge_contract.py
           tests/test_runtime_converge_action_relay.py
           tests/test_runtime_converge_capability.py
           tests/test_runtime_converge_bootstrap_contract.py
+          tests/test_action_relay_generation_reconcile.py

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -51,16 +51,22 @@ def main():
     # 1. Health & Structure (Bootstrap)
     run_script("bootstrap.py")
 
-    # 2. Reliability Check (Watchdog Service)
+    # 2. Core immutable Action Relay generation convergence.  The reconciler is
+    # source/ref/SHA fixed and runs only on the production Core profile; client
+    # nodes never gain service-install authority through maintenance.
+    if str(os.environ.get("AGENT_MODE") or "CLIENT").strip().upper() == "CORE":
+        run_script("reconcile_action_relay_runtime.py")
+
+    # 3. Reliability Check (Watchdog Service)
     check_os_watchdog()
     
-    # 3. Task Aggregation (Global Todo Hub)
+    # 4. Task Aggregation (Global Todo Hub)
     run_script("aggregate_tasks.py")
     
-    # 4. Memory Compaction (AI GC)
+    # 5. Memory Compaction (AI GC)
     run_script("compactor.py")
 
-    # 5. Ecosystem Autonomous Reporting
+    # 6. Ecosystem Autonomous Reporting
     logger.info("Running ecosystem-report...")
     result = subprocess.run(["python3", "scripts/run_workflow.py", "ecosystem-report"], cwd=PROJECT_ROOT)
     if result.returncode != 0:

--- a/scripts/reconcile_action_relay_runtime.py
+++ b/scripts/reconcile_action_relay_runtime.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+SOURCE_REF = "core/integration"
+MARKER_SCHEMA = "agentos.action-relay-capabilities/v1"
+SERVICE = "agentos-action-relay.service"
+
+
+def _run(argv: list[str], *, cwd: Path, env: dict[str, str] | None = None, timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _git_value(repo: Path, *args: str) -> str:
+    result = _run(["git", *args], cwd=repo)
+    if result.returncode != 0:
+        raise RuntimeError("action_relay_reconcile_git_failed")
+    return result.stdout.strip()
+
+
+def _marker_current(marker: Path, *, source_commit: str) -> bool:
+    if not marker.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(
+        isinstance(payload, dict)
+        and payload.get("schema") == MARKER_SCHEMA
+        and payload.get("source_ref") == SOURCE_REF
+        and payload.get("source_commit") == source_commit
+        and "agentos.runtime.converge" in set(payload.get("actions") or [])
+        and "node.runtime.converge" in set(payload.get("node_capabilities") or [])
+    )
+
+
+def _service_active(repo: Path) -> bool:
+    result = _run(["systemctl", "--user", "is-active", "--quiet", SERVICE], cwd=repo, timeout=20)
+    return result.returncode == 0
+
+
+def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
+    repo = repo.resolve()
+    data_root = data_root.resolve()
+    if not (repo / ".git").exists():
+        raise RuntimeError("action_relay_reconcile_repo_missing")
+    installer = repo / "scripts" / "install_action_relay_user.sh"
+    if not installer.is_file():
+        raise RuntimeError("action_relay_reconcile_installer_missing")
+
+    dirty = _git_value(repo, "status", "--porcelain", "--untracked-files=no")
+    if dirty:
+        raise RuntimeError("action_relay_reconcile_tracked_checkout_dirty")
+    current = _git_value(repo, "rev-parse", "HEAD")
+    fetched = _run(["git", "fetch", "--no-tags", "origin", SOURCE_REF], cwd=repo)
+    if fetched.returncode != 0:
+        raise RuntimeError("action_relay_reconcile_source_fetch_failed")
+    expected = _git_value(repo, "rev-parse", "FETCH_HEAD")
+    if current != expected:
+        raise RuntimeError("action_relay_reconcile_checkout_not_current_core_integration")
+
+    marker = data_root / "runtime" / "action-relay" / "capabilities.json"
+    if _marker_current(marker, source_commit=current) and _service_active(repo):
+        return {
+            "schema": "agentos.action-relay-generation-reconcile/v1",
+            "status": "current",
+            "source_ref": SOURCE_REF,
+            "source_commit": current,
+            "service_active": True,
+            "credential_exposed": False,
+        }
+
+    env = os.environ.copy()
+    env.update({
+        "AGENTOS_REPO": str(repo),
+        "AGENT_DATA_ROOT": str(data_root),
+        "AGENTOS_ACTION_SOURCE_REF": SOURCE_REF,
+        "AGENTOS_ACTION_SOURCE_COMMIT": current,
+    })
+    installed = _run(["bash", str(installer)], cwd=repo, env=env, timeout=300)
+    if installed.returncode != 0:
+        raise RuntimeError("action_relay_reconcile_install_failed")
+    if not _marker_current(marker, source_commit=current):
+        raise RuntimeError("action_relay_reconcile_marker_mismatch")
+    if not _service_active(repo):
+        raise RuntimeError("action_relay_reconcile_service_not_active")
+
+    return {
+        "schema": "agentos.action-relay-generation-reconcile/v1",
+        "status": "reconciled",
+        "source_ref": SOURCE_REF,
+        "source_commit": current,
+        "service_active": True,
+        "credential_exposed": False,
+    }
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parent.parent
+    data_root = Path(os.environ.get("AGENT_DATA_ROOT") or os.environ.get("AGENT_DATA_DIR") or Path.home() / "agent-data")
+    try:
+        result = reconcile(repo=repo, data_root=data_root)
+    except RuntimeError as exc:
+        print(json.dumps({
+            "schema": "agentos.action-relay-generation-reconcile/v1",
+            "status": "failed",
+            "error_code": str(exc),
+            "credential_exposed": False,
+        }, sort_keys=True))
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_action_relay_generation_reconcile.py
+++ b/tests/test_action_relay_generation_reconcile.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import reconcile_action_relay_runtime as reconcile
+
+
+SHA = "a" * 40
+
+
+class Proc(SimpleNamespace):
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "agentmanager"
+    data = tmp_path / "agent-data"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "install_action_relay_user.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    return repo, data
+
+
+def _git_current(monkeypatch):
+    def fake_git_value(repo, *args):
+        if args[:2] == ("status", "--porcelain"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return SHA
+        if args == ("rev-parse", "FETCH_HEAD"):
+            return SHA
+        raise AssertionError(args)
+
+    monkeypatch.setattr(reconcile, "_git_value", fake_git_value)
+
+
+def test_current_marker_and_service_do_not_reinstall(monkeypatch, tmp_path):
+    repo, data = _repo(tmp_path)
+    _git_current(monkeypatch)
+    marker = data / "runtime" / "action-relay" / "capabilities.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(json.dumps({
+        "schema": reconcile.MARKER_SCHEMA,
+        "source_ref": reconcile.SOURCE_REF,
+        "source_commit": SHA,
+        "actions": ["agentos.runtime.converge"],
+        "node_capabilities": ["node.runtime.converge"],
+    }), encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, *, cwd, env=None, timeout=120):
+        calls.append(list(argv))
+        if argv[:3] == ["git", "fetch", "--no-tags"]:
+            return Proc(returncode=0)
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(reconcile, "_run", fake_run)
+    monkeypatch.setattr(reconcile, "_service_active", lambda repo: True)
+    result = reconcile.reconcile(repo=repo, data_root=data)
+    assert result["status"] == "current"
+    assert calls == [["git", "fetch", "--no-tags", "origin", "core/integration"]]
+
+
+def test_generation_drift_runs_only_fixed_installer_with_exact_generation(monkeypatch, tmp_path):
+    repo, data = _repo(tmp_path)
+    _git_current(monkeypatch)
+    calls = []
+
+    def fake_run(argv, *, cwd, env=None, timeout=120):
+        calls.append((list(argv), dict(env or {})))
+        if argv[:3] == ["git", "fetch", "--no-tags"]:
+            return Proc(returncode=0)
+        if argv[0] == "bash":
+            marker = data / "runtime" / "action-relay" / "capabilities.json"
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text(json.dumps({
+                "schema": reconcile.MARKER_SCHEMA,
+                "source_ref": reconcile.SOURCE_REF,
+                "source_commit": SHA,
+                "actions": ["agentos.runtime.converge"],
+                "node_capabilities": ["node.runtime.converge"],
+            }), encoding="utf-8")
+            return Proc(returncode=0)
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(reconcile, "_run", fake_run)
+    monkeypatch.setattr(reconcile, "_service_active", lambda repo: True)
+    result = reconcile.reconcile(repo=repo, data_root=data)
+    assert result["status"] == "reconciled"
+    install_argv, install_env = calls[-1]
+    assert install_argv == ["bash", str(repo / "scripts" / "install_action_relay_user.sh")]
+    assert install_env["AGENTOS_ACTION_SOURCE_REF"] == "core/integration"
+    assert install_env["AGENTOS_ACTION_SOURCE_COMMIT"] == SHA
+    assert install_env["AGENTOS_REPO"] == str(repo)
+    assert install_env["AGENT_DATA_ROOT"] == str(data)
+
+
+def test_reconciler_refuses_checkout_not_equal_to_current_core_integration(monkeypatch, tmp_path):
+    repo, data = _repo(tmp_path)
+
+    def fake_git_value(repo, *args):
+        if args[:2] == ("status", "--porcelain"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return "b" * 40
+        if args == ("rev-parse", "FETCH_HEAD"):
+            return SHA
+        raise AssertionError(args)
+
+    monkeypatch.setattr(reconcile, "_git_value", fake_git_value)
+    monkeypatch.setattr(reconcile, "_run", lambda argv, **kwargs: Proc(returncode=0) if argv[:3] == ["git", "fetch", "--no-tags"] else (_ for _ in ()).throw(AssertionError(argv)))
+    with pytest.raises(RuntimeError, match="checkout_not_current_core_integration"):
+        reconcile.reconcile(repo=repo, data_root=data)
+
+
+def test_maintenance_invokes_generation_reconciler_only_on_core_profile():
+    source = (Path(__file__).resolve().parents[1] / "scripts" / "maintenance.py").read_text(encoding="utf-8")
+    assert 'AGENT_MODE' in source
+    assert '== "CORE"' in source
+    assert 'run_script("reconcile_action_relay_runtime.py")' in source


### PR DESCRIPTION
Closes the live generation gap exposed by #238: the stable Core checkout may already be current while the isolated Action Relay worktree/process still executes an older immutable generation.

This adds a narrow Core-only maintenance reconciler that:
- accepts no caller-supplied ref/SHA/path/service/argv
- fixes source_ref to `core/integration`
- requires the stable checkout to be clean and exactly equal to the current remote `core/integration` head
- treats an exact capability marker + active service as already current
- otherwise invokes the existing fixed `install_action_relay_user.sh` with the exact current SHA
- verifies the new capability marker and service liveness
- never prints credentials

`maintenance.py` invokes this only when `AGENT_MODE=CORE`, so client nodes do not gain service-install authority. Because maintenance is a oneshot timer launched from the stable checkout, it can repair an old long-lived Action Relay process without requiring GitHub Actions or manual SSH.

Tests pin exact-ref behavior, no-op current behavior, fixed installer inputs, and fail-closed checkout mismatch.

Refs #238