### PR TITLE
fix(social): add safe browser OAuth handoff for #267

### DIFF
--- a/.github/workflows/core-social-runtime-guard.yml
+++ b/.github/workflows/core-social-runtime-guard.yml
@@ -8,6 +8,7 @@ on:
       - core/issue-267-social-runtime-bootstrap
       - core/issue-267-social-gateway
       - core/issue-267-threads-redirect-contract
+      - core/issue-267-browser-handoff
     paths:
       - 'agentos_node/social/**'
       - 'agentos_node/bootstrap_control.py'
@@ -54,7 +55,7 @@ jobs:
         run: python -m pip install --disable-pip-version-check pytest
       - name: Compile shared social runtime and bootstrap control
         run: python -m compileall -q agentos_node/social agentos_node/bootstrap_control.py
-      - name: Validate rollout shell, gateway, and redirect boundary
+      - name: Validate rollout shell, gateway, browser handoff, and redirect boundary
         run: |
           bash -n scripts/install_social_runtime_user.sh
           bash -n scripts/deploy_social_runtime_user.sh
@@ -62,6 +63,7 @@ jobs:
           from pathlib import Path
           callback='https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback'
           route=Path('dashboard/app/api/social/[...path]/route.ts').read_text(encoding='utf-8')
+          runtime=Path('agentos_node/social/runtime_http.py').read_text(encoding='utf-8')
           deploy=Path('scripts/deploy_social_runtime_user.sh').read_text(encoding='utf-8')
           docs=Path('docs/SOCIAL_RUNTIME.md').read_text(encoding='utf-8')
           for required in (
@@ -70,6 +72,7 @@ jobs:
               '/v1/social/publish',
               '/v1/social/reply',
               '/v1/social/disconnect',
+              '/v1/social/oauth/threads/start',
               '/v1/social/oauth/threads/callback',
               '/dashboard/api/social/v1/social/oauth/threads/callback',
               'x-agentos-product-key',
@@ -79,13 +82,20 @@ jobs:
               assert required in route, required
           assert '/internal/v1/social/acceptances' not in route
           assert 'x-agentos-control-token' not in route.lower()
+          assert 'agentos.social-browser-handoff/v1' in runtime
+          assert 'browser_start_url' in runtime
+          assert 'ticket' in runtime
+          assert 'api_key' not in runtime.split('browser_start_url', 1)[1].split('\n', 8)[0]
           assert f"THREADS_REDIRECT_URI='{callback}'" in deploy
           assert "raise SystemExit('social_runtime_threads_redirect=NON_CANONICAL')" in deploy
           assert "print('social_runtime_threads_redirect=CANONICAL')" in deploy
           for leaking in ('print(observed)', 'print(f"{observed}', "print(f'{observed}", '% observed'):
               assert leaking not in deploy, leaking
           assert callback in docs
+          assert 'opaque `browser_start_url`' in docs
+          assert 'product key MUST remain server-side' in docs
           print('social_gateway_static_boundary=PASS')
+          print('social_browser_handoff_boundary=PASS')
           print('social_threads_redirect_contract=PASS')
           PY
       - name: Exercise redirect migration fail-closed semantics

--- a/agentos_node/social/runtime_http.py
+++ b/agentos_node/social/runtime_http.py
@@ -5,6 +5,7 @@ import hmac
 import json
 import os
 import secrets
+import time
 import urllib.parse
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -26,6 +27,7 @@ DEFAULT_PORT = 8771
 DEFAULT_CREDENTIAL_PATH = Path("/home/ubuntu/agent-data/runtime/social/credentials.json")
 DEFAULT_PUBLIC_BASE = "https://studio.milkcat.org/dashboard/api/social"
 SESSION_COOKIE = "agentos_social_session"
+BROWSER_HANDOFF_TTL_SECONDS = 300
 
 
 @dataclass(frozen=True)
@@ -95,6 +97,43 @@ class BrowserContextStore:
         return product_id, expected_session
 
 
+@dataclass(frozen=True)
+class BrowserHandoff:
+    product_id: str
+    platform: str
+    return_to: str
+    expires_at: float
+
+
+class BrowserHandoffStore:
+    """Opaque one-time bridge from authenticated product backend to the user's browser."""
+
+    def __init__(self, ttl_seconds: int = BROWSER_HANDOFF_TTL_SECONDS) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._items: dict[str, BrowserHandoff] = {}
+        self._lock = RLock()
+
+    def issue(self, *, product_id: str, platform: str, return_to: str) -> str:
+        now = time.time()
+        ticket = secrets.token_urlsafe(32)
+        with self._lock:
+            self._items = {key: item for key, item in self._items.items() if item.expires_at > now}
+            self._items[ticket] = BrowserHandoff(
+                product_id=product_id,
+                platform=platform,
+                return_to=return_to,
+                expires_at=now + self.ttl_seconds,
+            )
+        return ticket
+
+    def consume(self, ticket: str) -> BrowserHandoff:
+        with self._lock:
+            item = self._items.pop(str(ticket or ""), None)
+        if item is None or item.expires_at <= time.time():
+            raise PermissionError("social_browser_handoff_invalid_or_expired")
+        return item
+
+
 class SocialRuntime:
     def __init__(
         self,
@@ -103,20 +142,25 @@ class SocialRuntime:
         threads: ThreadsCapability,
         acceptances: OneShotAcceptanceStore | None = None,
         browser_contexts: BrowserContextStore | None = None,
+        browser_handoffs: BrowserHandoffStore | None = None,
         control_token: str = "",
         threads_lifecycle: ThreadsLifecycleCallbacks | None = None,
+        public_base: str = DEFAULT_PUBLIC_BASE,
     ) -> None:
         self.products = products
         self.threads = threads
         self.acceptances = acceptances or OneShotAcceptanceStore()
         self.browser_contexts = browser_contexts or BrowserContextStore()
+        self.browser_handoffs = browser_handoffs or BrowserHandoffStore()
         self.control_token = control_token
         self.threads_lifecycle = threads_lifecycle
+        self.public_base = str(public_base or DEFAULT_PUBLIC_BASE).rstrip("/")
 
     @classmethod
     def from_env(cls, credential_path: str | Path = DEFAULT_CREDENTIAL_PATH) -> "SocialRuntime":
         products = ProductRegistry.from_env()
         vault = FileCredentialVault(credential_path)
+        public_base = os.environ.get("AGENTOS_SOCIAL_PUBLIC_BASE", DEFAULT_PUBLIC_BASE)
 
         def config_loader() -> ThreadsProviderConfig:
             return ThreadsProviderConfig(
@@ -130,13 +174,14 @@ class SocialRuntime:
         lifecycle = ThreadsLifecycleCallbacks(
             vault=vault,
             transport=transport,
-            public_base=os.environ.get("AGENTOS_SOCIAL_PUBLIC_BASE", DEFAULT_PUBLIC_BASE),
+            public_base=public_base,
         )
         return cls(
             products=products,
             threads=threads,
             control_token=os.environ.get("AGENTOS_SOCIAL_CONTROL_TOKEN", ""),
             threads_lifecycle=lifecycle,
+            public_base=public_base,
         )
 
     def configured_status(self) -> dict[str, Any]:
@@ -151,12 +196,41 @@ class SocialRuntime:
         return self.threads.status(request)
 
     def connect(self, request: SocialRequest) -> dict[str, Any]:
+        """Create only a product-safe browser handoff; provider OAuth state stays runtime-side."""
         self.products.registration(request.product_id)
+        if request.operation != "connect" or request.platform != "threads":
+            raise ValueError("threads_connect_operation_required")
+        ticket = self.browser_handoffs.issue(
+            product_id=request.product_id,
+            platform=request.platform,
+            return_to=str(request.return_to or "/"),
+        )
+        query = urllib.parse.urlencode({"ticket": ticket})
+        return {
+            "schema": "agentos.social-browser-handoff/v1",
+            "browser_start_url": f"{self.public_base}/v1/social/oauth/threads/start?{query}",
+            "expires_in": self.browser_handoffs.ttl_seconds,
+        }
+
+    def begin_browser_connect(self, ticket: str) -> tuple[str, str]:
+        handoff = self.browser_handoffs.consume(ticket)
+        if handoff.platform != "threads":
+            raise PermissionError("social_browser_handoff_platform_mismatch")
+        self.products.registration(handoff.product_id)
         browser_session_id = secrets.token_urlsafe(24)
+        request = SocialRequest(
+            product_id=handoff.product_id,
+            platform="threads",
+            operation="connect",
+            return_to=handoff.return_to,
+        ).validate()
         value = self.threads.begin_connect(request, browser_session_id=browser_session_id)
-        state = value.pop("state")
-        self.browser_contexts.bind(state, request.product_id, browser_session_id)
-        return {**value, "browser_session_id": browser_session_id}
+        state = str(value.pop("state"))
+        authorization_url = str(value.get("authorization_url") or "")
+        if not authorization_url:
+            raise RuntimeError("social_oauth_authorization_url_missing")
+        self.browser_contexts.bind(state, handoff.product_id, browser_session_id)
+        return authorization_url, browser_session_id
 
     def complete_connect(self, *, state: str, code: str, browser_session_id: str) -> tuple[str, dict[str, Any]]:
         product_id, expected_session = self.browser_contexts.consume(state, browser_session_id)
@@ -224,6 +298,17 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _redirect(self, location: str, *, session_cookie: str | None = None) -> None:
+        self.send_response(HTTPStatus.FOUND)
+        self.send_header("Location", location)
+        self.send_header("Cache-Control", "no-store")
+        if session_cookie:
+            self.send_header(
+                "Set-Cookie",
+                f"{SESSION_COOKIE}={session_cookie}; Path=/v1/social/oauth/threads/callback; HttpOnly; Secure; SameSite=Lax",
+            )
+        self.end_headers()
+
     def _raw_body(self) -> bytes:
         try:
             length = int(self.headers.get("Content-Length", "0"))
@@ -282,6 +367,18 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
                 return
             self._json(HTTPStatus.OK, {"status": "completed", "confirmation_code": code})
             return
+        if parsed.path == "/v1/social/oauth/threads/start":
+            ticket = str((urllib.parse.parse_qs(parsed.query).get("ticket") or [""])[0])
+            if not ticket:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "social_browser_handoff_required"})
+                return
+            try:
+                location, browser_session_id = self.runtime.begin_browser_connect(ticket)
+            except (ValueError, PermissionError, RuntimeError) as exc:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(exc)})
+                return
+            self._redirect(location, session_cookie=browser_session_id)
+            return
         if parsed.path == "/v1/social/oauth/threads/callback":
             query = urllib.parse.parse_qs(parsed.query)
             state = str((query.get("state") or [""])[0])
