### PR TITLE
Core #267: expose bounded shared social gateway

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -6,6 +6,7 @@ on:
       - core/issue-267-social-runtime
       - core/issue-267-social-runtime-rollout
       - core/issue-267-social-runtime-bootstrap
+      - core/issue-267-social-gateway
     paths:
       - 'agentos_node/social/**'
       - 'agentos_node/bootstrap_control.py'
@@ -14,6 +15,7 @@ on:
       - 'docs/SOCIAL_RUNTIME.md'
       - 'scripts/install_social_runtime_user.sh'
       - 'scripts/deploy_social_runtime_user.sh'
+      - 'dashboard/app/api/social/**'
       - '.github/workflows/core-social-runtime-guard.yml'
       - '.github/workflows/oracle-social-runtime-rollout.yml'
   pull_request:
@@ -27,6 +29,7 @@ on:
       - 'docs/SOCIAL_RUNTIME.md'
       - 'scripts/install_social_runtime_user.sh'
       - 'scripts/deploy_social_runtime_user.sh'
+      - 'dashboard/app/api/social/**'
       - '.github/workflows/core-social-runtime-guard.yml'
       - '.github/workflows/oracle-social-runtime-rollout.yml'
 
@@ -41,14 +44,40 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
       - name: Install focused test dependency
         run: python -m pip install --disable-pip-version-check pytest
       - name: Compile shared social runtime and bootstrap control
         run: python -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
-      - name: Validate rollout shell contracts
+      - name: Validate rollout shell and gateway boundary
         run: |
           bash -n scripts/install_social_runtime_user.sh
           bash -n scripts/deploy_social_runtime_user.sh
+          python3 - <<'PY'
+          from pathlib import Path
+          p=Path('dashboard/app/api/social/[...path]/route.ts')
+          s=p.read_text(encoding='utf-8')
+          for required in (
+              'http://127.0.0.1:8771',
+              '/v1/social/connect',
+              '/v1/social/publish',
+              '/v1/social/reply',
+              '/v1/social/disconnect',
+              '/v1/social/oauth/threads/callback',
+              '/dashboard/api/social/v1/social/oauth/threads/callback',
+              'x-agentos-product-key',
+              'x-agentos-acceptance-id',
+              'x-agentos-social-gateway',
+          ):
+              assert required in s, required
+          assert '/internal/v1/social/acceptances' not in s
+          assert 'x-agentos-control-token' not in s.lower()
+          print('social_gateway_static_boundary=PASS')
+          PY
       - name: Run shared runtime contract suite
         run: >-
           python -m pytest -q
@@ -56,3 +85,8 @@ jobs:
           tests/test_social_runtime_bootstrap_contract.py
           tests/test_social_capability_contract.py
           tests/test_social_threads_capability.py
+      - name: Build dashboard social gateway
+        working-directory: dashboard
+        run: |
+          npm ci
+          npm run build

--- a/.github/workflows/oracle-social-runtime-rollout.yml
+++ b/.github/workflows/oracle-social-runtime-rollout.yml
@@ -9,6 +9,7 @@ on:
       - 'agentos_node/bootstrap_control.py'
       - 'scripts/deploy_social_runtime_user.sh'
       - 'agentos_node/social/**'
+      - 'dashboard/app/api/social/**'
 
 permissions:
   contents: read
@@ -16,7 +17,7 @@ permissions:
 jobs:
   rollout:
     runs-on: [self-hosted, Linux, ARM64, oracle]
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -29,6 +30,7 @@ jobs:
           printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'
           python3 -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
           bash -n scripts/deploy_social_runtime_user.sh
+          test -f 'dashboard/app/api/social/[...path]/route.ts'
           echo "social_runtime_rollout_source_ref=core/integration"
           echo "social_runtime_rollout_source_commit=$GITHUB_SHA"
 
@@ -73,12 +75,10 @@ jobs:
           }
           tmp = path.with_suffix(path.suffix + ".tmp")
           tmp.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-          # Owner remains agentos-node. The ubuntu bootstrap worker needs read access,
