### PR TITLE
Core #267: add host-local social product provisioning

### DIFF
--- a/.github/workflows/social-runtime-local-config-guard.yml
+++ b/.github/workflows/social-runtime-local-config-guard.yml
@@ -1,0 +1,45 @@
+name: Social Runtime Local Config Guard
+
+on:
+  pull_request:
+    branches: [core/integration]
+    paths:
+      - 'scripts/social_runtime_local_config.py'
+      - 'tests/test_social_runtime_local_config.py'
+      - 'docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md'
+      - '.github/workflows/social-runtime-local-config-guard.yml'
+  push:
+    branches:
+      - 'core/267-local-secret-provisioning'
+      - 'core/integration'
+    paths:
+      - 'scripts/social_runtime_local_config.py'
+      - 'tests/test_social_runtime_local_config.py'
+      - 'docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md'
+      - '.github/workflows/social-runtime-local-config-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run local provisioning unit tests
+        run: python3 -m unittest -v tests.test_social_runtime_local_config
+      - name: Verify committed files contain no generated runtime secret values
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          script = Path('scripts/social_runtime_local_config.py').read_text(encoding='utf-8')
+          docs = Path('docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md').read_text(encoding='utf-8')
+          assert 'AGENTOS_SOCIAL_PRODUCT_KEY=' not in docs
+          assert 'AGENTOS_SOCIAL_CONTROL_TOKEN=' not in docs
+          assert 'print(api_key)' not in script
+          assert 'print(token)' not in script
+          print('social_runtime_local_config_secret_guard=PASS')
+          PY

--- a/docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md
+++ b/docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md
@@ -13,7 +13,7 @@ The production defaults are fixed under `/home/ubuntu/.config/agentos`:
 - runtime env: `social-runtime.env`
 - product secret files: `social-products/<product_id>.env`
 
-All writes are atomic and mode `0600`. Secret values are never printed by the tool.
+All writes are atomic and mode `0600`. Secret values are never printed by the tool. The dedicated `Social Runtime Local Config Guard` workflow runs the unit and static secret-exposure checks for this boundary.
 
 ## Control-plane token
 

--- a/docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md
+++ b/docs/SOCIAL_RUNTIME_LOCAL_PROVISIONING.md
@@ -1,0 +1,64 @@
+# Social Runtime Host-Local Provisioning
+
+Issue: #267.
+
+This operator boundary prepares the shared social runtime for real product OAuth and governed writes without moving product credentials or the Core control token through GitHub, workflow inputs, chat, browser JavaScript, receipts, or public HTTP responses.
+
+## Tool
+
+`python3 scripts/social_runtime_local_config.py`
+
+The production defaults are fixed under `/home/ubuntu/.config/agentos`:
+
+- runtime env: `social-runtime.env`
+- product secret files: `social-products/<product_id>.env`
+
+All writes are atomic and mode `0600`. Secret values are never printed by the tool.
+
+## Control-plane token
+
+Run on the Oracle host as the runtime owner:
+
+```bash
+python3 scripts/social_runtime_local_config.py ensure-control-token
+```
+
+If `AGENTOS_SOCIAL_CONTROL_TOKEN` is empty, the tool creates a cryptographically random value in the host-local runtime env. If a value already exists, it is preserved. The command reports only `GENERATED` or `PRESERVED`.
+
+The control token remains separate from every product key and is still usable only against the private `127.0.0.1` runtime control route. The public gateway must continue to block `/internal/v1/social/acceptances`.
+
+## Product registration
+
+After the product's canonical return base is accepted, register it locally:
+
+```bash
+python3 scripts/social_runtime_local_config.py register-product \
+  leopardcat-tarot \
+  https://studio.milkcat.org/leopardcat-tarot
+```
+
+The helper:
+
+1. validates a bounded product ID and HTTPS return base;
+2. generates a random product API key only for a new registration;
+3. updates `AGENTOS_SOCIAL_PRODUCTS_JSON` atomically;
+4. writes the product's server-side credential to the fixed host-local file `social-products/<product_id>.env`;
+5. never prints the key value;
+6. is idempotent for the exact same registration;
+7. fails closed if an existing product is silently pointed at a different return base.
+
+A return-base change is therefore an explicit migration event rather than an accidental credential reuse.
+
+## Safe status
+
+```bash
+python3 scripts/social_runtime_local_config.py status leopardcat-tarot
+```
+
+Status returns booleans only: whether the product is registered, whether its fixed secret file exists, and whether the Core control token is configured. It does not expose provider credentials, product API keys, or the control token.
+
+## Boundary with product repos
+
+Core owns generation and storage of the shared-runtime product credential. A product backend may consume its host-local `social-products/<product_id>.env` secret through its deployment/runtime boundary, but the value must never be committed to the product repository or sent to browser code.
+
+For LeopardCat, actual registration should wait until `https://studio.milkcat.org/leopardcat-tarot` is verified as the canonical product return base. This Core tool does not implement the LeopardCat route, UI, or product deployment.

