### PR TITLE
Core #267: add Threads lifecycle callbacks

### DIFF
--- a/agentos_node/social/provider_callbacks.py
+++ b/agentos_node/social/provider_callbacks.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any
+
+from .runtime_storage import FileCredentialVault
+from .threads import ThreadsProviderConfig, ThreadsProviderError, ThreadsProviderTransport
+
+
+def _b64url_decode(value: str) -> bytes:
+    value = str(value or "").strip()
+    if not value:
+        raise ValueError("threads_signed_request_invalid")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode((value + padding).encode("ascii"))
+    except Exception as exc:
+        raise ValueError("threads_signed_request_invalid") from exc
+
+
+def verify_signed_request(signed_request: str, app_secret: str) -> dict[str, Any]:
+    secret = str(app_secret or "")
+    if not secret:
+        raise ThreadsProviderError("threads_oauth_not_configured")
+    try:
+        encoded_sig, encoded_payload = str(signed_request or "").split(".", 1)
+    except ValueError as exc:
+        raise ValueError("threads_signed_request_invalid") from exc
+    actual_sig = _b64url_decode(encoded_sig)
+    expected_sig = hmac.new(secret.encode("utf-8"), encoded_payload.encode("ascii"), hashlib.sha256).digest()
+    if not hmac.compare_digest(actual_sig, expected_sig):
+        raise PermissionError("threads_signed_request_signature_invalid")
+    try:
+        payload = json.loads(_b64url_decode(encoded_payload).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("threads_signed_request_payload_invalid") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("threads_signed_request_payload_invalid")
+    algorithm = str(payload.get("algorithm") or "HMAC-SHA256").upper()
+    if algorithm != "HMAC-SHA256":
+        raise PermissionError("threads_signed_request_algorithm_invalid")
+    return payload
+
+
+@dataclass(frozen=True)
+class ThreadsLifecycleCallbacks:
+    vault: FileCredentialVault
+    transport: ThreadsProviderTransport
+    public_base: str
+
+    def _config(self) -> ThreadsProviderConfig:
+        return self.transport.config()
+
+    def _payload(self, signed_request: str) -> dict[str, Any]:
+        return verify_signed_request(signed_request, self._config().app_secret)
+
+    def _provider_user_id(self, payload: dict[str, Any]) -> str:
+        user_id = str(payload.get("user_id") or payload.get("id") or "").strip()
+        if not user_id:
+            raise ValueError("threads_signed_request_user_id_required")
+        return user_id
+
+    def deauthorize(self, signed_request: str) -> dict[str, Any]:
+        payload = self._payload(signed_request)
+        user_id = self._provider_user_id(payload)
+        removed = self.vault.disconnect_provider_account(platform="threads", provider_account_id=user_id)
+        return {
+            "schema": "agentos.social-provider-deauthorization/v1",
+            "ok": True,
+            "platform": "threads",
+            "bindings_removed": removed,
+        }
+
+    def data_deletion(self, signed_request: str) -> dict[str, Any]:
+        payload = self._payload(signed_request)
+        user_id = self._provider_user_id(payload)
+        removed = self.vault.disconnect_provider_account(platform="threads", provider_account_id=user_id)
+        confirmation_code = secrets.token_urlsafe(18)
+        base = self.public_base.rstrip("/")
+        status_url = (
+            base
+            + "/v1/social/webhooks/threads/data-deletion/status?"
+            + urllib.parse.urlencode({"code": confirmation_code})
+        )
+        return {
+            "url": status_url,
+            "confirmation_code": confirmation_code,
+            "bindings_removed": removed,
+        }

--- a/agentos_node/social/runtime_http.py
+++ b/agentos_node/social/runtime_http.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from .contracts import SocialRequest
 from .oauth import sanitized_oauth_return
+from .provider_callbacks import ThreadsLifecycleCallbacks
 from .runtime_storage import FileCredentialVault, OneShotAcceptanceStore
 from .threads import ThreadsCapability, ThreadsProviderConfig, ThreadsProviderTransport
 
@@ -23,6 +24,7 @@ MAX_BODY = 64 * 1024
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8771
 DEFAULT_CREDENTIAL_PATH = Path("/home/ubuntu/agent-data/runtime/social/credentials.json")
+DEFAULT_PUBLIC_BASE = "https://studio.milkcat.org/dashboard/api/social"
 SESSION_COOKIE = "agentos_social_session"
 
 
@@ -102,12 +104,14 @@ class SocialRuntime:
         acceptances: OneShotAcceptanceStore | None = None,
         browser_contexts: BrowserContextStore | None = None,
         control_token: str = "",
+        threads_lifecycle: ThreadsLifecycleCallbacks | None = None,
     ) -> None:
         self.products = products
         self.threads = threads
         self.acceptances = acceptances or OneShotAcceptanceStore()
         self.browser_contexts = browser_contexts or BrowserContextStore()
         self.control_token = control_token
