### PR TITLE
Core #267: pin shared Threads callback URI

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -7,6 +7,7 @@ on:
       - core/issue-267-social-runtime-rollout
       - core/issue-267-social-runtime-bootstrap
       - core/issue-267-social-gateway
+      - core/issue-267-threads-redirect-contract
     paths:
       - 'agentos_node/social/**'
       - 'agentos_node/bootstrap_control.py'
@@ -53,14 +54,16 @@ jobs:
         run: python -m pip install --disable-pip-version-check pytest
       - name: Compile shared social runtime and bootstrap control
         run: python -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
-      - name: Validate rollout shell and gateway boundary
+      - name: Validate rollout shell, gateway, and redirect boundary
         run: |
           bash -n scripts/install_social_runtime_user.sh
           bash -n scripts/deploy_social_runtime_user.sh
           python3 - <<'PY'
           from pathlib import Path
-          p=Path('dashboard/app/api/social/[...path]/route.ts')
-          s=p.read_text(encoding='utf-8')
+          callback='https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback'
+          route=Path('dashboard/app/api/social/[...path]/route.ts').read_text(encoding='utf-8')
+          deploy=Path('scripts/deploy_social_runtime_user.sh').read_text(encoding='utf-8')
+          docs=Path('docs/SOCIAL_RUNTIME.md').read_text(encoding='utf-8')
           for required in (
               'http://127.0.0.1:8771',
               '/v1/social/connect',
@@ -73,10 +76,45 @@ jobs:
               'x-agentos-acceptance-id',
               'x-agentos-social-gateway',
           ):
-              assert required in s, required
-          assert '/internal/v1/social/acceptances' not in s
-          assert 'x-agentos-control-token' not in s.lower()
+              assert required in route, required
+          assert '/internal/v1/social/acceptances' not in route
+          assert 'x-agentos-control-token' not in route.lower()
+          assert f"THREADS_REDIRECT_URI='{callback}'" in deploy
+          assert 'social_runtime_threads_redirect=NON_CANONICAL' in deploy
+          assert 'social_runtime_threads_redirect=CANONICAL' in deploy
+          assert 'observed' not in deploy.split("social_runtime_threads_redirect=NON_CANONICAL", 1)[1][:200]
+          assert callback in docs
           print('social_gateway_static_boundary=PASS')
+          print('social_threads_redirect_contract=PASS')
+          PY
+      - name: Exercise redirect migration fail-closed semantics
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import os, tempfile
+          canonical='https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback'
+
+          def migrate(text: str):
+              lines=text.splitlines()
+              prefix='AGENTOS_THREADS_REDIRECT_URI='
+              indexes=[i for i,line in enumerate(lines) if line.startswith(prefix)]
+              if len(indexes)>1: return 'DUPLICATE', text
+              if not indexes:
+                  lines.append(prefix+canonical); return 'CANONICAL', '\n'.join(lines)+'\n'
+              idx=indexes[0]; observed=lines[idx][len(prefix):].strip()
+              if observed and observed != canonical: return 'NON_CANONICAL', text
+              lines[idx]=prefix+canonical; return 'CANONICAL', '\n'.join(lines)+'\n'
+
+          verdict, out=migrate('AGENTOS_THREADS_REDIRECT_URI=\nAGENTOS_THREADS_APP_SECRET=SECRET\n')
+          assert verdict=='CANONICAL' and canonical in out and 'SECRET' in out
+          verdict, out=migrate(f'AGENTOS_THREADS_REDIRECT_URI={canonical}\n')
+          assert verdict=='CANONICAL'
+          original='AGENTOS_THREADS_REDIRECT_URI=https://other.invalid/callback\nAGENTOS_THREADS_APP_SECRET=SECRET\n'
+          verdict, out=migrate(original)
+          assert verdict=='NON_CANONICAL' and out==original
+          verdict, _=migrate('AGENTOS_THREADS_REDIRECT_URI=\nAGENTOS_THREADS_REDIRECT_URI=\n')
+          assert verdict=='DUPLICATE'
+          print('social_threads_redirect_migration=PASS')
           PY
       - name: Run shared runtime contract suite
         run: >-