--- a/scripts/social_runtime_local_config.py
+++ b/scripts/social_runtime_local_config.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import tempfile
+from pathlib import Path
+from urllib.parse import urlsplit
+
+DEFAULT_ENV_FILE = Path('/home/ubuntu/.config/agentos/social-runtime.env')
+DEFAULT_PRODUCT_SECRET_DIR = Path('/home/ubuntu/.config/agentos/social-products')
+PRODUCT_ID_RE = re.compile(r'^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$')
+
+
+def _read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        raise RuntimeError('social_runtime_env_missing')
+    return path.read_text(encoding='utf-8').splitlines()
+
+
+def _index_key(lines: list[str], key: str) -> int | None:
+    prefix = key + '='
+    matches = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+    if len(matches) > 1:
+        raise RuntimeError(f'social_runtime_env_duplicate_key:{key}')
+    return matches[0] if matches else None
+
+
+def _get(lines: list[str], key: str, default: str = '') -> str:
+    idx = _index_key(lines, key)
+    if idx is None:
+        return default
+    return lines[idx].split('=', 1)[1]
+
+
+def _set(lines: list[str], key: str, value: str) -> None:
+    if '\n' in value or '\r' in value:
+        raise ValueError('social_runtime_env_multiline_value_forbidden')
+    idx = _index_key(lines, key)
+    line = f'{key}={value}'
+    if idx is None:
+        lines.append(line)
+    else:
+        lines[idx] = line
+
+
+def _atomic_write(path: Path, text: str, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=path.name + '.', dir=str(path.parent), text=True)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, mode)
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+    os.chmod(path, mode)
+
+
+def _validate_product_id(product_id: str) -> str:
+    value = str(product_id or '').strip()
+    if not PRODUCT_ID_RE.fullmatch(value):
+        raise ValueError('social_product_id_invalid')
+    return value
+
+
+def _validate_return_base(return_base: str) -> str:
+    value = str(return_base or '').strip().rstrip('/')
+    parsed = urlsplit(value)
+    if parsed.scheme != 'https' or not parsed.netloc or parsed.username or parsed.password:
+        raise ValueError('social_product_return_base_invalid')
+    if parsed.query or parsed.fragment:
+        raise ValueError('social_product_return_base_invalid')
+    if parsed.path and not parsed.path.startswith('/'):
+        raise ValueError('social_product_return_base_invalid')
+    return value
+
+
+def ensure_control_token(env_file: Path = DEFAULT_ENV_FILE) -> bool:
+    lines = _read_lines(env_file)
+    current = _get(lines, 'AGENTOS_SOCIAL_CONTROL_TOKEN')
+    changed = not bool(current)
+    if changed:
+        _set(lines, 'AGENTOS_SOCIAL_CONTROL_TOKEN', secrets.token_urlsafe(48))
+        _atomic_write(env_file, '\n'.join(lines) + '\n')
+    else:
+        os.chmod(env_file, 0o600)
+    return changed
+
+
+def register_product(
+    product_id: str,
+    return_base: str,
+    *,
+    env_file: Path = DEFAULT_ENV_FILE,
+    product_secret_dir: Path = DEFAULT_PRODUCT_SECRET_DIR,
+) -> tuple[bool, Path]:
+    product_id = _validate_product_id(product_id)
+    return_base = _validate_return_base(return_base)
+    lines = _read_lines(env_file)
+    raw = _get(lines, 'AGENTOS_SOCIAL_PRODUCTS_JSON', '{}') or '{}'
+    try:
+        registry = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError('social_product_registry_invalid') from exc
+    if not isinstance(registry, dict):
+        raise RuntimeError('social_product_registry_invalid')
+
+    existing = registry.get(product_id)
+    created = existing is None
+    if existing is None:
+        api_key = secrets.token_urlsafe(48)
+        registry[product_id] = {'api_key': api_key, 'return_base': return_base}
+    else:
+        if not isinstance(existing, dict):
+            raise RuntimeError('social_product_registry_invalid')
+        api_key = str(existing.get('api_key') or '')
+        existing_return = str(existing.get('return_base') or '').rstrip('/')
+        if not api_key or existing_return != return_base:
+            raise RuntimeError('social_product_registration_conflict')
+
+    compact = json.dumps(registry, ensure_ascii=False, separators=(',', ':'), sort_keys=True)
+    _set(lines, 'AGENTOS_SOCIAL_PRODUCTS_JSON', compact)
+    _atomic_write(env_file, '\n'.join(lines) + '\n')
+
+    secret_path = product_secret_dir / f'{product_id}.env'
+    secret_text = (
+        f'AGENTOS_SOCIAL_PRODUCT_ID={product_id}\n'
+        f'AGENTOS_SOCIAL_PRODUCT_KEY={api_key}\n'
+        f'AGENTOS_SOCIAL_RETURN_BASE={return_base}\n'
+    )
+    _atomic_write(secret_path, secret_text)
+    return created, secret_path
+
+
+def status(product_id: str, *, env_file: Path = DEFAULT_ENV_FILE, product_secret_dir: Path = DEFAULT_PRODUCT_SECRET_DIR) -> dict[str, bool]:
+    product_id = _validate_product_id(product_id)
+    lines = _read_lines(env_file)
+    raw = _get(lines, 'AGENTOS_SOCIAL_PRODUCTS_JSON', '{}') or '{}'
+    try:
+        registry = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError('social_product_registry_invalid') from exc
+    if not isinstance(registry, dict):
+        raise RuntimeError('social_product_registry_invalid')
+    return {
+        'registered': product_id in registry,
+        'secret_file_present': (product_secret_dir / f'{product_id}.env').is_file(),
+        'control_token_configured': bool(_get(lines, 'AGENTOS_SOCIAL_CONTROL_TOKEN')),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description='Host-local AgentOS Social runtime secret provisioning.')
+    parser.add_argument('--env-file', type=Path, default=DEFAULT_ENV_FILE)
+    parser.add_argument('--product-secret-dir', type=Path, default=DEFAULT_PRODUCT_SECRET_DIR)
+    sub = parser.add_subparsers(dest='command', required=True)
+    sub.add_parser('ensure-control-token')
+    register = sub.add_parser('register-product')
+    register.add_argument('product_id')
+    register.add_argument('return_base')
+    status_cmd = sub.add_parser('status')
+    status_cmd.add_argument('product_id')
+    args = parser.parse_args(argv)
+
+    if args.command == 'ensure-control-token':
+        changed = ensure_control_token(args.env_file)
+        print('social_runtime_control_token=' + ('GENERATED' if changed else 'PRESERVED'))
+        return 0
+    if args.command == 'register-product':
+        created, secret_path = register_product(
+            args.product_id,
+            args.return_base,
+            env_file=args.env_file,
+            product_secret_dir=args.product_secret_dir,
+        )
+        print('social_runtime_product=' + ('REGISTERED' if created else 'PRESERVED'))
+        print('social_runtime_product_secret_file=' + str(secret_path))
+        print('social_runtime_secret_value_exposure=NONE')
+        return 0
+    if args.command == 'status':
+        value = status(args.product_id, env_file=args.env_file, product_secret_dir=args.product_secret_dir)
+        print(json.dumps(value, sort_keys=True))
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_social_runtime_local_config.py
+++ b/tests/test_social_runtime_local_config.py
@@ -1,0 +1,121 @@
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'social_runtime_local_config.py'
+spec = importlib.util.spec_from_file_location('social_runtime_local_config', MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+
+class SocialRuntimeLocalConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        root = Path(self.temp.name)
+        self.env = root / 'social-runtime.env'
+        self.secret_dir = root / 'products'
+        self.env.write_text(
+            'AGENTOS_SOCIAL_PRODUCTS_JSON={}\n'
+            'AGENTOS_SOCIAL_CONTROL_TOKEN=\n'
+            'AGENTOS_THREADS_APP_ID=public-id\n'
+            'AGENTOS_THREADS_APP_SECRET=provider-secret\n',
+            encoding='utf-8',
+        )
+        os.chmod(self.env, 0o600)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_control_token_generated_without_overwriting_other_secrets(self):
+        before = self.env.read_text(encoding='utf-8')
+        self.assertTrue(module.ensure_control_token(self.env))
+        after = self.env.read_text(encoding='utf-8')
+        self.assertIn('AGENTOS_THREADS_APP_SECRET=provider-secret', after)
+        self.assertNotEqual(before, after)
+        token = next(line.split('=', 1)[1] for line in after.splitlines() if line.startswith('AGENTOS_SOCIAL_CONTROL_TOKEN='))
+        self.assertGreaterEqual(len(token), 40)
+        self.assertFalse(module.ensure_control_token(self.env))
+        self.assertEqual(after, self.env.read_text(encoding='utf-8'))
+        self.assertEqual(stat.S_IMODE(self.env.stat().st_mode), 0o600)
+
+    def test_register_product_is_idempotent_and_writes_fixed_secret_file(self):
+        created, path = module.register_product(
+            'leopardcat-tarot',
+            'https://studio.milkcat.org/leopardcat-tarot',
+            env_file=self.env,
+            product_secret_dir=self.secret_dir,
+        )
+        self.assertTrue(created)
+        self.assertEqual(path, self.secret_dir / 'leopardcat-tarot.env')
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        secret_text = path.read_text(encoding='utf-8')
+        self.assertIn('AGENTOS_SOCIAL_PRODUCT_ID=leopardcat-tarot', secret_text)
+        self.assertIn('AGENTOS_SOCIAL_RETURN_BASE=https://studio.milkcat.org/leopardcat-tarot', secret_text)
+        key_line = next(line for line in secret_text.splitlines() if line.startswith('AGENTOS_SOCIAL_PRODUCT_KEY='))
+        key = key_line.split('=', 1)[1]
+        self.assertGreaterEqual(len(key), 40)
+
+        raw = next(line.split('=', 1)[1] for line in self.env.read_text(encoding='utf-8').splitlines() if line.startswith('AGENTOS_SOCIAL_PRODUCTS_JSON='))
+        registry = json.loads(raw)
+        self.assertEqual(registry['leopardcat-tarot']['return_base'], 'https://studio.milkcat.org/leopardcat-tarot')
+        self.assertEqual(registry['leopardcat-tarot']['api_key'], key)
+
+        created_again, _ = module.register_product(
+            'leopardcat-tarot',
+            'https://studio.milkcat.org/leopardcat-tarot',
+            env_file=self.env,
+            product_secret_dir=self.secret_dir,
+        )
+        self.assertFalse(created_again)
+        self.assertIn(key, path.read_text(encoding='utf-8'))
+
+    def test_return_base_change_fails_closed_and_preserves_registration(self):
+        module.register_product(
+            'leopardcat-tarot',
+            'https://studio.milkcat.org/leopardcat-tarot',
+            env_file=self.env,
+            product_secret_dir=self.secret_dir,
+        )
+        before = self.env.read_text(encoding='utf-8')
+        with self.assertRaisesRegex(RuntimeError, 'social_product_registration_conflict'):
+            module.register_product(
+                'leopardcat-tarot',
+                'https://example.invalid/other',
+                env_file=self.env,
+                product_secret_dir=self.secret_dir,
+            )
+        self.assertEqual(before, self.env.read_text(encoding='utf-8'))
+
+    def test_invalid_product_or_return_base_rejected(self):
+        for product_id in ('../escape', 'UPPER', 'a/b'):
+            with self.assertRaises(ValueError):
+                module.register_product(product_id, 'https://example.com/app', env_file=self.env, product_secret_dir=self.secret_dir)
+        for return_base in ('http://example.com/app', 'https://user:pass@example.com/app', 'https://example.com/app?q=1'):
+            with self.assertRaises(ValueError):
+                module.register_product('safe-product', return_base, env_file=self.env, product_secret_dir=self.secret_dir)
+
+    def test_status_is_secret_free(self):
+        module.ensure_control_token(self.env)
+        module.register_product(
+            'leopardcat-tarot',
+            'https://studio.milkcat.org/leopardcat-tarot',
+            env_file=self.env,
+            product_secret_dir=self.secret_dir,
+        )
+        value = module.status('leopardcat-tarot', env_file=self.env, product_secret_dir=self.secret_dir)
+        self.assertEqual(
+            value,
+            {'registered': True, 'secret_file_present': True, 'control_token_configured': True},
+        )
+        self.assertNotIn('key', json.dumps(value).lower())
+        self.assertNotIn('token', json.dumps(value).lower().replace('control_token_configured', ''))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds the missing host-local provisioning primitive needed before real product OAuth/write proof. It can generate/preserve the private Core control token and register a product with a generated server-side API key without printing secret values or putting them in GitHub. Product secrets are written atomically to a fixed 0600 host-local path; exact re-registration is idempotent and return-base changes fail closed. Includes unit coverage and operator docs. Target is core/integration only; protected main is untouched.