### PR TITLE
Core #267: activate governed shared social runtime

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -1,0 +1,37 @@
+name: Core Social Runtime Guard
+
+on:
+  push:
+    branches:
+      - core/issue-267-social-runtime
+    paths:
+      - 'agentos_node/social/**'
+      - 'tests/test_social_runtime_activation.py'
+      - 'docs/SOCIAL_RUNTIME.md'
+      - '.github/workflows/core-social-runtime-guard.yml'
+  pull_request:
+    branches:
+      - core/integration
+    paths:
+      - 'agentos_node/social/**'
+      - 'tests/test_social_runtime_activation.py'
+      - 'docs/SOCIAL_RUNTIME.md'
+      - '.github/workflows/core-social-runtime-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install focused test dependency
+        run: python -m pip install --disable-pip-version-check pytest
+      - name: Compile shared social runtime
+        run: python -m compileall -q agentos_node/social
+      - name: Run shared runtime contract suite
+        run: python -m pytest -q tests/test_social_runtime_activation.py tests/test_social_capability_contract.py tests/test_social_threads_capability.py

--- a/agentos_node/social/runtime_http.py
+++ b/agentos_node/social/runtime_http.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import urllib.parse
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+from .contracts import SocialRequest
+from .oauth import sanitized_oauth_return
+from .runtime_storage import FileCredentialVault, OneShotAcceptanceStore
+from .threads import ThreadsCapability, ThreadsProviderConfig, ThreadsProviderTransport
+
+MAX_BODY = 64 * 1024
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8771
+DEFAULT_CREDENTIAL_PATH = Path("/home/ubuntu/agent-data/runtime/social/credentials.json")
+SESSION_COOKIE = "agentos_social_session"
+
+
+@dataclass(frozen=True)
+class ProductRegistration:
+    product_id: str
+    api_key: str
+    return_base: str
+
+
+class ProductRegistry:
+    def __init__(self, registrations: dict[str, ProductRegistration]) -> None:
+        self._items = registrations
+
+    @classmethod
+    def from_env(cls) -> "ProductRegistry":
+        raw = os.environ.get("AGENTOS_SOCIAL_PRODUCTS_JSON", "{}")
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("social_product_registry_invalid") from exc
+        if not isinstance(value, dict):
+            raise RuntimeError("social_product_registry_invalid")
+        items: dict[str, ProductRegistration] = {}
+        for product_id, item in value.items():
+            if not isinstance(item, dict):
+                raise RuntimeError("social_product_registry_invalid")
+            api_key = str(item.get("api_key") or "")
+            return_base = str(item.get("return_base") or "").rstrip("/")
+            parsed = urllib.parse.urlsplit(return_base)
+            if not product_id or not api_key or parsed.scheme not in {"https", "http"} or not parsed.netloc:
+                raise RuntimeError("social_product_registry_invalid")
+            items[str(product_id)] = ProductRegistration(str(product_id), api_key, return_base)
+        return cls(items)
+
+    def registration(self, product_id: str) -> ProductRegistration:
+        item = self._items.get(product_id)
+        if item is None:
+            raise PermissionError("social_product_not_registered")
+        return item
+
+    def authenticate(self, product_id: str, supplied: str) -> ProductRegistration:
+        item = self.registration(product_id)
+        if not hmac.compare_digest(item.api_key, str(supplied or "")):
+            raise PermissionError("social_product_auth_failed")
+        return item
+
+
+class BrowserContextStore:
+    """Short-lived in-process callback context. Restart fails closed."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, tuple[str, str]] = {}
+        self._lock = RLock()
+
+    def bind(self, state: str, product_id: str, browser_session_id: str) -> None:
+        with self._lock:
+            self._items[state] = (product_id, browser_session_id)
+
+    def consume(self, state: str) -> tuple[str, str]:
+        with self._lock:
+            value = self._items.pop(state, None)
+        if value is None:
+            raise PermissionError("social_oauth_browser_context_invalid_or_consumed")
+        return value
+
+
+class SocialRuntime:
+    def __init__(
+        self,
+        *,
+        products: ProductRegistry,
+        threads: ThreadsCapability,
+        acceptances: OneShotAcceptanceStore | None = None,
+        browser_contexts: BrowserContextStore | None = None,
+        control_token: str = "",
+    ) -> None:
+        self.products = products
+        self.threads = threads
+        self.acceptances = acceptances or OneShotAcceptanceStore()
+        self.browser_contexts = browser_contexts or BrowserContextStore()
+        self.control_token = control_token
+
+    @classmethod
+    def from_env(cls, credential_path: str | Path = DEFAULT_CREDENTIAL_PATH) -> "SocialRuntime":
+        products = ProductRegistry.from_env()
+        vault = FileCredentialVault(credential_path)
+
+        def config_loader() -> ThreadsProviderConfig:
+            return ThreadsProviderConfig(
+                app_id=os.environ.get("AGENTOS_THREADS_APP_ID", ""),
+                app_secret=os.environ.get("AGENTOS_THREADS_APP_SECRET", ""),
+                redirect_uri=os.environ.get("AGENTOS_THREADS_REDIRECT_URI", ""),
+            )
+
+        return cls(
+            products=products,
+            threads=ThreadsCapability(vault, ThreadsProviderTransport(config_loader)),
+            control_token=os.environ.get("AGENTOS_SOCIAL_CONTROL_TOKEN", ""),
+        )
+
+    def configured_status(self) -> dict[str, Any]:
+        return {
+            "schema": "agentos.social-runtime-status/v1",
+            "service": "agentos-social-runtime",
+            "threads": {"configured": self.threads._configured()},
+        }
+
+    def status(self, request: SocialRequest) -> dict[str, Any]:
+        self.products.registration(request.product_id)
+        return self.threads.status(request)
+
+    def connect(self, request: SocialRequest) -> dict[str, Any]:
+        self.products.registration(request.product_id)
+        browser_session_id = secrets.token_urlsafe(24)
+        value = self.threads.begin_connect(request, browser_session_id=browser_session_id)
+        state = value.pop("state")
+        self.browser_contexts.bind(state, request.product_id, browser_session_id)
+        return {**value, "browser_session_id": browser_session_id}
+
+    def complete_connect(self, *, state: str, code: str) -> tuple[str, dict[str, Any]]:
+        product_id, browser_session_id = self.browser_contexts.consume(state)
+        registration = self.products.registration(product_id)
+        result = self.threads.complete_connect(
+            product_id=product_id,
+            browser_session_id=browser_session_id,
+            state=state,
+            code=code,
+        )
+        relative = sanitized_oauth_return(
+            str(result.get("return_to") or "/"),
+            connected=True,
+            binding_id=str(result.get("binding_id") or ""),
+        )
+        return registration.return_base + relative, {
+            "schema": "agentos.social-oauth-complete/v1",
+            "connected": True,
+            "binding_id": result.get("binding_id"),
+            "account": result.get("account"),
+        }
+
+    def issue_acceptance(self, request: SocialRequest, supplied_control_token: str) -> dict[str, str]:
+        if not self.control_token or not hmac.compare_digest(self.control_token, str(supplied_control_token or "")):
+            raise PermissionError("social_runtime_control_auth_failed")
+        self.products.registration(request.product_id)
+        acceptance_id = self.acceptances.issue(request)
+        return {"schema": "agentos.social-write-acceptance/v1", "acceptance_id": acceptance_id, "one_shot": "true"}
+
+    def execute_write(self, request: SocialRequest, acceptance_id: str) -> dict[str, Any]:
+        self.products.registration(request.product_id)
+        acceptance = self.acceptances.consume(acceptance_id, request)
+        if request.operation == "publish" or request.operation == "reply":
+            return self.threads.publish(request, acceptance=acceptance)
+        if request.operation == "disconnect":
+            return self.threads.disconnect(request, acceptance=acceptance)
+        raise ValueError("unsupported_social_write_operation")
+
+
+class SocialRuntimeHandler(BaseHTTPRequestHandler):
+    runtime: SocialRuntime
+    server_version = "AgentOSSocialRuntime/0.1"
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict[str, Any]:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError as exc:
+            raise ValueError("invalid_content_length") from exc
+        if length <= 0 or length > MAX_BODY:
+            raise ValueError("request_body_size_invalid")
+        value = json.loads(self.rfile.read(length).decode("utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("json_object_required")
+        return value
+
+    def _request(self, body: dict[str, Any]) -> SocialRequest:
+        allowed = {
+            "schema", "product_id", "platform", "operation", "account_binding_id", "target_account_id",
+            "primary_text", "text_attachment", "object_id", "reply_to_id", "return_to", "write_intent_id",
+        }
+        if set(body) - allowed:
+            raise ValueError("unsupported_social_request_field")
+        return SocialRequest(**body).validate()
+
+    def _product_auth(self, request: SocialRequest) -> None:
+        self.runtime.products.authenticate(request.product_id, self.headers.get("X-AgentOS-Product-Key", ""))
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlsplit(self.path)
+        if parsed.path == "/healthz":
+            self._json(HTTPStatus.OK, self.runtime.configured_status())
+            return
+        if parsed.path == "/v1/social/oauth/threads/callback":
+            query = urllib.parse.parse_qs(parsed.query)
+            state = str((query.get("state") or [""])[0])
+            code = str((query.get("code") or [""])[0])
+            if not state or not code:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "oauth_callback_fields_required"})
+                return
+            try:
+                location, _result = self.runtime.complete_connect(state=state, code=code)
+            except (ValueError, PermissionError, RuntimeError) as exc:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(exc)})
+                return
+            self.send_response(HTTPStatus.FOUND)
+            self.send_header("Location", location)
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            return
+        self._json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        try:
+            body = self._body()
+            request = self._request(body)
+            if self.path == "/v1/social/status":
+                self._product_auth(request)
+                self._json(HTTPStatus.OK, self.runtime.status(request))
+                return
+            if self.path == "/v1/social/connect":
+                self._product_auth(request)
+                value = self.runtime.connect(request)
+                # browser_session_id is runtime-private callback context; never return it.
+                value.pop("browser_session_id", None)
+                self._json(HTTPStatus.OK, value)
+                return
+            if self.path in {"/v1/social/publish", "/v1/social/reply", "/v1/social/disconnect"}:
+                self._product_auth(request)
+                acceptance_id = self.headers.get("X-AgentOS-Acceptance-ID", "")
+                self._json(HTTPStatus.OK, self.runtime.execute_write(request, acceptance_id))
+                return
+            if self.path == "/internal/v1/social/acceptances":
+                value = self.runtime.issue_acceptance(request, self.headers.get("X-AgentOS-Control-Token", ""))
+                self._json(HTTPStatus.CREATED, value)
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not_found"})
+        except PermissionError as exc:
+            self._json(HTTPStatus.FORBIDDEN, {"ok": False, "error": str(exc)})
+        except (TypeError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(exc)})
+        except RuntimeError as exc:
+            self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"ok": False, "error": str(exc)})
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Avoid writing OAuth codes, write payloads, or product content to generic logs.
+        return
+
+
+def handler_for(runtime: SocialRuntime):
+    class Handler(SocialRuntimeHandler):
+        pass
+    Handler.runtime = runtime
+    return Handler
+
+
+def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, credential_path: str | Path = DEFAULT_CREDENTIAL_PATH) -> None:
+    runtime = SocialRuntime.from_env(credential_path)
+    ThreadingHTTPServer((host, port), handler_for(runtime)).serve_forever()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--credential-path", default=str(DEFAULT_CREDENTIAL_PATH))
+    args = parser.parse_args(argv)
+    serve(args.host, args.port, args.credential_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentos_node/social/runtime_http.py
+++ b/agentos_node/social/runtime_http.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import hmac
 import json
 import os
@@ -9,6 +8,7 @@ import secrets
 import urllib.parse
 from dataclasses import dataclass
 from http import HTTPStatus
+from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import RLock
@@ -82,12 +82,15 @@ class BrowserContextStore:
         with self._lock:
             self._items[state] = (product_id, browser_session_id)
 
-    def consume(self, state: str) -> tuple[str, str]:
+    def consume(self, state: str, browser_session_id: str) -> tuple[str, str]:
         with self._lock:
             value = self._items.pop(state, None)
         if value is None:
             raise PermissionError("social_oauth_browser_context_invalid_or_consumed")
-        return value
+        product_id, expected_session = value
+        if not hmac.compare_digest(expected_session, str(browser_session_id or "")):
+            raise PermissionError("social_oauth_browser_session_mismatch")
+        return product_id, expected_session
 
 
 class SocialRuntime:
@@ -143,12 +146,12 @@ class SocialRuntime:
         self.browser_contexts.bind(state, request.product_id, browser_session_id)
         return {**value, "browser_session_id": browser_session_id}
 
-    def complete_connect(self, *, state: str, code: str) -> tuple[str, dict[str, Any]]:
-        product_id, browser_session_id = self.browser_contexts.consume(state)
+    def complete_connect(self, *, state: str, code: str, browser_session_id: str) -> tuple[str, dict[str, Any]]:
+        product_id, expected_session = self.browser_contexts.consume(state, browser_session_id)
         registration = self.products.registration(product_id)
         result = self.threads.complete_connect(
             product_id=product_id,
-            browser_session_id=browser_session_id,
+            browser_session_id=expected_session,
             state=state,
             code=code,
         )
@@ -174,7 +177,7 @@ class SocialRuntime:
     def execute_write(self, request: SocialRequest, acceptance_id: str) -> dict[str, Any]:
         self.products.registration(request.product_id)
         acceptance = self.acceptances.consume(acceptance_id, request)
-        if request.operation == "publish" or request.operation == "reply":
+        if request.operation in {"publish", "reply"}:
             return self.threads.publish(request, acceptance=acceptance)
         if request.operation == "disconnect":
             return self.threads.disconnect(request, acceptance=acceptance)
@@ -185,11 +188,16 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
     runtime: SocialRuntime
     server_version = "AgentOSSocialRuntime/0.1"
 
-    def _json(self, status: int, payload: dict[str, Any]) -> None:
+    def _json(self, status: int, payload: dict[str, Any], *, session_cookie: str | None = None) -> None:
         body = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Cache-Control", "no-store")
+        if session_cookie:
+            self.send_header(
+                "Set-Cookie",
+                f"{SESSION_COOKIE}={session_cookie}; Path=/v1/social/oauth/threads/callback; HttpOnly; Secure; SameSite=Lax",
+            )
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -218,6 +226,12 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
     def _product_auth(self, request: SocialRequest) -> None:
         self.runtime.products.authenticate(request.product_id, self.headers.get("X-AgentOS-Product-Key", ""))
 
+    def _browser_session_cookie(self) -> str:
+        cookie = SimpleCookie()
+        cookie.load(self.headers.get("Cookie", ""))
+        morsel = cookie.get(SESSION_COOKIE)
+        return morsel.value if morsel else ""
+
     def do_GET(self) -> None:  # noqa: N802
         parsed = urllib.parse.urlsplit(self.path)
         if parsed.path == "/healthz":
@@ -227,17 +241,26 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
             query = urllib.parse.parse_qs(parsed.query)
             state = str((query.get("state") or [""])[0])
             code = str((query.get("code") or [""])[0])
-            if not state or not code:
-                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "oauth_callback_fields_required"})
+            browser_session_id = self._browser_session_cookie()
+            if not state or not code or not browser_session_id:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "oauth_callback_context_required"})
                 return
             try:
-                location, _result = self.runtime.complete_connect(state=state, code=code)
+                location, _result = self.runtime.complete_connect(
+                    state=state,
+                    code=code,
+                    browser_session_id=browser_session_id,
+                )
             except (ValueError, PermissionError, RuntimeError) as exc:
                 self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(exc)})
                 return
             self.send_response(HTTPStatus.FOUND)
             self.send_header("Location", location)
             self.send_header("Cache-Control", "no-store")
+            self.send_header(
+                "Set-Cookie",
+                f"{SESSION_COOKIE}=; Path=/v1/social/oauth/threads/callback; Max-Age=0; HttpOnly; Secure; SameSite=Lax",
+            )
             self.end_headers()
             return
         self._json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not_found"})
@@ -253,9 +276,8 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
             if self.path == "/v1/social/connect":
                 self._product_auth(request)
                 value = self.runtime.connect(request)
-                # browser_session_id is runtime-private callback context; never return it.
-                value.pop("browser_session_id", None)
-                self._json(HTTPStatus.OK, value)
+                browser_session_id = str(value.pop("browser_session_id"))
+                self._json(HTTPStatus.OK, value, session_cookie=browser_session_id)
                 return
             if self.path in {"/v1/social/publish", "/v1/social/reply", "/v1/social/disconnect"}:
                 self._product_auth(request)

--- a/agentos_node/social/runtime_storage.py
+++ b/agentos_node/social/runtime_storage.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import RLock
+
+from .contracts import SocialRequest, WRITE_OPERATIONS
+from .credentials import AccountBinding, CredentialVault
+from .governance import RuntimeWriteAcceptance
+
+
+class FileCredentialVault(CredentialVault):
+    """Runtime-owned credential persistence.
+
+    Tokens are stored only inside the runtime host in a mode-0600 JSON file.
+    Product-facing APIs expose AccountBinding values but never this file or token
+    material. The file format is deliberately private to the runtime.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._lock = RLock()
+        self._ensure()
+
+    def _ensure(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"bindings": {}}, handle)
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+
+    def _load(self) -> dict:
+        self._ensure()
+        with self.path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        if not isinstance(value, dict) or not isinstance(value.get("bindings"), dict):
+            raise RuntimeError("social_credential_store_invalid")
+        return value
+
+    def _save(self, value: dict) -> None:
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=False, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, self.path)
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+
+    def get_binding(self, binding_id: str) -> AccountBinding | None:
+        with self._lock:
+            item = self._load()["bindings"].get(binding_id)
+            if not isinstance(item, dict):
+                return None
+            return AccountBinding(
+                binding_id=binding_id,
+                product_id=str(item.get("product_id") or ""),
+                platform=str(item.get("platform") or ""),
+                provider_account_id=str(item.get("provider_account_id") or ""),
+                username=(str(item.get("username")) if item.get("username") is not None else None),
+            )
+
+    def get_access_token(self, binding_id: str) -> str:
+        with self._lock:
+            item = self._load()["bindings"].get(binding_id)
+            token = str(item.get("access_token") or "") if isinstance(item, dict) else ""
+            if not token:
+                raise RuntimeError("social_credential_unavailable")
+            return token
+
+    def bind(self, binding: AccountBinding, access_token: str) -> None:
+        token = str(access_token or "").strip()
+        if not token:
+            raise ValueError("social_access_token_required")
+        with self._lock:
+            value = self._load()
+            value["bindings"][binding.binding_id] = {
+                "product_id": binding.product_id,
+                "platform": binding.platform,
+                "provider_account_id": binding.provider_account_id,
+                "username": binding.username,
+                "access_token": token,
+            }
+            self._save(value)
+
+    def disconnect(self, binding_id: str) -> None:
+        with self._lock:
+            value = self._load()
+            value["bindings"].pop(binding_id, None)
+            self._save(value)
+
+
+@dataclass(frozen=True)
+class OneShotAcceptance:
+    acceptance: RuntimeWriteAcceptance
+    write_intent_id: str
+
+
+class OneShotAcceptanceStore:
+    """Process-local, single-consume write authority.
+
+    Issuance belongs to the runtime control-plane, never the product endpoint.
+    Exact product/platform/operation/account/write-intent matching is required.
+    """
+
+    def __init__(self) -> None:
+        self._items: dict[str, OneShotAcceptance] = {}
+        self._lock = RLock()
+
+    def issue(self, request: SocialRequest) -> str:
+        request.validate()
+        if request.operation not in WRITE_OPERATIONS:
+            raise ValueError("write_operation_required")
+        if not request.account_binding_id or not request.write_intent_id:
+            raise ValueError("exact_write_scope_required")
+        acceptance_id = secrets.token_urlsafe(24)
+        acceptance = RuntimeWriteAcceptance(
+            acceptance_id=acceptance_id,
+            product_id=request.product_id,
+            platform=request.platform,
+            operations=frozenset({request.operation}),
+            account_binding_ids=frozenset({request.account_binding_id}),
+        )
+        with self._lock:
+            self._items[acceptance_id] = OneShotAcceptance(acceptance, request.write_intent_id)
+        return acceptance_id
+
+    def consume(self, acceptance_id: str, request: SocialRequest) -> RuntimeWriteAcceptance:
+        with self._lock:
+            item = self._items.pop(str(acceptance_id or ""), None)
+        if item is None:
+            raise PermissionError("social_write_acceptance_invalid_or_consumed")
+        if item.write_intent_id != request.write_intent_id:
+            raise PermissionError("social_write_intent_mismatch")
+        acceptance = item.acceptance
+        if (
+            acceptance.product_id != request.product_id
+            or acceptance.platform != request.platform
+            or request.operation not in acceptance.operations
+            or request.account_binding_id not in acceptance.account_binding_ids
+        ):
+            raise PermissionError("social_write_acceptance_scope_mismatch")
+        return acceptance

