### PR TITLE
Core #267: deploy social runtime through bounded bootstrap

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - core/issue-267-social-runtime
       - core/issue-267-social-runtime-rollout
+      - core/issue-267-social-runtime-bootstrap
     paths:
       - 'agentos_node/social/**'
+      - 'agentos_node/bootstrap_control.py'
       - 'tests/test_social_runtime_activation.py'
+      - 'tests/test_social_runtime_bootstrap_contract.py'
       - 'docs/SOCIAL_RUNTIME.md'
       - 'scripts/install_social_runtime_user.sh'
+      - 'scripts/deploy_social_runtime_user.sh'
       - '.github/workflows/core-social-runtime-guard.yml'
       - '.github/workflows/oracle-social-runtime-rollout.yml'
   pull_request:
@@ -17,9 +21,12 @@ on:
       - core/integration
     paths:
       - 'agentos_node/social/**'
+      - 'agentos_node/bootstrap_control.py'
       - 'tests/test_social_runtime_activation.py'
+      - 'tests/test_social_runtime_bootstrap_contract.py'
       - 'docs/SOCIAL_RUNTIME.md'
       - 'scripts/install_social_runtime_user.sh'
+      - 'scripts/deploy_social_runtime_user.sh'
       - '.github/workflows/core-social-runtime-guard.yml'
       - '.github/workflows/oracle-social-runtime-rollout.yml'
 
@@ -36,9 +43,16 @@ jobs:
           python-version: '3.12'
       - name: Install focused test dependency
         run: python -m pip install --disable-pip-version-check pytest
-      - name: Compile shared social runtime
-        run: python -m compileall -q agentos_node/social
-      - name: Validate rollout shell contract
-        run: bash -n scripts/install_social_runtime_user.sh
+      - name: Compile shared social runtime and bootstrap control
+        run: python -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
+      - name: Validate rollout shell contracts
+        run: |
+          bash -n scripts/install_social_runtime_user.sh
+          bash -n scripts/deploy_social_runtime_user.sh
       - name: Run shared runtime contract suite
-        run: python -m pytest -q tests/test_social_runtime_activation.py tests/test_social_capability_contract.py tests/test_social_threads_capability.py
+        run: >-
+          python -m pytest -q
+          tests/test_social_runtime_activation.py
+          tests/test_social_runtime_bootstrap_contract.py
+          tests/test_social_capability_contract.py
+          tests/test_social_threads_capability.py

--- a/.github/workflows/oracle-social-runtime-rollout.yml
+++ b/.github/workflows/oracle-social-runtime-rollout.yml
@@ -6,7 +6,8 @@ on:
       - core/integration
     paths:
       - '.github/workflows/oracle-social-runtime-rollout.yml'
-      - 'scripts/install_social_runtime_user.sh'
+      - 'agentos_node/bootstrap_control.py'
+      - 'scripts/deploy_social_runtime_user.sh'
       - 'agentos_node/social/**'
 
 permissions:
@@ -26,27 +27,80 @@ jobs:
           test "$GITHUB_REF" = 'refs/heads/core/integration'
           test "$(id -un)" = 'agentos-node'
           printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'
-          python3 -m compileall -q agentos_node/social
-          bash -n scripts/install_social_runtime_user.sh
+          python3 -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
+          bash -n scripts/deploy_social_runtime_user.sh
           echo "social_runtime_rollout_source_ref=core/integration"
           echo "social_runtime_rollout_source_commit=$GITHUB_SHA"
 
-      - name: Install exact-generation shared runtime
+      - name: Publish bounded bootstrap hook and request deploy
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/install_social_runtime_user.sh "$GITHUB_WORKSPACE" "$GITHUB_SHA"
+          LIVE=/home/ubuntu/agentmanager
+          ROOT=/tmp/agentos-bootstrap-control
+          REQUESTS="$ROOT/requests"
+          RECEIPTS="$ROOT/receipts"
+          REQUEST_ID="social-runtime-rollout-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          REQUEST="$REQUESTS/$REQUEST_ID.request.json"
+          RECEIPT="$RECEIPTS/$REQUEST_ID.json"
 
