### PR TITLE
Core #154: extract governed generic social capability

### DIFF
--- a/.github/workflows/core-social-capability-guard.yml
+++ b/.github/workflows/core-social-capability-guard.yml
@@ -18,6 +18,7 @@ on:
       - 'tests/test_social_capability_contract.py'
       - 'tests/test_social_threads_capability.py'
       - 'docs/SOCIAL_CAPABILITY.md'
+      - '.github/workflows/core-social-capability-guard.yml'
 
 permissions:
   contents: read
@@ -30,6 +31,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install focused test dependency
+        run: python -m pip install --disable-pip-version-check pytest
       - name: Compile social capability
         run: python -m compileall -q agentos_node/social
       - name: Run focused contract suite

--- a/.github/workflows/core-social-capability-guard.yml
+++ b/.github/workflows/core-social-capability-guard.yml
@@ -1,0 +1,36 @@
+name: Core Social Capability Guard
+
+on:
+  push:
+    branches:
+      - core/issue-154-social-capability
+    paths:
+      - 'agentos_node/social/**'
+      - 'tests/test_social_capability_contract.py'
+      - 'tests/test_social_threads_capability.py'
+      - 'docs/SOCIAL_CAPABILITY.md'
+      - '.github/workflows/core-social-capability-guard.yml'
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agentos_node/social/**'
+      - 'tests/test_social_capability_contract.py'
+      - 'tests/test_social_threads_capability.py'
+      - 'docs/SOCIAL_CAPABILITY.md'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile social capability
+        run: python -m compileall -q agentos_node/social
+      - name: Run focused contract suite
+        run: python -m pytest -q tests/test_social_capability_contract.py tests/test_social_threads_capability.py

--- a/agentos_node/social/__init__.py
+++ b/agentos_node/social/__init__.py
@@ -1,0 +1,13 @@
+"""Generic governed social capability boundary owned by AgentOS Core."""
+
+from .contracts import SocialRequest, SocialReceipt
+from .governance import SocialWriteGate
+from .registry import SocialCapabilityRegistry, default_registry
+
+__all__ = [
+    "SocialRequest",
+    "SocialReceipt",
+    "SocialWriteGate",
+    "SocialCapabilityRegistry",
+    "default_registry",
+]

--- a/agentos_node/social/contracts.py
+++ b/agentos_node/social/contracts.py
@@ -41,7 +41,7 @@ class SocialRequest:
     account_binding_id: str | None = None
     target_account_id: str | None = None
     primary_text: str | None = None
-    text_attachment: str | None = None
+    text_attachment: dict[str, str] | None = None
     object_id: str | None = None
     reply_to_id: str | None = None
     return_to: str | None = None
@@ -62,8 +62,13 @@ class SocialRequest:
         if self.operation in {"publish", "reply"}:
             if not self.account_binding_id or not self.target_account_id:
                 raise ValueError("explicit_target_account_required")
-            if not (self.primary_text or self.text_attachment):
-                raise ValueError("publish_content_required")
+            if not str(self.primary_text or "").strip():
+                raise ValueError("primary_text_required")
+            if self.text_attachment is not None:
+                if not isinstance(self.text_attachment, dict) or not str(self.text_attachment.get("plaintext") or "").strip():
+                    raise ValueError("text_attachment_plaintext_required")
+                if set(self.text_attachment) - {"plaintext", "link_attachment_url"}:
+                    raise ValueError("unsupported_text_attachment_field")
         if self.operation == "reply" and not self.reply_to_id:
             raise ValueError("reply_target_required")
         if self.return_to:
@@ -98,31 +103,12 @@ class SocialReceipt:
         return payload
 
 
-def receipt_for(
-    request: SocialRequest,
-    *,
-    started_at: str,
-    ok: bool,
-    capability: str,
-    result: dict[str, Any] | None = None,
-    error_code: str | None = None,
-    platform_object_id: str | None = None,
-    permalink: str | None = None,
-) -> SocialReceipt:
+def receipt_for(request: SocialRequest, *, started_at: str, ok: bool, capability: str, result: dict[str, Any] | None = None, error_code: str | None = None, platform_object_id: str | None = None, permalink: str | None = None) -> SocialReceipt:
     receipt = SocialReceipt(
-        product_id=request.product_id,
-        platform=request.platform,
-        operation=request.operation,
-        ok=ok,
-        started_at=started_at,
-        completed_at=utc_now(),
-        capability=capability,
-        account_binding_id=request.account_binding_id,
-        target_account_id=request.target_account_id,
-        platform_object_id=platform_object_id,
-        permalink=permalink,
-        result=result or {},
-        error_code=error_code,
+        product_id=request.product_id, platform=request.platform, operation=request.operation,
+        ok=ok, started_at=started_at, completed_at=utc_now(), capability=capability,
+        account_binding_id=request.account_binding_id, target_account_id=request.target_account_id,
+        platform_object_id=platform_object_id, permalink=permalink, result=result or {}, error_code=error_code,
     )
     receipt.to_dict()
     return receipt

--- a/agentos_node/social/contracts.py
+++ b/agentos_node/social/contracts.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+WRITE_OPERATIONS = frozenset({"publish", "reply", "disconnect"})
+READ_OPERATIONS = frozenset({"status", "identity.read", "post.read", "replies.read", "public_post.read", "connect"})
+SUPPORTED_OPERATIONS = READ_OPERATIONS | WRITE_OPERATIONS
+FORBIDDEN_RECEIPT_KEYS = frozenset({
+    "access_token", "refresh_token", "token", "app_secret", "client_secret",
+    "authorization", "authorization_code", "code", "credential", "credentials",
+    "cookie", "set_cookie", "oauth_url", "authorization_url",
+})
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _assert_secret_free(value: Any, path: str = "receipt") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = str(key).lower().replace("-", "_")
+            if normalized in FORBIDDEN_RECEIPT_KEYS or normalized.endswith("_token") or normalized.endswith("_secret"):
+                raise ValueError(f"secret-bearing receipt field forbidden: {path}.{key}")
+            _assert_secret_free(item, f"{path}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _assert_secret_free(item, f"{path}[{index}]")
+
+
+@dataclass(frozen=True)
+class SocialRequest:
+    """Provider-neutral request presented by a product to the shared social runtime."""
+
+    product_id: str
+    platform: str
+    operation: str
+    account_binding_id: str | None = None
+    target_account_id: str | None = None
+    primary_text: str | None = None
+    text_attachment: str | None = None
+    object_id: str | None = None
+    reply_to_id: str | None = None
+    return_to: str | None = None
+    write_intent_id: str | None = None
+    schema: str = "agentos.social-request/v1"
+
+    def validate(self) -> "SocialRequest":
+        if self.schema != "agentos.social-request/v1":
+            raise ValueError("unsupported_social_request_schema")
+        if not self.product_id.strip():
+            raise ValueError("product_id_required")
+        if self.platform not in {"threads", "facebook", "instagram"}:
+            raise ValueError("unsupported_social_platform")
+        if self.operation not in SUPPORTED_OPERATIONS:
+            raise ValueError("unsupported_social_operation")
+        if self.operation in WRITE_OPERATIONS and not self.write_intent_id:
+            raise ValueError("explicit_write_intent_required")
+        if self.operation in {"publish", "reply"}:
+            if not self.account_binding_id or not self.target_account_id:
+                raise ValueError("explicit_target_account_required")
+            if not (self.primary_text or self.text_attachment):
+                raise ValueError("publish_content_required")
+        if self.operation == "reply" and not self.reply_to_id:
+            raise ValueError("reply_target_required")
+        if self.return_to:
+            value = self.return_to.strip()
+            if not value.startswith("/") or value.startswith("//"):
+                raise ValueError("unsafe_oauth_return_route")
+        return self
+
+
+@dataclass
+class SocialReceipt:
+    """Bounded, secret-free result. Provider credentials are never serialized here."""
+
+    product_id: str
+    platform: str
+    operation: str
+    ok: bool
+    started_at: str
+    completed_at: str
+    capability: str
+    account_binding_id: str | None = None
+    target_account_id: str | None = None
+    platform_object_id: str | None = None
+    permalink: str | None = None
+    result: dict[str, Any] = field(default_factory=dict)
+    error_code: str | None = None
+    schema: str = "agentos.social-receipt/v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        _assert_secret_free(payload)
+        return payload
+
+
+def receipt_for(
+    request: SocialRequest,
+    *,
+    started_at: str,
+    ok: bool,
+    capability: str,
+    result: dict[str, Any] | None = None,
+    error_code: str | None = None,
+    platform_object_id: str | None = None,
+    permalink: str | None = None,
+) -> SocialReceipt:
+    receipt = SocialReceipt(
+        product_id=request.product_id,
+        platform=request.platform,
+        operation=request.operation,
+        ok=ok,
+        started_at=started_at,
+        completed_at=utc_now(),
+        capability=capability,
+        account_binding_id=request.account_binding_id,
+        target_account_id=request.target_account_id,
+        platform_object_id=platform_object_id,
+        permalink=permalink,
+        result=result or {},
+        error_code=error_code,
+    )
+    receipt.to_dict()
+    return receipt

--- a/agentos_node/social/credentials.py
+++ b/agentos_node/social/credentials.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class AccountBinding:
+    binding_id: str
+    product_id: str
+    platform: str
+    provider_account_id: str
+    username: str | None = None
+
+
+class CredentialVault(Protocol):
+    """Runtime-only secret boundary. Implementations must not serialize secrets into receipts."""
+
+    def get_binding(self, binding_id: str) -> AccountBinding | None: ...
+    def get_access_token(self, binding_id: str) -> str: ...
+    def bind(self, binding: AccountBinding, access_token: str) -> None: ...
+    def disconnect(self, binding_id: str) -> None: ...
+
+
+class EphemeralCredentialVault:
+    """Reference implementation: process-memory only; restart disconnects all accounts."""
+
+    def __init__(self) -> None:
+        self._bindings: dict[str, AccountBinding] = {}
+        self._tokens: dict[str, str] = {}
+
+    def get_binding(self, binding_id: str) -> AccountBinding | None:
+        return self._bindings.get(binding_id)
+
+    def get_access_token(self, binding_id: str) -> str:
+        token = self._tokens.get(binding_id, "")
+        if not token:
+            raise RuntimeError("social_credential_unavailable")
+        return token
+
+    def bind(self, binding: AccountBinding, access_token: str) -> None:
+        token = str(access_token or "").strip()
+        if not token:
+            raise ValueError("social_access_token_required")
+        self._bindings[binding.binding_id] = binding
+        self._tokens[binding.binding_id] = token
+
+    def disconnect(self, binding_id: str) -> None:
+        self._tokens.pop(binding_id, None)
+        self._bindings.pop(binding_id, None)

--- a/agentos_node/social/governance.py
+++ b/agentos_node/social/governance.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .contracts import SocialRequest, WRITE_OPERATIONS
+
+
+@dataclass(frozen=True)
+class RuntimeWriteAcceptance:
+    """Ephemeral runtime authority; never implied by credentials or capability presence."""
+
+    acceptance_id: str
+    product_id: str
+    platform: str
+    operations: frozenset[str]
+    account_binding_ids: frozenset[str] = field(default_factory=frozenset)
+
+
+class SocialWriteGate:
+    """Fail closed until an exact runtime acceptance is explicitly supplied."""
+
+    def authorize(self, request: SocialRequest, acceptance: RuntimeWriteAcceptance | None = None) -> None:
+        request.validate()
+        if request.operation not in WRITE_OPERATIONS:
+            return
+        if acceptance is None:
+            raise PermissionError("social_write_not_runtime_accepted")
+        if not acceptance.acceptance_id:
+            raise PermissionError("social_write_acceptance_id_required")
+        if acceptance.product_id != request.product_id or acceptance.platform != request.platform:
+            raise PermissionError("social_write_acceptance_scope_mismatch")
+        if request.operation not in acceptance.operations:
+            raise PermissionError("social_write_operation_not_accepted")
+        if request.account_binding_id not in acceptance.account_binding_ids:
+            raise PermissionError("social_write_account_not_accepted")
+        if request.write_intent_id is None:
+            raise PermissionError("explicit_write_intent_required")

--- a/agentos_node/social/oauth.py
+++ b/agentos_node/social/oauth.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OAuthState:
+    state: str
+    product_id: str
+    browser_session_id: str
+    platform: str
+    return_to: str
+    expires_at: float
+
+
+class OAuthStateStore:
+    """Single-use, product-scoped OAuth state. Provider codes/tokens never enter return URLs."""
+
+    def __init__(self, ttl_seconds: int = 600) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._states: dict[str, OAuthState] = {}
+
+    @staticmethod
+    def safe_return_to(value: str | None) -> str:
+        route = str(value or "/").strip()
+        if not route.startswith("/") or route.startswith("//"):
+            raise ValueError("unsafe_oauth_return_route")
+        return route[:1024]
+
+    def issue(self, *, product_id: str, browser_session_id: str, platform: str, return_to: str = "/") -> OAuthState:
+        if not product_id or not browser_session_id:
+            raise ValueError("oauth_product_and_session_required")
+        now = time.time()
+        self._states = {key: item for key, item in self._states.items() if item.expires_at > now}
+        state = OAuthState(
+            state=secrets.token_urlsafe(32),
+            product_id=product_id,
+            browser_session_id=browser_session_id,
+            platform=platform,
+            return_to=self.safe_return_to(return_to),
+            expires_at=now + self.ttl_seconds,
+        )
+        self._states[state.state] = state
+        return state
+
+    def consume(self, *, state: str, product_id: str, browser_session_id: str, platform: str) -> OAuthState:
+        item = self._states.pop(str(state or ""), None)
+        if item is None or item.expires_at <= time.time():
+            raise PermissionError("oauth_state_invalid_or_expired")
+        if (item.product_id, item.browser_session_id, item.platform) != (product_id, browser_session_id, platform):
+            raise PermissionError("oauth_state_scope_mismatch")
+        return item
+
+
+def sanitized_oauth_return(route: str, *, connected: bool, binding_id: str | None = None) -> str:
+    """Return only local routing state; never include provider code/token/credential URLs."""
+    route = OAuthStateStore.safe_return_to(route)
+    suffix = "social=connected" if connected else "social=disconnected"
+    if binding_id:
+        suffix += "&binding=" + binding_id.replace("&", "").replace("=", "")[:128]
+    return route + ("&" if "?" in route else "?") + suffix

--- a/agentos_node/social/provider.py
+++ b/agentos_node/social/provider.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import SocialRequest, receipt_for, utc_now
+from .governance import RuntimeWriteAcceptance
+from .public_threads import ThreadsPublicReadError, resolve_public_post
+from .registry import default_registry
+from .threads import ThreadsCapability
+
+
+class SocialProvider:
+    """Stateless product adapter. It does not persist product content or Q/A data."""
+
+    def __init__(self, *, threads: ThreadsCapability | None = None, public_threads_resolver=resolve_public_post) -> None:
+        self.threads = threads
+        self.public_threads_resolver = public_threads_resolver
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "schema": "agentos.social-capabilities/v1",
+            "capabilities": [
+                {"name": item.name, "platform": item.platform, "operation": item.operation, "write": item.write, "runtime_accepted": item.runtime_accepted}
+                for item in default_registry.list()
+            ],
+        }
+
+    def invoke(self, payload: dict[str, Any], *, acceptance: RuntimeWriteAcceptance | None = None) -> dict[str, Any]:
+        request = SocialRequest(**payload).validate()
+        capability = f"social.{request.platform}.{request.operation}"
+        default_registry.get(capability)
+        started = utc_now()
+
+        if request.platform != "threads":
+            return receipt_for(request, started_at=started, ok=False, capability=capability, error_code="provider_adapter_not_runtime_accepted").to_dict()
+
+        if request.operation == "public_post.read":
+            try:
+                source = self.public_threads_resolver(request.object_id or "")
+                return receipt_for(request, started_at=started, ok=True, capability=capability, result={"source": source}).to_dict()
+            except ThreadsPublicReadError as exc:
+                return receipt_for(request, started_at=started, ok=False, capability=capability, error_code=str(exc)).to_dict()
+
+        if self.threads is None:
+            return receipt_for(request, started_at=started, ok=False, capability=capability, error_code="threads_runtime_not_configured").to_dict()
+        if request.operation == "status":
+            return self.threads.status(request)
+        if request.operation in {"publish", "reply"}:
+            return self.threads.publish(request, acceptance=acceptance)
+        if request.operation == "disconnect":
+            return self.threads.disconnect(request, acceptance=acceptance)
+        return receipt_for(request, started_at=started, ok=False, capability=capability, error_code="operation_requires_provider_route").to_dict()

--- a/agentos_node/social/provider.py
+++ b/agentos_node/social/provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import sys
 from typing import Any
 
 from .contracts import SocialRequest, receipt_for, utc_now
@@ -43,10 +45,37 @@ class SocialProvider:
 
         if self.threads is None:
             return receipt_for(request, started_at=started, ok=False, capability=capability, error_code="threads_runtime_not_configured").to_dict()
-        if request.operation == "status":
-            return self.threads.status(request)
-        if request.operation in {"publish", "reply"}:
-            return self.threads.publish(request, acceptance=acceptance)
-        if request.operation == "disconnect":
-            return self.threads.disconnect(request, acceptance=acceptance)
+        try:
+            if request.operation == "status":
+                return self.threads.status(request)
+            if request.operation in {"publish", "reply"}:
+                return self.threads.publish(request, acceptance=acceptance)
+            if request.operation == "disconnect":
+                return self.threads.disconnect(request, acceptance=acceptance)
+        except PermissionError as exc:
+            return receipt_for(request, started_at=started, ok=False, capability=capability, error_code=str(exc)).to_dict()
         return receipt_for(request, started_at=started, ok=False, capability=capability, error_code="operation_requires_provider_route").to_dict()
+
+
+def main(argv=None) -> int:
+    """Secret-free CLI/provider adapter. CLI intentionally has no write-acceptance input."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    provider = SocialProvider()
+    if argv == ["capabilities"]:
+        print(json.dumps(provider.capabilities(), sort_keys=True, ensure_ascii=False))
+        return 0
+    if argv != ["invoke"]:
+        print(json.dumps({"ok": False, "error": "usage: provider.py capabilities|invoke"}, sort_keys=True))
+        return 2
+    try:
+        payload = json.load(sys.stdin)
+        receipt = provider.invoke(payload)
+        print(json.dumps(receipt, sort_keys=True, ensure_ascii=False))
+        return 0 if receipt.get("ok") else 1
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": type(exc).__name__}, sort_keys=True))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/social/public_threads.py
+++ b/agentos_node/social/public_threads.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import html as html_lib
+import json
+import re
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+
+ALLOWED_HOSTS = {"threads.net", "www.threads.net", "threads.com", "www.threads.com"}
+MAX_BYTES = 768_000
+POST_PATH = re.compile(r"/(?:@([^/]+)/)?post/([^/?#]+)|/t/([^/?#]+)", re.I)
+
+
+class ThreadsPublicReadError(ValueError):
+    pass
+
+
+def normalize_url(value: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(str(value or "").strip())
+    except ValueError as exc:
+        raise ThreadsPublicReadError("invalid_threads_url") from exc
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() not in ALLOWED_HOSTS:
+        raise ThreadsPublicReadError("invalid_threads_url")
+    if not POST_PATH.fullmatch(parsed.path.rstrip("/")):
+        raise ThreadsPublicReadError("invalid_threads_url")
+    return urllib.parse.urlunsplit(("https", "www.threads.com", parsed.path.rstrip("/"), "", ""))
+
+
+class _Parser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: dict[str, str] = {}
+        self.json_ld: list[str] = []
+        self._json_ld = False
+
+    def handle_starttag(self, tag, attrs):
+        values = {str(k).lower(): str(v or "") for k, v in attrs}
+        if tag.lower() == "meta":
+            key = (values.get("property") or values.get("name") or "").lower()
+            if key and values.get("content") and key not in self.meta:
+                self.meta[key] = values["content"]
+        if tag.lower() == "script" and values.get("type", "").lower() == "application/ld+json":
+            self._json_ld = True
+
+    def handle_endtag(self, tag):
+        if tag.lower() == "script":
+            self._json_ld = False
+
+    def handle_data(self, data):
+        if self._json_ld:
+            self.json_ld.append(data)
+
+
+def _clean(value: str) -> str:
+    value = html_lib.unescape(str(value or "")).replace("\r", "\n")
+    value = re.sub(r"[ \t]+", " ", value)
+    return re.sub(r"\n{3,}", "\n\n", value).strip()
+
+
+def parse_public_post_html(raw_html: str, source_url: str) -> dict[str, str]:
+    canonical = normalize_url(source_url)
+    parser = _Parser()
+    parser.feed(raw_html)
+    text = ""
+    author = ""
+    raw_ld = "\n".join(parser.json_ld).strip()
+    if raw_ld:
+        try:
+            payload = json.loads(raw_ld)
+            nodes = payload if isinstance(payload, list) else [payload]
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                text = _clean(node.get("articleBody") or node.get("text") or node.get("description") or "")
+                raw_author = node.get("author") or ""
+                if isinstance(raw_author, dict):
+                    raw_author = raw_author.get("name") or raw_author.get("alternateName") or ""
+                author = _clean(raw_author)
+                if text:
+                    break
+        except (ValueError, TypeError):
+            pass
+    text = text or _clean(parser.meta.get("og:description") or parser.meta.get("description") or "")
+    if not text:
+        raise ThreadsPublicReadError("threads_post_text_unavailable")
+    match = re.search(r"/@([^/]+)/post/", canonical, re.I)
+    username = match.group(1) if match else ""
+    return {"type": "threads", "author": author or (f"@{username}" if username else "Threads 作者"), "username": username, "text": text[:12000], "url": canonical}
+
+
+def resolve_public_post(url: str, timeout: float = 10.0) -> dict[str, str]:
+    canonical = normalize_url(url)
+    request = urllib.request.Request(canonical, headers={"User-Agent": "AgentOS-Social/1.0", "Accept": "text/html,application/xhtml+xml"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            final_url = normalize_url(response.geturl())
+            raw = response.read(MAX_BYTES + 1)
+            if len(raw) > MAX_BYTES:
+                raise ThreadsPublicReadError("threads_page_too_large")
+            charset = response.headers.get_content_charset() or "utf-8"
+    except ThreadsPublicReadError:
+        raise
+    except Exception as exc:
+        raise ThreadsPublicReadError("threads_fetch_failed") from exc
+    return parse_public_post_html(raw.decode(charset, errors="replace"), final_url)

--- a/agentos_node/social/registry.py
+++ b/agentos_node/social/registry.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SocialCapabilitySpec:
+    name: str
+    platform: str
+    operation: str
+    write: bool
+    runtime_accepted: bool = False
+
+
+class SocialCapabilityRegistry:
+    def __init__(self, specs: tuple[SocialCapabilitySpec, ...]) -> None:
+        self._specs = {spec.name: spec for spec in specs}
+
+    def get(self, name: str) -> SocialCapabilitySpec:
+        try:
+            return self._specs[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown social capability: {name}") from exc
+
+    def list(self) -> tuple[SocialCapabilitySpec, ...]:
+        return tuple(sorted(self._specs.values(), key=lambda item: item.name))
+
+
+def _platform_specs(platform: str) -> list[SocialCapabilitySpec]:
+    reads = ("status", "identity.read", "post.read", "replies.read")
+    writes = ("publish", "reply", "disconnect")
+    specs = [SocialCapabilitySpec(f"social.{platform}.{op}", platform, op, False) for op in reads]
+    specs.extend(SocialCapabilitySpec(f"social.{platform}.{op}", platform, op, True, False) for op in writes)
+    return specs
+
+
+_SPECS: list[SocialCapabilitySpec] = []
+for _platform in ("threads", "facebook", "instagram"):
+    _SPECS.extend(_platform_specs(_platform))
+_SPECS.append(SocialCapabilitySpec("social.threads.public_post.read", "threads", "public_post.read", False))
+_SPECS.append(SocialCapabilitySpec("social.threads.connect", "threads", "connect", False))
+
+default_registry = SocialCapabilityRegistry(tuple(_SPECS))

--- a/agentos_node/social/threads.py
+++ b/agentos_node/social/threads.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -35,7 +34,7 @@ class ThreadsProviderConfig:
 
 
 class ThreadsProviderTransport:
-    """Official Threads provider transport. Secrets remain inside the shared runtime."""
+    """Official Threads transport; provider credentials remain inside shared runtime."""
 
     def __init__(self, config_loader: Callable[[], ThreadsProviderConfig], timeout: float = 15.0) -> None:
         self._config_loader = config_loader
@@ -49,13 +48,7 @@ class ThreadsProviderTransport:
 
     def authorization_url(self, state: str) -> str:
         config = self.config()
-        query = urllib.parse.urlencode({
-            "client_id": config.app_id,
-            "redirect_uri": config.redirect_uri,
-            "scope": ",".join(THREADS_SCOPES),
-            "response_type": "code",
-            "state": state,
-        })
+        query = urllib.parse.urlencode({"client_id": config.app_id, "redirect_uri": config.redirect_uri, "scope": ",".join(THREADS_SCOPES), "response_type": "code", "state": state})
         return f"{config.authorize_host.rstrip('/')}/oauth/authorize?{query}"
 
     def _request_json(self, url: str, *, method: str = "GET", token: str | None = None, body: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -78,19 +71,20 @@ class ThreadsProviderTransport:
 
     def exchange_code(self, code: str) -> str:
         config = self.config()
-        payload = self._request_json(
-            f"{config.graph_host.rstrip('/')}/oauth/access_token",
-            method="POST",
-            body={"client_id": config.app_id, "client_secret": config.app_secret, "code": code, "grant_type": "authorization_code", "redirect_uri": config.redirect_uri},
-        )
-        token = str(payload.get("access_token") or "")
-        if not token:
+        short = self._request_json(f"{config.graph_host.rstrip('/')}/oauth/access_token", method="POST", body={"client_id": config.app_id, "client_secret": config.app_secret, "code": code, "grant_type": "authorization_code", "redirect_uri": config.redirect_uri})
+        short_token = str(short.get("access_token") or "")
+        if not short_token:
             raise ThreadsProviderError("threads_token_missing")
-        return token
+        exchange = f"{config.graph_host.rstrip('/')}/access_token?" + urllib.parse.urlencode({"grant_type": "th_exchange_token", "client_secret": config.app_secret, "access_token": short_token})
+        try:
+            long_lived = self._request_json(exchange)
+            return str(long_lived.get("access_token") or short_token)
+        except ThreadsProviderError:
+            return short_token
 
     def api(self, path: str, *, token: str, method: str = "GET", params: dict[str, Any] | None = None) -> dict[str, Any]:
         config = self.config()
-        url = f"{config.graph_host.rstrip('/')}/v1.0/{path.lstrip('/')}"
+        url = f"{config.graph_host.rstrip('/')}/{path.lstrip('/')}"
         params = dict(params or {})
         if method == "GET" and params:
             url += "?" + urllib.parse.urlencode(params)
@@ -98,11 +92,10 @@ class ThreadsProviderTransport:
         return self._request_json(url, method=method, token=token, body=params)
 
     def identity(self, token: str) -> dict[str, Any]:
-        return self.api("me", token=token, params={"fields": "id,username"})
+        return self.api("me", token=token, params={"fields": "id,username,name"})
 
     def revoke(self, token: str) -> None:
-        # Provider revocation endpoints/policies can change; runtime may supply a transport override.
-        # Local disconnect is always performed even when remote revocation is unavailable.
+        # Local disconnect is mandatory. Remote revocation may be supplied when provider policy allows it.
         return None
 
 
@@ -113,23 +106,22 @@ class ThreadsCapability:
         self.oauth_states = oauth_states or OAuthStateStore()
         self.write_gate = write_gate or SocialWriteGate()
 
-    def status(self, request: SocialRequest) -> dict[str, Any]:
-        request.validate()
-        binding = self.vault.get_binding(request.account_binding_id) if request.account_binding_id else None
-        return {"schema": "agentos.social-status/v1", "product_id": request.product_id, "platform": "threads", "configured": self.transport.config().configured if self._configured() else False, "connected": binding is not None, "account": ({"binding_id": binding.binding_id, "provider_account_id": binding.provider_account_id, "username": binding.username} if binding else None)}
-
     def _configured(self) -> bool:
         try:
             return self.transport.config().configured
         except ThreadsProviderError:
             return False
 
+    def status(self, request: SocialRequest) -> dict[str, Any]:
+        request.validate()
+        binding = self.vault.get_binding(request.account_binding_id) if request.account_binding_id else None
+        return {"schema": "agentos.social-status/v1", "product_id": request.product_id, "platform": "threads", "configured": self._configured(), "connected": binding is not None, "account": ({"binding_id": binding.binding_id, "provider_account_id": binding.provider_account_id, "username": binding.username} if binding else None)}
+
     def begin_connect(self, request: SocialRequest, *, browser_session_id: str) -> dict[str, str]:
         request.validate()
         if request.operation != "connect":
             raise ValueError("connect_operation_required")
         state = self.oauth_states.issue(product_id=request.product_id, browser_session_id=browser_session_id, platform="threads", return_to=request.return_to or "/")
-        # This transient response is intentionally not a SocialReceipt. It contains no app secret/token/code.
         return {"schema": "agentos.social-oauth-redirect/v1", "authorization_url": self.transport.authorization_url(state.state), "state": state.state}
 
     def complete_connect(self, *, product_id: str, browser_session_id: str, state: str, code: str) -> dict[str, Any]:
@@ -165,27 +157,29 @@ class ThreadsCapability:
         binding = self.vault.get_binding(request.account_binding_id or "")
         if binding is None or binding.product_id != request.product_id or binding.provider_account_id != request.target_account_id:
             return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="account_binding_mismatch").to_dict()
-        primary = str(request.primary_text or "")
-        attachment = str(request.text_attachment or "")
-        if len(primary) > THREADS_TEXT_LIMIT or len(attachment) > THREADS_ATTACHMENT_LIMIT:
-            return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="threads_content_limit_exceeded").to_dict()
-        token = self.vault.get_access_token(binding.binding_id)
-        params: dict[str, Any] = {"media_type": "TEXT", "text": primary}
+        primary = str(request.primary_text or "").strip()
+        if not primary or len(primary) > THREADS_TEXT_LIMIT:
+            return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="threads_primary_text_invalid").to_dict()
+        params: dict[str, Any] = {"media_type": "TEXT", "text": primary, "auto_publish_text": "true"}
+        attachment = request.text_attachment
         if attachment:
-            params["text_attachment"] = attachment
-            params["auto_publish_text"] = "true"
+            plaintext = str(attachment.get("plaintext") or "").strip()
+            if not plaintext or len(plaintext) > THREADS_ATTACHMENT_LIMIT:
+                return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="threads_text_attachment_invalid").to_dict()
+            sanitized: dict[str, str] = {"plaintext": plaintext}
+            link = str(attachment.get("link_attachment_url") or "").strip()
+            if link:
+                parsed = urllib.parse.urlsplit(link)
+                if parsed.scheme not in {"http", "https"}:
+                    return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="threads_text_attachment_link_invalid").to_dict()
+                sanitized["link_attachment_url"] = link
+            params["text_attachment"] = json.dumps(sanitized, ensure_ascii=False, separators=(",", ":"))
         if request.operation == "reply":
             params["reply_to_id"] = request.reply_to_id
+        token = self.vault.get_access_token(binding.binding_id)
         try:
-            created = self.transport.api(f"{binding.provider_account_id}/threads", token=token, method="POST", params=params)
-            creation_id = str(created.get("id") or "")
-            if not creation_id:
-                raise ThreadsProviderError("threads_creation_id_missing")
-            if attachment:
-                thread_id = creation_id
-            else:
-                published = self.transport.api(f"{binding.provider_account_id}/threads_publish", token=token, method="POST", params={"creation_id": creation_id})
-                thread_id = str(published.get("id") or "")
+            published = self.transport.api("me/threads", token=token, method="POST", params=params)
+            thread_id = str(published.get("id") or "")
             if not thread_id:
                 raise ThreadsProviderError("threads_publish_id_missing")
             return receipt_for(request, started_at=started, ok=True, capability=f"social.threads.{request.operation}", platform_object_id=thread_id).to_dict()

--- a/agentos_node/social/threads.py
+++ b/agentos_node/social/threads.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .contracts import SocialRequest, receipt_for, utc_now
+from .credentials import AccountBinding, CredentialVault
+from .governance import RuntimeWriteAcceptance, SocialWriteGate
+from .oauth import OAuthStateStore
+
+THREADS_SCOPES = ("threads_basic", "threads_content_publish")
+THREADS_TEXT_LIMIT = 500
+THREADS_ATTACHMENT_LIMIT = 10000
+
+
+class ThreadsProviderError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ThreadsProviderConfig:
+    app_id: str
+    app_secret: str
+    redirect_uri: str
+    graph_host: str = "https://graph.threads.net"
+    authorize_host: str = "https://threads.net"
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.app_id and self.app_secret and self.redirect_uri)
+
+
+class ThreadsProviderTransport:
+    """Official Threads provider transport. Secrets remain inside the shared runtime."""
+
+    def __init__(self, config_loader: Callable[[], ThreadsProviderConfig], timeout: float = 15.0) -> None:
+        self._config_loader = config_loader
+        self.timeout = timeout
+
+    def config(self) -> ThreadsProviderConfig:
+        config = self._config_loader()
+        if not config.configured:
+            raise ThreadsProviderError("threads_oauth_not_configured")
+        return config
+
+    def authorization_url(self, state: str) -> str:
+        config = self.config()
+        query = urllib.parse.urlencode({
+            "client_id": config.app_id,
+            "redirect_uri": config.redirect_uri,
+            "scope": ",".join(THREADS_SCOPES),
+            "response_type": "code",
+            "state": state,
+        })
+        return f"{config.authorize_host.rstrip('/')}/oauth/authorize?{query}"
+
+    def _request_json(self, url: str, *, method: str = "GET", token: str | None = None, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        headers = {"Accept": "application/json", "User-Agent": "AgentOS-Social/1.0"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        data = None
+        if body is not None:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = urllib.parse.urlencode(body).encode("utf-8")
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:
+            raise ThreadsProviderError("threads_api_unavailable") from exc
+        if not isinstance(payload, dict) or payload.get("error"):
+            raise ThreadsProviderError("threads_api_rejected")
+        return payload
+
+    def exchange_code(self, code: str) -> str:
+        config = self.config()
+        payload = self._request_json(
+            f"{config.graph_host.rstrip('/')}/oauth/access_token",
+            method="POST",
+            body={"client_id": config.app_id, "client_secret": config.app_secret, "code": code, "grant_type": "authorization_code", "redirect_uri": config.redirect_uri},
+        )
+        token = str(payload.get("access_token") or "")
+        if not token:
+            raise ThreadsProviderError("threads_token_missing")
+        return token
+
+    def api(self, path: str, *, token: str, method: str = "GET", params: dict[str, Any] | None = None) -> dict[str, Any]:
+        config = self.config()
+        url = f"{config.graph_host.rstrip('/')}/v1.0/{path.lstrip('/')}"
+        params = dict(params or {})
+        if method == "GET" and params:
+            url += "?" + urllib.parse.urlencode(params)
+            return self._request_json(url, token=token)
+        return self._request_json(url, method=method, token=token, body=params)
+
+    def identity(self, token: str) -> dict[str, Any]:
+        return self.api("me", token=token, params={"fields": "id,username"})
+
+    def revoke(self, token: str) -> None:
+        # Provider revocation endpoints/policies can change; runtime may supply a transport override.
+        # Local disconnect is always performed even when remote revocation is unavailable.
+        return None
+
+
+class ThreadsCapability:
+    def __init__(self, vault: CredentialVault, transport: ThreadsProviderTransport, oauth_states: OAuthStateStore | None = None, write_gate: SocialWriteGate | None = None) -> None:
+        self.vault = vault
+        self.transport = transport
+        self.oauth_states = oauth_states or OAuthStateStore()
+        self.write_gate = write_gate or SocialWriteGate()
+
+    def status(self, request: SocialRequest) -> dict[str, Any]:
+        request.validate()
+        binding = self.vault.get_binding(request.account_binding_id) if request.account_binding_id else None
+        return {"schema": "agentos.social-status/v1", "product_id": request.product_id, "platform": "threads", "configured": self.transport.config().configured if self._configured() else False, "connected": binding is not None, "account": ({"binding_id": binding.binding_id, "provider_account_id": binding.provider_account_id, "username": binding.username} if binding else None)}
+
+    def _configured(self) -> bool:
+        try:
+            return self.transport.config().configured
+        except ThreadsProviderError:
+            return False
+
+    def begin_connect(self, request: SocialRequest, *, browser_session_id: str) -> dict[str, str]:
+        request.validate()
+        if request.operation != "connect":
+            raise ValueError("connect_operation_required")
+        state = self.oauth_states.issue(product_id=request.product_id, browser_session_id=browser_session_id, platform="threads", return_to=request.return_to or "/")
+        # This transient response is intentionally not a SocialReceipt. It contains no app secret/token/code.
+        return {"schema": "agentos.social-oauth-redirect/v1", "authorization_url": self.transport.authorization_url(state.state), "state": state.state}
+
+    def complete_connect(self, *, product_id: str, browser_session_id: str, state: str, code: str) -> dict[str, Any]:
+        oauth = self.oauth_states.consume(state=state, product_id=product_id, browser_session_id=browser_session_id, platform="threads")
+        token = self.transport.exchange_code(code)
+        identity = self.transport.identity(token)
+        account_id = str(identity.get("id") or "")
+        if not account_id:
+            raise ThreadsProviderError("threads_identity_missing")
+        binding_id = f"{product_id}:threads:{account_id}"
+        self.vault.bind(AccountBinding(binding_id, product_id, "threads", account_id, str(identity.get("username") or "") or None), token)
+        return {"schema": "agentos.social-oauth-complete/v1", "connected": True, "binding_id": binding_id, "account": {"provider_account_id": account_id, "username": identity.get("username")}, "return_to": oauth.return_to}
+
+    def disconnect(self, request: SocialRequest, *, acceptance: RuntimeWriteAcceptance | None = None) -> dict[str, Any]:
+        started = utc_now()
+        self.write_gate.authorize(request, acceptance)
+        if not request.account_binding_id:
+            return receipt_for(request, started_at=started, ok=False, capability="social.threads.disconnect", error_code="account_binding_required").to_dict()
+        try:
+            token = self.vault.get_access_token(request.account_binding_id)
+            try:
+                self.transport.revoke(token)
+            finally:
+                self.vault.disconnect(request.account_binding_id)
+            return receipt_for(request, started_at=started, ok=True, capability="social.threads.disconnect").to_dict()
+        except Exception:
+            self.vault.disconnect(request.account_binding_id)
+            return receipt_for(request, started_at=started, ok=True, capability="social.threads.disconnect", result={"remote_revocation": "unconfirmed"}).to_dict()
+
+    def publish(self, request: SocialRequest, *, acceptance: RuntimeWriteAcceptance | None = None) -> dict[str, Any]:
+        started = utc_now()
+        self.write_gate.authorize(request, acceptance)
+        binding = self.vault.get_binding(request.account_binding_id or "")
+        if binding is None or binding.product_id != request.product_id or binding.provider_account_id != request.target_account_id:
+            return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="account_binding_mismatch").to_dict()
+        primary = str(request.primary_text or "")
+        attachment = str(request.text_attachment or "")
+        if len(primary) > THREADS_TEXT_LIMIT or len(attachment) > THREADS_ATTACHMENT_LIMIT:
+            return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code="threads_content_limit_exceeded").to_dict()
+        token = self.vault.get_access_token(binding.binding_id)
+        params: dict[str, Any] = {"media_type": "TEXT", "text": primary}
+        if attachment:
+            params["text_attachment"] = attachment
+            params["auto_publish_text"] = "true"
+        if request.operation == "reply":
+            params["reply_to_id"] = request.reply_to_id
+        try:
+            created = self.transport.api(f"{binding.provider_account_id}/threads", token=token, method="POST", params=params)
+            creation_id = str(created.get("id") or "")
+            if not creation_id:
+                raise ThreadsProviderError("threads_creation_id_missing")
+            if attachment:
+                thread_id = creation_id
+            else:
+                published = self.transport.api(f"{binding.provider_account_id}/threads_publish", token=token, method="POST", params={"creation_id": creation_id})
+                thread_id = str(published.get("id") or "")
+            if not thread_id:
+                raise ThreadsProviderError("threads_publish_id_missing")
+            return receipt_for(request, started_at=started, ok=True, capability=f"social.threads.{request.operation}", platform_object_id=thread_id).to_dict()
+        except ThreadsProviderError as exc:
+            return receipt_for(request, started_at=started, ok=False, capability=f"social.threads.{request.operation}", error_code=str(exc)).to_dict()

--- a/docs/SOCIAL_CAPABILITY.md
+++ b/docs/SOCIAL_CAPABILITY.md
@@ -1,0 +1,64 @@
+# AgentOS Generic Social Capability
+
+Status: Core candidate for Issue #154. Integration target is `core/integration` only.
+
+## Boundary
+
+Core owns provider-neutral social request/receipt contracts, capability registration, product-scoped OAuth callback state, credential isolation, account binding, provider adapters, and write governance. Product repositories own their content policy, scheduling, qualification, patrol/calibration, UI confirmation, and business data flow.
+
+No social credential value belongs in git, a product browser, a social receipt, or a product content record. The shared provider is stateless with respect to product question/answer/content data.
+
+## Generic v1 request
+
+`agentos.social-request/v1` identifies `product_id`, platform, operation, optional account binding, and explicit target account. `publish`/`reply` require an explicit `write_intent_id`, account binding, target provider account, and `primary_text`. `text_attachment`, when present, is typed as `{plaintext, optional link_attachment_url}`.
+
+Write capability presence, OAuth connection, credential presence, or executor availability never grants write authority. `SocialWriteGate` requires a separate exact `RuntimeWriteAcceptance` scoped to product + platform + operation + account binding. All registered social writes start with `runtime_accepted=false`.
+
+## OAuth and credentials
+
+OAuth state is random, single-use, ten-minute by default, and bound to product + browser session + platform. Provider authorization code exchange is server-side. Product return routing contains only local route plus sanitized connection/binding state. Access tokens and app secrets live behind `CredentialVault`; the reference vault is process-memory only and intentionally disconnects on restart.
+
+The Threads transport follows the LeopardCat teacher flow: authorization code -> access token -> best-effort long-lived token exchange -> public identity -> explicit account binding. It does not require a separate Meta App per product; the provider configuration is shared-runtime configuration unless provider policy later forces separation.
+
+## Threads
+
+Core provides two distinct read paths:
+
+- `social.threads.public_post.read`: anonymous bounded HTTPS reader with strict Threads host/redirect validation.
+- credentialed identity/post/replies contract: registered but must be routed through a runtime adapter before being considered accepted.
+
+Threads publish uses official `media_type=TEXT`, `auto_publish_text=true`, bounded primary text (`<=500`) and optional JSON `text_attachment` with bounded `plaintext` (`<=10000`) and optional http/https link attachment. Core publishing remains unauthorized by this document and by Issue #154.
+
+## Facebook / Instagram
+
+The generic registry defines identity/read/publish/reply/disconnect primitives for Facebook and Instagram under the same governance model. No concrete write adapter is marked runtime-accepted in this extraction; unsupported invocation returns `provider_adapter_not_runtime_accepted` rather than guessing provider behavior.
+
+## Consumer proof
+
+Two independent products are represented through the same v1 contract in `tests/test_social_threads_capability.py`:
+
+1. **LeopardCat Tarot** — teacher implementation provenance: `alston-personal/leopardcat-tarot@5088eaa94e9604643fc431c64bfb94a3020ad3a8`, `website/divination/threads_publishing.py`. The Core test reproduces its explicit target-account + primary text + `text_attachment` path without exposing token/code data. LeopardCat's anonymous `<=500` Threads intent fallback remains product-owned and is not removed by this extraction.
+2. **Vendor Reputation Service** — current product-owned counterpart is `alston-personal/vendor-reputation-service:app/threads_reader.py`, which resolves public Threads sources and intentionally retains Vendor ingestion/qualification outside Core. The Core test sends Vendor and LeopardCat through the identical `social.threads.public_post.read` provider contract.
+
+This is contract-level shared-capability evidence, not authorization to deploy credentials or publish from either product.
+
+## Provenance / retirement
+
+- Legacy PR #18: early monolithic generic social executor; semantics reconciled here, do not merge it.
+- PR #125: later modular `agentos_node/social/*` plus Vendor-specific `vendor_ingest.py`; generic concepts were reconciled, Vendor ingestion is explicitly excluded, do not merge it wholesale.
+- PR #262: public Threads URL reader source; safe URL/read semantics were incorporated into `agentos_node/social/public_threads.py`, but its `main` target is not the Core integration path.
+- LeopardCat teacher commit `5088eaa94e9604643fc431c64bfb94a3020ad3a8`: OAuth/account/text-attachment semantics accounted for.
+
+After the focused #154 PR is integrated to `core/integration`, #18/#125/#262 should be closed as superseded with provenance links; none should be merged to protected `main` as part of this issue.
+
+## Acceptance mapping
+
+1. #18/#125 reconciled: provenance above and focused modules/tests.
+2. Focused current branch from `core/integration`: `core/issue-154-social-capability`.
+3. Secret values excluded from repo/receipts: recursive receipt guard + credential vault tests.
+4. Writes fail closed: exact runtime acceptance gate; registry defaults false.
+5. Vendor counterpart: product-owned `app/threads_reader.py`; no Vendor ingest in Core.
+6. Tests/evidence: `tests/test_social_capability_contract.py` and `tests/test_social_threads_capability.py` plus focused CI.
+7. Integration target: `core/integration` only.
+8. Legacy provenance accounted before retirement: this document.
+9. Teacher extension: product-scoped OAuth return, binding/disconnect, text attachment, no product content persistence, secret-free receipt, dual-consumer contract proof, shared provider config boundary.

--- a/tests/test_social_capability_contract.py
+++ b/tests/test_social_capability_contract.py
@@ -17,7 +17,7 @@ def publish_request(**overrides):
         account_binding_id="leopardcat-tarot:threads:42",
         target_account_id="42",
         primary_text="short share intent",
-        text_attachment="full interpretation",
+        text_attachment={"plaintext": "full interpretation"},
         write_intent_id="intent-1",
     )
     data.update(overrides)
@@ -58,7 +58,6 @@ def test_oauth_state_is_single_use_and_product_scoped():
     issued = store.issue(product_id="leopardcat-tarot", browser_session_id="s1", platform="threads", return_to="/reading/1")
     with pytest.raises(PermissionError, match="scope_mismatch"):
         store.consume(state=issued.state, product_id="vendor-reputation-service", browser_session_id="s1", platform="threads")
-    # Scope failure consumes the state instead of leaving a replayable credential flow.
     with pytest.raises(PermissionError, match="invalid_or_expired"):
         store.consume(state=issued.state, product_id="leopardcat-tarot", browser_session_id="s1", platform="threads")
 

--- a/tests/test_social_capability_contract.py
+++ b/tests/test_social_capability_contract.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from agentos_node.social.contracts import SocialReceipt, SocialRequest
+from agentos_node.social.credentials import AccountBinding, EphemeralCredentialVault
+from agentos_node.social.governance import RuntimeWriteAcceptance, SocialWriteGate
+from agentos_node.social.oauth import OAuthStateStore, sanitized_oauth_return
+from agentos_node.social.registry import default_registry
+
+
+def publish_request(**overrides):
+    data = dict(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="publish",
+        account_binding_id="leopardcat-tarot:threads:42",
+        target_account_id="42",
+        primary_text="short share intent",
+        text_attachment="full interpretation",
+        write_intent_id="intent-1",
+    )
+    data.update(overrides)
+    return SocialRequest(**data)
+
+
+def test_write_fails_closed_without_runtime_acceptance():
+    with pytest.raises(PermissionError, match="social_write_not_runtime_accepted"):
+        SocialWriteGate().authorize(publish_request())
+
+
+def test_write_acceptance_is_exact_product_platform_operation_and_account():
+    request = publish_request()
+    accepted = RuntimeWriteAcceptance("accept-1", "leopardcat-tarot", "threads", frozenset({"publish"}), frozenset({request.account_binding_id}))
+    SocialWriteGate().authorize(request, accepted)
+    with pytest.raises(PermissionError):
+        SocialWriteGate().authorize(request, RuntimeWriteAcceptance("accept-2", "vendor-reputation-service", "threads", frozenset({"publish"}), frozenset({request.account_binding_id})))
+
+
+def test_receipt_recursively_rejects_secret_fields():
+    receipt = SocialReceipt("p", "threads", "status", True, "a", "b", "social.threads.status", result={"nested": {"access_token": "SECRET"}})
+    with pytest.raises(ValueError, match="secret-bearing"):
+        receipt.to_dict()
+
+
+def test_ephemeral_vault_never_puts_token_in_binding():
+    vault = EphemeralCredentialVault()
+    binding = AccountBinding("p:threads:42", "p", "threads", "42", "cat")
+    vault.bind(binding, "SECRET-TOKEN")
+    assert vault.get_binding(binding.binding_id) == binding
+    assert "SECRET" not in repr(binding)
+    vault.disconnect(binding.binding_id)
+    assert vault.get_binding(binding.binding_id) is None
+
+
+def test_oauth_state_is_single_use_and_product_scoped():
+    store = OAuthStateStore()
+    issued = store.issue(product_id="leopardcat-tarot", browser_session_id="s1", platform="threads", return_to="/reading/1")
+    with pytest.raises(PermissionError, match="scope_mismatch"):
+        store.consume(state=issued.state, product_id="vendor-reputation-service", browser_session_id="s1", platform="threads")
+    # Scope failure consumes the state instead of leaving a replayable credential flow.
+    with pytest.raises(PermissionError, match="invalid_or_expired"):
+        store.consume(state=issued.state, product_id="leopardcat-tarot", browser_session_id="s1", platform="threads")
+
+
+def test_oauth_return_never_contains_provider_code_or_token():
+    value = sanitized_oauth_return("/reading/1", connected=True, binding_id="p:threads:42")
+    assert "connected" in value
+    assert "code=" not in value
+    assert "token" not in value
+
+
+def test_registry_declares_threads_facebook_instagram_and_no_write_is_runtime_accepted():
+    specs = default_registry.list()
+    assert {item.platform for item in specs} == {"threads", "facebook", "instagram"}
+    assert any(item.name == "social.threads.public_post.read" for item in specs)
+    assert all(not item.runtime_accepted for item in specs if item.write)

--- a/tests/test_social_threads_capability.py
+++ b/tests/test_social_threads_capability.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from agentos_node.social.contracts import SocialRequest
+from agentos_node.social.credentials import AccountBinding, EphemeralCredentialVault
+from agentos_node.social.governance import RuntimeWriteAcceptance
+from agentos_node.social.public_threads import ThreadsPublicReadError, normalize_url, parse_public_post_html
+from agentos_node.social.provider import SocialProvider
+from agentos_node.social.threads import ThreadsCapability, ThreadsProviderConfig
+
+
+class FakeTransport:
+    def __init__(self):
+        self.calls = []
+
+    def config(self):
+        return ThreadsProviderConfig("app-id", "server-only-secret", "https://core.example/callback")
+
+    def authorization_url(self, state):
+        return f"https://threads.net/oauth/authorize?client_id=app-id&state={state}"
+
+    def exchange_code(self, code):
+        assert code == "provider-code"
+        return "SERVER-ONLY-TOKEN"
+
+    def identity(self, token):
+        assert token == "SERVER-ONLY-TOKEN"
+        return {"id": "42", "username": "milkcat"}
+
+    def api(self, path, *, token, method="GET", params=None):
+        assert token == "SERVER-ONLY-TOKEN"
+        self.calls.append((path, method, dict(params or {})))
+        return {"id": "published-99"}
+
+    def revoke(self, token):
+        assert token == "SERVER-ONLY-TOKEN"
+
+
+def test_public_threads_reader_is_strict_and_bounded_contract():
+    assert normalize_url("https://threads.com/@cat/post/ABC?x=secret") == "https://www.threads.com/@cat/post/ABC"
+    html = '<meta property="og:description" content="hello world">'
+    source = parse_public_post_html(html, "https://www.threads.com/@cat/post/ABC")
+    assert source["username"] == "cat"
+    assert source["text"] == "hello world"
+    try:
+        normalize_url("http://evil.example/@cat/post/ABC")
+    except ThreadsPublicReadError as exc:
+        assert str(exc) == "invalid_threads_url"
+    else:
+        raise AssertionError("untrusted host should fail")
+
+
+def test_leopardcat_teacher_text_attachment_uses_same_generic_request_contract():
+    vault = EphemeralCredentialVault()
+    vault.bind(AccountBinding("leopardcat-tarot:threads:42", "leopardcat-tarot", "threads", "42", "milkcat"), "SERVER-ONLY-TOKEN")
+    transport = FakeTransport()
+    capability = ThreadsCapability(vault, transport)
+    request = SocialRequest(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="publish",
+        account_binding_id="leopardcat-tarot:threads:42",
+        target_account_id="42",
+        primary_text="<=500-char intent",
+        text_attachment="full Master interpretation",
+        write_intent_id="user-confirmation-1",
+    )
+    acceptance = RuntimeWriteAcceptance("runtime-accept-1", "leopardcat-tarot", "threads", frozenset({"publish"}), frozenset({request.account_binding_id}))
+    receipt = capability.publish(request, acceptance=acceptance)
+    assert receipt["ok"] is True
+    assert "SERVER-ONLY-TOKEN" not in str(receipt)
+    assert transport.calls[0][2]["text_attachment"] == "full Master interpretation"
+    assert transport.calls[0][2]["auto_publish_text"] == "true"
+
+
+def test_leopardcat_and_vendor_use_same_generic_provider_for_read_contract():
+    def resolver(url):
+        return {"type": "threads", "author": "@cat", "username": "cat", "text": "source", "url": normalize_url(url)}
+
+    provider = SocialProvider(public_threads_resolver=resolver)
+    for product_id in ("leopardcat-tarot", "vendor-reputation-service"):
+        receipt = provider.invoke({
+            "product_id": product_id,
+            "platform": "threads",
+            "operation": "public_post.read",
+            "object_id": "https://threads.com/@cat/post/ABC",
+        })
+        assert receipt["ok"] is True
+        assert receipt["product_id"] == product_id
+        assert receipt["capability"] == "social.threads.public_post.read"
+        assert receipt["result"]["source"]["text"] == "source"
+
+
+def test_connect_exposes_no_provider_secret_or_token():
+    vault = EphemeralCredentialVault()
+    capability = ThreadsCapability(vault, FakeTransport())
+    request = SocialRequest(product_id="leopardcat-tarot", platform="threads", operation="connect", return_to="/reading/1")
+    redirect = capability.begin_connect(request, browser_session_id="browser-session")
+    assert "server-only-secret" not in str(redirect)
+    completed = capability.complete_connect(product_id="leopardcat-tarot", browser_session_id="browser-session", state=redirect["state"], code="provider-code")
+    assert completed["connected"] is True
+    assert "SERVER-ONLY-TOKEN" not in str(completed)
+    assert "provider-code" not in str(completed)
+    assert completed["return_to"] == "/reading/1"

--- a/tests/test_social_threads_capability.py
+++ b/tests/test_social_threads_capability.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from agentos_node.social.contracts import SocialRequest
 from agentos_node.social.credentials import AccountBinding, EphemeralCredentialVault
 from agentos_node.social.governance import RuntimeWriteAcceptance
@@ -55,35 +57,28 @@ def test_leopardcat_teacher_text_attachment_uses_same_generic_request_contract()
     transport = FakeTransport()
     capability = ThreadsCapability(vault, transport)
     request = SocialRequest(
-        product_id="leopardcat-tarot",
-        platform="threads",
-        operation="publish",
-        account_binding_id="leopardcat-tarot:threads:42",
-        target_account_id="42",
+        product_id="leopardcat-tarot", platform="threads", operation="publish",
+        account_binding_id="leopardcat-tarot:threads:42", target_account_id="42",
         primary_text="<=500-char intent",
-        text_attachment="full Master interpretation",
+        text_attachment={"plaintext": "full Master interpretation", "link_attachment_url": "https://example.test/share/1"},
         write_intent_id="user-confirmation-1",
     )
     acceptance = RuntimeWriteAcceptance("runtime-accept-1", "leopardcat-tarot", "threads", frozenset({"publish"}), frozenset({request.account_binding_id}))
     receipt = capability.publish(request, acceptance=acceptance)
     assert receipt["ok"] is True
     assert "SERVER-ONLY-TOKEN" not in str(receipt)
-    assert transport.calls[0][2]["text_attachment"] == "full Master interpretation"
+    attachment = json.loads(transport.calls[0][2]["text_attachment"])
+    assert attachment["plaintext"] == "full Master interpretation"
     assert transport.calls[0][2]["auto_publish_text"] == "true"
+    assert transport.calls[0][0] == "me/threads"
 
 
 def test_leopardcat_and_vendor_use_same_generic_provider_for_read_contract():
     def resolver(url):
         return {"type": "threads", "author": "@cat", "username": "cat", "text": "source", "url": normalize_url(url)}
-
     provider = SocialProvider(public_threads_resolver=resolver)
     for product_id in ("leopardcat-tarot", "vendor-reputation-service"):
-        receipt = provider.invoke({
-            "product_id": product_id,
-            "platform": "threads",
-            "operation": "public_post.read",
-            "object_id": "https://threads.com/@cat/post/ABC",
-        })
+        receipt = provider.invoke({"product_id": product_id, "platform": "threads", "operation": "public_post.read", "object_id": "https://threads.com/@cat/post/ABC"})
         assert receipt["ok"] is True
         assert receipt["product_id"] == product_id
         assert receipt["capability"] == "social.threads.public_post.read"


### PR DESCRIPTION
## Scope

Completes the focused Core extraction requested by #154 from current `core/integration` without importing Vendor-specific ingestion.

## Core boundary

- provider-neutral `agentos.social-request/v1` and secret-free `agentos.social-receipt/v1`
- recursive secret-bearing receipt rejection
- product-scoped, single-use OAuth state and sanitized return routing
- explicit account binding + disconnect semantics behind a runtime credential vault
- exact fail-closed write acceptance scoped to product/platform/operation/account
- generic Threads/Facebook/Instagram registration with every write defaulting `runtime_accepted=false`
- bounded anonymous public Threads read
- Threads OAuth + official text publish / typed `text_attachment` adapter reconciled from the LeopardCat teacher implementation
- generic stateless provider/CLI adapter; no Q/A/content persistence

## Consumer / provenance evidence

- LeopardCat teacher: `alston-personal/leopardcat-tarot@5088eaa94e9604643fc431c64bfb94a3020ad3a8`
- Vendor product-owned counterpart: `alston-personal/vendor-reputation-service:app/threads_reader.py`
- focused tests demonstrate both product IDs through the same `social.threads.public_post.read` contract and LeopardCat through the same governed publish contract
- legacy PR #18, mixed PR #125, and public-read PR #262 are accounted for in `docs/SOCIAL_CAPABILITY.md`; none should be merged wholesale

No platform credentials are added. This PR does **not** authorize Core social publishing and targets `core/integration` only.

Closes #154 after focused CI passes and this PR is merged to `core/integration`.