-          # while bootstrap validation rejects group/world writable request files.
           os.chmod(tmp, 0o644); tmp.replace(path); os.chmod(path, 0o644)
           PY
 
-          for i in $(seq 1 360); do [ -f "$RECEIPT" ] && break; sleep 1; done
+          for i in $(seq 1 540); do [ -f "$RECEIPT" ] && break; sleep 1; done
           test -f "$RECEIPT" || { echo 'social_runtime_bootstrap_receipt=TIMEOUT'; exit 3; }
 
           python3 - "$RECEIPT" "$GITHUB_SHA" <<'PY'
@@ -91,39 +91,64 @@ jobs:
           assert receipt.get('source_commit') == expected, receipt
           assert receipt.get('ok') is True, receipt
           text = '\n'.join(str(s.get('stdout', '')) + '\n' + str(s.get('stderr', '')) for s in receipt.get('steps', []))
-          assert 'social_runtime_deploy=PASS' in text, text[-12000:]
-          assert 'social_runtime_service_identity=ubuntu' in text, text[-12000:]
-          assert 'social_runtime_root_privilege=NONE' in text, text[-12000:]
-          assert f'social_runtime_source_commit={expected}' in text, text[-12000:]
+          for marker in (
+              'social_runtime_deploy=PASS',
+              'social_runtime_service_identity=ubuntu',
+              'social_runtime_root_privilege=NONE',
+              'social_gateway_route_guard=PASS',
+              'social_gateway_dashboard_build=PASS',
+              'social_gateway_local=PASS',
+              'social_gateway_internal_control_public=BLOCKED',
+              'social_gateway_public=PASS',
+              'social_gateway_nginx_mutation=NONE',
+          ):
+              assert marker in text, (marker, text[-16000:])
+          assert f'social_runtime_source_commit={expected}' in text, text[-16000:]
           print('social_runtime_bootstrap_receipt=PASS')
           print('social_runtime_bootstrap_executor=ubuntu')
+          print('social_gateway_bootstrap_public=PASS')
           PY
 
-      - name: Verify bounded local endpoint independently
+      - name: Verify local and public endpoints independently
         shell: bash
         run: |
           set -euo pipefail
           curl -fsS --max-time 3 http://127.0.0.1:8771/healthz > "$RUNNER_TEMP/social-runtime-health.json"
-          python3 - "$RUNNER_TEMP/social-runtime-health.json" <<'PY'
+          curl -fsS --max-time 8 https://studio.milkcat.org/dashboard/api/social/healthz > "$RUNNER_TEMP/social-gateway-public-health.json"
+          python3 - "$RUNNER_TEMP/social-runtime-health.json" "$RUNNER_TEMP/social-gateway-public-health.json" <<'PY'
           import json, sys
-          p = json.load(open(sys.argv[1], encoding='utf-8'))
-          assert p.get('schema') == 'agentos.social-runtime-status/v1', p
-          assert p.get('service') == 'agentos-social-runtime', p
-          threads = p.get('threads')
-          assert isinstance(threads, dict) and set(threads) == {'configured'}, p
-          assert isinstance(threads['configured'], bool), p
-          text = json.dumps(p, sort_keys=True).lower()
-          for forbidden in ('app_secret', 'access_token', 'refresh_token', 'authorization_code'):
-              assert forbidden not in text, text
+          local = json.load(open(sys.argv[1], encoding='utf-8'))
+          public = json.load(open(sys.argv[2], encoding='utf-8'))
+          for p in (local, public):
+              assert p.get('schema') == 'agentos.social-runtime-status/v1', p
+              assert p.get('service') == 'agentos-social-runtime', p
+              threads = p.get('threads')
+              assert isinstance(threads, dict) and set(threads) == {'configured'}, p
+              assert isinstance(threads['configured'], bool), p
+              text = json.dumps(p, sort_keys=True).lower()
+              for forbidden in ('app_secret', 'access_token', 'refresh_token', 'authorization_code'):
+                  assert forbidden not in text, text
+          assert local == public, (local, public)
           print('oracle_social_runtime_endpoint=PASS')