+        self.threads_lifecycle = threads_lifecycle
 
     @classmethod
     def from_env(cls, credential_path: str | Path = DEFAULT_CREDENTIAL_PATH) -> "SocialRuntime":
@@ -121,10 +125,18 @@ class SocialRuntime:
                 redirect_uri=os.environ.get("AGENTOS_THREADS_REDIRECT_URI", ""),
             )
 
+        transport = ThreadsProviderTransport(config_loader)
+        threads = ThreadsCapability(vault, transport)
+        lifecycle = ThreadsLifecycleCallbacks(
+            vault=vault,
+            transport=transport,
+            public_base=os.environ.get("AGENTOS_SOCIAL_PUBLIC_BASE", DEFAULT_PUBLIC_BASE),
+        )
         return cls(
             products=products,
-            threads=ThreadsCapability(vault, ThreadsProviderTransport(config_loader)),
+            threads=threads,
             control_token=os.environ.get("AGENTOS_SOCIAL_CONTROL_TOKEN", ""),
+            threads_lifecycle=lifecycle,
         )
 
     def configured_status(self) -> dict[str, Any]:
@@ -167,6 +179,16 @@ class SocialRuntime:
             "account": result.get("account"),
         }
 
+    def provider_deauthorize(self, signed_request: str) -> dict[str, Any]:
+        if self.threads_lifecycle is None:
+            raise RuntimeError("threads_lifecycle_callbacks_unavailable")
+        return self.threads_lifecycle.deauthorize(signed_request)
+
+    def provider_data_deletion(self, signed_request: str) -> dict[str, Any]:
+        if self.threads_lifecycle is None:
+            raise RuntimeError("threads_lifecycle_callbacks_unavailable")
+        return self.threads_lifecycle.data_deletion(signed_request)
+
     def issue_acceptance(self, request: SocialRequest, supplied_control_token: str) -> dict[str, str]:
         if not self.control_token or not hmac.compare_digest(self.control_token, str(supplied_control_token or "")):
             raise PermissionError("social_runtime_control_auth_failed")
@@ -202,17 +224,33 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _body(self) -> dict[str, Any]:
+    def _raw_body(self) -> bytes:
         try:
             length = int(self.headers.get("Content-Length", "0"))
         except ValueError as exc:
             raise ValueError("invalid_content_length") from exc
         if length <= 0 or length > MAX_BODY:
             raise ValueError("request_body_size_invalid")
-        value = json.loads(self.rfile.read(length).decode("utf-8"))
+        return self.rfile.read(length)
+
+    def _body(self) -> dict[str, Any]:
+        value = json.loads(self._raw_body().decode("utf-8"))
         if not isinstance(value, dict):
             raise ValueError("json_object_required")
         return value
+
+    def _signed_request(self) -> str:
+        content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        raw = self._raw_body().decode("utf-8")
+        if content_type == "application/json":
+            value = json.loads(raw)
+            signed = value.get("signed_request") if isinstance(value, dict) else ""
+        else:
+            signed = (urllib.parse.parse_qs(raw, keep_blank_values=True).get("signed_request") or [""])[0]
+        signed = str(signed or "")
+        if not signed:
+            raise ValueError("threads_signed_request_required")
+        return signed
 
     def _request(self, body: dict[str, Any]) -> SocialRequest:
         allowed = {
@@ -236,6 +274,13 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
         parsed = urllib.parse.urlsplit(self.path)
         if parsed.path == "/healthz":
             self._json(HTTPStatus.OK, self.runtime.configured_status())
+            return
+        if parsed.path == "/v1/social/webhooks/threads/data-deletion/status":
+            code = str((urllib.parse.parse_qs(parsed.query).get("code") or [""])[0])
+            if not code:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "confirmation_code_required"})
+                return
+            self._json(HTTPStatus.OK, {"status": "completed", "confirmation_code": code})
             return
         if parsed.path == "/v1/social/oauth/threads/callback":
             query = urllib.parse.parse_qs(parsed.query)
@@ -267,24 +312,32 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802
         try:
+            parsed = urllib.parse.urlsplit(self.path)
+            if parsed.path == "/v1/social/webhooks/threads/deauthorize":
+                self._json(HTTPStatus.OK, self.runtime.provider_deauthorize(self._signed_request()))
+                return
+            if parsed.path == "/v1/social/webhooks/threads/data-deletion":
+                self._json(HTTPStatus.OK, self.runtime.provider_data_deletion(self._signed_request()))
+                return
+
             body = self._body()
             request = self._request(body)
