### PR TITLE
Core #238: make runtime converge request-id at-most-once

### DIFF
--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -7,13 +7,16 @@ service names and installer sequence are fixed here.
 """
 from __future__ import annotations
 
+import fcntl
 import json
+import os
 import re
 import subprocess
 import urllib.request
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping
 
 from agent_core.runtime_converge_contract import validate_runtime_converge_request
 from agentos_node.action_relay import ACTIONS, ActionRelayClient
@@ -23,6 +26,14 @@ ACTION = "agentos.runtime.converge"
 DEFAULT_RELAY_ROOT = Path("/home/ubuntu/agent-data/runtime/action-relay")
 DEFAULT_REPO = Path("/home/ubuntu/agentmanager")
 CAPABILITY_MARKER = DEFAULT_RELAY_ROOT / "capabilities.json"
+REQUEST_ID_FIELDS = (
+    "schema",
+    "request_id",
+    "node_id",
+    "repository",
+    "source_ref",
+    "source_commit",
+)
 ALLOWED_ORIGIN_RE = re.compile(
     r"^(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
     r"alston-personal/agentmanager(?:\.git)?/?$"
@@ -234,6 +245,116 @@ if ACTION in ACTIONS and ACTIONS[ACTION] is not _execute:
 ACTIONS[ACTION] = _execute
 
 
+def _read_object(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _request_from_capsule(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    if payload.get("action") != ACTION:
+        return None
+    params = payload.get("params")
+    if not isinstance(params, Mapping):
+        return None
+    request = params.get("request")
+    if not isinstance(request, Mapping):
+        return None
+    try:
+        return validate_runtime_converge_request(request).as_payload()
+    except (TypeError, ValueError):
+        return None
+
+
+def _request_from_receipt(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    if payload.get("action") != ACTION or not payload.get("request_id"):
+        return None
+    candidate = {key: payload.get(key) for key in REQUEST_ID_FIELDS}
+    candidate["schema"] = "agentos.runtime-converge-request/v1"
+    try:
+        return validate_runtime_converge_request(candidate).as_payload()
+    except (TypeError, ValueError):
+        return None
+
+
+def _same_request_id(canonical: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return str(observed.get("request_id") or "") == str(canonical["request_id"])
+
+
+def _require_same_request(canonical: Mapping[str, Any], observed: Mapping[str, Any]) -> None:
+    if not _same_request_id(canonical, observed):
+        return
+    for key in REQUEST_ID_FIELDS:
+        if str(observed.get(key) or "") != str(canonical.get(key) or ""):
+            raise RuntimeError("runtime_converge_request_id_collision")
+
+
+@contextmanager
+def _request_submit_lock(root: Path) -> Iterator[None]:
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".runtime-converge-submit.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o660)
+    try:
+        os.fchmod(fd, 0o660)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _existing_runtime_converge(root: Path, canonical: Mapping[str, Any]) -> tuple[str, str] | None:
+    """Resolve one durable request-id execution without replaying ambiguity.
+
+    Priority is intentionally conservative: a quarantined capsule with an
+    ``outcome=unknown`` receipt wins over any duplicate success left by older
+    buggy submitters.  A request whose execution outcome became unknown may not
+    be replayed merely because another duplicate happened to finish later.
+    """
+    buckets = {name: root / name for name in ("inbox", "processing", "receipts", "quarantine")}
+
+    # First bind quarantined raw capsules to their terminal unknown receipts.
+    for capsule_path in sorted(buckets["quarantine"].glob("action-*.json")) if buckets["quarantine"].exists() else []:
+        capsule = _read_object(capsule_path)
+        if not capsule:
+            continue
+        observed = _request_from_capsule(capsule)
+        if not observed or not _same_request_id(canonical, observed):
+            continue
+        _require_same_request(canonical, observed)
+        capsule_id = str(capsule.get("capsule_id") or capsule_path.stem)
+        receipt = _read_object(buckets["receipts"] / f"{capsule_id}.json")
+        if receipt and receipt.get("outcome") == "unknown":
+            return capsule_id, "unknown"
+
+    # A terminal receipt is authoritative for a clean request-id history.
+    for receipt_path in sorted(buckets["receipts"].glob("action-*.json")) if buckets["receipts"].exists() else []:
+        receipt = _read_object(receipt_path)
+        if not receipt:
+            continue
+        observed = _request_from_receipt(receipt)
+        if not observed or not _same_request_id(canonical, observed):
+            continue
+        _require_same_request(canonical, observed)
+        capsule_id = str(receipt.get("capsule_id") or receipt_path.stem)
+        return capsule_id, "unknown" if receipt.get("outcome") == "unknown" else "completed"
+
+    for bucket, state in (("processing", "processing"), ("inbox", "queued")):
+        directory = buckets[bucket]
+        for capsule_path in sorted(directory.glob("action-*.json")) if directory.exists() else []:
+            capsule = _read_object(capsule_path)
+            if not capsule:
+                continue
+            observed = _request_from_capsule(capsule)
+            if not observed or not _same_request_id(canonical, observed):
+                continue
+            _require_same_request(canonical, observed)
+            return str(capsule.get("capsule_id") or capsule_path.stem), state
+    return None
+
+
 class ActionRelayRuntimeConvergeDispatcher:
     def __init__(self, root: str | Path = DEFAULT_RELAY_ROOT):
         self.root = Path(root)
@@ -241,17 +362,25 @@ class ActionRelayRuntimeConvergeDispatcher:
 
     def submit(self, *, request: Mapping[str, Any]) -> dict[str, Any]:
         canonical = validate_runtime_converge_request(request).as_payload()
-        capsule = self.client.submit(ACTION, {"request": canonical})
+        with _request_submit_lock(self.root):
+            existing = _existing_runtime_converge(self.root, canonical)
+            if existing is None:
+                capsule = self.client.submit(ACTION, {"request": canonical})
+                task_id = str(capsule["capsule_id"])
+                state = "queued"
+            else:
+                task_id, state = existing
         return {
             "schema": "agentos.runtime-converge-submission/v1",
-            "ok": True,
+            "ok": state != "unknown",
             "action": "node.runtime.converge",
-            "task_id": str(capsule["capsule_id"]),
+            "task_id": task_id,
             "request_id": canonical["request_id"],
             "node_id": canonical["node_id"],
             "source_ref": canonical["source_ref"],
             "source_commit": canonical["source_commit"],
-            "state": "queued",
+            "state": state,
+            "deduplicated": existing is not None,
         }
 
     def inspect(self, task_id: str) -> dict[str, Any] | None:

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -143,6 +144,86 @@ def test_rollback_ambiguity_is_unknown_and_not_success(monkeypatch, tmp_path):
     assert result["classification"] == "ROLLBACK_OUTCOME_UNKNOWN"
     assert result["rollback"] == "unknown"
     assert result["status"] == "failed"
+
+
+def _dispatcher(tmp_path: Path) -> relay.ActionRelayRuntimeConvergeDispatcher:
+    return relay.ActionRelayRuntimeConvergeDispatcher(tmp_path / "relay")
+
+
+def test_runtime_converge_duplicate_request_reuses_same_inbox_capsule(tmp_path):
+    dispatcher = _dispatcher(tmp_path)
+    first = dispatcher.submit(request=request())
+    second = dispatcher.submit(request=request())
+    assert second["task_id"] == first["task_id"]
+    assert second["state"] == "queued"
+    assert second["deduplicated"] is True
+    assert len(list((dispatcher.root / "inbox").glob("action-*.json"))) == 1
+
+
+def test_runtime_converge_duplicate_request_reuses_processing_capsule(tmp_path):
+    dispatcher = _dispatcher(tmp_path)
+    first = dispatcher.submit(request=request())
+    inbox = dispatcher.root / "inbox" / f'{first["task_id"]}.json'
+    processing = dispatcher.root / "processing" / inbox.name
+    inbox.replace(processing)
+    second = dispatcher.submit(request=request())
+    assert second["task_id"] == first["task_id"]
+    assert second["state"] == "processing"
+    assert second["deduplicated"] is True
+    assert len(list((dispatcher.root / "inbox").glob("action-*.json"))) == 0
+
+
+def test_runtime_converge_terminal_receipt_is_reused_not_resubmitted(tmp_path):
+    dispatcher = _dispatcher(tmp_path)
+    first = dispatcher.submit(request=request())
+    inbox = dispatcher.root / "inbox" / f'{first["task_id"]}.json'
+    inbox.unlink()
+    receipt = {
+        "schema": "agentos.action-receipt/v1",
+        "capsule_id": first["task_id"],
+        "action": relay.ACTION,
+        **request(),
+        "status": "completed",
+        "classification": "CURRENT_GENERATION_RECONCILED",
+        "credential_exposed": False,
+    }
+    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(json.dumps(receipt), encoding="utf-8")
+    second = dispatcher.submit(request=request())
+    assert second["task_id"] == first["task_id"]
+    assert second["state"] == "completed"
+    assert second["deduplicated"] is True
+    assert len(list((dispatcher.root / "inbox").glob("action-*.json"))) == 0
+
+
+def test_runtime_converge_quarantined_unknown_wins_and_is_never_replayed(tmp_path):
+    dispatcher = _dispatcher(tmp_path)
+    first = dispatcher.submit(request=request())
+    inbox = dispatcher.root / "inbox" / f'{first["task_id"]}.json'
+    quarantine = dispatcher.root / "quarantine" / inbox.name
+    inbox.replace(quarantine)
+    unknown_receipt = {
+        "schema": "agentos.action-receipt/v1",
+        "capsule_id": first["task_id"],
+        "action": relay.ACTION,
+        "outcome": "unknown",
+        "replayed": False,
+        "ok": False,
+    }
+    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(json.dumps(unknown_receipt), encoding="utf-8")
+    second = dispatcher.submit(request=request())
+    assert second["task_id"] == first["task_id"]
+    assert second["state"] == "unknown"
+    assert second["ok"] is False
+    assert second["deduplicated"] is True
+    assert len(list((dispatcher.root / "inbox").glob("action-*.json"))) == 0
+
+
+def test_runtime_converge_request_id_collision_fails_closed(tmp_path):
+    dispatcher = _dispatcher(tmp_path)
+    dispatcher.submit(request=request())
+    with pytest.raises(RuntimeError, match="request_id_collision"):
+        dispatcher.submit(request=request(source_commit="b" * 40))
+    assert len(list((dispatcher.root / "inbox").glob("action-*.json"))) == 1
 
 
 class NodeRegistry:

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -146,8 +146,31 @@ def test_rollback_ambiguity_is_unknown_and_not_success(monkeypatch, tmp_path):
     assert result["status"] == "failed"
 
 
+class _FileOnlyRelayClient:
+    """Exercise dispatcher spool semantics without Oracle's production Unix group."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        for name in ("inbox", "processing", "receipts", "quarantine"):
+            (root / name).mkdir(parents=True, exist_ok=True)
+
+    def submit(self, action, params):
+        existing = sum(len(list((self.root / name).glob("action-test-*.json"))) for name in ("inbox", "processing", "receipts", "quarantine"))
+        capsule_id = f"action-test-{existing + 1}"
+        payload = {"schema": "agentos.action-relay/v1", "capsule_id": capsule_id, "action": action, "params": params}
+        (self.root / "inbox" / f"{capsule_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+        return payload
+
+    def receipt(self, capsule_id):
+        path = self.root / "receipts" / f"{capsule_id}.json"
+        return json.loads(path.read_text(encoding="utf-8")) if path.is_file() else None
+
+
 def _dispatcher(tmp_path: Path) -> relay.ActionRelayRuntimeConvergeDispatcher:
-    return relay.ActionRelayRuntimeConvergeDispatcher(tmp_path / "relay")
+    root = tmp_path / "relay"
+    dispatcher = relay.ActionRelayRuntimeConvergeDispatcher(root)
+    dispatcher.client = _FileOnlyRelayClient(root)
+    return dispatcher
 
 
 def test_runtime_converge_duplicate_request_reuses_same_inbox_capsule(tmp_path):


### PR DESCRIPTION
Live #238 acceptance exposed a control-plane retry bug: the same canonical `node.runtime.converge` `request_id` was repeatedly submitted as distinct Action Relay capsules. Each duplicate successfully replayed the fixed installer as `CURRENT_GENERATION_RECONCILED`, restarting Supervisor and the shared Worker Host every few seconds and forcing both product Employee dispatch ledgers to `unknown` before claim.

This change makes typed runtime convergence idempotent by canonical request identity at the Action Relay dispatcher boundary:
- submission is serialized by a fixed relay-root flock;
- inbox / processing / receipts / quarantine are checked before any new capsule is created;
- the same `request_id` + exact canonical request returns the existing task/capsule instead of resubmitting;
- a request-id collision with different canonical fields fails closed;
- a quarantined execution with `outcome=unknown` has conservative precedence and is never replayed, even if older buggy duplicate history also contains successes;
- terminal receipts, processing capsules, and queued capsules are all reused;
- no new caller execution surface, path, argv, credential, or service authority is introduced.

Tests pin queued, processing, completed, unknown/quarantine, and request-id collision behavior.

Refs #238