### PR TITLE
Core #267: deploy shared social runtime to Oracle

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - core/issue-267-social-runtime
+      - core/issue-267-social-runtime-rollout
     paths:
       - 'agentos_node/social/**'
       - 'tests/test_social_runtime_activation.py'
       - 'docs/SOCIAL_RUNTIME.md'
+      - 'scripts/install_social_runtime_user.sh'
       - '.github/workflows/core-social-runtime-guard.yml'
+      - '.github/workflows/oracle-social-runtime-rollout.yml'
   pull_request:
     branches:
       - core/integration
@@ -16,7 +19,9 @@ on:
       - 'agentos_node/social/**'
       - 'tests/test_social_runtime_activation.py'
       - 'docs/SOCIAL_RUNTIME.md'
+      - 'scripts/install_social_runtime_user.sh'
       - '.github/workflows/core-social-runtime-guard.yml'
+      - '.github/workflows/oracle-social-runtime-rollout.yml'
 
 permissions:
   contents: read
@@ -33,5 +38,7 @@ jobs:
         run: python -m pip install --disable-pip-version-check pytest
       - name: Compile shared social runtime
         run: python -m compileall -q agentos_node/social
+      - name: Validate rollout shell contract
+        run: bash -n scripts/install_social_runtime_user.sh
       - name: Run shared runtime contract suite
         run: python -m pytest -q tests/test_social_runtime_activation.py tests/test_social_capability_contract.py tests/test_social_threads_capability.py