-          print('oracle_social_runtime_configured=' + str(threads['configured']).lower())
+          print('oracle_social_gateway_public=PASS')
+          print('oracle_social_runtime_configured=' + str(local['threads']['configured']).lower())
           PY
+
+          code=$(curl -sS -o "$RUNNER_TEMP/social-gateway-internal-block.json" -w '%{http_code}' --max-time 8 \
+            -X POST https://studio.milkcat.org/dashboard/api/social/internal/v1/social/acceptances \
+            -H 'content-type: application/json' --data '{}')
+          test "$code" = 404
+          grep -q 'Social gateway route not allowlisted' "$RUNNER_TEMP/social-gateway-internal-block.json"
+          echo 'oracle_social_gateway_internal_control=BLOCKED'
 
       - name: Upload sanitized endpoint evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: oracle-social-runtime-${{ github.run_id }}
-          path: ${{ runner.temp }}/social-runtime-health.json
+          path: |
+            ${{ runner.temp }}/social-runtime-health.json
+            ${{ runner.temp }}/social-gateway-public-health.json
+            ${{ runner.temp }}/social-gateway-internal-block.json
           if-no-files-found: warn
           retention-days: 14

--- a/dashboard/app/api/social/[...path]/route.ts
+++ b/dashboard/app/api/social/[...path]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from "next/server";
+
+const UPSTREAM = "http://127.0.0.1:8771";
+const PUBLIC_CALLBACK_PATH = "/dashboard/api/social/v1/social/oauth/threads/callback";
+const INTERNAL_CALLBACK_PATH = "/v1/social/oauth/threads/callback";
+
+const ALLOWED: Record<string, Set<string>> = {
+  GET: new Set(["/healthz", INTERNAL_CALLBACK_PATH]),
+  POST: new Set([
+    "/v1/social/status",
+    "/v1/social/connect",
+    "/v1/social/publish",
+    "/v1/social/reply",
+    "/v1/social/disconnect",
+  ]),
+};
+
+function safePath(parts: string[]): string {
+  const path = "/" + parts.map((part) => encodeURIComponent(decodeURIComponent(part))).join("/");
+  if (path.includes("..")) throw new Error("invalid social path");
+  return path;
+}
+
+function rewriteCookiePath(value: string): string {
+  return value.replace(
+    /Path=\/v1\/social\/oauth\/threads\/callback(?=;|$)/i,
+    `Path=${PUBLIC_CALLBACK_PATH}`,
+  );
+}
+
+async function proxy(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+) {
+  const method = request.method.toUpperCase();
+  const { path: parts } = await context.params;
+  let path: string;
+  try {
+    path = safePath(parts || []);
+  } catch {
+    return Response.json({ ok: false, error: "Social gateway path invalid" }, { status: 404 });
+  }
+  if (!ALLOWED[method]?.has(path)) {
+    return Response.json(
+      { ok: false, error: "Social gateway route not allowlisted" },
+      { status: 404, headers: { "cache-control": "no-store", "x-agentos-social-gateway": "v0.1" } },
+    );
+  }
+
+  const incoming = new URL(request.url);
+  const target = new URL(path + incoming.search, UPSTREAM);
+  const headers = new Headers({ Accept: "application/json" });
+  const contentType = request.headers.get("content-type");
+  const productKey = request.headers.get("x-agentos-product-key");
+  const acceptanceId = request.headers.get("x-agentos-acceptance-id");
+  if (contentType) headers.set("content-type", contentType);
+  if (productKey) headers.set("x-agentos-product-key", productKey);
+  if (acceptanceId) headers.set("x-agentos-acceptance-id", acceptanceId);
+  if (method === "GET" && path === INTERNAL_CALLBACK_PATH) {
+    const cookie = request.headers.get("cookie");
+    if (cookie) headers.set("cookie", cookie);
+  }
+
+  const init: RequestInit = { method, headers, cache: "no-store", redirect: "manual" };
+  if (method !== "GET" && method !== "HEAD") init.body = await request.arrayBuffer();
+
+  try {
+    const upstream = await fetch(target, init);
+    const body = await upstream.arrayBuffer();
+    const responseHeaders = new Headers({
+      "content-type": upstream.headers.get("content-type") || "application/json; charset=utf-8",
+      "cache-control": "no-store",
+      "x-agentos-social-gateway": "v0.1",
+    });
+    const location = upstream.headers.get("location");
+    if (location) responseHeaders.set("location", location);
+    const setCookie = upstream.headers.get("set-cookie");
+    if (setCookie) responseHeaders.set("set-cookie", rewriteCookiePath(setCookie));
+    return new Response(body, { status: upstream.status, headers: responseHeaders });
+  } catch (error) {
+    return Response.json(
+      { ok: false, error: `Social upstream unavailable: ${error instanceof Error ? error.message : "unknown"}` },
+      { status: 502, headers: { "cache-control": "no-store", "x-agentos-social-gateway": "v0.1" } },
+    );
+  }
+}
+
+export async function GET(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  return proxy(request, context);
+}
+
+export async function POST(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  return proxy(request, context);
+}