--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -80,9 +80,10 @@ jobs:
           assert '/internal/v1/social/acceptances' not in route
           assert 'x-agentos-control-token' not in route.lower()
           assert f"THREADS_REDIRECT_URI='{callback}'" in deploy
-          assert 'social_runtime_threads_redirect=NON_CANONICAL' in deploy
-          assert 'social_runtime_threads_redirect=CANONICAL' in deploy
-          assert 'observed' not in deploy.split("social_runtime_threads_redirect=NON_CANONICAL", 1)[1][:200]
+          assert "raise SystemExit('social_runtime_threads_redirect=NON_CANONICAL')" in deploy
+          assert "print('social_runtime_threads_redirect=CANONICAL')" in deploy
+          for leaking in ('print(observed)', 'print(f"{observed}', "print(f'{observed}", '% observed'):
+              assert leaking not in deploy, leaking
           assert callback in docs
           print('social_gateway_static_boundary=PASS')
           print('social_threads_redirect_contract=PASS')
@@ -90,8 +91,6 @@ jobs:
       - name: Exercise redirect migration fail-closed semantics
         run: |
           python3 - <<'PY'
-          from pathlib import Path
-          import os, tempfile
           canonical='https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback'
 
           def migrate(text: str):

--- a/docs/SOCIAL_RUNTIME.md
+++ b/docs/SOCIAL_RUNTIME.md
@@ -6,7 +6,9 @@ Issue: #267. This runtime activates the generic social capability extracted by #
 
 The runtime is a Core-owned service around `agentos_node.social`; product repositories do not import provider adapters, store Threads App Secret/access tokens, or exchange OAuth codes themselves.
 
-Default bind: `127.0.0.1:8771`. External exposure, if required, belongs behind the AgentOS/reverse-proxy authentication boundary. The service itself accepts only fixed JSON contracts and never arbitrary provider URLs, HTTP methods, commands, argv, or secret retrieval.
+Default bind: `127.0.0.1:8771`. The accepted public product boundary is `https://studio.milkcat.org/dashboard/api/social`, backed by a strict Next.js allowlist to the fixed local upstream. It is not a generic proxy: the internal acceptance endpoint and control token are never exposed publicly.
+
+The service itself accepts only fixed JSON contracts and never arbitrary provider URLs, HTTP methods, commands, argv, or secret retrieval.
 
 ### Product API
 
@@ -20,13 +22,13 @@ Default bind: `127.0.0.1:8771`. External exposure, if required, belongs behind t
 
 Product calls require an exact registered `product_id` plus `X-AgentOS-Product-Key`. Registration is runtime configuration, not repository data.
 
-`connect` creates a runtime-owned OAuth state and an HttpOnly/Secure/SameSite=Lax browser-session cookie. The provider callback must match both the single-use OAuth state and the original browser-session cookie. On success the browser is redirected only to the pre-registered product return base plus the previously validated relative `return_to` route. The return contains only connection/binding information; provider authorization code/token material stays server-side.
+`connect` creates a runtime-owned OAuth state and an HttpOnly/Secure/SameSite=Lax browser-session cookie. The public gateway rewrites only that callback cookie path from the runtime-local callback path to the fixed public callback path. The provider callback must match both the single-use OAuth state and the original browser-session cookie. On success the browser is redirected only to the pre-registered product return base plus the previously validated relative `return_to` route. The return contains only connection/binding information; provider authorization code/token material stays server-side.
 
 ### Runtime control API
 
 - `POST /internal/v1/social/acceptances`
 