-      - name: Verify bounded unconfigured endpoint
+          test -w "$LIVE/agentos_node" || test -w "$LIVE/agentos_node/bootstrap_control.py"
+          cat agentos_node/bootstrap_control.py > "$LIVE/agentos_node/bootstrap_control.py"
+          chmod 0664 "$LIVE/agentos_node/bootstrap_control.py" || true
+          python3 -m py_compile "$LIVE/agentos_node/bootstrap_control.py"
+
+          for i in $(seq 1 120); do
+            [ -d "$REQUESTS" ] && [ -d "$RECEIPTS" ] && break
+            sleep 1
+          done
+          test -d "$REQUESTS"
+          test -d "$RECEIPTS"
+          test "$(stat -c '%U' "$REQUESTS")" = ubuntu
+          test "$(stat -c '%a' "$REQUESTS")" = 1777
+
+          python3 - "$REQUEST" "$REQUEST_ID" "$GITHUB_SHA" <<'PY'
+          import json, os, sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+          path = Path(sys.argv[1]); request_id = sys.argv[2]; sha = sys.argv[3]
+          payload = {
+              "schema": "agentos.bootstrap-request/v1",
+              "request_id": request_id,
+              "action": "agentos.social_runtime.deploy",
+              "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "params": {"source_commit": sha},
+              "authority": {"source": "github-actions", "target_user": "ubuntu", "arbitrary_shell": False},
+          }
+          tmp = path.with_suffix(path.suffix + ".tmp")
+          tmp.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+          os.chmod(tmp, 0o600); tmp.replace(path); os.chmod(path, 0o600)
+          PY
+
+          for i in $(seq 1 360); do [ -f "$RECEIPT" ] && break; sleep 1; done
+          test -f "$RECEIPT" || { echo 'social_runtime_bootstrap_receipt=TIMEOUT'; exit 3; }
+
+          python3 - "$RECEIPT" "$GITHUB_SHA" <<'PY'
+          import json, sys
+          receipt = json.load(open(sys.argv[1], encoding='utf-8')); expected = sys.argv[2]
+          assert receipt.get('schema') == 'agentos.bootstrap-receipt/v1', receipt
+          assert receipt.get('action') == 'agentos.social_runtime.deploy', receipt
+          assert receipt.get('executor_user') == 'ubuntu', receipt
+          assert receipt.get('executor_uid') == 1001, receipt
+          assert receipt.get('source_commit') == expected, receipt
+          assert receipt.get('ok') is True, receipt
+          text = '\n'.join(str(s.get('stdout', '')) + '\n' + str(s.get('stderr', '')) for s in receipt.get('steps', []))
+          assert 'social_runtime_deploy=PASS' in text, text[-12000:]
+          assert 'social_runtime_service_identity=ubuntu' in text, text[-12000:]
+          assert 'social_runtime_root_privilege=NONE' in text, text[-12000:]
+          assert f'social_runtime_source_commit={expected}' in text, text[-12000:]
+          print('social_runtime_bootstrap_receipt=PASS')
+          print('social_runtime_bootstrap_executor=ubuntu')
+          PY
+
+      - name: Verify bounded local endpoint independently
         shell: bash
         run: |
           set -euo pipefail
-          RUNTIME="$HOME/.local/share/agentos/social-runtime"
-          ENV_FILE="$HOME/.config/agentos/social-runtime.env"
-          test "$(stat -c '%a' "$ENV_FILE")" = 600
-          grep -q '^source_ref=core/integration$' "$RUNTIME/GENERATION"
-          grep -q "^source_commit=$GITHUB_SHA$" "$RUNTIME/GENERATION"
-          systemctl --user is-active --quiet agentos-social-runtime.service
           curl -fsS --max-time 3 http://127.0.0.1:8771/healthz > "$RUNNER_TEMP/social-runtime-health.json"
           python3 - "$RUNNER_TEMP/social-runtime-health.json" <<'PY'
           import json, sys

--- a/agentos_node/bootstrap_control.py
+++ b/agentos_node/bootstrap_control.py
@@ -14,7 +14,12 @@ SCHEMA = "agentos.bootstrap-request/v1"
 RECEIPT_SCHEMA = "agentos.bootstrap-receipt/v1"
 ACTION_REPAIR_TRANSPORT = "agentos.transport.repair"
 ACTION_DEPLOY_REALM_GATEWAY = "agentos.realm_gateway.deploy"