--- a/scripts/deploy_social_runtime_user.sh
+++ b/scripts/deploy_social_runtime_user.sh
@@ -14,6 +14,12 @@ CONFIG_ROOT="${HOME}/.config/agentos"
 UNIT_ROOT="${HOME}/.config/systemd/user"
 ENV_FILE="${CONFIG_ROOT}/social-runtime.env"
 UNIT_FILE="${UNIT_ROOT}/agentos-social-runtime.service"
+DASH="$REPO/dashboard"
+ROUTE_REL='dashboard/app/api/social/[...path]/route.ts'
+ROUTE="$REPO/$ROUTE_REL"
+PUBLIC_HEALTH='https://studio.milkcat.org/dashboard/api/social/healthz'
+PUBLIC_INTERNAL='https://studio.milkcat.org/dashboard/api/social/internal/v1/social/acceptances'
+LOCAL_GATEWAY='http://127.0.0.1:3000/dashboard/api/social/healthz'
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -22,13 +28,34 @@ printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$' || {
   exit 2
 }
 test -d "$REPO/.git" || { echo "social_runtime_deploy=REPO_MISSING" >&2; exit 2; }
+test -f "$DASH/package.json" || { echo "social_gateway_deploy=DASHBOARD_MISSING" >&2; exit 2; }
 
 git -C "$REPO" fetch --no-tags origin "$SOURCE_COMMIT"
 git -C "$REPO" cat-file -e "$SOURCE_COMMIT^{commit}"
 git -C "$REPO" archive "$SOURCE_COMMIT" agentos_node/social agentos_node/__init__.py | tar -x -C "$TMP_ROOT"
+mkdir -p "$TMP_ROOT/route"
+git -C "$REPO" show "$SOURCE_COMMIT:$ROUTE_REL" > "$TMP_ROOT/route/route.ts"
 test -f "$TMP_ROOT/agentos_node/social/runtime_http.py"
 test -f "$TMP_ROOT/agentos_node/social/runtime_storage.py"
 python3 -m compileall -q "$TMP_ROOT/agentos_node/social"
+python3 - "$TMP_ROOT/route/route.ts" <<'PY'
+from pathlib import Path
+import sys
+s = Path(sys.argv[1]).read_text(encoding='utf-8')
+required = [
+    '127.0.0.1:8771',
+    '/v1/social/connect',
+    '/v1/social/publish',
+    '/v1/social/oauth/threads/callback',
+    '/dashboard/api/social/v1/social/oauth/threads/callback',
+    'x-agentos-social-gateway',
+]
+missing = [x for x in required if x not in s]
+assert not missing, missing
+assert '/internal/v1/social/acceptances' not in s
+assert 'x-agentos-control-token' not in s.lower()
+print('social_gateway_route_guard=PASS')
+PY
 
 mkdir -p "$RUNTIME_ROOT/agentos_node" "$STATE_ROOT" "$CONFIG_ROOT" "$UNIT_ROOT"
 rm -rf "$RUNTIME_ROOT/agentos_node/social"