-This route requires `X-AgentOS-Control-Token` and is deliberately separate from product authentication. It issues a process-local one-shot acceptance for exactly one:
+This route requires `X-AgentOS-Control-Token`, is deliberately separate from product authentication, and is not exposed through the public social gateway. It issues a process-local one-shot acceptance for exactly one:
 
 - product
 - platform
@@ -38,13 +40,18 @@ A credential/account binding never creates publish authority. Product credential
 
 ## Runtime-owned secret configuration
 
-No values belong in Git.
+No secret values belong in Git.
 
 - `AGENTOS_THREADS_APP_ID`
 - `AGENTOS_THREADS_APP_SECRET`
-- `AGENTOS_THREADS_REDIRECT_URI`
 - `AGENTOS_SOCIAL_CONTROL_TOKEN`
 - `AGENTOS_SOCIAL_PRODUCTS_JSON`
+
+The Threads redirect URI is a non-secret shared Core contract and is fixed to:
+
+`https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback`
+
+The Oracle host-local `AGENTOS_THREADS_REDIRECT_URI` entry is hydrated to that value only when it is missing or empty. A different non-empty operator value fails closed and is never overwritten or printed by the rollout.
 
 `AGENTOS_SOCIAL_PRODUCTS_JSON` maps product IDs to a runtime API key and a fixed return base, for example structurally (values omitted):
 
@@ -61,24 +68,26 @@ The provider config is shared by default. #267 does not create a LeopardCat-spec
 
 ## Credential storage
 
-The runtime persists account binding metadata and access tokens in its private runtime credential file (default `/home/ubuntu/agent-data/runtime/social/credentials.json`, mode `0600`). Products receive only the non-secret binding ID/provider account identity. Receipts remain subject to the recursive secret guard from #154.
+The runtime persists account binding metadata and access tokens in its private runtime credential file, mode `0600`. Products receive only the non-secret binding ID/provider account identity. Receipts remain subject to the recursive secret guard from #154.
 
-## Deployment
+## Deployment and current evidence
 
 ```bash
 python -m agentos_node.social.runtime_http --host 127.0.0.1 --port 8771
 ```
 
-The service is valid while Threads is unconfigured; `/healthz` reports `threads.configured=false` and OAuth connect fails closed. This permits deployment before shared Meta App credentials are provisioned.
+The Oracle persistent runtime and public gateway have live rollout evidence. The service remains valid while Threads is unconfigured; `/healthz` reports `threads.configured=false` and OAuth connect fails closed. This permits the Core-owned runtime, public route, and canonical callback URI to be deployed before the shared Meta App ID/Secret are provisioned.
 
 ## LeopardCat proving sequence
 
 1. Deploy this shared runtime from `core/integration`.
-2. Register `leopardcat-tarot` as a runtime consumer without creating a product-local Meta App.
-3. Install shared Meta App credentials in the runtime secret boundary when available.
-4. Complete a real Threads OAuth callback and capture only sanitized account binding evidence.
-5. Issue one exact write acceptance from the AgentOS control plane for a user-click-generated `write_intent_id`.
-6. Publish `primary_text` plus optional typed `text_attachment` through the runtime and retain only the secret-free receipt/permalink/object id.
-7. Then integrate LeopardCat #65 against the accepted endpoint; its existing production fallback remains valid until that live proof exists.
+2. Keep the fixed shared Threads callback registered as `https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback`.
+3. Register `leopardcat-tarot` as a runtime consumer without creating a product-local Meta App.
+4. Install shared Meta App ID/Secret in the host-local runtime secret boundary when available.
+5. Verify public `/healthz` changes to `threads.configured=true` without exposing provider values.
+6. Complete a real Threads OAuth callback and capture only sanitized account binding evidence.
+7. Issue one exact write acceptance from the AgentOS control plane for a user-click-generated `write_intent_id`.
+8. Publish `primary_text` plus optional typed `text_attachment` through the runtime and retain only the secret-free receipt/permalink/object id.
+9. Then integrate LeopardCat #65 against the accepted endpoint; its existing production fallback remains valid until that live proof exists.
 
 A live provider receipt is required before #267 can be closed. Unit/hosted CI proves the boundary and fail-closed behavior, not Meta availability or credentials.