--- a/docs/SOCIAL_RUNTIME.md
+++ b/docs/SOCIAL_RUNTIME.md
@@ -1,0 +1,84 @@
+# AgentOS Shared Social Runtime
+
+Issue: #267. This runtime activates the generic social capability extracted by #154 without granting broad social-write authority.
+
+## Boundary
+
+The runtime is a Core-owned service around `agentos_node.social`; product repositories do not import provider adapters, store Threads App Secret/access tokens, or exchange OAuth codes themselves.
+
+Default bind: `127.0.0.1:8771`. External exposure, if required, belongs behind the AgentOS/reverse-proxy authentication boundary. The service itself accepts only fixed JSON contracts and never arbitrary provider URLs, HTTP methods, commands, argv, or secret retrieval.
+
+### Product API
+
+- `GET /healthz`: reports service and provider configured/unconfigured booleans only.
+- `POST /v1/social/status`
+- `POST /v1/social/connect`
+- `GET /v1/social/oauth/threads/callback`
+- `POST /v1/social/disconnect`
+- `POST /v1/social/publish`
+- `POST /v1/social/reply`
+
+Product calls require an exact registered `product_id` plus `X-AgentOS-Product-Key`. Registration is runtime configuration, not repository data.
+
+`connect` creates a runtime-owned OAuth state and an HttpOnly/Secure/SameSite=Lax browser-session cookie. The provider callback must match both the single-use OAuth state and the original browser-session cookie. On success the browser is redirected only to the pre-registered product return base plus the previously validated relative `return_to` route. The return contains only connection/binding information; provider authorization code/token material stays server-side.
+
+### Runtime control API
+
+- `POST /internal/v1/social/acceptances`
+
+This route requires `X-AgentOS-Control-Token` and is deliberately separate from product authentication. It issues a process-local one-shot acceptance for exactly one:
+
+- product
+- platform
+- operation
+- account binding
+- `write_intent_id`
+
+A credential/account binding never creates publish authority. Product credentials cannot mint write acceptance. The acceptance is consumed before provider execution; mismatch also consumes it and fails closed.
+
+## Runtime-owned secret configuration
+
+No values belong in Git.
+
+- `AGENTOS_THREADS_APP_ID`
+- `AGENTOS_THREADS_APP_SECRET`
+- `AGENTOS_THREADS_REDIRECT_URI`
+- `AGENTOS_SOCIAL_CONTROL_TOKEN`
+- `AGENTOS_SOCIAL_PRODUCTS_JSON`
+
+`AGENTOS_SOCIAL_PRODUCTS_JSON` maps product IDs to a runtime API key and a fixed return base, for example structurally (values omitted):
+
+```json
+{
+  "leopardcat-tarot": {
+    "api_key": "<runtime-secret>",
+    "return_base": "https://<product-host>"
+  }
+}
+```
+
+The provider config is shared by default. #267 does not create a LeopardCat-specific Meta App. If Meta policy later requires per-product applications, that must be introduced as an explicit provider-policy boundary rather than silently copied into product repos.
+
+## Credential storage
+
+The runtime persists account binding metadata and access tokens in its private runtime credential file (default `/home/ubuntu/agent-data/runtime/social/credentials.json`, mode `0600`). Products receive only the non-secret binding ID/provider account identity. Receipts remain subject to the recursive secret guard from #154.
+
+## Deployment
+
+```bash
+python -m agentos_node.social.runtime_http --host 127.0.0.1 --port 8771
+```
+
+The service is valid while Threads is unconfigured; `/healthz` reports `threads.configured=false` and OAuth connect fails closed. This permits deployment before shared Meta App credentials are provisioned.
+
+## LeopardCat proving sequence
+
+1. Deploy this shared runtime from `core/integration`.
+2. Register `leopardcat-tarot` as a runtime consumer without creating a product-local Meta App.
+3. Install shared Meta App credentials in the runtime secret boundary when available.
+4. Complete a real Threads OAuth callback and capture only sanitized account binding evidence.
+5. Issue one exact write acceptance from the AgentOS control plane for a user-click-generated `write_intent_id`.
+6. Publish `primary_text` plus optional typed `text_attachment` through the runtime and retain only the secret-free receipt/permalink/object id.
+7. Then integrate LeopardCat #65 against the accepted endpoint; its existing production fallback remains valid until that live proof exists.
+
+A live provider receipt is required before #267 can be closed. Unit/hosted CI proves the boundary and fail-closed behavior, not Meta availability or credentials.

