### PR TITLE
Core: add live Node capability attestation (#284)

### DIFF
--- a/agent_core/capability_attestation.py
+++ b/agent_core/capability_attestation.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping
+
+
+CAPABILITY_ATTESTATION_SCHEMA = 'agentos.capability-attestation/v0.1'
+CAPABILITY_VERIFICATION_STATES = frozenset({'verified', 'degraded', 'unavailable', 'unknown'})
+VISUAL_LOOP_CAPABILITY = 'desktop.visual-loop'
+VISUAL_LOOP_PRIMITIVES = (
+    'desktop.screenshot',
+    'desktop.mouse',
+    'desktop.keyboard',
+)
+
+_FORBIDDEN_KEYS = frozenset({
+    'access_token',
+    'authorization',
+    'credential',
+    'credentials',
+    'image_base64',
+    'password',
+    'refresh_token',
+    'secret',
+    'session_cookie',
+    'token',
+})
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _contains_forbidden_payload(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            normalized = str(key).strip().lower()
+            if normalized in _FORBIDDEN_KEYS:
+                return normalized
+            found = _contains_forbidden_payload(nested)
+            if found:
+                return found
+    elif isinstance(value, (list, tuple)):
+        for nested in value:
+            found = _contains_forbidden_payload(nested)
+            if found:
+                return found
+    return None
+
+
+def validate_capability_attestation(attestation: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one sanitized live capability observation.
+
+    Attestation is evidence of recent operability only. It deliberately carries
+    no execution authorization and must never contain credentials or raw image
+    payloads.
+    """
+    data = dict(attestation)
+    if data.get('schema') != CAPABILITY_ATTESTATION_SCHEMA:
+        raise ValueError('invalid capability attestation schema')
+
+    node_id = str(data.get('node_id') or '').strip()
+    capability_id = str(data.get('capability_id') or '').strip()
+    state = str(data.get('verification_state') or '').strip()
+    observed_at = _parse_utc(data.get('observed_at'))
+    valid_until = _parse_utc(data.get('valid_until')) if data.get('valid_until') else None
+
+    if not node_id or not capability_id:
+        raise ValueError('node_id and capability_id are required')
+    if state not in CAPABILITY_VERIFICATION_STATES:
+        raise ValueError('invalid verification_state')
+    if observed_at is None:
+        raise ValueError('valid observed_at is required')
+    if valid_until is not None and valid_until < observed_at:
+        raise ValueError('valid_until cannot precede observed_at')
+    if 'authorized' in data:
+        raise ValueError('capability attestation must not carry authorization state')
+
+    forbidden = _contains_forbidden_payload(data)
+    if forbidden:
+        raise ValueError(f'forbidden capability attestation field: {forbidden}')
+
+    return data
+
+
+def effective_capability_attestation(
+    attestation: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+    default_ttl_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Project a stored attestation into current freshness-aware live state."""
+    result = validate_capability_attestation(attestation)
+    observed_at = _parse_utc(result.get('observed_at'))
+    assert observed_at is not None
+    current = (now or _utc_now()).astimezone(timezone.utc)
+
+    if default_ttl_seconds is None:
+        default_ttl_seconds = max(1, int(os.environ.get('AGENTOS_CAPABILITY_ATTESTATION_TTL_SECONDS', '300')))
+    else:
+        default_ttl_seconds = max(1, int(default_ttl_seconds))
+
+    valid_until = _parse_utc(result.get('valid_until'))
+    expiry = valid_until or (observed_at + timedelta(seconds=default_ttl_seconds))
+    age = max(0, int((current - observed_at).total_seconds()))
+    stale = current > expiry
+
+    result['reported_verification_state'] = result['verification_state']
+    result['attestation_age_seconds'] = age
+    result['attestation_stale'] = stale
+    result['effective_valid_until'] = expiry.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    if stale:
+        result['verification_state'] = 'unknown'
+        result['verification_reason'] = 'attestation_expired'
+    return result
+
+
+def _runtime_boundary(attestation: Mapping[str, Any]) -> tuple[str, str, str] | None:
+    provider_id = str(attestation.get('provider_id') or '').strip()
+    executor_id = str(attestation.get('executor_id') or '').strip()
+    runtime_session_id = str(attestation.get('runtime_session_id') or '').strip()
+    if not (provider_id and executor_id and runtime_session_id):
+        return None
+    return provider_id, executor_id, runtime_session_id
+
+
+def derive_visual_loop_attestation(
+    attestations: Iterable[Mapping[str, Any]],
+    *,
+    now: datetime | None = None,
+    default_ttl_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Derive `desktop.visual-loop` only from fresh, same-boundary primitives."""
+    current = now or _utc_now()
+    by_capability: dict[str, dict[str, Any]] = {}
+    for raw in attestations:
+        effective = effective_capability_attestation(
+            raw,
+            now=current,
+            default_ttl_seconds=default_ttl_seconds,
+        )
+        capability_id = str(effective.get('capability_id') or '')
+        if capability_id in VISUAL_LOOP_PRIMITIVES:
+            by_capability[capability_id] = effective
+
+    missing = [capability for capability in VISUAL_LOOP_PRIMITIVES if capability not in by_capability]
+    base = {
+        'schema': 'agentos.derived-capability/v0.1',
+        'capability_id': VISUAL_LOOP_CAPABILITY,
+        'required_capabilities': list(VISUAL_LOOP_PRIMITIVES),
+    }
+    if missing:
+        return {
+            **base,
+            'verification_state': 'unknown',
+            'verification_reason': 'required_attestation_missing',
+            'missing_capabilities': missing,
+        }
+
+    not_verified = [
+        capability
+        for capability, attestation in by_capability.items()
+        if attestation.get('verification_state') != 'verified'
+    ]
+    if not_verified:
+        return {
+            **base,
+            'verification_state': 'unknown',
+            'verification_reason': 'required_attestation_not_verified',
+            'unverified_capabilities': sorted(not_verified),
+        }
+
+    boundaries = [_runtime_boundary(by_capability[capability]) for capability in VISUAL_LOOP_PRIMITIVES]
+    if any(boundary is None for boundary in boundaries):
+        return {
+            **base,
+            'verification_state': 'unknown',
+            'verification_reason': 'runtime_boundary_unbound',
+        }
+    if len(set(boundaries)) != 1:
+        return {
+            **base,
+            'verification_state': 'unknown',
+            'verification_reason': 'runtime_boundary_mismatch',
+        }
+
+    provider_id, executor_id, runtime_session_id = boundaries[0]  # type: ignore[misc]
+    observed = [
+        _parse_utc(by_capability[capability].get('observed_at'))
+        for capability in VISUAL_LOOP_PRIMITIVES
+    ]
+    observed = [value for value in observed if value is not None]
+    oldest = min(observed)
+    newest = max(observed)
+    return {
+        **base,
+        'verification_state': 'verified',
+        'verification_reason': 'fresh_same_runtime_boundary_primitives',
+        'provider_id': provider_id,
+        'executor_id': executor_id,
+        'runtime_session_id': runtime_session_id,
+        'observed_at': oldest.replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+        'latest_component_observed_at': newest.replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+        'component_capabilities': list(VISUAL_LOOP_PRIMITIVES),
+    }

--- a/agent_core/node_registry.py
+++ b/agent_core/node_registry.py
@@ -9,6 +9,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
+from agent_core.capability_attestation import (
+    derive_visual_loop_attestation,
+    effective_capability_attestation,
+    validate_capability_attestation,
+)
 from agent_core.runtime_ota import RuntimeOTAPolicyStore
 
 
@@ -23,6 +28,14 @@ def _parse_utc(value: str | None) -> datetime | None:
         return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
     except ValueError:
         return None
+
+
+def _attestation_storage_key(attestation: dict[str, Any]) -> str:
+    return '::'.join((
+        str(attestation.get('capability_id') or ''),
+        str(attestation.get('provider_id') or ''),
+        str(attestation.get('executor_id') or ''),
+    ))
 
 
 class NodeRegistry:
@@ -129,7 +142,9 @@ class NodeRegistry:
             'hostname': manifest.get('hostname'),
             'platform': manifest.get('platform'),
             'platform_release': manifest.get('platform_release'),
+            # `capabilities` remains the v0.1 advertised manifest projection for compatibility.
             'capabilities': sorted(set(manifest.get('capabilities') or [])),
+            'capability_attestations': dict(existing.get('capability_attestations') or {}),
             'tool_presence': dict(manifest.get('tool_presence') or {}),
             'surface_inventory': dict(inventory),
             'runtime': dict(runtime) if isinstance(runtime, dict) else dict(existing.get('runtime') or {}),
@@ -180,6 +195,24 @@ class NodeRegistry:
 
         return self._mutate(mutate)
 
+    def record_capability_attestation(self, attestation: dict[str, Any]) -> dict[str, Any]:
+        snapshot = validate_capability_attestation(attestation)
+        node_id = str(snapshot['node_id'])
+        snapshot['recorded_at'] = _utc_now()
+        storage_key = _attestation_storage_key(snapshot)
+
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            if node_id not in data['nodes']:
+                raise KeyError(node_id)
+            entry = data['nodes'][node_id]
+            current = dict(entry.get('capability_attestations') or {})
+            current[storage_key] = snapshot
+            entry['capability_attestations'] = current
+            data['nodes'][node_id] = entry
+            return snapshot
+
+        return self._mutate(mutate)
+
     def record_benchmark(self, node_id: str, report: dict[str, Any]) -> dict[str, Any]:
         if report.get('schema') != 'agentos.one-uplift-report/v0.1':
             raise ValueError('invalid ONE uplift report')
@@ -211,7 +244,40 @@ class NodeRegistry:
             result['status_reason'] = 'heartbeat_stale'
         else:
             result['status'] = reported
+
+        result['advertised_capabilities'] = list(result.get('capabilities') or [])
+        stored_attestations = list((node.get('capability_attestations') or {}).values())
+        effective_attestations = [effective_capability_attestation(item) for item in stored_attestations]
+
+        if result.get('status') != 'online':
+            for attestation in effective_attestations:
+                if attestation.get('verification_state') == 'verified':
+                    attestation['verification_state'] = 'unknown'
+                    attestation['verification_reason'] = 'node_not_online'
+
+        visual_loop = derive_visual_loop_attestation(effective_attestations)
+        if result.get('status') != 'online' and visual_loop.get('verification_state') == 'verified':
+            visual_loop['verification_state'] = 'unknown'
+            visual_loop['verification_reason'] = 'node_not_online'
+
+        result['capability_attestations'] = effective_attestations
+        result['derived_capability_attestations'] = [visual_loop]
+        verified = {
+            str(item.get('capability_id'))
+            for item in effective_attestations
+            if item.get('verification_state') == 'verified'
+        }
+        if visual_loop.get('verification_state') == 'verified':
+            verified.add(str(visual_loop['capability_id']))
+        result['verified_capabilities'] = sorted(verified)
         return RuntimeOTAPolicyStore.annotate_node(result, self.ota_policy.load())
+
+    def has_verified_capability(self, node_id: str, capability_id: str) -> bool:
+        for node in self.node_map()['nodes']:
+            if node.get('node_id') != node_id:
+                continue
+            return node.get('status') == 'online' and capability_id in node.get('verified_capabilities', [])
+        return False
 
     def node_map(self) -> dict[str, Any]:
         data = self.load()
@@ -219,6 +285,12 @@ class NodeRegistry:
         nodes = [self._effective_node(node) for node in data['nodes'].values()]
         nodes.sort(key=lambda n: (n.get('role') != 'core', n.get('node_id', '')))
         realm_caps = sorted({cap for node in nodes for cap in node.get('capabilities', []) if node.get('status') != 'offline'})
+        realm_verified_caps = sorted({
+            cap
+            for node in nodes
+            if node.get('status') == 'online'
+            for cap in node.get('verified_capabilities', [])
+        })
         tools = sorted({tool for node in nodes for tool in node.get('tool_presence', {}) if node.get('status') != 'offline'})
         surface_providers = sorted({
             str(surface.get('provider'))
@@ -233,7 +305,10 @@ class NodeRegistry:
             'node_count': len(nodes),
             'online_node_count': sum(1 for node in nodes if node.get('status') == 'online'),
             'nodes': nodes,
+            # Keep the v0.1 field stable and make its advertised semantics explicit in parallel.
             'realm_capabilities': realm_caps,
+            'realm_advertised_capabilities': realm_caps,
+            'realm_verified_capabilities': realm_verified_caps,
             'realm_tool_presence': tools,
             'realm_surface_providers': surface_providers,
             'runtime_ota': policy,

--- a/tests/test_node_capability_attestation.py
+++ b/tests/test_node_capability_attestation.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from agent_core.capability_attestation import (
+    derive_visual_loop_attestation,
+    effective_capability_attestation,
+    validate_capability_attestation,
+)
+from agent_core.node_registry import NodeRegistry
+
+
+def _iso(value: datetime) -> str:
+    return value.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def _manifest(node_id: str = 'visual-node') -> dict:
+    return {
+        'schema': 'agentos.node-manifest/v0.1',
+        'realm_id': 'realm-test',
+        'node_id': node_id,
+        'role': 'client',
+        'hostname': node_id,
+        'platform': 'Windows',
+        'platform_release': 'test',
+        'capabilities': [
+            'desktop.screenshot',
+            'desktop.mouse',
+            'desktop.keyboard',
+        ],
+        'tool_presence': {},
+        'surface_inventory': {},
+    }
+
+
+def _heartbeat(registry: NodeRegistry, node_id: str = 'visual-node') -> None:
+    registry.record_heartbeat({
+        'schema': 'agentos.node-heartbeat/v0.1',
+        'realm_id': 'realm-test',
+        'node_id': node_id,
+        'role': 'client',
+        'status': 'online',
+        'uptime_seconds': 1,
+    })
+
+
+def _attestation(capability_id: str, *, runtime_session_id: str = 'desktop-session-1') -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        'schema': 'agentos.capability-attestation/v0.1',
+        'node_id': 'visual-node',
+        'capability_id': capability_id,
+        'verification_state': 'verified',
+        'probe_class': 'desktop-smoke/v1',
+        'provider_id': 'windows-interactive-desktop',
+        'executor_id': 'desktop-executor-1',
+        'runtime_session_id': runtime_session_id,
+        'observed_at': _iso(now),
+        'valid_until': _iso(now + timedelta(minutes=5)),
+        'receipt_id': f'receipt-{capability_id}',
+    }
+
+
+def test_advertised_capability_is_not_verified_without_attestation(tmp_path: Path) -> None:
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    registry.register_manifest(_manifest())
+    _heartbeat(registry)
+
+    node_map = registry.node_map()
+    node = node_map['nodes'][0]
+    assert 'desktop.screenshot' in node['advertised_capabilities']
+    assert 'desktop.screenshot' in node_map['realm_advertised_capabilities']
+    assert 'desktop.screenshot' not in node['verified_capabilities']
+    assert 'desktop.screenshot' not in node_map['realm_verified_capabilities']
+    assert not registry.has_verified_capability('visual-node', 'desktop.screenshot')
+
+
+def test_fresh_same_session_primitives_verify_visual_loop(tmp_path: Path) -> None:
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    registry.register_manifest(_manifest())
+    _heartbeat(registry)
+
+    for capability_id in ('desktop.screenshot', 'desktop.mouse', 'desktop.keyboard'):
+        registry.record_capability_attestation(_attestation(capability_id))
+
+    node_map = registry.node_map()
+    node = node_map['nodes'][0]
+    assert set(node['verified_capabilities']) == {
+        'desktop.screenshot',
+        'desktop.mouse',
+        'desktop.keyboard',
+        'desktop.visual-loop',
+    }
+    assert 'desktop.visual-loop' in node_map['realm_verified_capabilities']
+    assert registry.has_verified_capability('visual-node', 'desktop.visual-loop')
+    derived = node['derived_capability_attestations'][0]
+    assert derived['verification_state'] == 'verified'
+    assert derived['runtime_session_id'] == 'desktop-session-1'
+
+
+def test_visual_loop_fails_closed_when_runtime_boundary_differs() -> None:
+    items = [
+        _attestation('desktop.screenshot'),
+        _attestation('desktop.mouse'),
+        _attestation('desktop.keyboard', runtime_session_id='desktop-session-2'),
+    ]
+    derived = derive_visual_loop_attestation(items)
+    assert derived['verification_state'] == 'unknown'
+    assert derived['verification_reason'] == 'runtime_boundary_mismatch'
+
+
+def test_expired_attestation_does_not_remain_verified() -> None:
+    item = _attestation('desktop.screenshot')
+    item['observed_at'] = '2020-01-01T00:00:00Z'
+    item['valid_until'] = '2020-01-01T00:05:00Z'
+    effective = effective_capability_attestation(item)
+    assert effective['reported_verification_state'] == 'verified'
+    assert effective['verification_state'] == 'unknown'
+    assert effective['attestation_stale'] is True
+    assert effective['verification_reason'] == 'attestation_expired'
+
+
+def test_node_not_online_invalidates_live_verified_projection(tmp_path: Path) -> None:
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    registry.register_manifest(_manifest())
+    registry.record_capability_attestation(_attestation('desktop.screenshot'))
+
+    node = registry.node_map()['nodes'][0]
+    assert node['reported_status'] == 'unknown'
+    assert 'desktop.screenshot' not in node['verified_capabilities']
+    effective = node['capability_attestations'][0]
+    assert effective['verification_state'] == 'unknown'
+    assert effective['verification_reason'] == 'node_not_online'
+
+
+def test_manifest_refresh_preserves_live_attestations(tmp_path: Path) -> None:
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    registry.register_manifest(_manifest())
+    _heartbeat(registry)
+    registry.record_capability_attestation(_attestation('desktop.screenshot'))
+
+    refreshed = _manifest()
+    refreshed['platform_release'] = 'next'
+    registry.register_manifest(refreshed)
+
+    node = registry.node_map()['nodes'][0]
+    assert node['platform_release'] == 'next'
+    assert 'desktop.screenshot' in node['verified_capabilities']
+
+
+def test_attestation_cannot_smuggle_authority_or_raw_image_payload() -> None:
+    with pytest.raises(ValueError, match='authorization'):
+        validate_capability_attestation({
+            **_attestation('desktop.screenshot'),
+            'authorized': True,
+        })
+
+    with pytest.raises(ValueError, match='image_base64'):
+        validate_capability_attestation({
+            **_attestation('desktop.screenshot'),
+            'evidence': {'image_base64': 'AAAA'},
+        })
+
+
+def test_attestation_for_unknown_node_is_rejected(tmp_path: Path) -> None:
+    registry = NodeRegistry(tmp_path / 'nodes.json')
+    with pytest.raises(KeyError):
+        registry.record_capability_attestation(_attestation('desktop.screenshot'))


### PR DESCRIPTION
Implements the first Core slice of #284 on top of `core/integration`.

## What changes
- adds `agentos.capability-attestation/v0.1` validation and freshness projection;
- keeps existing manifest `capabilities` as **advertised** for v0.1 compatibility;
- persists live capability attestations separately in the Node registry;
- exposes `advertised_capabilities`, `verified_capabilities`, and `realm_verified_capabilities` separately;
- adds `NodeRegistry.has_verified_capability(...)` as a verification-only query (not routing or authorization);
- derives `desktop.visual-loop` only when `desktop.screenshot`, `desktop.mouse`, and `desktop.keyboard` are all fresh `verified` observations bound to the same provider/executor/runtime session;
- invalidates verified projection when the Node is not currently online;
- rejects authorization state, credentials/secrets, and raw screenshot base64 from attestation records.

## Semantic boundary

`advertised != verified != routable != authorized != successful`

This PR implements only the **verified** dimension and its Node Map projection. It deliberately does not grant route or execution authority.

## Tests added
- advertised-only does not become verified;
- fresh same-session primitives derive `desktop.visual-loop`;
- runtime-session mismatch fails closed;
- expired attestation becomes unknown;
- Node offline/unknown invalidates verified projection;
- manifest refresh preserves attestation evidence;
- authority/raw-image smuggling is rejected;
- unknown-node attestation is rejected.

## Follow-up acceptance
The real `vopc5750` probe/evidence path from #105 still needs to emit these records and demonstrate freshness expiry in the live Realm before #284 can be closed.

No protected `main` mutation. Target is `core/integration`.