-ALLOWED_ACTIONS = {ACTION_REPAIR_TRANSPORT, ACTION_DEPLOY_REALM_GATEWAY}
+ACTION_DEPLOY_SOCIAL_RUNTIME = "agentos.social_runtime.deploy"
+ALLOWED_ACTIONS = {
+    ACTION_REPAIR_TRANSPORT,
+    ACTION_DEPLOY_REALM_GATEWAY,
+    ACTION_DEPLOY_SOCIAL_RUNTIME,
+}
 MAX_REQUEST_AGE_SECONDS = 900
 REQUEST_OWNER = "agentos-node"
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -70,8 +75,8 @@ def _validate_request(path: Path, payload: dict[str, Any]) -> tuple[str, str, st
     source_commit = str(params.get("source_commit") or "").strip() or None
     if source_commit is not None and not COMMIT_RE.fullmatch(source_commit):
         raise ValueError("source_commit must be an exact lowercase 40-hex commit SHA")
-    if action == ACTION_DEPLOY_REALM_GATEWAY and source_commit is None:
-        raise ValueError("realm gateway deploy requires exact source_commit")
+    if action in {ACTION_DEPLOY_REALM_GATEWAY, ACTION_DEPLOY_SOCIAL_RUNTIME} and source_commit is None:
+        raise ValueError(f"{action} requires exact source_commit")
     created = _parse_time(str(payload.get("created_at") or ""))
     age = (datetime.now(timezone.utc) - created).total_seconds()
     if age < -60 or age > MAX_REQUEST_AGE_SECONDS:
@@ -147,6 +152,8 @@ def _execute(action: str, source_commit: str | None) -> dict[str, Any]:
         return _run_canonical_script("scripts/repair_antigravity_relay_user.sh", timeout=180, source_commit=source_commit, env_extra=env_extra)
     if action == ACTION_DEPLOY_REALM_GATEWAY:
         return _run_canonical_script("scripts/deploy_realm_gateway_user.sh", timeout=300, source_commit=source_commit)
+    if action == ACTION_DEPLOY_SOCIAL_RUNTIME:
+        return _run_canonical_script("scripts/deploy_social_runtime_user.sh", timeout=180, source_commit=source_commit)
     raise ValueError("unsupported bootstrap action")
 
 

--- a/scripts/deploy_social_runtime_user.sh
+++ b/scripts/deploy_social_runtime_user.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -un)" != "ubuntu" ]; then
+  echo "social_runtime_deploy=WRONG_USER" >&2
+  exit 2
+fi
+
+REPO="${AGENTOS_REPO:-/home/ubuntu/agentmanager}"
+SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"
+RUNTIME_ROOT="${HOME}/.local/share/agentos/social-runtime"
+STATE_ROOT="${HOME}/.local/state/agentos/social"
+CONFIG_ROOT="${HOME}/.config/agentos"
+UNIT_ROOT="${HOME}/.config/systemd/user"
+ENV_FILE="${CONFIG_ROOT}/social-runtime.env"
+UNIT_FILE="${UNIT_ROOT}/agentos-social-runtime.service"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$' || {
+  echo "social_runtime_deploy=SOURCE_COMMIT_REQUIRED" >&2
+  exit 2
+}
+test -d "$REPO/.git" || { echo "social_runtime_deploy=REPO_MISSING" >&2; exit 2; }
+
+git -C "$REPO" fetch --no-tags origin "$SOURCE_COMMIT"
+git -C "$REPO" cat-file -e "$SOURCE_COMMIT^{commit}"
+git -C "$REPO" archive "$SOURCE_COMMIT" agentos_node/social agentos_node/__init__.py | tar -x -C "$TMP_ROOT"
+test -f "$TMP_ROOT/agentos_node/social/runtime_http.py"
+test -f "$TMP_ROOT/agentos_node/social/runtime_storage.py"
+python3 -m compileall -q "$TMP_ROOT/agentos_node/social"
+
+mkdir -p "$RUNTIME_ROOT/agentos_node" "$STATE_ROOT" "$CONFIG_ROOT" "$UNIT_ROOT"
+rm -rf "$RUNTIME_ROOT/agentos_node/social"
+cp -a "$TMP_ROOT/agentos_node/social" "$RUNTIME_ROOT/agentos_node/social"
+cp "$TMP_ROOT/agentos_node/__init__.py" "$RUNTIME_ROOT/agentos_node/__init__.py"
+cat > "$RUNTIME_ROOT/GENERATION" <<EOF
+source_ref=core/integration
+source_commit=$SOURCE_COMMIT
+EOF
+chmod -R go-rwx "$RUNTIME_ROOT" "$STATE_ROOT" || true
+
+if [ ! -e "$ENV_FILE" ]; then
+  umask 077
+  cat > "$ENV_FILE" <<'EOF'
+# Runtime-owned shared configuration. Provider values are never committed.
+AGENTOS_SOCIAL_PRODUCTS_JSON={}
+AGENTOS_SOCIAL_CONTROL_TOKEN=
+AGENTOS_THREADS_APP_ID=
+AGENTOS_THREADS_APP_SECRET=
+AGENTOS_THREADS_REDIRECT_URI=
+EOF
+fi
+chmod 0600 "$ENV_FILE"
+
+cat > "$UNIT_FILE" <<EOF
+[Unit]
+Description=AgentOS Shared Social Runtime (Core control-plane identity)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$RUNTIME_ROOT
+Environment=PYTHONPATH=$RUNTIME_ROOT
+EnvironmentFile=$ENV_FILE
+ExecStart=/usr/bin/python3 -m agentos_node.social.runtime_http --host 127.0.0.1 --port 8771 --credential-path $STATE_ROOT/credentials.json
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$RUNTIME_ROOT $STATE_ROOT $CONFIG_ROOT
+
+[Install]
+WantedBy=default.target
+EOF
+
+# ubuntu is the existing persistent Core control-plane identity on Oracle.
+# This action deliberately adds no sudo/root/UID-switch or linger authority.
+systemctl --user daemon-reload
+systemctl --user enable agentos-social-runtime.service >/dev/null
+systemctl --user restart agentos-social-runtime.service
+
+stable=0
+for _ in $(seq 1 20); do
+  if systemctl --user is-active --quiet agentos-social-runtime.service; then
+    stable=$((stable + 1))
+    [ "$stable" -ge 3 ] && break
+  else
+    stable=0
+  fi
+  sleep 1
+done
+if [ "$stable" -lt 3 ]; then
+  systemctl --user --no-pager --full status agentos-social-runtime.service || true
+  journalctl --user -u agentos-social-runtime.service -n 80 --no-pager >&2 || true
+  echo "social_runtime_stable_liveness=FAIL" >&2
+  exit 4
+fi
+
+HEALTH_FILE="$STATE_ROOT/health.json"
+curl -fsS --max-time 3 http://127.0.0.1:8771/healthz > "$HEALTH_FILE"
+python3 - "$HEALTH_FILE" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1], encoding='utf-8'))
+assert p.get('schema') == 'agentos.social-runtime-status/v1', p
+assert p.get('service') == 'agentos-social-runtime', p
+threads = p.get('threads') or {}
+assert set(threads) == {'configured'}, p
+assert isinstance(threads.get('configured'), bool), p
+text = json.dumps(p, sort_keys=True).lower()
+for forbidden in ('app_secret', 'access_token', 'refresh_token', 'authorization_code'):
+    assert forbidden not in text, text
+print('social_runtime_health=PASS')
+print('social_runtime_threads_configured=' + str(threads['configured']).lower())
+PY
+
+grep -q '^source_ref=core/integration$' "$RUNTIME_ROOT/GENERATION"
+grep -q "^source_commit=$SOURCE_COMMIT$" "$RUNTIME_ROOT/GENERATION"
+echo "social_runtime_service_identity=ubuntu"
+echo "social_runtime_root_privilege=NONE"
+echo "social_runtime_source_ref=core/integration"
+echo "social_runtime_source_commit=$SOURCE_COMMIT"
+echo "social_runtime_stable_liveness=PASS"
+echo "social_runtime_deploy=PASS"

