### PR TITLE
Core #165: clean governed cross-repo execution boundary

### DIFF
--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -1,0 +1,50 @@
+name: Core 165 Clean Governed Execution Smoke
+
+on:
+  push:
+    branches:
+      - core/issue-165-clean-execution-v1
+  pull_request:
+    paths:
+      - 'governance/execution-authority.json'
+      - 'scripts/run_governed_execution_request.py'
+      - 'tests/test_governed_execution_request.py'
+      - 'docs/GOVERNED_EXECUTION_REQUESTS.md'
+      - '.github/workflows/core-issue-165-clean-smoke.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-165-clean-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate bounded contract
+        run: |
+          python3 -m pytest -q tests/test_governed_execution_request.py
+          python3 -m py_compile scripts/run_governed_execution_request.py
+
+  product-owned-smoke:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch product-owned request candidate
+        run: |
+          set -euo pipefail
+          curl -fsSL --max-time 15 \
+            https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/ops/agentos-execution-request-v1/.agentos/execution-requests/production-parity.json \
+            -o /tmp/leopardcat-production-parity.json
+      - name: Execute bounded product request
+        run: |
+          set +e
+          python3 scripts/run_governed_execution_request.py \
+            /tmp/leopardcat-production-parity.json \
+            /tmp/leopardcat-production-parity-receipt.json
+          code=$?
+          cat /tmp/leopardcat-production-parity-receipt.json
+          exit "$code"

--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -29,17 +29,17 @@ jobs:
           python3 tests/test_governed_execution_request.py
           python3 -m py_compile scripts/run_governed_execution_request.py
 
-  product-owned-smoke:
+  leopardcat-owned-smoke:
     runs-on: [self-hosted, Linux, ARM64, oracle]
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch canonical product-owned request
+      - name: Fetch canonical LeopardCat request
         run: |
           set -euo pipefail
           curl -fsSL --max-time 15 \
             https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/main/.agentos/execution-requests/production-parity.json \
             -o /tmp/leopardcat-production-parity.json
-      - name: Execute bounded product request
+      - name: Execute bounded LeopardCat request
         id: execute
         run: |
           set +e
@@ -50,7 +50,7 @@ jobs:
           cat /tmp/leopardcat-production-parity-receipt.json
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
-      - name: Persist sanitized receipt artifact
+      - name: Persist sanitized LeopardCat receipt artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -58,6 +58,39 @@ jobs:
           path: /tmp/leopardcat-production-parity-receipt.json
           if-no-files-found: error
           retention-days: 30
-      - name: Enforce execution result
+      - name: Enforce LeopardCat execution result
+        if: always()
+        run: test "${{ steps.execute.outputs.exit_code }}" = "0"
+
+  vendor-owned-smoke:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch canonical Vendor request
+        run: |
+          set -euo pipefail
+          curl -fsSL --max-time 15 \
+            https://raw.githubusercontent.com/alston-personal/vendor-reputation-service/main/.agentos/execution-requests/production-runtime.json \
+            -o /tmp/vendor-production-runtime.json
+      - name: Execute bounded Vendor request
+        id: execute
+        run: |
+          set +e
+          python3 scripts/run_governed_execution_request.py \
+            /tmp/vendor-production-runtime.json \
+            /tmp/vendor-production-runtime-receipt.json
+          code=$?
+          cat /tmp/vendor-production-runtime-receipt.json
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Persist sanitized Vendor receipt artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor-production-runtime-receipt
+          path: /tmp/vendor-production-runtime-receipt.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Enforce Vendor execution result
         if: always()
         run: test "${{ steps.execute.outputs.exit_code }}" = "0"

--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -33,11 +33,11 @@ jobs:
     runs-on: [self-hosted, Linux, ARM64, oracle]
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch product-owned request candidate
+      - name: Fetch canonical product-owned request
         run: |
           set -euo pipefail
           curl -fsSL --max-time 15 \
-            https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/ops/agentos-execution-request-v1/.agentos/execution-requests/production-parity.json \
+            https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/main/.agentos/execution-requests/production-parity.json \
             -o /tmp/leopardcat-production-parity.json
       - name: Execute bounded product request
         run: |

--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'governance/execution-authority.json'
       - 'scripts/run_governed_execution_request.py'
+      - 'scripts/fetch_governed_product_request.py'
       - 'tests/test_governed_execution_request.py'
       - 'docs/GOVERNED_EXECUTION_REQUESTS.md'
       - '.github/workflows/core-issue-165-clean-smoke.yml'
@@ -27,18 +28,17 @@ jobs:
       - name: Validate bounded contract
         run: |
           python3 tests/test_governed_execution_request.py
-          python3 -m py_compile scripts/run_governed_execution_request.py
+          python3 -m py_compile scripts/run_governed_execution_request.py scripts/fetch_governed_product_request.py
 
   leopardcat-owned-smoke:
     runs-on: [self-hosted, Linux, ARM64, oracle]
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch canonical LeopardCat request
+      - name: Fetch canonical LeopardCat request through governed product source
         run: |
-          set -euo pipefail
-          curl -fsSL --max-time 15 \
-            https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/main/.agentos/execution-requests/production-parity.json \
-            -o /tmp/leopardcat-production-parity.json
+          python3 scripts/fetch_governed_product_request.py \
+            leopardcat-tarot \
+            /tmp/leopardcat-production-parity.json
       - name: Execute bounded LeopardCat request
         id: execute
         run: |
@@ -66,12 +66,11 @@ jobs:
     runs-on: [self-hosted, Linux, ARM64, oracle]
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch canonical Vendor request
+      - name: Fetch canonical Vendor request through governed product source
         run: |
-          set -euo pipefail
-          curl -fsSL --max-time 15 \
-            https://raw.githubusercontent.com/alston-personal/vendor-reputation-service/main/.agentos/execution-requests/production-runtime.json \
-            -o /tmp/vendor-production-runtime.json
+          python3 scripts/fetch_governed_product_request.py \
+            vendor-reputation-service \
+            /tmp/vendor-production-runtime.json
       - name: Execute bounded Vendor request
         id: execute
         run: |

--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate bounded contract
         run: |
-          python3 -m pytest -q tests/test_governed_execution_request.py
+          python3 tests/test_governed_execution_request.py
           python3 -m py_compile scripts/run_governed_execution_request.py
 
   product-owned-smoke:

--- a/.github/workflows/core-issue-165-clean-smoke.yml
+++ b/.github/workflows/core-issue-165-clean-smoke.yml
@@ -40,6 +40,7 @@ jobs:
             https://raw.githubusercontent.com/alston-personal/leopardcat-tarot/main/.agentos/execution-requests/production-parity.json \
             -o /tmp/leopardcat-production-parity.json
       - name: Execute bounded product request
+        id: execute
         run: |
           set +e
           python3 scripts/run_governed_execution_request.py \