--- a/scripts/deploy_social_runtime_user.sh
+++ b/scripts/deploy_social_runtime_user.sh
@@ -19,6 +19,7 @@ ROUTE_REL='dashboard/app/api/social/[...path]/route.ts'
 ROUTE="$REPO/$ROUTE_REL"
 PUBLIC_HEALTH='https://studio.milkcat.org/dashboard/api/social/healthz'
 PUBLIC_INTERNAL='https://studio.milkcat.org/dashboard/api/social/internal/v1/social/acceptances'
+THREADS_REDIRECT_URI='https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback'
 LOCAL_GATEWAY='http://127.0.0.1:3000/dashboard/api/social/healthz'
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -69,16 +70,57 @@ chmod -R go-rwx "$RUNTIME_ROOT" "$STATE_ROOT" || true
 
 if [ ! -e "$ENV_FILE" ]; then
   umask 077
-  cat > "$ENV_FILE" <<'EOF'
+  cat > "$ENV_FILE" <<EOF
 # Runtime-owned shared configuration. Provider values are never committed.
 AGENTOS_SOCIAL_PRODUCTS_JSON={}
 AGENTOS_SOCIAL_CONTROL_TOKEN=
 AGENTOS_THREADS_APP_ID=
 AGENTOS_THREADS_APP_SECRET=
-AGENTOS_THREADS_REDIRECT_URI=
+AGENTOS_THREADS_REDIRECT_URI=$THREADS_REDIRECT_URI
 EOF
 fi
 chmod 0600 "$ENV_FILE"
+
+# The redirect URI is part of the shared Core contract, not a product secret.
+# Existing operator configuration is preserved: only an empty value is hydrated.
+# A different non-empty value fails closed without printing that value.
+python3 - "$ENV_FILE" "$THREADS_REDIRECT_URI" <<'PY'
+from pathlib import Path
+import os, sys, tempfile
+path = Path(sys.argv[1])
+canonical = sys.argv[2]
+lines = path.read_text(encoding='utf-8').splitlines()
+prefix = 'AGENTOS_THREADS_REDIRECT_URI='
+indexes = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+if len(indexes) > 1:
+    raise SystemExit('social_runtime_threads_redirect=DUPLICATE_KEY')
+if not indexes:
+    lines.append(prefix + canonical)
+    changed = True
+else:
+    idx = indexes[0]
+    observed = lines[idx][len(prefix):].strip()
+    if observed and observed != canonical:
+        raise SystemExit('social_runtime_threads_redirect=NON_CANONICAL')
+    changed = observed != canonical
+    lines[idx] = prefix + canonical
+if changed:
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + '.', dir=str(path.parent), text=True)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            handle.write('\n'.join(lines) + '\n')
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+os.chmod(path, 0o600)
+print('social_runtime_threads_redirect=CANONICAL')
+PY
 
 cat > "$UNIT_FILE" <<EOF
 [Unit]


### PR DESCRIPTION
## Scope
Pin the shared Threads OAuth redirect URI to the already-live public social gateway without adding or exposing provider credentials.

Canonical callback:
`https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback`

### Host-local migration
- new runtime env files receive the canonical redirect URI
- existing empty/missing redirect entry is hydrated to the canonical URI
- existing canonical value is preserved/idempotent
- a different non-empty value fails closed
- duplicate redirect keys fail closed
- rollout never prints the observed non-canonical value
- env remains mode `0600`; App ID/Secret remain host-local and untouched

### Governance
This does not create a Meta App and does not create a LeopardCat-specific provider configuration. It only closes the callback-contract part of #267 so later shared Meta App activation requires credential injection rather than another architecture change.

Protected `main` remains untouched.