--- a/tests/test_social_runtime_bootstrap_contract.py
+++ b/tests/test_social_runtime_bootstrap_contract.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from agentos_node import bootstrap_control as bc
+
+
+SHA = "a" * 40
+
+
+def _payload(*, params: dict | None = None, authority: dict | None = None) -> dict:
+    return {
+        "schema": bc.SCHEMA,
+        "request_id": "social-test",
+        "action": bc.ACTION_DEPLOY_SOCIAL_RUNTIME,
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "params": {"source_commit": SHA} if params is None else params,
+        "authority": authority
+        or {"source": "github-actions", "target_user": "ubuntu", "arbitrary_shell": False},
+    }
+
+
+def _owned_request(tmp_path, monkeypatch):
+    path = tmp_path / "social-test.request.json"
+    path.write_text("{}\n", encoding="utf-8")
+    os.chmod(path, 0o600)
+    monkeypatch.setattr(bc.pwd, "getpwuid", lambda _uid: SimpleNamespace(pw_name="agentos-node"))
+    return path
+
+
+def test_social_runtime_action_is_explicitly_allowlisted():
+    assert bc.ACTION_DEPLOY_SOCIAL_RUNTIME == "agentos.social_runtime.deploy"
+    assert bc.ACTION_DEPLOY_SOCIAL_RUNTIME in bc.ALLOWED_ACTIONS
+
+
+def test_social_runtime_action_requires_exact_source_commit(tmp_path, monkeypatch):
+    path = _owned_request(tmp_path, monkeypatch)
+    with pytest.raises(ValueError, match="requires exact source_commit"):
+        bc._validate_request(path, _payload(params={}))
+    with pytest.raises(ValueError, match="40-hex"):
+        bc._validate_request(path, _payload(params={"source_commit": "main"}))
+
+
+def test_social_runtime_action_rejects_caller_selected_execution_fields(tmp_path, monkeypatch):
+    path = _owned_request(tmp_path, monkeypatch)
+    for forbidden in ("script", "path", "argv", "env", "user", "command"):
+        with pytest.raises(ValueError, match="unsupported bootstrap params"):
+            bc._validate_request(path, _payload(params={"source_commit": SHA, forbidden: "x"}))
+
+
+def test_social_runtime_action_requires_bounded_authority(tmp_path, monkeypatch):
+    path = _owned_request(tmp_path, monkeypatch)
+    with pytest.raises(ValueError, match="invalid authority envelope"):
+        bc._validate_request(
+            path,
+            _payload(authority={"source": "github-actions", "target_user": "agentos-node", "arbitrary_shell": False}),
+        )
+    with pytest.raises(ValueError, match="arbitrary shell is forbidden"):
+        bc._validate_request(
+            path,
+            _payload(authority={"source": "github-actions", "target_user": "ubuntu", "arbitrary_shell": True}),
+        )
+
+
+def test_social_runtime_execute_uses_only_fixed_canonical_script(monkeypatch):
+    calls = []
+
+    def fake(script_rel, *, timeout, source_commit=None, env_extra=None):
+        calls.append((script_rel, timeout, source_commit, env_extra))
+        return {"ok": True, "source_commit": source_commit}
+
+    monkeypatch.setattr(bc, "_run_canonical_script", fake)
+    result = bc._execute(bc.ACTION_DEPLOY_SOCIAL_RUNTIME, SHA)
+    assert result == {"ok": True, "source_commit": SHA}
+    assert calls == [("scripts/deploy_social_runtime_user.sh", 180, SHA, None)]