@@ -328,9 +425,7 @@ class SocialRuntimeHandler(BaseHTTPRequestHandler):
                 return
             if parsed.path == "/v1/social/connect":
                 self._product_auth(request)
-                value = self.runtime.connect(request)
-                browser_session_id = str(value.pop("browser_session_id"))
-                self._json(HTTPStatus.OK, value, session_cookie=browser_session_id)
+                self._json(HTTPStatus.OK, self.runtime.connect(request))
                 return
             if parsed.path in {"/v1/social/publish", "/v1/social/reply", "/v1/social/disconnect"}:
                 self._product_auth(request)

--- a/dashboard/app/api/social/[...path]/route.ts
+++ b/dashboard/app/api/social/[...path]/route.ts
@@ -3,12 +3,13 @@ import { NextRequest } from "next/server";
 const UPSTREAM = "http://127.0.0.1:8771";
 const PUBLIC_CALLBACK_PATH = "/dashboard/api/social/v1/social/oauth/threads/callback";
 const INTERNAL_CALLBACK_PATH = "/v1/social/oauth/threads/callback";
+const INTERNAL_START_PATH = "/v1/social/oauth/threads/start";
 const THREADS_DEAUTHORIZE_PATH = "/v1/social/webhooks/threads/deauthorize";
 const THREADS_DATA_DELETION_PATH = "/v1/social/webhooks/threads/data-deletion";
 const THREADS_DATA_DELETION_STATUS_PATH = "/v1/social/webhooks/threads/data-deletion/status";
 
 const ALLOWED: Record<string, Set<string>> = {
-  GET: new Set(["/healthz", INTERNAL_CALLBACK_PATH, THREADS_DATA_DELETION_STATUS_PATH]),
+  GET: new Set(["/healthz", INTERNAL_START_PATH, INTERNAL_CALLBACK_PATH, THREADS_DATA_DELETION_STATUS_PATH]),
   POST: new Set([
     "/v1/social/status",
     "/v1/social/connect",

--- a/docs/SOCIAL_RUNTIME.md
+++ b/docs/SOCIAL_RUNTIME.md
@@ -15,14 +15,21 @@ The service itself accepts only fixed JSON contracts and never arbitrary provide
 - `GET /healthz`: reports service and provider configured/unconfigured booleans only.
 - `POST /v1/social/status`
 - `POST /v1/social/connect`
+- `GET /v1/social/oauth/threads/start?ticket=<opaque-one-time-ticket>`
 - `GET /v1/social/oauth/threads/callback`
 - `POST /v1/social/disconnect`
 - `POST /v1/social/publish`
 - `POST /v1/social/reply`
 
-Product calls require an exact registered `product_id` plus `X-AgentOS-Product-Key`. Registration is runtime configuration, not repository data.
+Product server calls require an exact registered `product_id` plus `X-AgentOS-Product-Key`. Registration is runtime configuration, not repository data. The product key MUST remain server-side; it is never placed in browser JavaScript, a redirect URL, an OAuth state, a receipt, or a cookie.
 
-`connect` creates a runtime-owned OAuth state and an HttpOnly/Secure/SameSite=Lax browser-session cookie. The public gateway rewrites only that callback cookie path from the runtime-local callback path to the fixed public callback path. The provider callback must match both the single-use OAuth state and the original browser-session cookie. On success the browser is redirected only to the pre-registered product return base plus the previously validated relative `return_to` route. The return contains only connection/binding information; provider authorization code/token material stays server-side.
+`connect` is intentionally split across a backend leg and a browser leg. The authenticated product backend receives only a short-lived opaque `browser_start_url`; it does not receive the provider authorization URL, provider OAuth state, browser callback session, app credential, or token. The user's browser navigates to that one-time start URL on the shared gateway. Only there does the runtime consume the ticket, create the provider OAuth state, create the browser callback session, set an HttpOnly/Secure/SameSite=Lax callback cookie on the shared gateway origin, and redirect to Threads authorization.
+
+This split prevents the cross-origin failure mode where a product backend receives `Set-Cookie` from the shared runtime but the end user's browser never stores it. It also avoids the unsafe alternative of exposing `X-AgentOS-Product-Key` to browser code.
+
+The public gateway rewrites only the callback cookie path from the runtime-local callback path to the fixed public callback path. The provider callback must match both the single-use OAuth state and the original browser-session cookie. On success the browser is redirected only to the pre-registered product return base plus the previously validated relative `return_to` route. The return contains only connection/binding information; provider authorization code/token material stays server-side.
+
+The browser handoff ticket is process-local, random, single-use, and short-lived (five minutes by default). Runtime restart or ticket replay fails closed. It contains no credential material and is useless after redemption.
 
 ### Runtime control API
 
@@ -76,18 +83,19 @@ The runtime persists account binding metadata and access tokens in its private r
 python -m agentos_node.social.runtime_http --host 127.0.0.1 --port 8771
 ```
 
-The Oracle persistent runtime and public gateway have live rollout evidence. The service remains valid while Threads is unconfigured; `/healthz` reports `threads.configured=false` and OAuth connect fails closed. This permits the Core-owned runtime, public route, and canonical callback URI to be deployed before the shared Meta App ID/Secret are provisioned.
+The Oracle persistent runtime and public gateway have live rollout evidence. The configured-provider verification through the public gateway has passed with `threads.configured=true` while keeping the actual App ID/Secret values out of Core, GitHub logs, workflow inputs, artifacts, and receipts. This is configuration evidence only; it is not yet real-user OAuth or publish acceptance.
 
 ## LeopardCat proving sequence
 
 1. Deploy this shared runtime from `core/integration`.
 2. Keep the fixed shared Threads callback registered as `https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/callback`.
 3. Register `leopardcat-tarot` as a runtime consumer without creating a product-local Meta App.
-4. Install shared Meta App ID/Secret in the host-local runtime secret boundary when available.
-5. Verify public `/healthz` changes to `threads.configured=true` without exposing provider values.
+4. Verify public `/healthz` reports `threads.configured=true` without exposing provider values.
+5. Have LeopardCat's backend call `POST /v1/social/connect` with its server-side product credential and redirect the user only to the returned opaque `browser_start_url`.
 6. Complete a real Threads OAuth callback and capture only sanitized account binding evidence.
 7. Issue one exact write acceptance from the AgentOS control plane for a user-click-generated `write_intent_id`.
 8. Publish `primary_text` plus optional typed `text_attachment` through the runtime and retain only the secret-free receipt/permalink/object id.
-9. Then integrate LeopardCat #65 against the accepted endpoint; its existing production fallback remains valid until that live proof exists.
+9. Integrate LeopardCat #65 against the accepted endpoint; its anonymous `<=500` production fallback remains valid until the live proof succeeds.
+10. Perform real iPhone acceptance before closing the product issue.
 
-A live provider receipt is required before #267 can be closed. Unit/hosted CI proves the boundary and fail-closed behavior, not Meta availability or credentials.
+A live provider receipt is required before #267 can be closed. Unit/hosted CI and configured-provider checks prove the boundary and fail-closed behavior, not real user OAuth, account binding, Threads publication, or real-device UX.

--- a/tests/test_social_runtime_activation.py
+++ b/tests/test_social_runtime_activation.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
 from agentos_node.social.contracts import SocialRequest
 from agentos_node.social.credentials import AccountBinding, EphemeralCredentialVault
-from agentos_node.social.runtime_http import BrowserContextStore, ProductRegistration, ProductRegistry, SocialRuntime
+from agentos_node.social.runtime_http import (
+    BrowserContextStore,
+    BrowserHandoffStore,
+    ProductRegistration,
+    ProductRegistry,
+    SocialRuntime,
+)
 from agentos_node.social.runtime_storage import FileCredentialVault, OneShotAcceptanceStore
 from agentos_node.social.threads import ThreadsCapability, ThreadsProviderConfig, ThreadsProviderTransport
 
@@ -51,7 +58,7 @@ def registry() -> ProductRegistry:
     })
 
 
-def runtime(configured: bool = True):
+def runtime(configured: bool = True, *, browser_handoffs: BrowserHandoffStore | None = None):
     vault = EphemeralCredentialVault()
     transport = FakeThreadsTransport(configured=configured)
     threads = ThreadsCapability(vault, transport)
@@ -60,8 +67,24 @@ def runtime(configured: bool = True):
         threads=threads,
         acceptances=OneShotAcceptanceStore(),
         browser_contexts=BrowserContextStore(),
+        browser_handoffs=browser_handoffs,
         control_token="control-key",
+        public_base="https://studio.milkcat.org/dashboard/api/social",
     ), vault, transport
+
+
+def connect_request():
+    return SocialRequest(
+        product_id="leopardcat-tarot",
+        platform="threads",
+        operation="connect",
+        return_to="/reading/1",
+    )
+
+
+def handoff_ticket(value: dict[str, object]) -> str:
+    parsed = urlsplit(str(value["browser_start_url"]))
+    return parse_qs(parsed.query)["ticket"][0]
 
 
 def publish_request(**overrides):
@@ -97,17 +120,44 @@ def test_product_registry_requires_exact_product_key():
         reg.authenticate("vendor-reputation-service", "product-key")
 
 
+def test_product_connect_returns_only_opaque_browser_handoff():
+    rt, _vault, _transport = runtime()
+    started = rt.connect(connect_request())
+    assert started["schema"] == "agentos.social-browser-handoff/v1"
+    assert started["expires_in"] == 300
+    assert started["browser_start_url"].startswith(
+        "https://studio.milkcat.org/dashboard/api/social/v1/social/oauth/threads/start?ticket="
+    )
+    text = repr(started).lower()
+    assert "threads.example" not in text
+    assert "product-key" not in text
+    assert "secret" not in text
+    assert "token" not in text
+    assert "state=" not in text
+
+
+def test_browser_handoff_is_single_use_before_provider_oauth_state_exists():
+    rt, _vault, _transport = runtime()
+    ticket = handoff_ticket(rt.connect(connect_request()))
+    authorization_url, browser_session_id = rt.begin_browser_connect(ticket)
+    assert authorization_url.startswith("https://threads.example/oauth?state=")
+    assert browser_session_id
+    with pytest.raises(PermissionError, match="handoff_invalid_or_expired"):
+        rt.begin_browser_connect(ticket)
+
+
+def test_browser_handoff_expires_fail_closed():
+    rt, _vault, _transport = runtime(browser_handoffs=BrowserHandoffStore(ttl_seconds=0))
+    ticket = handoff_ticket(rt.connect(connect_request()))
+    with pytest.raises(PermissionError, match="handoff_invalid_or_expired"):
+        rt.begin_browser_connect(ticket)
+
+
 def test_oauth_callback_is_single_use_and_browser_session_bound():
     rt, vault, _transport = runtime()
-    request = SocialRequest(
-        product_id="leopardcat-tarot",
-        platform="threads",
-        operation="connect",
-        return_to="/reading/1",
-    )
-    started = rt.connect(request)
-    browser_session_id = started["browser_session_id"]
-    state = started["authorization_url"].split("state=", 1)[1]
+    ticket = handoff_ticket(rt.connect(connect_request()))
+    authorization_url, browser_session_id = rt.begin_browser_connect(ticket)
+    state = authorization_url.split("state=", 1)[1]
 
     with pytest.raises(PermissionError, match="browser_session_mismatch"):
         rt.complete_connect(state=state, code="provider-code", browser_session_id="other-browser")
@@ -118,18 +168,13 @@ def test_oauth_callback_is_single_use_and_browser_session_bound():
 
 def test_realistic_oauth_completion_returns_binding_not_token():
     rt, vault, _transport = runtime()
-    request = SocialRequest(
-        product_id="leopardcat-tarot",
-        platform="threads",
-        operation="connect",
-        return_to="/reading/1",
-    )
-    started = rt.connect(request)
-    state = started["authorization_url"].split("state=", 1)[1]
+    ticket = handoff_ticket(rt.connect(connect_request()))
+    authorization_url, browser_session_id = rt.begin_browser_connect(ticket)
+    state = authorization_url.split("state=", 1)[1]
     location, result = rt.complete_connect(
         state=state,
         code="provider-code",
-        browser_session_id=started["browser_session_id"],
+        browser_session_id=browser_session_id,
     )
     assert location.startswith("https://tarot.example/reading/1")
     assert result["binding_id"] == "leopardcat-tarot:threads:42"


### PR DESCRIPTION
## Goal
Close the cross-origin OAuth bootstrap gap in #267 without exposing the product key or provider OAuth state to browser code.

## Change
- authenticated product `POST /v1/social/connect` now returns only a short-lived opaque `browser_start_url`;
- new public `GET /v1/social/oauth/threads/start?ticket=...` consumes the one-time ticket inside the shared runtime, creates provider OAuth state + browser callback session, sets the callback cookie on the shared gateway origin, then redirects to Threads;
- ticket is random, five-minute, process-local, single-use, and fails closed on restart/replay/expiry;
- dashboard gateway allowlists only the fixed start route in addition to the existing callback;
- product key never enters the browser URL/cookie/OAuth state;
- focused tests cover handoff shape, replay, expiry, callback browser-session binding, secret-free completion, and existing one-shot publish acceptance;
- docs/guard updated to make the boundary machine-checkable.

## Why
The previous server-to-server `connect` response carried `Set-Cookie`. A product backend could receive that cookie, but the user's browser on the shared gateway origin would not, so a real cross-origin callback could not satisfy the browser-session binding. Sending `X-AgentOS-Product-Key` from browser JS would fix the cookie placement but violate the credential boundary. The opaque browser handoff keeps both properties.

Target: `core/integration` only. No protected-main write. No provider credentials added.

Refs #267, alston-personal/leopardcat-tarot#65