### PR TITLE
feat(agentos): extract public Threads source capability

### DIFF
--- a/.github/workflows/social-threads-source-ci.yml
+++ b/.github/workflows/social-threads-source-ci.yml
@@ -1,0 +1,19 @@
+name: Social Threads Source CI
+on:
+  push:
+    branches: [feat/social-threads-source]
+  pull_request:
+    paths:
+      - 'agent_core/social_threads.py'
+      - 'tests/test_social_threads.py'
+      - '.github/workflows/social-threads-source-ci.yml'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m unittest tests.test_social_threads
+      - run: python -m py_compile agent_core/social_threads.py

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The repository currently contains working, tested slices of that architecture:
 - **Resource registry / world-state lookup** — query registered resources first and verify only when stale or missing.
 - **Cross-node / Realm fabric work** — node manifests, enrollment/control surfaces, and remote command artifacts.
 - **Platform abstraction** — Linux, Windows, and macOS runtime/service drivers.
+- **Public Threads source reader** — reusable read-side capability for resolving a public Threads post URL into author, post text, and canonical URL (`agent_core/social_threads.py`, `tests/test_social_threads.py`).
 - **Evidence-first operation** — `.agentos/evidence/` records acceptance and live-control-plane results rather than relying only on prose claims.
 
 See **[Current Architecture & Reality](docs/CURRENT_STATE.md)** for the maintained implementation map and current research boundary.