### PR DESCRIPTION
## Scope
Replace the failed direct `agentos-node` user-service rollout with the existing governed bootstrap boundary.

### Architecture
- Oracle GitHub runner remains `agentos-node` and can only submit a fixed-schema bootstrap request.
- New allowlisted action: `agentos.social_runtime.deploy`.
- Request may carry only the exact immutable `source_commit`; caller cannot choose script/path/argv/env/user/command.
- Existing ubuntu bootstrap worker executes only the fixed canonical `scripts/deploy_social_runtime_user.sh`.
- The social daemon runs as the existing persistent Core control-plane identity `ubuntu`; this adds no sudo/root/UID-switch/linger authority.
- Service stays local-only on `127.0.0.1:8771` and preserves runtime-owned private config/state.

### Evidence model
On merge to `core/integration`, Oracle rollout:
1. validates exact generation,
2. publishes the bounded bootstrap handler,
3. submits `agentos.social_runtime.deploy`,
4. requires a sanitized ubuntu bootstrap receipt tied to the exact commit,
5. independently probes `/healthz` from the `agentos-node` runner.

No Meta credentials are created or exposed. `threads.configured` remains only a boolean; social writes remain fail-closed without exact one-shot acceptance. #267 stays open until real shared Meta OAuth and real `text_attachment` publish evidence exist. LeopardCat #65 remains blocked until then. Protected `main` is untouched.