### PR TITLE
Core #238: make relay reconcile timer sole generation owner

### DIFF
--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -51,22 +51,22 @@ def main():
     # 1. Health & Structure (Bootstrap)
     run_script("bootstrap.py")
 
-    # 2. Core immutable Action Relay generation convergence.  The reconciler is
-    # source/ref/SHA fixed and runs only on the production Core profile; client
-    # nodes never gain service-install authority through maintenance.
-    if str(os.environ.get("AGENT_MODE") or "CLIENT").strip().upper() == "CORE":
-        run_script("reconcile_action_relay_runtime.py")
+    # Action Relay immutable-generation convergence intentionally does not live
+    # in this legacy maintenance pipeline.  The independent
+    # agentos-action-relay-reconcile.timer owns that Core self-heal lane so a
+    # failure in reporting, compaction, or any other maintenance task cannot
+    # prevent executor-generation repair.
 
-    # 3. Reliability Check (Watchdog Service)
+    # 2. Reliability Check (Watchdog Service)
     check_os_watchdog()
     
-    # 4. Task Aggregation (Global Todo Hub)
+    # 3. Task Aggregation (Global Todo Hub)
     run_script("aggregate_tasks.py")
     
-    # 5. Memory Compaction (AI GC)
+    # 4. Memory Compaction (AI GC)
     run_script("compactor.py")
 
-    # 6. Ecosystem Autonomous Reporting
+    # 5. Ecosystem Autonomous Reporting
     logger.info("Running ecosystem-report...")
     result = subprocess.run(["python3", "scripts/run_workflow.py", "ecosystem-report"], cwd=PROJECT_ROOT)
     if result.returncode != 0:

--- a/tests/test_action_relay_generation_reconcile.py
+++ b/tests/test_action_relay_generation_reconcile.py
@@ -191,8 +191,7 @@ def test_timer_installer_has_fixed_group_context_and_no_caller_execution_surface
     assert "systemctl --user start agentos-action-relay-reconcile.service" not in source
 
 
-def test_maintenance_keeps_transitional_core_only_reconcile_fallback():
+def test_legacy_maintenance_no_longer_owns_relay_generation_reconcile():
     source = (Path(__file__).resolve().parents[1] / "scripts" / "maintenance.py").read_text(encoding="utf-8")
-    assert 'AGENT_MODE' in source
-    assert '== "CORE"' in source
-    assert 'run_script("reconcile_action_relay_runtime.py")' in source
+    assert 'run_script("reconcile_action_relay_runtime.py")' not in source
+    assert "agentos-action-relay-reconcile.timer" in source


### PR DESCRIPTION
Live #238 acceptance at 2026-09-05 22:57 CST proved the independent `agentos-action-relay-reconcile.timer` repaired the immutable Action Relay runtime from `2bf676...` to exact stable/Core generation `b7eb986...`, published the matching capability marker, stayed enabled/active, and allowed legacy maintenance to complete.

The bootstrap transition is therefore complete. Remove the temporary Core-only call to `reconcile_action_relay_runtime.py` from the legacy maintenance pipeline. The independent 5-minute persistent timer is now the sole owner of Action Relay generation convergence, so failures in reporting, compaction, Telegram formatting, or other legacy maintenance tasks cannot block executor self-heal.

Tests are updated to pin that ownership boundary.

Refs #238