@@ -47,4 +48,16 @@ jobs:
             /tmp/leopardcat-production-parity-receipt.json
           code=$?
           cat /tmp/leopardcat-production-parity-receipt.json
-          exit "$code"
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Persist sanitized receipt artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: leopardcat-production-parity-receipt
+          path: /tmp/leopardcat-production-parity-receipt.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Enforce execution result
+        if: always()
+        run: test "${{ steps.execute.outputs.exit_code }}" = "0"

--- a/docs/GOVERNED_EXECUTION_REQUESTS.md
+++ b/docs/GOVERNED_EXECUTION_REQUESTS.md
@@ -4,11 +4,19 @@ Core #165 introduces a narrow boundary between product-owned intent and Core-own
 
 ## Authority flow
 
-`product manifest -> Project Identity/release-lane registry -> capability adapter -> Oracle execution -> sanitized receipt`
+`product manifest -> governed product-source fetch -> Project Identity/release-lane registry -> capability adapter -> Oracle execution -> sanitized receipt`
 
 The product manifest is data, not executable content. `agentos.execution-request/v1` carries the project, canonical repository, exact 40-character source SHA, source ref, environment, capability, typed parameters, replay policy, and expected receipt contract.
 
-Core is authoritative for the project/repository mapping, allowed release lane, capability-to-project mapping, exact parameter values, runtime path, health/public endpoint, and installed adapter. A request cannot create a new capability or change those values.
+Core is authoritative for the project/repository mapping, allowed release lane, product request path/source, capability-to-project mapping, exact parameter values, runtime path, health/public endpoint, and installed adapter. A request cannot create a new capability or change those values.
+
+## Product request acquisition
+
+Public GitHub URLs are not the authority boundary because private product repositories cannot be read with an unrelated repository-scoped `GITHUB_TOKEN`. The clean path therefore fetches request data through the product's already-enrolled Oracle-local repository.
+
+`fetch_governed_product_request.py` accepts only a `project_id`. The registry fixes the product repo root, release ref, and request path. The fetch performs `git fetch` plus `git show` against that fixed local repo; it does not checkout or mutate the production working tree. The fetched JSON must still pass the same Project Identity, release-lane, capability and typed-parameter checks before execution. Git fetch stderr/stdout is deliberately not echoed on failure so a credential-bearing remote cannot leak through CI logs.
+
+This gives public and private products the same request path without copying cross-repository GitHub credentials into Core workflows.
 
 ## Security invariants
 
@@ -18,12 +26,12 @@ Core is authoritative for the project/repository mapping, allowed release lane, 
 - HTTP(S) remote userinfo is stripped before it can enter receipts.
 - Provider/Oracle credentials remain at the privileged execution boundary and are never returned in receipts.
 - Read-only inspection is explicitly idempotent. Mutating adapters must define stronger replay/idempotency semantics before they can be registered.
-- Product-specific source/build/deploy logic remains in the product repository. Core contains only the generic dispatcher, authority registry, and bounded capability adapters.
+- Product-specific source/build/deploy logic remains in the product repository. Core contains only the generic dispatcher, authority registry, governed request fetcher, and bounded capability adapters.
 - Runtime branch policy is registry-owned. A product request cannot relax `source_ref` matching or opt into detached-HEAD acceptance.
 
 ## Receipt persistence
 
-The clean smoke keeps repository permissions read-only and persists sanitized execution receipts as GitHub Actions artifacts for 30 days. This preserves independent evidence without granting the Oracle job contents-write authority or committing runtime evidence back into Core history.
+The clean smoke keeps Core repository permissions read-only and persists sanitized execution receipts as GitHub Actions artifacts for 30 days. This preserves independent evidence without granting the Oracle job contents-write authority or committing runtime evidence back into Core history.
 
 A receipt records the request/project/repository/source/capability/environment identity, executor identity, exact runtime HEAD, sanitized remote, dirty-state result, endpoint/artifact evidence, and final status. It must never contain provider tokens, Oracle credentials, authorization codes, credential-bearing URLs, arbitrary command material, or secret values.
 

--- a/docs/GOVERNED_EXECUTION_REQUESTS.md
+++ b/docs/GOVERNED_EXECUTION_REQUESTS.md
@@ -1,0 +1,31 @@
+# Governed cross-repository execution requests
+
+Core #165 introduces a narrow boundary between product-owned intent and Core-owned Oracle authority.
+
+## Authority flow
+
+`product manifest -> Project Identity/release-lane registry -> capability adapter -> Oracle execution -> sanitized receipt`
+
+The product manifest is data, not executable content. `agentos.execution-request/v1` carries the project, canonical repository, exact 40-character source SHA, source ref, environment, capability, typed parameters, replay policy, and expected receipt contract.
+
+Core is authoritative for the project/repository mapping, allowed release lane, capability-to-project mapping, exact parameter values, runtime path, public origin, and installed adapter. A request cannot create a new capability or change those values.
+
+## Security invariants
+
+- No shell, executable, argv, script path, filesystem path, sudo request, or secret may be tunneled through the manifest.
+- Exact source SHA is mandatory; a branch name is never sufficient authority.
+- Runtime remote, branch, HEAD, dirty-state allowlist, listener, built artifact and public artifact are verified by the capability adapter.
+- HTTP(S) remote userinfo is stripped before it can enter receipts.
+- Provider/Oracle credentials remain at the privileged execution boundary and are never returned in receipts.
+- Read-only parity inspection is explicitly idempotent. Mutating adapters must define stronger replay/idempotency semantics before they can be registered.
+- Product-specific source/build/deploy logic remains in the product repository. Core contains only the generic dispatcher, authority registry, and bounded capability adapters.
+
+## First consumer
+
+Leopard Cat Tarot owns `.agentos/execution-requests/production-parity.json`. Core resolves that request against `governance/execution-authority.json` and invokes only `leopardcat_production_parity_inspect` on the Oracle runner.
+
+The first adapter is deliberately read-only. Production deployment remains on the retained legacy carrier until a separately governed deploy capability is designed and accepted. This prevents #165 cleanup from silently widening deployment authority.
+
+## Contaminated prototype
+
+`core/issue-165-execution-v1` was useful as an experiment and evidence source but is not mergeable because earlier history contained credential-bearing evidence. The clean implementation must originate from current Core `main`; no commits are rebased or cherry-picked from the contaminated branch.

--- a/docs/GOVERNED_EXECUTION_REQUESTS.md
+++ b/docs/GOVERNED_EXECUTION_REQUESTS.md
@@ -8,29 +8,38 @@ Core #165 introduces a narrow boundary between product-owned intent and Core-own
 
 The product manifest is data, not executable content. `agentos.execution-request/v1` carries the project, canonical repository, exact 40-character source SHA, source ref, environment, capability, typed parameters, replay policy, and expected receipt contract.
 
