### PR TITLE
Core #267: fix bootstrap request read boundary

### DIFF
--- a/.github/workflows/oracle-social-runtime-rollout.yml
+++ b/.github/workflows/oracle-social-runtime-rollout.yml
@@ -73,7 +73,9 @@ jobs:
           }
           tmp = path.with_suffix(path.suffix + ".tmp")
           tmp.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-          os.chmod(tmp, 0o600); tmp.replace(path); os.chmod(path, 0o600)
+          # Owner remains agentos-node. The ubuntu bootstrap worker needs read access,
+          # while bootstrap validation rejects group/world writable request files.
+          os.chmod(tmp, 0o644); tmp.replace(path); os.chmod(path, 0o644)
           PY
 
           for i in $(seq 1 360); do [ -f "$RECEIPT" ] && break; sleep 1; done


### PR DESCRIPTION
## Fix
The third Oracle social rollout proved the new bootstrap architecture reached the ubuntu control plane, but the social request was created `0600` and therefore could not be read by ubuntu while owned by `agentos-node`.

The canonical bootstrap contract already uses `0644`: request ownership remains `agentos-node`, while validation rejects any group/world writable mode. This change aligns the social rollout with that existing boundary.

No authority expansion: no new action, no new params, no sudo/root/linger, no credential change. Protected `main` remains untouched.