--- a/tests/test_social_runtime_activation.py
+++ b/tests/test_social_runtime_activation.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos_node.social.contracts import SocialRequest
+from agentos_node.social.credentials import AccountBinding, EphemeralCredentialVault
+from agentos_node.social.runtime_http import BrowserContextStore, ProductRegistration, ProductRegistry, SocialRuntime
+from agentos_node.social.runtime_storage import FileCredentialVault, OneShotAcceptanceStore
+from agentos_node.social.threads import ThreadsCapability, ThreadsProviderConfig, ThreadsProviderTransport
+
+
+class FakeThreadsTransport(ThreadsProviderTransport):
+    def __init__(self, configured: bool = True) -> None:
+        self._configured_value = configured
+        self.published = []
+
+    def config(self) -> ThreadsProviderConfig:
+        if not self._configured_value:
+            from agentos_node.social.threads import ThreadsProviderError
+            raise ThreadsProviderError("threads_oauth_not_configured")
+        return ThreadsProviderConfig("app", "secret", "https://runtime.example/v1/social/oauth/threads/callback")
+
+    def authorization_url(self, state: str) -> str:
+        return f"https://threads.example/oauth?state={state}"
+
+    def exchange_code(self, code: str) -> str:
+        assert code == "provider-code"
+        return "provider-token"
+
+    def identity(self, token: str):
+        assert token == "provider-token"
+        return {"id": "42", "username": "cat"}
+
+    def api(self, path: str, *, token: str, method: str = "GET", params=None):
+        assert token == "provider-token"
+        self.published.append((path, method, params))
+        return {"id": "thread-1"}
+
+    def revoke(self, token: str) -> None:
+        return None
+
+
+def registry() -> ProductRegistry:
+    return ProductRegistry({
+        "leopardcat-tarot": ProductRegistration(
+            "leopardcat-tarot", "product-key", "https://tarot.example"
+        )
+    })
+
+
+def runtime(configured: bool = True):
+    vault = EphemeralCredentialVault()
+    transport = FakeThreadsTransport(configured=configured)
+    threads = ThreadsCapability(vault, transport)
+    return SocialRuntime(
+        products=registry(),
+        threads=threads,
+        acceptances=OneShotAcceptanceStore(),
+        browser_contexts=BrowserContextStore(),
+        control_token="control-key",
+    ), vault, transport
+
+
+def publish_request(**overrides):
+    data = dict(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="publish",
+        account_binding_id="leopardcat-tarot:threads:42",
+        target_account_id="42",
+        primary_text="short intent",
+        text_attachment={"plaintext": "full reading"},
+        write_intent_id="intent-1",
+    )
+    data.update(overrides)
+    return SocialRequest(**data)
+
+
+def test_runtime_config_status_never_exposes_provider_values():
+    rt, _vault, _transport = runtime(configured=True)
+    value = rt.configured_status()
+    assert value["threads"] == {"configured": True}
+    text = repr(value).lower()
+    assert "secret" not in text
+    assert "provider-token" not in text
+
+
+def test_product_registry_requires_exact_product_key():
+    reg = registry()
+    assert reg.authenticate("leopardcat-tarot", "product-key").product_id == "leopardcat-tarot"
+    with pytest.raises(PermissionError, match="auth_failed"):
+        reg.authenticate("leopardcat-tarot", "wrong")
+    with pytest.raises(PermissionError, match="not_registered"):
+        reg.authenticate("vendor-reputation-service", "product-key")
+
+
+def test_oauth_callback_is_single_use_and_browser_session_bound():
+    rt, vault, _transport = runtime()
+    request = SocialRequest(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="connect",
+        return_to="/reading/1",
+    )
+    started = rt.connect(request)
+    browser_session_id = started["browser_session_id"]
+    state = started["authorization_url"].split("state=", 1)[1]
+
+    with pytest.raises(PermissionError, match="browser_session_mismatch"):
+        rt.complete_connect(state=state, code="provider-code", browser_session_id="other-browser")
+    with pytest.raises(PermissionError, match="invalid_or_consumed"):
+        rt.complete_connect(state=state, code="provider-code", browser_session_id=browser_session_id)
+    assert vault.get_binding("leopardcat-tarot:threads:42") is None
+
+
+def test_realistic_oauth_completion_returns_binding_not_token():
+    rt, vault, _transport = runtime()
+    request = SocialRequest(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="connect",
+        return_to="/reading/1",
+    )
+    started = rt.connect(request)
+    state = started["authorization_url"].split("state=", 1)[1]
+    location, result = rt.complete_connect(
+        state=state,
+        code="provider-code",
+        browser_session_id=started["browser_session_id"],
+    )
+    assert location.startswith("https://tarot.example/reading/1")
+    assert result["binding_id"] == "leopardcat-tarot:threads:42"
+    assert result["account"]["provider_account_id"] == "42"
+    assert "token" not in repr(result).lower()
+    assert vault.get_access_token(result["binding_id"]) == "provider-token"
+
+
+def test_publish_requires_control_issued_exact_one_shot_acceptance():
+    rt, vault, transport = runtime()
+    request = publish_request()
+    vault.bind(AccountBinding(request.account_binding_id, request.product_id, "threads", "42", "cat"), "provider-token")
+
+    with pytest.raises(PermissionError, match="invalid_or_consumed"):
+        rt.execute_write(request, "missing")
+
+    issued = rt.issue_acceptance(request, "control-key")
+    receipt = rt.execute_write(request, issued["acceptance_id"])
+    assert receipt["ok"] is True
+    assert receipt["platform_object_id"] == "thread-1"
+    assert transport.published[0][2]["text_attachment"] == '{"plaintext":"full reading"}'
+
+    with pytest.raises(PermissionError, match="invalid_or_consumed"):
+        rt.execute_write(request, issued["acceptance_id"])
+
+
+def test_acceptance_cannot_be_reused_for_different_write_intent():
+    rt, vault, _transport = runtime()
+    original = publish_request()
+    vault.bind(AccountBinding(original.account_binding_id, original.product_id, "threads", "42", "cat"), "provider-token")
+    issued = rt.issue_acceptance(original, "control-key")
+    changed = publish_request(write_intent_id="intent-2")
+    with pytest.raises(PermissionError, match="write_intent_mismatch"):
+        rt.execute_write(changed, issued["acceptance_id"])
+    with pytest.raises(PermissionError, match="invalid_or_consumed"):
+        rt.execute_write(original, issued["acceptance_id"])
+
+
+def test_control_token_is_independent_from_product_auth():
+    rt, _vault, _transport = runtime()
+    with pytest.raises(PermissionError, match="control_auth_failed"):
+        rt.issue_acceptance(publish_request(), "product-key")
+
+
+def test_file_vault_persists_runtime_secret_only_and_mode_is_private(tmp_path: Path):
+    path = tmp_path / "social" / "credentials.json"
+    vault = FileCredentialVault(path)
+    binding = AccountBinding("p:threads:42", "p", "threads", "42", "cat")
+    vault.bind(binding, "SECRET-TOKEN")
+    assert FileCredentialVault(path).get_binding(binding.binding_id) == binding
+    assert FileCredentialVault(path).get_access_token(binding.binding_id) == "SECRET-TOKEN"
+    if os.name == "posix":
+        assert path.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Scope