-Core is authoritative for the project/repository mapping, allowed release lane, capability-to-project mapping, exact parameter values, runtime path, public origin, and installed adapter. A request cannot create a new capability or change those values.
+Core is authoritative for the project/repository mapping, allowed release lane, capability-to-project mapping, exact parameter values, runtime path, health/public endpoint, and installed adapter. A request cannot create a new capability or change those values.
 
 ## Security invariants
 
 - No shell, executable, argv, script path, filesystem path, sudo request, or secret may be tunneled through the manifest.
 - Exact source SHA is mandatory; a branch name is never sufficient authority.
-- Runtime remote, branch, HEAD, dirty-state allowlist, listener, built artifact and public artifact are verified by the capability adapter.
+- Runtime remote, branch policy, HEAD, dirty-state allowlist, listener and endpoint/artifact evidence are verified by the capability adapter.
 - HTTP(S) remote userinfo is stripped before it can enter receipts.
 - Provider/Oracle credentials remain at the privileged execution boundary and are never returned in receipts.
-- Read-only parity inspection is explicitly idempotent. Mutating adapters must define stronger replay/idempotency semantics before they can be registered.
+- Read-only inspection is explicitly idempotent. Mutating adapters must define stronger replay/idempotency semantics before they can be registered.
 - Product-specific source/build/deploy logic remains in the product repository. Core contains only the generic dispatcher, authority registry, and bounded capability adapters.
+- Runtime branch policy is registry-owned. A product request cannot relax `source_ref` matching or opt into detached-HEAD acceptance.
 
 ## Receipt persistence
 
-The clean smoke keeps repository permissions read-only and persists the sanitized execution receipt as a GitHub Actions artifact for 30 days. This preserves independent evidence without granting the Oracle job contents-write authority or committing runtime evidence back into Core history.
+The clean smoke keeps repository permissions read-only and persists sanitized execution receipts as GitHub Actions artifacts for 30 days. This preserves independent evidence without granting the Oracle job contents-write authority or committing runtime evidence back into Core history.
 
-A receipt records the request/project/repository/source/capability/environment identity, executor identity, exact runtime HEAD, sanitized remote, dirty-state result, HTTP results, artifact digests, and final status. It must never contain provider tokens, Oracle credentials, authorization codes, credential-bearing URLs, arbitrary command material, or secret values.
+A receipt records the request/project/repository/source/capability/environment identity, executor identity, exact runtime HEAD, sanitized remote, dirty-state result, endpoint/artifact evidence, and final status. It must never contain provider tokens, Oracle credentials, authorization codes, credential-bearing URLs, arbitrary command material, or secret values.
 
-## First consumer
+## Consumers
 
-Leopard Cat Tarot owns `.agentos/execution-requests/production-parity.json`. Core resolves that request against `governance/execution-authority.json` and invokes only `leopardcat_production_parity_inspect` on the Oracle runner.
+### Leopard Cat Tarot
 
-The first adapter is deliberately read-only. Production deployment remains on the retained legacy carrier until a separately governed deploy capability is designed and accepted. This prevents #165 cleanup from silently widening deployment authority.
+Leopard Cat Tarot owns `.agentos/execution-requests/production-parity.json`. Core resolves that request against `governance/execution-authority.json` and invokes only `leopardcat_production_parity_inspect` on the Oracle runner. Its evidence level is `runtime_repo+deployed_artifact`, including local/localhost/public bundle parity.
+
+### Vendor Reputation Service
+
+Vendor Reputation Service owns `.agentos/execution-requests/production-runtime.json`. Core resolves it to the generic `repository_service_inspect` adapter. The request can select only the fixed production API listener; repository root, health path, expected health identity, dirty-state allowlist and detached-vs-branch runtime policy all remain registry-owned.
+
+The Vendor runtime historically deploys an exact SHA with detached HEAD, so its authority explicitly permits only `detached_or_source_ref`; an arbitrary feature branch still fails closed. The health probe records only status, expected-identity match and response digest, not database contents or private Threads evidence. Its evidence level is `runtime_repo+service_endpoint`, so the receipt does not falsely label a health-response digest as a deployed artifact digest.
+
+Both consumers are deliberately read-only. Production deployment and Vendor monitored-source mutation remain on retained carriers until separately governed mutating capabilities define exact replay/idempotency, secret-broker and sanitized-receipt contracts. This prevents #165 cleanup from silently widening deployment authority.
 
 ## Contaminated prototype
 

--- a/docs/GOVERNED_EXECUTION_REQUESTS.md
+++ b/docs/GOVERNED_EXECUTION_REQUESTS.md
@@ -20,6 +20,12 @@ Core is authoritative for the project/repository mapping, allowed release lane, 
 - Read-only parity inspection is explicitly idempotent. Mutating adapters must define stronger replay/idempotency semantics before they can be registered.
 - Product-specific source/build/deploy logic remains in the product repository. Core contains only the generic dispatcher, authority registry, and bounded capability adapters.
 
+## Receipt persistence
+
+The clean smoke keeps repository permissions read-only and persists the sanitized execution receipt as a GitHub Actions artifact for 30 days. This preserves independent evidence without granting the Oracle job contents-write authority or committing runtime evidence back into Core history.
+
+A receipt records the request/project/repository/source/capability/environment identity, executor identity, exact runtime HEAD, sanitized remote, dirty-state result, HTTP results, artifact digests, and final status. It must never contain provider tokens, Oracle credentials, authorization codes, credential-bearing URLs, arbitrary command material, or secret values.
+
 ## First consumer
 
 Leopard Cat Tarot owns `.agentos/execution-requests/production-parity.json`. Core resolves that request against `governance/execution-authority.json` and invokes only `leopardcat_production_parity_inspect` on the Oracle runner.

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -7,7 +7,8 @@
       "allowed_source_refs": ["main"],
       "request_source": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
-        "source_ref": "main"
+        "source_ref": "main",
+        "execution_user": "ubuntu"
       }
     },
     "vendor-reputation-service": {
@@ -16,7 +17,8 @@
       "allowed_source_refs": ["main"],
       "request_source": {
         "repo_root": "/home/ubuntu/vendor-reputation-service",
-        "source_ref": "main"
+        "source_ref": "main",
+        "execution_user": "ubuntu"
       }
     }
   },

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -5,6 +5,11 @@
       "repository": "alston-personal/leopardcat-tarot",
       "request_path": ".agentos/execution-requests/production-parity.json",
       "allowed_source_refs": ["main"]