@@ -117,6 +144,109 @@ print('social_runtime_health=PASS')
 print('social_runtime_threads_configured=' + str(threads['configured']).lower())
 PY
 
+find_dashboard_runtime() {
+  python3 - "$DASH" <<'PY'
+from pathlib import Path
+import os, sys
+root = Path('/proc'); target = str(Path(sys.argv[1]).resolve()); rows = []
+for entry in root.iterdir():
+    if not entry.name.isdigit(): continue
+    pid = int(entry.name)
+    try:
+        if entry.stat().st_uid != os.getuid(): continue
+        cwd = str((entry/'cwd').resolve())
+        raw = (entry/'cmdline').read_bytes().replace(b'\0', b' ').decode('utf-8','replace').strip()
+        ppid = -1
+        for line in (entry/'status').read_text().splitlines():
+            if line.startswith('PPid:'):
+                ppid = int(line.split()[1]); break
+        pgid = os.getpgid(pid)
+    except (OSError, PermissionError, ProcessLookupError):
+        continue
+    if cwd == target and (raw.startswith('npm start') or 'next start' in raw or raw.startswith('next-server')):
+        rows.append((pid, ppid, pgid, raw))
+for pid, ppid, pgid, raw in sorted(rows):
+    print(f'{pid}\t{ppid}\t{pgid}\t{raw}')
+PY
+}
+
+find_dashboard_npm_pid() {
+  find_dashboard_runtime | awk -F '\t' '$4 ~ /^npm start/ {print $1}'
+}
+
+restart_dashboard() {
+  local before groups old_npm new_npm own_pgid
+  before=$(find_dashboard_runtime)
+  [ -n "$before" ] || { echo "ERROR: no dashboard runtime found" >&2; return 4; }
+  old_npm=$(printf '%s\n' "$before" | awk -F '\t' '$4 ~ /^npm start/ {print $1}')
+  [ "$(printf '%s\n' "$old_npm" | sed '/^$/d' | wc -l)" -eq 1 ] || {
+    echo "ERROR: expected exactly one dashboard npm start, got: $old_npm" >&2; return 4;
+  }
+  groups=$(printf '%s\n' "$before" | awk -F '\t' '{print $3}' | sort -nu)
+  own_pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+  for pgid in $groups; do
+    [ "$pgid" != "$own_pgid" ] || { echo "ERROR: refusing own process group" >&2; return 4; }
+    kill -TERM -- "-$pgid" 2>/dev/null || true
+  done
+  new_npm=''
+  for _ in $(seq 1 30); do
+    sleep 1
+    new_npm=$(find_dashboard_npm_pid 2>/dev/null || true)
+    [ -n "$new_npm" ] && [ "$new_npm" != "$old_npm" ] && break
+  done
+  [ -n "$new_npm" ] && [ "$new_npm" != "$old_npm" ] || {
+    echo "ERROR: dashboard supervisor did not restart npm start" >&2; return 4;
+  }
+  echo "social_gateway_dashboard_old_pid=$old_npm"
+  echo "social_gateway_dashboard_new_pid=$new_npm"
+}
+
+mkdir -p "$(dirname "$ROUTE")"
+BACKUP="$TMP_ROOT/route.backup"
+HAD_ROUTE=0
+if [ -f "$ROUTE" ]; then cp "$ROUTE" "$BACKUP"; HAD_ROUTE=1; fi
+rollback_gateway() {
+  set +e
+  if [ "$HAD_ROUTE" = 1 ]; then cp "$BACKUP" "$ROUTE"; else rm -f "$ROUTE"; fi
+  (cd "$DASH" && npm run build >/tmp/agentos-social-gateway-rollback-build.log 2>&1)
+  restart_dashboard >/tmp/agentos-social-gateway-rollback-restart.log 2>&1 || true
+  set -e
+}
+trap 'rc=$?; if [ $rc -ne 0 ]; then rollback_gateway; fi; rm -rf "$TMP_ROOT"; exit $rc' EXIT
+cp "$TMP_ROOT/route/route.ts" "$ROUTE"
+chmod 0664 "$ROUTE" || true
+(cd "$DASH" && npm run build)
+echo "social_gateway_dashboard_build=PASS"
+restart_dashboard
+
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 3 "$LOCAL_GATEWAY" > "$TMP_ROOT/local-gateway-health.json" 2>/dev/null; then break; fi
+  sleep 1
+done
+curl -fsS --max-time 3 "$LOCAL_GATEWAY" > "$TMP_ROOT/local-gateway-health.json"
+grep -q 'agentos.social-runtime-status/v1' "$TMP_ROOT/local-gateway-health.json"
+echo "social_gateway_local=PASS"
+
+INTERNAL_CODE=$(curl -sS -o "$TMP_ROOT/internal-block.json" -w '%{http_code}' --max-time 5 -X POST "$PUBLIC_INTERNAL" -H 'content-type: application/json' --data '{}')
+[ "$INTERNAL_CODE" = 404 ]
+grep -q 'Social gateway route not allowlisted' "$TMP_ROOT/internal-block.json"
+echo "social_gateway_internal_control_public=BLOCKED"
+
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 5 "$PUBLIC_HEALTH" > "$TMP_ROOT/public-health.json" 2>/dev/null; then break; fi
+  sleep 1
+done
+curl -fsS --max-time 5 "$PUBLIC_HEALTH" > "$TMP_ROOT/public-health.json"
+python3 - "$TMP_ROOT/public-health.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1], encoding='utf-8'))
+assert p.get('schema') == 'agentos.social-runtime-status/v1', p
+assert p.get('service') == 'agentos-social-runtime', p
+assert set(p.get('threads') or {}) == {'configured'}, p
+print('social_gateway_public=PASS')
+print('social_gateway_public_configured=' + str(p['threads']['configured']).lower())
+PY
+
 grep -q '^source_ref=core/integration$' "$RUNTIME_ROOT/GENERATION"
 grep -q "^source_commit=$SOURCE_COMMIT$" "$RUNTIME_ROOT/GENERATION"
 echo "social_runtime_service_identity=ubuntu"