-            if self.path == "/v1/social/status":
+            if parsed.path == "/v1/social/status":
                 self._product_auth(request)
                 self._json(HTTPStatus.OK, self.runtime.status(request))
                 return
-            if self.path == "/v1/social/connect":
+            if parsed.path == "/v1/social/connect":
                 self._product_auth(request)
                 value = self.runtime.connect(request)
                 browser_session_id = str(value.pop("browser_session_id"))
                 self._json(HTTPStatus.OK, value, session_cookie=browser_session_id)
                 return
-            if self.path in {"/v1/social/publish", "/v1/social/reply", "/v1/social/disconnect"}:
+            if parsed.path in {"/v1/social/publish", "/v1/social/reply", "/v1/social/disconnect"}:
                 self._product_auth(request)
                 acceptance_id = self.headers.get("X-AgentOS-Acceptance-ID", "")
                 self._json(HTTPStatus.OK, self.runtime.execute_write(request, acceptance_id))
                 return
-            if self.path == "/internal/v1/social/acceptances":
+            if parsed.path == "/internal/v1/social/acceptances":
                 value = self.runtime.issue_acceptance(request, self.headers.get("X-AgentOS-Control-Token", ""))
                 self._json(HTTPStatus.CREATED, value)
                 return
@@ -297,7 +350,7 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
             self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"ok": False, "error": str(exc)})
 
     def log_message(self, fmt: str, *args: Any) -> None:
-        # Avoid writing OAuth codes, write payloads, or product content to generic logs.
+        # Avoid writing OAuth codes, signed requests, write payloads, or product content to generic logs.
         return
 
 

--- a/agentos_node/social/runtime_storage.py
+++ b/agentos_node/social/runtime_storage.py
@@ -99,6 +99,33 @@ class FileCredentialVault(CredentialVault):
             value["bindings"].pop(binding_id, None)
             self._save(value)
 
+    def disconnect_provider_account(self, *, platform: str, provider_account_id: str) -> int:
+        """Delete every local binding/token for an authenticated provider account.
+
+        Provider lifecycle callbacks do not carry product credentials, so removal
+        must be keyed by the provider identity proven by the provider signature.
+        Only matching bindings are deleted; token values are never returned.
+        """
+        platform = str(platform or "").strip()
+        provider_account_id = str(provider_account_id or "").strip()
+        if not platform or not provider_account_id:
+            raise ValueError("provider_account_scope_required")
+        with self._lock:
+            value = self._load()
+            bindings = value["bindings"]
+            matching = [
+                binding_id
+                for binding_id, item in bindings.items()
+                if isinstance(item, dict)
+                and str(item.get("platform") or "") == platform
+                and str(item.get("provider_account_id") or "") == provider_account_id
+            ]
+            for binding_id in matching:
+                bindings.pop(binding_id, None)
+            if matching:
+                self._save(value)
+            return len(matching)
+
 
 @dataclass(frozen=True)
 class OneShotAcceptance:

--- a/dashboard/app/api/social/[...path]/route.ts
+++ b/dashboard/app/api/social/[...path]/route.ts
@@ -3,15 +3,20 @@ import { NextRequest } from "next/server";
 const UPSTREAM = "http://127.0.0.1:8771";
 const PUBLIC_CALLBACK_PATH = "/dashboard/api/social/v1/social/oauth/threads/callback";
 const INTERNAL_CALLBACK_PATH = "/v1/social/oauth/threads/callback";
+const THREADS_DEAUTHORIZE_PATH = "/v1/social/webhooks/threads/deauthorize";
+const THREADS_DATA_DELETION_PATH = "/v1/social/webhooks/threads/data-deletion";
+const THREADS_DATA_DELETION_STATUS_PATH = "/v1/social/webhooks/threads/data-deletion/status";
 
 const ALLOWED: Record<string, Set<string>> = {
-  GET: new Set(["/healthz", INTERNAL_CALLBACK_PATH]),
+  GET: new Set(["/healthz", INTERNAL_CALLBACK_PATH, THREADS_DATA_DELETION_STATUS_PATH]),
   POST: new Set([
     "/v1/social/status",
     "/v1/social/connect",
     "/v1/social/publish",
     "/v1/social/reply",
     "/v1/social/disconnect",
+    THREADS_DEAUTHORIZE_PATH,
+    THREADS_DATA_DELETION_PATH,
   ]),
 };
 