+    },
+    "vendor-reputation-service": {
+      "repository": "alston-personal/vendor-reputation-service",
+      "request_path": ".agentos/execution-requests/production-runtime.json",
+      "allowed_source_refs": ["main"]
     }
   },
   "capabilities": {
@@ -19,6 +24,26 @@
       "runtime": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
         "public_origin": "https://leopardcat-tarot.milkcat.org"
+      }
+    },
+    "vendor.production.runtime.inspect": {
+      "project_id": "vendor-reputation-service",
+      "environment": "production",
+      "adapter": "repository_service_inspect",
+      "parameters": {
+        "listen_port": 18765
+      },
+      "replay_policy": "idempotent",
+      "runtime": {
+        "repo_root": "/home/ubuntu/vendor-reputation-service",
+        "health_path": "/healthz",
+        "branch_policy": "detached_or_source_ref",
+        "expected_health": {
+          "ok": true,
+          "service": "vendor-reputation-service"
+        },
+        "allowed_dirty_exact": [],
+        "allowed_dirty_prefixes": [".claude/"]
       }
     }
   }

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -4,12 +4,20 @@
     "leopardcat-tarot": {
       "repository": "alston-personal/leopardcat-tarot",
       "request_path": ".agentos/execution-requests/production-parity.json",
-      "allowed_source_refs": ["main"]
+      "allowed_source_refs": ["main"],
+      "request_source": {
+        "repo_root": "/home/ubuntu/leopardcat-tarot",
+        "source_ref": "main"
+      }
     },
     "vendor-reputation-service": {
       "repository": "alston-personal/vendor-reputation-service",
       "request_path": ".agentos/execution-requests/production-runtime.json",
-      "allowed_source_refs": ["main"]
+      "allowed_source_refs": ["main"],
+      "request_source": {
+        "repo_root": "/home/ubuntu/vendor-reputation-service",
+        "source_ref": "main"
+      }
     }
   },
   "capabilities": {

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -1,0 +1,25 @@
+{
+  "schema": "agentos.execution-authority/v1",
+  "projects": {
+    "leopardcat-tarot": {
+      "repository": "alston-personal/leopardcat-tarot",
+      "request_path": ".agentos/execution-requests/production-parity.json",
+      "allowed_source_refs": ["main"]
+    }
+  },
+  "capabilities": {
+    "leopardcat.production.parity.inspect": {
+      "project_id": "leopardcat-tarot",
+      "environment": "production",
+      "adapter": "leopardcat_production_parity_inspect",
+      "parameters": {
+        "listen_port": 8088
+      },
+      "replay_policy": "idempotent",
+      "runtime": {
+        "repo_root": "/home/ubuntu/leopardcat-tarot",
+        "public_origin": "https://leopardcat-tarot.milkcat.org"
+      }
+    }
+  }
+}

--- a/scripts/fetch_governed_product_request.py
+++ b/scripts/fetch_governed_product_request.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Fetch a product-owned execution request through its Oracle-local repository.
 
-This solves the private-repository boundary without copying a cross-repository GitHub
-credential into Core workflows. Core accepts only a project id; repository root,
-source ref, and request path come from the execution authority registry. The fetch
-updates Git metadata only and never checks out or mutates the production working tree.
+The workflow supplies only a project id. Repository root, release ref, request path,
+and optional runtime user are registry-owned. A runtime-user transition is allowed only
+for the fixed git fetch/show operations below; no request-controlled argv is accepted.
 """
 import json
 import subprocess
@@ -18,17 +17,16 @@ def fail(message):
     raise RuntimeError(message)
 
 
-def run_git(repo_root, *args):
-    return subprocess.run(
-        ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root, *args],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+def run_git(repo_root, execution_user, *args):
+    git_argv = ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root, *args]
+    argv = git_argv if not execution_user else ["sudo", "-n", "-u", execution_user, "--", *git_argv]
+    return subprocess.run(argv, text=True, capture_output=True, check=False)
 
 
 def classify_git_failure(proc):
     text = f"{proc.stderr or ''}\n{proc.stdout or ''}".lower()
+    if "a password is required" in text or "not allowed to execute" in text or "sudoers" in text:
+        return "runtime-user-transition-denied"
     if "dubious ownership" in text or "safe.directory" in text:
         return "safe-directory"
     if "permission denied" in text:
@@ -51,19 +49,22 @@ def fetch_product_request(project_id, registry):
     source = project.get("request_source") or {}
     repo_root = source.get("repo_root")
     source_ref = source.get("source_ref")
+    execution_user = source.get("execution_user")
     request_path = project.get("request_path")
     if not all(isinstance(value, str) and value for value in (repo_root, source_ref, request_path)):
         fail("project request source is incomplete")
+    if execution_user is not None and execution_user not in ("ubuntu",):
+        fail("request source execution user is not allowlisted")
     if source_ref not in project.get("allowed_source_refs", []):
         fail("request source ref is outside release-lane authority")
     if request_path.startswith("/") or ".." in Path(request_path).parts:
         fail("request path is outside repository authority")
 
-    fetch = run_git(repo_root, "fetch", "--depth=1", "origin", source_ref)
+    fetch = run_git(repo_root, execution_user, "fetch", "--depth=1", "origin", source_ref)
     if fetch.returncode:
         # Never echo raw git output; it can contain a credential-bearing remote.
         fail(f"product repository fetch failed [{classify_git_failure(fetch)}]")
-    show = run_git(repo_root, "show", f"FETCH_HEAD:{request_path}")
+    show = run_git(repo_root, execution_user, "show", f"FETCH_HEAD:{request_path}")
     if show.returncode:
         fail(f"product request is missing at the governed path [{classify_git_failure(show)}]")
     try:

--- a/scripts/fetch_governed_product_request.py
+++ b/scripts/fetch_governed_product_request.py
@@ -20,11 +20,28 @@ def fail(message):
 
 def run_git(repo_root, *args):
     return subprocess.run(
-        ["git", "-C", repo_root, *args],
+        ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root, *args],
         text=True,
         capture_output=True,
         check=False,
     )
+
+
+def classify_git_failure(proc):
+    text = f"{proc.stderr or ''}\n{proc.stdout or ''}".lower()
+    if "dubious ownership" in text or "safe.directory" in text:
+        return "safe-directory"
+    if "permission denied" in text:
+        return "filesystem-or-transport-permission"
+    if "authentication failed" in text or "could not read username" in text or "terminal prompts disabled" in text:
+        return "remote-authentication"
+    if "repository not found" in text:
+        return "remote-repository-unavailable"
+    if "not a git repository" in text:
+        return "local-repository-unavailable"
+    if "could not resolve host" in text or "failed to connect" in text:
+        return "network-unavailable"
+    return "unclassified"
 
 
 def fetch_product_request(project_id, registry):
@@ -44,11 +61,11 @@ def fetch_product_request(project_id, registry):
 
     fetch = run_git(repo_root, "fetch", "--depth=1", "origin", source_ref)
     if fetch.returncode:
-        # Do not echo git stderr/stdout: a misconfigured remote may contain credentials.
-        fail("product repository fetch failed")
+        # Never echo raw git output; it can contain a credential-bearing remote.
+        fail(f"product repository fetch failed [{classify_git_failure(fetch)}]")
     show = run_git(repo_root, "show", f"FETCH_HEAD:{request_path}")
     if show.returncode:
-        fail("product request is missing at the governed path")
+        fail(f"product request is missing at the governed path [{classify_git_failure(show)}]")
     try:
         request = json.loads(show.stdout)
     except json.JSONDecodeError:

--- a/scripts/fetch_governed_product_request.py
+++ b/scripts/fetch_governed_product_request.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fetch a product-owned execution request through its Oracle-local repository.
+
+This solves the private-repository boundary without copying a cross-repository GitHub
+credential into Core workflows. Core accepts only a project id; repository root,
+source ref, and request path come from the execution authority registry. The fetch
+updates Git metadata only and never checks out or mutates the production working tree.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from run_governed_execution_request import load_json, resolve_authority
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def run_git(repo_root, *args):
+    return subprocess.run(
+        ["git", "-C", repo_root, *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def fetch_product_request(project_id, registry):
+    project = registry.get("projects", {}).get(project_id)
+    if not project:
+        fail("project is not allowlisted")
+    source = project.get("request_source") or {}
+    repo_root = source.get("repo_root")
+    source_ref = source.get("source_ref")
+    request_path = project.get("request_path")
+    if not all(isinstance(value, str) and value for value in (repo_root, source_ref, request_path)):
+        fail("project request source is incomplete")
+    if source_ref not in project.get("allowed_source_refs", []):
+        fail("request source ref is outside release-lane authority")
+    if request_path.startswith("/") or ".." in Path(request_path).parts:
+        fail("request path is outside repository authority")
+
+    fetch = run_git(repo_root, "fetch", "--depth=1", "origin", source_ref)
+    if fetch.returncode:
+        # Do not echo git stderr/stdout: a misconfigured remote may contain credentials.
+        fail("product repository fetch failed")
+    show = run_git(repo_root, "show", f"FETCH_HEAD:{request_path}")
+    if show.returncode:
+        fail("product request is missing at the governed path")
+    try:
+        request = json.loads(show.stdout)
+    except json.JSONDecodeError as exc:
+        fail("product request is not valid JSON") from exc
+
+    resolved_project, _ = resolve_authority(request, registry)
+    if request.get("project_id") != project_id:
+        fail("product request project identity mismatch")
+    if request.get("source_ref") != source_ref:
+        fail("product request release lane mismatch")
+    if resolved_project is not project:
+        fail("resolved project authority mismatch")
+    return request, source_ref, request_path
+
+
+def main():
+    if len(sys.argv) not in (3, 4):
+        print("usage: fetch_governed_product_request.py PROJECT_ID OUTPUT [REGISTRY]", file=sys.stderr)
+        return 2
+    project_id = sys.argv[1]
+    output = Path(sys.argv[2])
+    registry_path = sys.argv[3] if len(sys.argv) == 4 else "governance/execution-authority.json"
+    try:
+        registry = load_json(registry_path)
+        request, source_ref, request_path = fetch_product_request(project_id, registry)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps({
+            "status": "success",
+            "project_id": project_id,
+            "source_ref": source_ref,
+            "request_path": request_path,
+            "request_id": request.get("request_id"),
+            "source_sha": request.get("source_sha"),
+            "capability": request.get("capability"),
+        }, sort_keys=True))
+        return 0
+    except Exception as exc:
+        print(json.dumps({
+            "status": "failed",
+            "project_id": project_id,
+            "error": f"{type(exc).__name__}: {exc}",
+        }, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_governed_product_request.py
+++ b/scripts/fetch_governed_product_request.py
@@ -51,8 +51,8 @@ def fetch_product_request(project_id, registry):
         fail("product request is missing at the governed path")
     try:
         request = json.loads(show.stdout)
-    except json.JSONDecodeError as exc:
-        fail("product request is not valid JSON") from exc
+    except json.JSONDecodeError:
+        fail("product request is not valid JSON")
 
     resolved_project, _ = resolve_authority(request, registry)
     if request.get("project_id") != project_id:

--- a/scripts/run_governed_execution_request.py
+++ b/scripts/run_governed_execution_request.py
@@ -78,7 +78,11 @@ def resolve_authority(request, registry):
     return project, capability
 
 
-def git_state(repo_root):
+def _path_allowed(path, exact, prefixes):
+    return path in exact or any(path.startswith(prefix) for prefix in prefixes)
+
+
+def git_state(repo_root, allowed_dirty_exact=(), allowed_dirty_prefixes=()):
     def git(*args):
         proc = run_fixed(["git", "-C", repo_root, *args])
         if proc.returncode:
@@ -89,23 +93,33 @@ def git_state(repo_root):
     for line in git("status", "--porcelain").splitlines():
         paths.append((line[2:] if len(line) > 2 else "").strip())
 
-    def allowed_dirty(path):
-        return (
-            path == "website/dist/index.html"
-            or path == "website/stats.json"
-            or path.startswith("website/node_modules/.vite/")
-            or path == ".claude/"
-            or path.startswith(".claude/")
-        )
-
+    exact = tuple(allowed_dirty_exact or ())
+    prefixes = tuple(allowed_dirty_prefixes or ())
     return {
         "root": repo_root,
         "head": git("rev-parse", "HEAD"),
         "branch": git("branch", "--show-current"),
         "remote_origin": sanitize_remote(git("remote", "get-url", "origin")),
         "dirty_paths": paths,
-        "unexpected_dirty_paths": [p for p in paths if not allowed_dirty(p)],
+        "unexpected_dirty_paths": [p for p in paths if not _path_allowed(p, exact, prefixes)],
     }
+
+
+def listener_state(port):
+    listener_proc = run_fixed(["ss", "-ltnp", f"sport = :{port}"])
+    listener_text = (listener_proc.stdout or "") + (listener_proc.stderr or "")
+    if listener_proc.returncode or "LISTEN" not in listener_text:
+        fail(f"no listener on port {port}")
+    pid_match = re.search(r"pid=(\d+)", listener_text)
+    return {"present": True, "pid": int(pid_match.group(1)) if pid_match else None}
+
+
+def branch_matches_policy(branch, source_ref, policy):
+    if policy == "source_ref":
+        return branch == source_ref
+    if policy == "detached_or_source_ref":
+        return branch in ("", source_ref)
+    fail(f"unsupported runtime branch policy: {policy}")
 
 
 def fetch_bytes(url):
@@ -124,14 +138,12 @@ def inspect_leopardcat_parity(request, capability):
     port = request["parameters"]["listen_port"]
     public_origin = runtime["public_origin"]
 
-    listener_proc = run_fixed(["ss", "-ltnp", f"sport = :{port}"])
-    listener_text = (listener_proc.stdout or "") + (listener_proc.stderr or "")
-    if listener_proc.returncode or "LISTEN" not in listener_text:
-        fail(f"no listener on port {port}")
-    pid_match = re.search(r"pid=(\d+)", listener_text)
-    listener = {"present": True, "pid": int(pid_match.group(1)) if pid_match else None}
-
-    state = git_state(repo_root)
+    listener = listener_state(port)
+    state = git_state(
+        repo_root,
+        allowed_dirty_exact=("website/dist/index.html", "website/stats.json", ".claude/"),
+        allowed_dirty_prefixes=("website/node_modules/.vite/", ".claude/"),
+    )
     index_path = Path(repo_root) / "website" / "dist" / "index.html"
     if not index_path.is_file():
         fail("production dist/index.html is missing")
@@ -177,11 +189,65 @@ def inspect_leopardcat_parity(request, capability):
         public_http == 200,
         root_http == 200,
     ])
-    return evidence, digests[2], accepted
+    return evidence, digests[2], accepted, "runtime_repo+deployed_artifact"
+
+
+def inspect_repository_service(request, capability):
+    runtime = capability["runtime"]
+    repo_root = runtime["repo_root"]
+    port = request["parameters"]["listen_port"]
+    health_path = runtime.get("health_path", "/healthz")
+    if not isinstance(health_path, str) or not health_path.startswith("/") or "://" in health_path:
+        fail("invalid registry-owned health path")
+
+    listener = listener_state(port)
+    state = git_state(
+        repo_root,
+        allowed_dirty_exact=runtime.get("allowed_dirty_exact", ()),
+        allowed_dirty_prefixes=runtime.get("allowed_dirty_prefixes", ()),
+    )
+    health_body, health_http = fetch_bytes(f"http://127.0.0.1:{port}{health_path}")
+    health_digest = sha256(health_body)
+    try:
+        health_payload = json.loads(health_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        health_payload = None
+
+    expected_health = runtime.get("expected_health", {})
+    health_matches_expected = isinstance(health_payload, dict) and all(
+        health_payload.get(key) == value for key, value in expected_health.items()
+    )
+    expected_remote = f"https://github.com/{request['repository']}.git"
+    branch_policy = runtime.get("branch_policy", "source_ref")
+    runtime_branch_matches = branch_matches_policy(state["branch"], request["source_ref"], branch_policy)
+
+    evidence = {
+        "listener": listener,
+        "runtime_git": state,
+        "repository_matches": state["remote_origin"] == expected_remote,
+        "requested_source_sha_matches_runtime_head": state["head"] == request["source_sha"],
+        "runtime_branch_policy": branch_policy,
+        "runtime_branch_matches_policy": runtime_branch_matches,
+        "runtime_dirty_state_allowed": not state["unexpected_dirty_paths"],
+        "health_path": health_path,
+        "health_http": health_http,
+        "health_response_sha256": health_digest,
+        "health_matches_expected": health_matches_expected,
+    }
+    accepted = all([
+        evidence["repository_matches"],
+        evidence["requested_source_sha_matches_runtime_head"],
+        evidence["runtime_branch_matches_policy"],
+        evidence["runtime_dirty_state_allowed"],
+        health_http == 200,
+        evidence["health_matches_expected"],
+    ])
+    return evidence, None, accepted, "runtime_repo+service_endpoint"
 
 
 ADAPTERS = {
     "leopardcat_production_parity_inspect": inspect_leopardcat_parity,
+    "repository_service_inspect": inspect_repository_service,
 }
 
 
@@ -218,10 +284,10 @@ def main():
         adapter = ADAPTERS.get(capability.get("adapter"))
         if not adapter:
             fail("capability adapter is not installed")
-        evidence, digest, accepted = adapter(request, capability)
+        evidence, digest, accepted, evidence_level = adapter(request, capability)
         receipt["evidence"] = evidence
         receipt["artifact_digest"] = digest
-        receipt["evidence_level"] = "runtime_repo+deployed_artifact"
+        receipt["evidence_level"] = evidence_level
         receipt["result_status"] = "success" if accepted else "mismatch"
     except Exception as exc:
         receipt["error"] = f"{type(exc).__name__}: {exc}"

--- a/scripts/run_governed_execution_request.py
+++ b/scripts/run_governed_execution_request.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""AgentOS governed execution-request v1 dispatcher.
+
+The request is data, never a shell command. Authority comes from the Core registry;
+the product manifest may only select an allowlisted capability and its exact typed
+parameters. Provider/deploy secrets are never accepted from or returned to a request.
+"""
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+ASSET_RE = re.compile(rb'src="(/assets/index-[^"]+\.js)"')
+REQUEST_KEYS = {
+    "schema", "request_id", "project_id", "repository", "source_ref",
+    "source_sha", "capability", "environment", "parameters",
+    "replay_policy", "expected_result",
+}
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run_fixed(argv):
+    return subprocess.run(argv, text=True, capture_output=True, check=False)
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def sanitize_remote(remote):
+    remote = str(remote or "")
+    if "://" in remote:
+        remote = re.sub(r"(https?://)[^/@]+@", r"\1", remote)
+    return remote
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def resolve_authority(request, registry):
+    if set(request) != REQUEST_KEYS:
+        fail(f"request keys mismatch: {sorted(set(request) ^ REQUEST_KEYS)}")
+    if request["schema"] != "agentos.execution-request/v1":
+        fail("unsupported request schema")
+    if request["expected_result"] != "agentos.execution-receipt/v1":
+        fail("unsupported receipt schema")
+    if not SHA40.fullmatch(str(request["source_sha"])):
+        fail("source_sha must be an exact lowercase 40-char SHA")
+    if registry.get("schema") != "agentos.execution-authority/v1":
+        fail("unsupported execution authority schema")
+
+    project = registry.get("projects", {}).get(request["project_id"])
+    capability = registry.get("capabilities", {}).get(request["capability"])
+    if not project or not capability:
+        fail("project or capability not allowlisted")
+    if capability.get("project_id") != request["project_id"]:
+        fail("capability is not authorized for project")
+    if project.get("repository") != request["repository"]:
+        fail("repository is outside Project Identity authority")
+    if request["source_ref"] not in project.get("allowed_source_refs", []):
+        fail("source_ref is outside release-lane authority")
+    if capability.get("environment") != request["environment"]:
+        fail("environment is outside capability authority")
+    if capability.get("parameters") != request["parameters"]:
+        fail("parameters are outside typed capability contract")
+    if capability.get("replay_policy") != request["replay_policy"]:
+        fail("replay policy mismatch")
+    return project, capability
+
+
+def git_state(repo_root):
+    def git(*args):
+        proc = run_fixed(["git", "-C", repo_root, *args])
+        if proc.returncode:
+            fail(f"git {' '.join(args)} failed: {(proc.stderr or proc.stdout).strip()[:400]}")
+        return proc.stdout.strip()
+
+    paths = []
+    for line in git("status", "--porcelain").splitlines():
+        paths.append((line[2:] if len(line) > 2 else "").strip())
+
+    def allowed_dirty(path):
+        return (
+            path == "website/dist/index.html"
+            or path == "website/stats.json"
+            or path.startswith("website/node_modules/.vite/")
+            or path == ".claude/"
+            or path.startswith(".claude/")
+        )
+
+    return {
+        "root": repo_root,
+        "head": git("rev-parse", "HEAD"),
+        "branch": git("branch", "--show-current"),
+        "remote_origin": sanitize_remote(git("remote", "get-url", "origin")),
+        "dirty_paths": paths,
+        "unexpected_dirty_paths": [p for p in paths if not allowed_dirty(p)],
+    }
+
+
+def fetch_bytes(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "agentos-governed-execution/1"})
+    with urllib.request.urlopen(req, timeout=15) as response:
+        return response.read(), int(getattr(response, "status", 200))
+
+
+def sha256(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def inspect_leopardcat_parity(request, capability):
+    runtime = capability["runtime"]
+    repo_root = runtime["repo_root"]
+    port = request["parameters"]["listen_port"]
+    public_origin = runtime["public_origin"]
+
+    listener_proc = run_fixed(["ss", "-ltnp", f"sport = :{port}"])
+    listener_text = (listener_proc.stdout or "") + (listener_proc.stderr or "")
+    if listener_proc.returncode or "LISTEN" not in listener_text:
+        fail(f"no listener on port {port}")
+    pid_match = re.search(r"pid=(\d+)", listener_text)
+    listener = {"present": True, "pid": int(pid_match.group(1)) if pid_match else None}
+
+    state = git_state(repo_root)
+    index_path = Path(repo_root) / "website" / "dist" / "index.html"
+    if not index_path.is_file():
+        fail("production dist/index.html is missing")
+    match = ASSET_RE.search(index_path.read_bytes())
+    if not match:
+        fail("unable to resolve hashed Vite asset")
+    asset_path = match.group(1).decode("utf-8")
+    local_path = Path(repo_root) / "website" / "dist" / asset_path.lstrip("/")
+    if not local_path.is_file():
+        fail("local built asset is missing")
+
+    local = local_path.read_bytes()
+    localhost, localhost_http = fetch_bytes(f"http://127.0.0.1:{port}{asset_path}")
+    public, public_http = fetch_bytes(f"{public_origin}{asset_path}")
+    _, root_http = fetch_bytes(f"{public_origin}/")
+    digests = [sha256(local), sha256(localhost), sha256(public)]
+
+    expected_remote = f"https://github.com/{request['repository']}.git"
+    evidence = {
+        "listener": listener,
+        "runtime_git": state,
+        "repository_matches": state["remote_origin"] == expected_remote,
+        "requested_source_sha_matches_runtime_head": state["head"] == request["source_sha"],
+        "runtime_branch_matches_source_ref": state["branch"] == request["source_ref"],
+        "runtime_dirty_state_allowed": not state["unexpected_dirty_paths"],
+        "vite_asset_path": asset_path,
+        "local_asset_sha256": digests[0],
+        "localhost_asset_sha256": digests[1],
+        "public_asset_sha256": digests[2],
+        "artifact_three_way_match": len(set(digests)) == 1,
+        "localhost_asset_http": localhost_http,
+        "public_asset_http": public_http,
+        "public_root_http": root_http,
+        "public_origin": public_origin,
+    }
+    accepted = all([
+        evidence["repository_matches"],
+        evidence["requested_source_sha_matches_runtime_head"],
+        evidence["runtime_branch_matches_source_ref"],
+        evidence["runtime_dirty_state_allowed"],
+        evidence["artifact_three_way_match"],
+        localhost_http == 200,
+        public_http == 200,
+        root_http == 200,
+    ])
+    return evidence, digests[2], accepted
+
+
+ADAPTERS = {
+    "leopardcat_production_parity_inspect": inspect_leopardcat_parity,
+}
+
+
+def main():
+    if len(sys.argv) not in (2, 3, 4):
+        print("usage: run_governed_execution_request.py REQUEST [RECEIPT] [REGISTRY]", file=sys.stderr)
+        return 2
+    request_path = sys.argv[1]
+    receipt_path = Path(sys.argv[2] if len(sys.argv) >= 3 else ".agentos/evidence/execution-receipt.json")
+    registry_path = sys.argv[3] if len(sys.argv) >= 4 else "governance/execution-authority.json"
+    receipt = {
+        "schema": "agentos.execution-receipt/v1",
+        "request_id": None,
+        "project_id": None,
+        "repository": None,
+        "environment": None,
+        "source_ref": None,
+        "source_sha": None,
+        "capability": None,
+        "result_status": "failed",
+        "evidence_level": None,
+        "artifact_digest": None,
+        "executor_identity": os.environ.get("RUNNER_NAME") or os.uname().nodename,
+        "started_at": now(),
+        "completed_at": None,
+        "evidence": {},
+        "error": None,
+    }
+    try:
+        request = load_json(request_path)
+        _, capability = resolve_authority(request, load_json(registry_path))
+        for key in ("request_id", "project_id", "repository", "environment", "source_ref", "source_sha", "capability"):
+            receipt[key] = request[key]
+        adapter = ADAPTERS.get(capability.get("adapter"))
+        if not adapter:
+            fail("capability adapter is not installed")
+        evidence, digest, accepted = adapter(request, capability)
+        receipt["evidence"] = evidence
+        receipt["artifact_digest"] = digest
+        receipt["evidence_level"] = "runtime_repo+deployed_artifact"
+        receipt["result_status"] = "success" if accepted else "mismatch"
+    except Exception as exc:
+        receipt["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        receipt["completed_at"] = now()
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0 if receipt["result_status"] == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_governed_execution_request.py
+++ b/tests/test_governed_execution_request.py
@@ -32,10 +32,36 @@ def request(**changes):
     return value
 
 
+def vendor_request(**changes):
+    value = {
+        "schema": "agentos.execution-request/v1",
+        "request_id": "vendor-production-runtime-" + "b" * 40,
+        "project_id": "vendor-reputation-service",
+        "repository": "alston-personal/vendor-reputation-service",
+        "source_ref": "main",
+        "source_sha": "b" * 40,
+        "capability": "vendor.production.runtime.inspect",
+        "environment": "production",
+        "parameters": {"listen_port": 18765},
+        "replay_policy": "idempotent",
+        "expected_result": "agentos.execution-receipt/v1",
+    }
+    value.update(changes)
+    return value
+
+
 def test_exact_typed_request_resolves_authority():
     project, capability = MODULE.resolve_authority(request(), registry())
     assert project["repository"] == "alston-personal/leopardcat-tarot"
     assert capability["adapter"] == "leopardcat_production_parity_inspect"
+
+
+def test_second_product_resolves_generic_runtime_inspector():
+    project, capability = MODULE.resolve_authority(vendor_request(), registry())
+    assert project["repository"] == "alston-personal/vendor-reputation-service"
+    assert capability["adapter"] == "repository_service_inspect"
+    assert capability["runtime"]["repo_root"] == "/home/ubuntu/vendor-reputation-service"
+    assert capability["runtime"]["health_path"] == "/healthz"
 
 
 def test_arbitrary_command_field_is_rejected():
@@ -58,6 +84,15 @@ def test_repository_cannot_be_swapped():
         raise AssertionError("repository substitution must be rejected")
 
 
+def test_vendor_cannot_select_leopardcat_capability():
+    try:
+        MODULE.resolve_authority(vendor_request(capability="leopardcat.production.parity.inspect"), registry())
+    except RuntimeError as exc:
+        assert "not authorized for project" in str(exc)
+    else:
+        raise AssertionError("cross-product capability substitution must be rejected")
+
+
 def test_source_ref_cannot_escape_release_lane():
     try:
         MODULE.resolve_authority(request(source_ref="feature/unsafe"), registry())
@@ -76,6 +111,15 @@ def test_parameter_widening_is_rejected():
         raise AssertionError("request-controlled privileged parameters must be rejected")
 
 
+def test_vendor_parameter_widening_is_rejected():
+    try:
+        MODULE.resolve_authority(vendor_request(parameters={"listen_port": 22}), registry())
+    except RuntimeError as exc:
+        assert "typed capability" in str(exc)
+    else:
+        raise AssertionError("Vendor request cannot retarget a privileged listener")
+
+
 def test_sha_must_be_exact_lowercase_40_char():
     for bad in ("main", "A" * 40, "a" * 39, "a" * 41):
         try:
@@ -88,6 +132,19 @@ def test_sha_must_be_exact_lowercase_40_char():
 
 def test_remote_userinfo_is_sanitized():
     assert MODULE.sanitize_remote("https://user:secret@github.com/o/r.git") == "https://github.com/o/r.git"
+
+
+def test_runtime_branch_policy_is_explicit_and_bounded():
+    assert MODULE.branch_matches_policy("main", "main", "source_ref") is True
+    assert MODULE.branch_matches_policy("", "main", "detached_or_source_ref") is True
+    assert MODULE.branch_matches_policy("main", "main", "detached_or_source_ref") is True
+    assert MODULE.branch_matches_policy("feature/unsafe", "main", "detached_or_source_ref") is False
+    try:
+        MODULE.branch_matches_policy("main", "main", "anything")
+    except RuntimeError as exc:
+        assert "unsupported runtime branch policy" in str(exc)
+    else:
+        raise AssertionError("unknown runtime branch policy must fail closed")
 
 
 def test_registry_contains_no_generic_shell_adapter():

--- a/tests/test_governed_execution_request.py
+++ b/tests/test_governed_execution_request.py
@@ -95,3 +95,10 @@ def test_registry_contains_no_generic_shell_adapter():
     assert '"shell"' not in text
     assert '"argv"' not in text
     assert '"executable"' not in text
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_") and callable(value)]
+    for test in tests:
+        test()
+    print(f"governed_execution_contract_tests=PASS count={len(tests)}")

--- a/tests/test_governed_execution_request.py
+++ b/tests/test_governed_execution_request.py
@@ -1,0 +1,97 @@
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "governed_execution", ROOT / "scripts" / "run_governed_execution_request.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def registry():
+    return json.loads((ROOT / "governance" / "execution-authority.json").read_text())
+
+
+def request(**changes):
+    value = {
+        "schema": "agentos.execution-request/v1",
+        "request_id": "leopardcat-production-parity-" + "a" * 40,
+        "project_id": "leopardcat-tarot",
+        "repository": "alston-personal/leopardcat-tarot",
+        "source_ref": "main",
+        "source_sha": "a" * 40,
+        "capability": "leopardcat.production.parity.inspect",
+        "environment": "production",
+        "parameters": {"listen_port": 8088},
+        "replay_policy": "idempotent",
+        "expected_result": "agentos.execution-receipt/v1",
+    }
+    value.update(changes)
+    return value
+
+
+def test_exact_typed_request_resolves_authority():
+    project, capability = MODULE.resolve_authority(request(), registry())
+    assert project["repository"] == "alston-personal/leopardcat-tarot"
+    assert capability["adapter"] == "leopardcat_production_parity_inspect"
+
+
+def test_arbitrary_command_field_is_rejected():
+    value = request()
+    value["command"] = "rm -rf /"
+    try:
+        MODULE.resolve_authority(value, registry())
+    except RuntimeError as exc:
+        assert "request keys mismatch" in str(exc)
+    else:
+        raise AssertionError("generic command tunneling must be rejected")
+
+
+def test_repository_cannot_be_swapped():
+    try:
+        MODULE.resolve_authority(request(repository="other/repo"), registry())
+    except RuntimeError as exc:
+        assert "Project Identity" in str(exc)
+    else:
+        raise AssertionError("repository substitution must be rejected")
+
+
+def test_source_ref_cannot_escape_release_lane():
+    try:
+        MODULE.resolve_authority(request(source_ref="feature/unsafe"), registry())
+    except RuntimeError as exc:
+        assert "release-lane" in str(exc)
+    else:
+        raise AssertionError("branch name alone cannot grant authority")
+
+
+def test_parameter_widening_is_rejected():
+    try:
+        MODULE.resolve_authority(request(parameters={"listen_port": 22}), registry())
+    except RuntimeError as exc:
+        assert "typed capability" in str(exc)
+    else:
+        raise AssertionError("request-controlled privileged parameters must be rejected")
+
+
+def test_sha_must_be_exact_lowercase_40_char():
+    for bad in ("main", "A" * 40, "a" * 39, "a" * 41):
+        try:
+            MODULE.resolve_authority(request(source_sha=bad), registry())
+        except RuntimeError as exc:
+            assert "40-char SHA" in str(exc)
+        else:
+            raise AssertionError(f"invalid SHA accepted: {bad!r}")
+
+
+def test_remote_userinfo_is_sanitized():
+    assert MODULE.sanitize_remote("https://user:secret@github.com/o/r.git") == "https://github.com/o/r.git"
+
+
+def test_registry_contains_no_generic_shell_adapter():
+    text = (ROOT / "governance" / "execution-authority.json").read_text().lower()
+    assert '"shell"' not in text
+    assert '"argv"' not in text
+    assert '"executable"' not in text


### PR DESCRIPTION
Implements a clean #165 execution-request boundary from current Core main, without rebasing or cherry-picking the contaminated prototype branch.

What this PR adds:
- `agentos.execution-authority/v1` registry for Project Identity, release lane, capability, typed parameters, runtime authority, and replay policy.
- `run_governed_execution_request.py`: data-only dispatcher with exact SHA validation and no shell/argv/executable/path tunneling.
- credential-safe remote sanitization and bounded LeopardCat production parity adapter.
- dependency-free contract tests for repository substitution, release-lane escape, parameter widening, arbitrary command injection, SHA format, and credential redaction.
- documented authority/security model.
- clean Oracle smoke consuming the **canonical product-owned manifest from LeopardCat main**.

Evidence before opening this PR:
- LeopardCat PR #71 merged the product-owned request into its main branch.
- clean smoke run `34071190621` completed success.
- hosted contract job passed.
- Oracle product-owned smoke passed against runtime HEAD `faf0ae71...`.
- three-way local/localhost/public artifact digest matched `4ee9a87b...`.

Scope intentionally remains read-only. This PR does not add deployment authority and does not retire the retained product deploy carrier yet. The contaminated `core/issue-165-execution-v1` branch remains non-mergeable.