### PR TITLE
Core #267: add private one-shot acceptance CLI

### DIFF
--- a/.github/workflows/social-runtime-private-acceptance-guard.yml
+++ b/.github/workflows/social-runtime-private-acceptance-guard.yml
@@ -1,0 +1,43 @@
+name: Social Runtime Private Acceptance Guard
+
+on:
+  pull_request:
+    branches: [core/integration]
+    paths:
+      - 'scripts/social_runtime_accept.py'
+      - 'tests/test_social_runtime_accept.py'
+      - '.github/workflows/social-runtime-private-acceptance-guard.yml'
+  push:
+    branches:
+      - 'core/267-private-acceptance-cli'
+      - 'core/integration'
+    paths:
+      - 'scripts/social_runtime_accept.py'
+      - 'tests/test_social_runtime_accept.py'
+      - '.github/workflows/social-runtime-private-acceptance-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run private acceptance CLI unit tests
+        run: python3 -m unittest -v tests.test_social_runtime_accept
+      - name: Verify fixed private control boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          s = Path('scripts/social_runtime_accept.py').read_text(encoding='utf-8')
+          assert "http://127.0.0.1:8771/internal/v1/social/acceptances" in s
+          assert 'X-AgentOS-Control-Token' in s
+          assert 'print(token)' not in s
+          assert 'sys.argv' not in s
+          assert 'LOCAL_ACCEPTANCE_URL' in s
+          print('social_runtime_private_acceptance_boundary=PASS')
+          PY