Activates the generic social capability completed in #154 as a bounded Core-owned runtime service for #267.

### Runtime boundary
- fixed product API: status/connect/OAuth callback/disconnect/publish/reply
- fixed internal control API for write-acceptance issuance
- no arbitrary provider URL, method, command, argv, or secret-read passthrough
- product registration/auth and fixed return-base routing are runtime configuration
- shared Threads provider configuration remains runtime-owned; this does **not** create a LeopardCat-specific Meta App

### OAuth / credential boundary
- server-side Threads code exchange and identity lookup
- single-use OAuth state plus HttpOnly/Secure browser-session binding
- callback returns only sanitized binding/account identity to the registered product return base
- runtime-private credential persistence (0600); products never receive access token/app secret/code
- configured/unconfigured health reports booleans only

### Write governance
- credential presence does not grant publish authority
- product auth cannot mint write authority
- separate runtime-control token issues exact one-shot acceptance scoped to product/platform/operation/account binding/write_intent_id
- acceptance is consumed before execution; mismatch/replay fail closed
- existing #154 recursive secret-free receipts remain authoritative

### Validation
Focused CI compiles `agentos_node/social` and runs the #267 activation suite plus the #154 social contract/provider suites.

Live Meta OAuth / `text_attachment` publish evidence is intentionally **not** claimed by this PR until shared Meta App credentials exist in the runtime boundary. Production LeopardCat fallback remains unchanged until that live proof is obtained.

Targets `core/integration` only. Does not authorize protected-main writes or autonomous/background social publishing.