### PR TITLE
Core #238: isolate Action Relay generation self-heal

### DIFF
--- a/.github/workflows/runtime-converge-contract-guard.yml
+++ b/.github/workflows/runtime-converge-contract-guard.yml
@@ -13,6 +13,7 @@ on:
       - 'agentos_node/runtime_converge_action_relay.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'scripts/install_action_relay_user.sh'
+      - 'scripts/install_action_relay_reconcile_timer_user.sh'
       - 'scripts/bootstrap_runtime_converger_oracle.sh'
       - 'scripts/reconcile_action_relay_runtime.py'
       - 'scripts/maintenance.py'

--- a/scripts/install_action_relay_reconcile_timer_user.sh
+++ b/scripts/install_action_relay_reconcile_timer_user.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "ERROR: run as ubuntu" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-$HOME/agentmanager}"
+DATA_ROOT="${AGENT_DATA_ROOT:-${AGENT_DATA_DIR:-$HOME/agent-data}}"
+ENV_FILE="$REPO/.env"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+SERVICE="$UNIT_DIR/agentos-action-relay-reconcile.service"
+TIMER="$UNIT_DIR/agentos-action-relay-reconcile.timer"
+LOG="$DATA_ROOT/logs/action-relay-reconcile.log"
+
+case "$REPO" in
+  /*) ;;
+  *) echo "ERROR: AGENTOS_REPO must be absolute" >&2; exit 2 ;;
+esac
+
+test -d "$REPO/.git" || { echo "ERROR: repo missing: $REPO" >&2; exit 2; }
+test -f "$ENV_FILE" || { echo "ERROR: env missing: $ENV_FILE" >&2; exit 2; }
+test -f "$REPO/scripts/reconcile_action_relay_runtime.py" || { echo "ERROR: reconciler missing" >&2; exit 2; }
+id -Gn ubuntu | tr ' ' '\n' | grep -qx agentos || { echo "ERROR: ubuntu must belong to agentos group" >&2; exit 3; }
+
+PYTHON_BIN="$REPO/venv/bin/python3"
+if [ ! -x "$PYTHON_BIN" ]; then
+  PYTHON_BIN="$REPO/.venv/bin/python3"
+fi
+if [ ! -x "$PYTHON_BIN" ]; then
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+mkdir -p "$UNIT_DIR" "$DATA_ROOT/logs"
+
+cat > "$SERVICE" <<EOF
+[Unit]
+Description=AgentOS Action Relay Immutable Generation Reconciler
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=$REPO
+EnvironmentFile=$ENV_FILE
+ExecStart=/usr/bin/sg agentos -c 'exec $PYTHON_BIN $REPO/scripts/reconcile_action_relay_runtime.py'
+StandardOutput=append:$LOG
+StandardError=append:$LOG
+
+[Install]
+WantedBy=default.target
+EOF
+
+cat > "$TIMER" <<EOF
+[Unit]
+Description=Reconcile AgentOS Action Relay immutable generation
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+Unit=agentos-action-relay-reconcile.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now agentos-action-relay-reconcile.timer >/dev/null
+
+# Installing the timer must not restart the Action Relay from inside a live
+# relay request. The timer owns future reconciliation; a separate explicit
+# start is intentionally omitted here.
+systemctl --user is-enabled --quiet agentos-action-relay-reconcile.timer
+
+echo "action_relay_reconcile_timer_install=PASS"
+echo "service=$SERVICE"
+echo "timer=$TIMER"
+echo "log=$LOG"

--- a/scripts/reconcile_action_relay_runtime.py
+++ b/scripts/reconcile_action_relay_runtime.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import grp
 import json
 import os
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 SOURCE_REF = "core/integration"
 MARKER_SCHEMA = "agentos.action-relay-capabilities/v1"
 SERVICE = "agentos-action-relay.service"
+SHARED_GROUP = "agentos"
+GROUP_REEXEC_GUARD = "AGENTOS_ACTION_RELAY_RECONCILE_GROUP_REEXEC"
 
 
 def _run(argv: list[str], *, cwd: Path, env: dict[str, str] | None = None, timeout: int = 120) -> subprocess.CompletedProcess[str]:
@@ -32,9 +37,9 @@ def _git_value(repo: Path, *args: str) -> str:
 
 
 def _marker_current(marker: Path, *, source_commit: str) -> bool:
-    if not marker.is_file():
-        return False
     try:
+        if not marker.is_file():
+            return False
         payload = json.loads(marker.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
@@ -51,6 +56,40 @@ def _marker_current(marker: Path, *, source_commit: str) -> bool:
 def _service_active(repo: Path) -> bool:
     result = _run(["systemctl", "--user", "is-active", "--quiet", SERVICE], cwd=repo, timeout=20)
     return result.returncode == 0
+
+
+def _in_shared_group() -> bool:
+    try:
+        gid = grp.getgrnam(SHARED_GROUP).gr_gid
+    except KeyError:
+        return False
+    return gid == os.getgid() or gid in os.getgroups()
+
+
+def _reexec_in_shared_group() -> int | None:
+    """Enter the fixed cross-owner boundary without granting caller-selected execution.
+
+    Older ubuntu user-manager sessions may predate membership in ``agentos`` even
+    though the account is correctly configured on disk. The long-lived Action
+    Relay already uses ``sg agentos`` for the same reason. Reconciliation uses the
+    exact same source-owned group and exact current script; no argv, path, shell,
+    service, or credential comes from a caller.
+    """
+    if _in_shared_group():
+        return None
+    if os.environ.get(GROUP_REEXEC_GUARD) == "1":
+        raise RuntimeError("action_relay_reconcile_agentos_group_unavailable")
+    script = Path(__file__).resolve()
+    command = f"exec {shlex.quote(sys.executable)} {shlex.quote(str(script))}"
+    env = os.environ.copy()
+    env[GROUP_REEXEC_GUARD] = "1"
+    completed = subprocess.run(
+        ["/usr/bin/sg", SHARED_GROUP, "-c", command],
+        cwd=str(script.parent.parent),
+        env=env,
+        check=False,
+    )
+    return int(completed.returncode)
 
 
 def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
@@ -110,6 +149,19 @@ def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
 
 
 def main() -> int:
+    try:
+        reexec = _reexec_in_shared_group()
+    except RuntimeError as exc:
+        print(json.dumps({
+            "schema": "agentos.action-relay-generation-reconcile/v1",
+            "status": "failed",
+            "error_code": str(exc),
+            "credential_exposed": False,
+        }, sort_keys=True))
+        return 2
+    if reexec is not None:
+        return reexec
+
     repo = Path(__file__).resolve().parent.parent
     data_root = Path(os.environ.get("AGENT_DATA_ROOT") or os.environ.get("AGENT_DATA_DIR") or Path.home() / "agent-data")
     try:

--- a/scripts/reconcile_action_relay_runtime.py
+++ b/scripts/reconcile_action_relay_runtime.py
@@ -13,6 +13,7 @@ from typing import Any
 SOURCE_REF = "core/integration"
 MARKER_SCHEMA = "agentos.action-relay-capabilities/v1"
 SERVICE = "agentos-action-relay.service"
+RECONCILE_TIMER = "agentos-action-relay-reconcile.timer"
 SHARED_GROUP = "agentos"
 GROUP_REEXEC_GUARD = "AGENTOS_ACTION_RELAY_RECONCILE_GROUP_REEXEC"
 
@@ -56,6 +57,25 @@ def _marker_current(marker: Path, *, source_commit: str) -> bool:
 def _service_active(repo: Path) -> bool:
     result = _run(["systemctl", "--user", "is-active", "--quiet", SERVICE], cwd=repo, timeout=20)
     return result.returncode == 0
+
+
+def _timer_enabled(repo: Path) -> bool:
+    result = _run(["systemctl", "--user", "is-enabled", "--quiet", RECONCILE_TIMER], cwd=repo, timeout=20)
+    return result.returncode == 0
+
+
+def _ensure_reconcile_timer(*, repo: Path, data_root: Path) -> bool:
+    if _timer_enabled(repo):
+        return False
+    installer = repo / "scripts" / "install_action_relay_reconcile_timer_user.sh"
+    if not installer.is_file():
+        raise RuntimeError("action_relay_reconcile_timer_installer_missing")
+    env = os.environ.copy()
+    env.update({"AGENTOS_REPO": str(repo), "AGENT_DATA_ROOT": str(data_root)})
+    installed = _run(["bash", str(installer)], cwd=repo, env=env, timeout=120)
+    if installed.returncode != 0 or not _timer_enabled(repo):
+        raise RuntimeError("action_relay_reconcile_timer_install_failed")
+    return True
 
 
 def _in_shared_group() -> bool:
@@ -114,12 +134,15 @@ def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
 
     marker = data_root / "runtime" / "action-relay" / "capabilities.json"
     if _marker_current(marker, source_commit=current) and _service_active(repo):
+        timer_installed = _ensure_reconcile_timer(repo=repo, data_root=data_root)
         return {
             "schema": "agentos.action-relay-generation-reconcile/v1",
             "status": "current",
             "source_ref": SOURCE_REF,
             "source_commit": current,
             "service_active": True,
+            "reconcile_timer_enabled": True,
+            "reconcile_timer_installed": timer_installed,
             "credential_exposed": False,
         }
 
@@ -137,6 +160,7 @@ def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
         raise RuntimeError("action_relay_reconcile_marker_mismatch")
     if not _service_active(repo):
         raise RuntimeError("action_relay_reconcile_service_not_active")
+    timer_installed = _ensure_reconcile_timer(repo=repo, data_root=data_root)
 
     return {
         "schema": "agentos.action-relay-generation-reconcile/v1",
@@ -144,6 +168,8 @@ def reconcile(*, repo: Path, data_root: Path) -> dict[str, Any]:
         "source_ref": SOURCE_REF,
         "source_commit": current,
         "service_active": True,
+        "reconcile_timer_enabled": True,
+        "reconcile_timer_installed": timer_installed,
         "credential_exposed": False,
     }
 

--- a/tests/test_action_relay_generation_reconcile.py
+++ b/tests/test_action_relay_generation_reconcile.py
@@ -24,6 +24,7 @@ def _repo(tmp_path: Path) -> tuple[Path, Path]:
     (repo / ".git").mkdir(parents=True)
     (repo / "scripts").mkdir(parents=True)
     (repo / "scripts" / "install_action_relay_user.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (repo / "scripts" / "install_action_relay_reconcile_timer_user.sh").write_text("#!/bin/sh\n", encoding="utf-8")
     return repo, data
 
 
@@ -40,11 +41,9 @@ def _git_current(monkeypatch):
     monkeypatch.setattr(reconcile, "_git_value", fake_git_value)
 
 
-def test_current_marker_and_service_do_not_reinstall(monkeypatch, tmp_path):
-    repo, data = _repo(tmp_path)
-    _git_current(monkeypatch)
+def _write_marker(data: Path) -> None:
     marker = data / "runtime" / "action-relay" / "capabilities.json"
-    marker.parent.mkdir(parents=True)
+    marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
         "schema": reconcile.MARKER_SCHEMA,
         "source_ref": reconcile.SOURCE_REF,
@@ -52,6 +51,12 @@ def test_current_marker_and_service_do_not_reinstall(monkeypatch, tmp_path):
         "actions": ["agentos.runtime.converge"],
         "node_capabilities": ["node.runtime.converge"],
     }), encoding="utf-8")
+
+
+def test_current_marker_service_and_timer_do_not_reinstall(monkeypatch, tmp_path):
+    repo, data = _repo(tmp_path)
+    _git_current(monkeypatch)
+    _write_marker(data)
     calls = []
 
     def fake_run(argv, *, cwd, env=None, timeout=120):
@@ -62,12 +67,42 @@ def test_current_marker_and_service_do_not_reinstall(monkeypatch, tmp_path):
 
     monkeypatch.setattr(reconcile, "_run", fake_run)
     monkeypatch.setattr(reconcile, "_service_active", lambda repo: True)
+    monkeypatch.setattr(reconcile, "_timer_enabled", lambda repo: True)
     result = reconcile.reconcile(repo=repo, data_root=data)
     assert result["status"] == "current"
+    assert result["reconcile_timer_enabled"] is True
+    assert result["reconcile_timer_installed"] is False
     assert calls == [["git", "fetch", "--no-tags", "origin", "core/integration"]]
 
 
-def test_generation_drift_runs_only_fixed_installer_with_exact_generation(monkeypatch, tmp_path):
+def test_current_generation_bootstraps_missing_independent_timer(monkeypatch, tmp_path):
+    repo, data = _repo(tmp_path)
+    _git_current(monkeypatch)
+    _write_marker(data)
+    timer_states = iter([False, True])
+    calls = []
+
+    def fake_run(argv, *, cwd, env=None, timeout=120):
+        calls.append((list(argv), dict(env or {})))
+        if argv[:3] == ["git", "fetch", "--no-tags"]:
+            return Proc(returncode=0)
+        if argv == ["bash", str(repo / "scripts" / "install_action_relay_reconcile_timer_user.sh")]:
+            return Proc(returncode=0)
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(reconcile, "_run", fake_run)
+    monkeypatch.setattr(reconcile, "_service_active", lambda repo: True)
+    monkeypatch.setattr(reconcile, "_timer_enabled", lambda repo: next(timer_states))
+    result = reconcile.reconcile(repo=repo, data_root=data)
+    assert result["status"] == "current"
+    assert result["reconcile_timer_installed"] is True
+    timer_call, timer_env = calls[-1]
+    assert timer_call == ["bash", str(repo / "scripts" / "install_action_relay_reconcile_timer_user.sh")]
+    assert timer_env["AGENTOS_REPO"] == str(repo)
+    assert timer_env["AGENT_DATA_ROOT"] == str(data)
+
+
+def test_generation_drift_runs_fixed_relay_installer_then_ensures_timer(monkeypatch, tmp_path):
     repo, data = _repo(tmp_path)
     _git_current(monkeypatch)
     calls = []
@@ -76,29 +111,56 @@ def test_generation_drift_runs_only_fixed_installer_with_exact_generation(monkey
         calls.append((list(argv), dict(env or {})))
         if argv[:3] == ["git", "fetch", "--no-tags"]:
             return Proc(returncode=0)
-        if argv[0] == "bash":
-            marker = data / "runtime" / "action-relay" / "capabilities.json"
-            marker.parent.mkdir(parents=True, exist_ok=True)
-            marker.write_text(json.dumps({
-                "schema": reconcile.MARKER_SCHEMA,
-                "source_ref": reconcile.SOURCE_REF,
-                "source_commit": SHA,
-                "actions": ["agentos.runtime.converge"],
-                "node_capabilities": ["node.runtime.converge"],
-            }), encoding="utf-8")
+        if argv == ["bash", str(repo / "scripts" / "install_action_relay_user.sh")]:
+            _write_marker(data)
+            return Proc(returncode=0)
+        if argv == ["bash", str(repo / "scripts" / "install_action_relay_reconcile_timer_user.sh")]:
             return Proc(returncode=0)
         raise AssertionError(argv)
 
+    timer_states = iter([False, True])
     monkeypatch.setattr(reconcile, "_run", fake_run)
     monkeypatch.setattr(reconcile, "_service_active", lambda repo: True)
+    monkeypatch.setattr(reconcile, "_timer_enabled", lambda repo: next(timer_states))
     result = reconcile.reconcile(repo=repo, data_root=data)
     assert result["status"] == "reconciled"
-    install_argv, install_env = calls[-1]
-    assert install_argv == ["bash", str(repo / "scripts" / "install_action_relay_user.sh")]
-    assert install_env["AGENTOS_ACTION_SOURCE_REF"] == "core/integration"
-    assert install_env["AGENTOS_ACTION_SOURCE_COMMIT"] == SHA
-    assert install_env["AGENTOS_REPO"] == str(repo)
-    assert install_env["AGENT_DATA_ROOT"] == str(data)
+    relay_argv, relay_env = calls[1]
+    assert relay_argv == ["bash", str(repo / "scripts" / "install_action_relay_user.sh")]
+    assert relay_env["AGENTOS_ACTION_SOURCE_REF"] == "core/integration"
+    assert relay_env["AGENTOS_ACTION_SOURCE_COMMIT"] == SHA
+    assert relay_env["AGENTOS_REPO"] == str(repo)
+    assert relay_env["AGENT_DATA_ROOT"] == str(data)
+    timer_argv, _ = calls[-1]
+    assert timer_argv == ["bash", str(repo / "scripts" / "install_action_relay_reconcile_timer_user.sh")]
+
+
+def test_reexec_enters_only_fixed_agentos_group_and_exact_script(monkeypatch, tmp_path):
+    script = tmp_path / "scripts" / "reconcile_action_relay_runtime.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n", encoding="utf-8")
+    monkeypatch.setattr(reconcile, "_in_shared_group", lambda: False)
+    monkeypatch.setattr(reconcile, "__file__", str(script))
+    seen = {}
+
+    def fake_subprocess_run(argv, *, cwd, env, check):
+        seen["argv"] = list(argv)
+        seen["cwd"] = cwd
+        seen["env"] = dict(env)
+        return Proc(returncode=7)
+
+    monkeypatch.setattr(reconcile.subprocess, "run", fake_subprocess_run)
+    rc = reconcile._reexec_in_shared_group()
+    assert rc == 7
+    assert seen["argv"][:3] == ["/usr/bin/sg", "agentos", "-c"]
+    assert str(script) in seen["argv"][3]
+    assert seen["env"][reconcile.GROUP_REEXEC_GUARD] == "1"
+
+
+def test_reexec_guard_fails_closed_if_agentos_group_still_unavailable(monkeypatch):
+    monkeypatch.setattr(reconcile, "_in_shared_group", lambda: False)
+    monkeypatch.setenv(reconcile.GROUP_REEXEC_GUARD, "1")
+    with pytest.raises(RuntimeError, match="agentos_group_unavailable"):
+        reconcile._reexec_in_shared_group()
 
 
 def test_reconciler_refuses_checkout_not_equal_to_current_core_integration(monkeypatch, tmp_path):
@@ -119,7 +181,17 @@ def test_reconciler_refuses_checkout_not_equal_to_current_core_integration(monke
         reconcile.reconcile(repo=repo, data_root=data)
 
 
-def test_maintenance_invokes_generation_reconciler_only_on_core_profile():
+def test_timer_installer_has_fixed_group_context_and_no_caller_execution_surface():
+    source = (Path(__file__).resolve().parents[1] / "scripts" / "install_action_relay_reconcile_timer_user.sh").read_text(encoding="utf-8")
+    assert "/usr/bin/sg agentos -c" in source
+    assert "reconcile_action_relay_runtime.py" in source
+    assert "OnUnitActiveSec=5min" in source
+    assert "Persistent=true" in source
+    assert "systemctl --user enable --now agentos-action-relay-reconcile.timer" in source
+    assert "systemctl --user start agentos-action-relay-reconcile.service" not in source
+
+
+def test_maintenance_keeps_transitional_core_only_reconcile_fallback():
     source = (Path(__file__).resolve().parents[1] / "scripts" / "maintenance.py").read_text(encoding="utf-8")
     assert 'AGENT_MODE' in source
     assert '== "CORE"' in source


### PR DESCRIPTION
Live #238 evidence showed `agent-maintenance.service` reached the new generation reconciler but failed immediately with `PermissionError` reading the shared Action Relay capability marker. The long-lived Action Relay already runs under the fixed `agentos` group boundary; the legacy maintenance oneshot did not reliably inherit that group in its user-manager session.

This change adds a bounded bootstrap escape hatch and an independent self-heal lane:
- the reconciler re-execs only its exact current source-owned script through fixed `/usr/bin/sg agentos -c` when the process lacks the shared group;
- no caller-supplied path, argv, service, ref, SHA, credential, or executable is accepted;
- after a successful relay-generation reconciliation, it installs `agentos-action-relay-reconcile.timer` as an independent 5-minute persistent Core timer;
- if the relay is already current but the timer is missing, it bootstraps the timer without restarting the relay;
- the timer service itself uses the same fixed `agentos` group boundary and intentionally does not run immediately from its installer, avoiding self-restart inside an active Action Relay request;
- legacy maintenance retains a temporary Core-only fallback only to bootstrap this transition; it will be removed after live timer acceptance.

Tests pin fixed group handoff, recursion fail-closed behavior, exact generation installer inputs, timer bootstrap/no-op semantics, and absence of an immediate timer-service start.

Refs #238