--- a/tests/test_social_provider_callbacks.py
+++ b/tests/test_social_provider_callbacks.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos_node.social.credentials import AccountBinding
+from agentos_node.social.provider_callbacks import ThreadsLifecycleCallbacks, verify_signed_request
+from agentos_node.social.runtime_storage import FileCredentialVault
+from agentos_node.social.threads import ThreadsProviderConfig, ThreadsProviderTransport
+
+
+def b64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def signed_request(payload: dict, secret: str = "app-secret") -> str:
+    encoded_payload = b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signature = hmac.new(secret.encode("utf-8"), encoded_payload.encode("ascii"), hashlib.sha256).digest()
+    return f"{b64url(signature)}.{encoded_payload}"
+
+
+def transport() -> ThreadsProviderTransport:
+    return ThreadsProviderTransport(
+        lambda: ThreadsProviderConfig(
+            app_id="app-id",
+            app_secret="app-secret",
+            redirect_uri="https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback",
+        )
+    )
+
+
+def callbacks(tmp_path: Path):
+    vault = FileCredentialVault(tmp_path / "credentials.json")
+    cb = ThreadsLifecycleCallbacks(
+        vault=vault,
+        transport=transport(),
+        public_base="https://studio.milkcat.org/dashboard/api/social",
+    )
+    return cb, vault
+
+
+def test_signed_request_requires_valid_hmac_sha256():
+    value = signed_request({"algorithm": "HMAC-SHA256", "user_id": "42"})
+    assert verify_signed_request(value, "app-secret")["user_id"] == "42"
+    with pytest.raises(PermissionError, match="signature_invalid"):
+        verify_signed_request(value, "wrong-secret")
+
+
+def test_deauthorize_removes_all_local_bindings_for_provider_account(tmp_path: Path):
+    cb, vault = callbacks(tmp_path)
+    vault.bind(AccountBinding("p1:threads:42", "p1", "threads", "42", "cat"), "TOKEN-1")
+    vault.bind(AccountBinding("p2:threads:42", "p2", "threads", "42", "cat"), "TOKEN-2")
+    vault.bind(AccountBinding("p1:threads:99", "p1", "threads", "99", "other"), "TOKEN-3")
+
+    result = cb.deauthorize(signed_request({"algorithm": "HMAC-SHA256", "user_id": "42"}))
+
+    assert result == {
+        "schema": "agentos.social-provider-deauthorization/v1",
+        "ok": True,
+        "platform": "threads",
+        "bindings_removed": 2,
+    }
+    assert vault.get_binding("p1:threads:42") is None
+    assert vault.get_binding("p2:threads:42") is None
+    assert vault.get_binding("p1:threads:99") is not None
+    assert "TOKEN" not in repr(result)
+
+
+def test_data_deletion_removes_binding_and_returns_provider_confirmation(tmp_path: Path):
+    cb, vault = callbacks(tmp_path)
+    vault.bind(AccountBinding("p:threads:42", "p", "threads", "42", "cat"), "SECRET-TOKEN")
+
+    result = cb.data_deletion(signed_request({"algorithm": "HMAC-SHA256", "user_id": "42"}))
+
+    assert vault.get_binding("p:threads:42") is None
+    assert result["confirmation_code"]
+    assert result["url"].startswith(
+        "https://studio.milkcat.org/dashboard/api/social/v1/social/webhooks/threads/data-deletion/status?code="
+    )
+    assert "SECRET-TOKEN" not in repr(result)
+
+
+def test_invalid_signature_does_not_delete_binding(tmp_path: Path):
+    cb, vault = callbacks(tmp_path)
+    vault.bind(AccountBinding("p:threads:42", "p", "threads", "42", "cat"), "SECRET-TOKEN")
+    forged = signed_request({"algorithm": "HMAC-SHA256", "user_id": "42"}, secret="forged")
+
+    with pytest.raises(PermissionError, match="signature_invalid"):
+        cb.data_deletion(forged)
+
+    assert vault.get_binding("p:threads:42") is not None


### PR DESCRIPTION
Adds bounded provider-required Threads lifecycle callbacks for Meta app configuration:

- signed-request HMAC-SHA256 verification using the server-side Threads App Secret
- deauthorize callback removes all local bindings/tokens for the authenticated provider account
- data-deletion callback removes local bindings and returns a confirmation URL/code
- public gateway allowlists only the two lifecycle POST callbacks plus deletion-status GET
- no product key or control token is exposed to Meta; internal acceptance endpoint remains non-public
- no provider secret or token is returned/logged
- focused tests cover valid/forged signatures and deletion scope

Target: `core/integration` only. Protected `main` untouched.