--- a/scripts/social_runtime_accept.py
+++ b/scripts/social_runtime_accept.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from agentos_node.social.contracts import SocialRequest, WRITE_OPERATIONS
+
+DEFAULT_ENV_FILE = Path('/home/ubuntu/.config/agentos/social-runtime.env')
+LOCAL_ACCEPTANCE_URL = 'http://127.0.0.1:8771/internal/v1/social/acceptances'
+MAX_STDIN_BYTES = 64 * 1024
+
+
+def _load_control_token(env_file: Path) -> str:
+    if not env_file.is_file():
+        raise RuntimeError('social_runtime_env_missing')
+    matches: list[str] = []
+    for line in env_file.read_text(encoding='utf-8').splitlines():
+        if line.startswith('AGENTOS_SOCIAL_CONTROL_TOKEN='):
+            matches.append(line.split('=', 1)[1])
+    if len(matches) != 1:
+        raise RuntimeError('social_runtime_control_token_invalid')
+    token = matches[0]
+    if not token:
+        raise RuntimeError('social_runtime_control_token_unconfigured')
+    return token
+
+
+def _read_request(stream) -> tuple[dict, SocialRequest]:
+    raw = stream.buffer.read(MAX_STDIN_BYTES + 1) if hasattr(stream, 'buffer') else stream.read(MAX_STDIN_BYTES + 1)
+    if isinstance(raw, str):
+        raw = raw.encode('utf-8')
+    if not raw or len(raw) > MAX_STDIN_BYTES:
+        raise ValueError('social_acceptance_request_size_invalid')
+    value = json.loads(raw.decode('utf-8'))
+    if not isinstance(value, dict):
+        raise ValueError('social_acceptance_request_object_required')
+    request = SocialRequest(**value).validate()
+    if request.operation not in WRITE_OPERATIONS:
+        raise ValueError('social_acceptance_write_operation_required')
+    if not request.write_intent_id:
+        raise ValueError('social_acceptance_write_intent_required')
+    return value, request
+
+
+def issue_acceptance(payload: dict, *, token: str, timeout: float = 5.0) -> dict[str, str]:
+    body = json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+    req = urllib.request.Request(
+        LOCAL_ACCEPTANCE_URL,
+        data=body,
+        method='POST',
+        headers={
+            'Content-Type': 'application/json',
+            'X-AgentOS-Control-Token': token,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            raw = response.read(MAX_STDIN_BYTES + 1)
+            if len(raw) > MAX_STDIN_BYTES:
+                raise RuntimeError('social_acceptance_response_size_invalid')
+            value = json.loads(raw.decode('utf-8'))
+    except urllib.error.HTTPError as exc:
+        # Never echo the submitted request body or authentication token.
+        raise RuntimeError(f'social_acceptance_runtime_http_{exc.code}') from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError('social_acceptance_runtime_unreachable') from exc
+    if not isinstance(value, dict):
+        raise RuntimeError('social_acceptance_response_invalid')
+    allowed = {'schema', 'acceptance_id', 'one_shot'}
+    if set(value) - allowed:
+        raise RuntimeError('social_acceptance_response_unexpected_field')
+    if value.get('schema') != 'agentos.social-write-acceptance/v1' or not value.get('acceptance_id'):
+        raise RuntimeError('social_acceptance_response_invalid')
+    return {
+        'schema': str(value['schema']),
+        'acceptance_id': str(value['acceptance_id']),
+        'one_shot': str(value.get('one_shot') or 'true'),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description='Issue one exact AgentOS Social write acceptance through the private local control plane.')
+    parser.add_argument('--env-file', type=Path, default=DEFAULT_ENV_FILE)
+    parser.add_argument('--timeout', type=float, default=5.0)
+    args = parser.parse_args(argv)
+    if args.timeout <= 0 or args.timeout > 30:
+        raise SystemExit('social_acceptance_timeout_invalid')
+
+    try:
+        payload, _request = _read_request(sys.stdin)
+        token = _load_control_token(args.env_file)
+        result = issue_acceptance(payload, token=token, timeout=args.timeout)
+    except (ValueError, RuntimeError, TypeError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    # Output is intentionally restricted to the one-shot acceptance envelope.
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_social_runtime_accept.py
+++ b/tests/test_social_runtime_accept.py
@@ -1,0 +1,103 @@
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'social_runtime_accept.py'
+spec = importlib.util.spec_from_file_location('social_runtime_accept', MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode('utf-8')
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+    def read(self, _limit=-1):
+        return self.payload
+
+
+class SocialRuntimeAcceptanceCliTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.env = Path(self.temp.name) / 'social-runtime.env'
+        self.env.write_text('AGENTOS_SOCIAL_CONTROL_TOKEN=private-control-value\n', encoding='utf-8')
+        self.payload = {
+            'schema': 'agentos.social-request/v1',
+            'product_id': 'leopardcat-tarot',
+            'platform': 'threads',
+            'operation': 'publish',
+            'account_binding_id': 'binding-1',
+            'target_account_id': 'account-1',
+            'primary_text': 'bounded primary text',
+            'text_attachment': {'plaintext': 'long interpretation'},
+            'write_intent_id': 'intent-1',
+        }
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_load_control_token_requires_exact_single_nonempty_value(self):
+        self.assertEqual(module._load_control_token(self.env), 'private-control-value')
+        self.env.write_text('AGENTOS_SOCIAL_CONTROL_TOKEN=\n', encoding='utf-8')
+        with self.assertRaisesRegex(RuntimeError, 'unconfigured'):
+            module._load_control_token(self.env)
+        self.env.write_text('AGENTOS_SOCIAL_CONTROL_TOKEN=a\nAGENTOS_SOCIAL_CONTROL_TOKEN=b\n', encoding='utf-8')
+        with self.assertRaisesRegex(RuntimeError, 'invalid'):
+            module._load_control_token(self.env)
+
+    def test_read_request_rejects_non_write(self):
+        payload = dict(self.payload, operation='status')
+        payload.pop('write_intent_id')
+        with self.assertRaisesRegex(ValueError, 'write_operation_required'):
+            module._read_request(io.StringIO(json.dumps(payload)))
+
+    def test_issue_acceptance_is_fixed_local_and_output_is_bounded(self):
+        returned = {
+            'schema': 'agentos.social-write-acceptance/v1',
+            'acceptance_id': 'acceptance-123',
+            'one_shot': 'true',
+        }
+        captured = {}
+        def fake_urlopen(req, timeout):
+            captured['url'] = req.full_url
+            captured['headers'] = dict(req.header_items())
+            captured['body'] = req.data
+            captured['timeout'] = timeout
+            return _Response(returned)
+        with mock.patch.object(module.urllib.request, 'urlopen', side_effect=fake_urlopen):
+            result = module.issue_acceptance(self.payload, token='private-control-value', timeout=4)
+        self.assertEqual(captured['url'], 'http://127.0.0.1:8771/internal/v1/social/acceptances')
+        self.assertEqual(captured['timeout'], 4)
+        self.assertEqual(json.loads(captured['body']), self.payload)
+        self.assertEqual(result, returned)
+        self.assertNotIn('private-control-value', json.dumps(result))
+        self.assertNotIn('bounded primary text', json.dumps(result))
+        self.assertNotIn('long interpretation', json.dumps(result))
+
+    def test_unexpected_runtime_field_rejected(self):
+        returned = {
+            'schema': 'agentos.social-write-acceptance/v1',
+            'acceptance_id': 'acceptance-123',
+            'one_shot': 'true',
+            'access_token': 'must-not-pass',
+        }
+        with mock.patch.object(module.urllib.request, 'urlopen', return_value=_Response(returned)):
+            with self.assertRaisesRegex(RuntimeError, 'unexpected_field'):
+                module.issue_acceptance(self.payload, token='private-control-value')
+
+    def test_oversized_stdin_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'request_size_invalid'):
+            module._read_request(io.StringIO('x' * (module.MAX_STDIN_BYTES + 1)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a Core-only operator/control-plane CLI for minting one exact social write acceptance without exposing the control token or product content. The CLI reads an exact SocialRequest from stdin, validates it as a write with explicit write_intent_id, reads the control token only from the fixed host-local runtime env, posts only to 127.0.0.1:8771/internal/v1/social/acceptances, and emits only the bounded acceptance envelope. Includes unit and static boundary guards. No public route or product authority is added; protected main remains untouched.