--- a/.github/workflows/oracle-social-runtime-rollout.yml
+++ b/.github/workflows/oracle-social-runtime-rollout.yml
@@ -1,0 +1,73 @@
+name: Oracle Social Runtime Rollout
+
+on:
+  push:
+    branches:
+      - core/integration
+    paths:
+      - '.github/workflows/oracle-social-runtime-rollout.yml'
+      - 'scripts/install_social_runtime_user.sh'
+      - 'agentos_node/social/**'
+
+permissions:
+  contents: read
+
+jobs:
+  rollout:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight canonical generation
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/core/integration'
+          test "$(id -un)" = 'agentos-node'
+          printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          python3 -m compileall -q agentos_node/social
+          bash -n scripts/install_social_runtime_user.sh
+          echo "social_runtime_rollout_source_ref=core/integration"
+          echo "social_runtime_rollout_source_commit=$GITHUB_SHA"
+
+      - name: Install exact-generation shared runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/install_social_runtime_user.sh "$GITHUB_WORKSPACE" "$GITHUB_SHA"
+
+      - name: Verify bounded unconfigured endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUNTIME="$HOME/.local/share/agentos/social-runtime"
+          ENV_FILE="$HOME/.config/agentos/social-runtime.env"
+          test "$(stat -c '%a' "$ENV_FILE")" = 600
+          grep -q '^source_ref=core/integration$' "$RUNTIME/GENERATION"
+          grep -q "^source_commit=$GITHUB_SHA$" "$RUNTIME/GENERATION"
+          systemctl --user is-active --quiet agentos-social-runtime.service
+          curl -fsS --max-time 3 http://127.0.0.1:8771/healthz > "$RUNNER_TEMP/social-runtime-health.json"
+          python3 - "$RUNNER_TEMP/social-runtime-health.json" <<'PY'
+          import json, sys
+          p = json.load(open(sys.argv[1], encoding='utf-8'))
+          assert p.get('schema') == 'agentos.social-runtime-status/v1', p
+          assert p.get('service') == 'agentos-social-runtime', p
+          threads = p.get('threads')
+          assert isinstance(threads, dict) and set(threads) == {'configured'}, p
+          assert isinstance(threads['configured'], bool), p
+          text = json.dumps(p, sort_keys=True).lower()
+          for forbidden in ('app_secret', 'access_token', 'refresh_token', 'authorization_code'):
+              assert forbidden not in text, text
+          print('oracle_social_runtime_endpoint=PASS')
+          print('oracle_social_runtime_configured=' + str(threads['configured']).lower())
+          PY
+
+      - name: Upload sanitized endpoint evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-social-runtime-${{ github.run_id }}
+          path: ${{ runner.temp }}/social-runtime-health.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/install_social_runtime_user.sh
+++ b/scripts/install_social_runtime_user.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_USER="agentos-node"
+SOURCE_ROOT="${1:-$(pwd)}"
+SOURCE_COMMIT="${2:-}"
+RUNTIME_ROOT="${HOME}/.local/share/agentos/social-runtime"
+STATE_ROOT="${HOME}/.local/state/agentos/social"
+CONFIG_ROOT="${HOME}/.config/agentos"
+UNIT_ROOT="${HOME}/.config/systemd/user"
+ENV_FILE="${CONFIG_ROOT}/social-runtime.env"
+UNIT_FILE="${UNIT_ROOT}/agentos-social-runtime.service"
+
+if [ "$(id -un)" != "$EXPECTED_USER" ]; then
+  echo "social_runtime_install=WRONG_USER"
+  exit 2
+fi
+if ! printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "social_runtime_install=SOURCE_COMMIT_REQUIRED"
+  exit 2
+fi
+
+test -f "$SOURCE_ROOT/agentos_node/social/runtime_http.py"
+test -f "$SOURCE_ROOT/agentos_node/social/runtime_storage.py"
+
+mkdir -p "$RUNTIME_ROOT/agentos_node" "$STATE_ROOT" "$CONFIG_ROOT" "$UNIT_ROOT"
+rm -rf "$RUNTIME_ROOT/agentos_node/social"
+cp -a "$SOURCE_ROOT/agentos_node/social" "$RUNTIME_ROOT/agentos_node/social"
+cp "$SOURCE_ROOT/agentos_node/__init__.py" "$RUNTIME_ROOT/agentos_node/__init__.py"
+
+cat > "$RUNTIME_ROOT/GENERATION" <<EOF
+source_ref=core/integration
+source_commit=$SOURCE_COMMIT
+EOF
+chmod -R go-rwx "$RUNTIME_ROOT" "$STATE_ROOT" || true
+
+if [ ! -e "$ENV_FILE" ]; then
+  umask 077
+  cat > "$ENV_FILE" <<'EOF'
+# Runtime-owned configuration. Do not commit values.
+AGENTOS_SOCIAL_PRODUCTS_JSON={}
+AGENTOS_SOCIAL_CONTROL_TOKEN=
+AGENTOS_THREADS_APP_ID=
+AGENTOS_THREADS_APP_SECRET=
+AGENTOS_THREADS_REDIRECT_URI=
+EOF
+fi
+chmod 0600 "$ENV_FILE"
+
+cat > "$UNIT_FILE" <<EOF
+[Unit]
+Description=AgentOS Shared Social Runtime
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$RUNTIME_ROOT
+Environment=PYTHONPATH=$RUNTIME_ROOT
+EnvironmentFile=$ENV_FILE
+ExecStart=/usr/bin/python3 -m agentos_node.social.runtime_http --host 127.0.0.1 --port 8771 --credential-path $STATE_ROOT/credentials.json
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$RUNTIME_ROOT $STATE_ROOT $CONFIG_ROOT
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now agentos-social-runtime.service
+
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 2 http://127.0.0.1:8771/healthz >/tmp/agentos-social-runtime-health.json; then
+    break
+  fi
+  sleep 1
+done
+curl -fsS --max-time 3 http://127.0.0.1:8771/healthz >/tmp/agentos-social-runtime-health.json
+python3 - <<'PY'
+import json
+p = json.load(open('/tmp/agentos-social-runtime-health.json', encoding='utf-8'))
+assert p.get('schema') == 'agentos.social-runtime-status/v1', p
+assert p.get('service') == 'agentos-social-runtime', p
+threads = p.get('threads') or {}
+assert isinstance(threads.get('configured'), bool), p
+assert set(threads) == {'configured'}, p
+print('social_runtime_health=PASS')
+print('social_runtime_threads_configured=' + str(threads['configured']).lower())
+PY
+
+grep -q '^source_ref=core/integration$' "$RUNTIME_ROOT/GENERATION"
+grep -q "^source_commit=$SOURCE_COMMIT$" "$RUNTIME_ROOT/GENERATION"
+echo "social_runtime_source_ref=core/integration"
+echo "social_runtime_source_commit=$SOURCE_COMMIT"
+echo "social_runtime_install=PASS"


### PR DESCRIPTION
## Scope
Deploy the #267 shared social runtime from exact `core/integration` generation onto the canonical Oracle `agentos-node` runtime without provisioning Meta credentials.

### Deployment
- installs `agentos_node.social` exact generation into the `agentos-node` user runtime
- creates a hardened systemd user service `agentos-social-runtime.service`
- binds locally on `127.0.0.1:8771`
- preserves an existing private runtime env file and creates an empty/unconfigured one only when absent
- stores runtime credentials under the `agentos-node` private state directory
- records `source_ref=core/integration` and exact source commit

### Rollout evidence
On merge to `core/integration`, `Oracle Social Runtime Rollout` runs on `[self-hosted, Linux, ARM64, oracle]`, verifies `agentos-node`, installs the exact generation, starts the service, calls `/healthz`, verifies the response contains only configured/unconfigured boolean provider status, and uploads sanitized evidence.

### Governance
This rollout intentionally does **not** create a LeopardCat-specific Meta App, does not install provider secret values, and does not enable social writes. With no shared Meta configuration, Threads remains `configured=false` and OAuth/publish fail closed.

#267 remains open after this PR until a shared Meta configuration exists and real sanitized OAuth + `text_attachment` publish evidence is obtained. LeopardCat #65 remains blocked on that live endpoint acceptance.

Targets `core/integration` only; protected `main` remains untouched.