@@ -124,4 +254,6 @@ echo "social_runtime_root_privilege=NONE"
 echo "social_runtime_source_ref=core/integration"
 echo "social_runtime_source_commit=$SOURCE_COMMIT"
 echo "social_runtime_stable_liveness=PASS"
+echo "social_gateway_url=https://studio.milkcat.org/dashboard/api/social"
+echo "social_gateway_nginx_mutation=NONE"
 echo "social_runtime_deploy=PASS"


### PR DESCRIPTION
## Scope
Make the already-live Oracle shared social runtime product-reachable without introducing a generic proxy or new bootstrap authority.

### Gateway boundary
- Public base: `https://studio.milkcat.org/dashboard/api/social`
- Fixed upstream: `127.0.0.1:8771`
- GET allowlist: `/healthz`, Threads OAuth callback only
- POST allowlist: status/connect/publish/reply/disconnect only
- `/internal/v1/social/acceptances` is never public
- forwards only content type, product key, acceptance id, and callback cookie
- never forwards the internal control token
- preserves callback Location and rewrites the runtime callback cookie Path to the fixed public callback path

### Deployment
Reuses the existing fixed `agentos.social_runtime.deploy` bootstrap action. The ubuntu bootstrap executor materializes the exact runtime generation plus the one fixed social dashboard route, runs the dashboard build/restart using the existing supervisor pattern, then proves local/public health and public blocking of the internal control endpoint. No root/sudo/nginx mutation and no new caller-selectable params.

### Provider state
No Meta credentials are added. `threads.configured=false` remains valid until the shared provider configuration phase. LeopardCat #65 remains blocked until this shared endpoint is verified public.

Protected `main` is untouched.