--- a/agent_core/social_threads.py
+++ b/agent_core/social_threads.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import html as html_lib
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+
+ALLOWED_HOSTS = {"threads.net", "www.threads.net", "threads.com", "www.threads.com"}
+MAX_BYTES = 768_000
+
+
+class ThreadsSourceError(ValueError):
+    pass
+
+
+def _clean(value: str) -> str:
+    value = html_lib.unescape(str(value or ""))
+    value = value.replace("\r\n", "\n").replace("\r", "\n")
+    value = re.sub(r"[ \t]+", " ", value)
+    value = re.sub(r"\n{3,}", "\n\n", value)
+    return value.strip()
+
+
+def _valid_url(url: str) -> bool:
+    try:
+        p = urllib.parse.urlparse(str(url or "").strip())
+    except Exception:
+        return False
+    if p.scheme != "https" or (p.hostname or "").lower() not in ALLOWED_HOSTS:
+        return False
+    return bool(re.search(r"/(?:@[^/]+/)?post/[^/?#]+|/t/[^/?#]+", p.path, re.I))
+
+
+class _Parser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.meta = {}
+        self.title = []
+        self.in_title = False
+        self.in_json_ld = False
+        self.json_ld = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = {str(k).lower(): str(v or "") for k, v in attrs}
+        tag = tag.lower()
+        if tag == "meta":
+            key = (attrs.get("property") or attrs.get("name") or "").lower()
+            content = attrs.get("content", "").strip()
+            if key and content and key not in self.meta:
+                self.meta[key] = content
+        elif tag == "title":
+            self.in_title = True
+        elif tag == "script" and attrs.get("type", "").lower() == "application/ld+json":
+            self.in_json_ld = True
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag == "title":
+            self.in_title = False
+        elif tag == "script":
+            self.in_json_ld = False
+
+    def handle_data(self, data):
+        if self.in_title:
+            self.title.append(data)
+        if self.in_json_ld:
+            self.json_ld.append(data)
+
+
+def _json_ld(parts):
+    raw = "\n".join(parts).strip()
+    if not raw:
+        return "", ""
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return "", ""
+    nodes = payload if isinstance(payload, list) else [payload]
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        text = node.get("articleBody") or node.get("text") or node.get("description") or ""
+        author = node.get("author") or ""
+        if isinstance(author, dict):
+            author = author.get("name") or author.get("alternateName") or ""
+        if text:
+            return _clean(text), _clean(author)
+    return "", ""
+
+
+def _username(url: str) -> str:
+    m = re.search(r"/@([^/]+)/post/", urllib.parse.urlparse(url).path, re.I)
+    return m.group(1) if m else ""
+
+
+def _author_from_title(title: str, username: str) -> str:
+    title = _clean(title)
+    for pattern in (
+        r"^(.+?)\s*\(@[^)]+\)\s+on\s+Threads",
+        r"^(.+?)\s+on\s+Threads",
+        r"^(.+?)\s*[|·-]\s*Threads",
+    ):
+        m = re.search(pattern, title, re.I)
+        if m:
+            value = _clean(m.group(1)).strip('"“” ')
+            if value:
+                return value
+    return f"@{username}" if username else "Threads 作者"
+
+
+def parse_public_post_html(raw_html: str, source_url: str) -> dict:
+    if not _valid_url(source_url):
+        raise ThreadsSourceError("invalid_threads_url")
+    parser = _Parser()
+    parser.feed(raw_html)
+    ld_text, ld_author = _json_ld(parser.json_ld)
+    text = ld_text or parser.meta.get("og:description") or parser.meta.get("twitter:description") or parser.meta.get("description") or ""
+    text = _clean(text)
+    if not text:
+        raise ThreadsSourceError("threads_post_text_unavailable")
+    title = parser.meta.get("og:title") or parser.meta.get("twitter:title") or _clean("".join(parser.title))
+    username = _username(source_url)
+    author = ld_author or _author_from_title(title, username)
+    return {
+        "type": "threads",
+        "author": _clean(author),
+        "username": username,
+        "text": text,
+        "url": source_url,
+    }
+
+
+def resolve_public_post(url: str, timeout: float = 10.0) -> dict:
+    url = str(url or "").strip()
+    if not _valid_url(url):
+        raise ThreadsSourceError("invalid_threads_url")
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "Mozilla/5.0 (compatible; AgentOS-Threads/1.0; +https://milkcat.org/)",
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "zh-TW,zh;q=0.9,en;q=0.8,ja;q=0.7",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            final_url = resp.geturl()
+            if not _valid_url(final_url):
+                raise ThreadsSourceError("threads_redirect_not_allowed")
+            raw = resp.read(MAX_BYTES + 1)
+            if len(raw) > MAX_BYTES:
+                raise ThreadsSourceError("threads_page_too_large")
+            charset = resp.headers.get_content_charset() or "utf-8"
+    except ThreadsSourceError:
+        raise
+    except Exception as exc:
+        raise ThreadsSourceError("threads_fetch_failed") from exc
+    return parse_public_post_html(raw.decode(charset, errors="replace"), final_url)
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 1:
+        print(json.dumps({"ok": False, "error": "usage: social_threads.py <threads-url>"}, ensure_ascii=False))
+        return 2
+    try:
+        data = resolve_public_post(argv[0])
+        print(json.dumps({"ok": True, "source": data}, ensure_ascii=False))
+        return 0
+    except ThreadsSourceError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_social_threads.py
+++ b/tests/test_social_threads.py
@@ -1,0 +1,37 @@
+import unittest
+
+from agent_core.social_threads import ThreadsSourceError, parse_public_post_html
+
+
+class SocialThreadsTest(unittest.TestCase):
+    def test_extracts_author_text_and_canonical_url(self):
+        html = '''<html><head>
+        <meta property="og:title" content="Nico (@nico1e.16) on Threads" />
+        <meta property="og:description" content="最近一直在想，工作是不是該換個方向？" />
+        </head></html>'''
+        url = "https://www.threads.com/@nico1e.16/post/DcWVvpwGTSh"
+        data = parse_public_post_html(html, url)
+        self.assertEqual(data["type"], "threads")
+        self.assertEqual(data["author"], "Nico")
+        self.assertEqual(data["username"], "nico1e.16")
+        self.assertEqual(data["text"], "最近一直在想，工作是不是該換個方向？")
+        self.assertEqual(data["url"], url)
+
+    def test_json_ld_wins_when_available(self):
+        html = '''<html><head><meta property="og:description" content="fallback" /></head>
+        <script type="application/ld+json">{"text":"日本語の投稿です。","author":{"name":"山田"}}</script></html>'''
+        data = parse_public_post_html(html, "https://www.threads.net/@yamada/post/ABC123")
+        self.assertEqual(data["text"], "日本語の投稿です。")
+        self.assertEqual(data["author"], "山田")
+
+    def test_rejects_non_threads_url(self):
+        with self.assertRaises(ThreadsSourceError):
+            parse_public_post_html('<meta property="og:description" content="x">', 'https://example.com/post/1')
+
+    def test_requires_post_text(self):
+        with self.assertRaises(ThreadsSourceError):
+            parse_public_post_html('<title>Threads</title>', 'https://www.threads.net/@x/post/ABC')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Extracts the public Threads URL reader from the Zeus-writer experiments into AgentOS canonical runtime capability `agent_core/social_threads.py`.

- strict Threads host + HTTPS validation and redirect revalidation
- bounded public HTML fetch
- extracts author, username, post text and canonical/final URL from JSON-LD / OG metadata
- stdlib-only CLI contract for project clients
- focused unit tests and hosted CI

This is the read-side counterpart to Zeus-writer's existing Threads publishing module and is intended for LeopardCat question-source integration.