### PR TITLE
Core #179: authenticated active continuation reads and identity-only Inbox inspection

### DIFF
--- a/.agent/CAPABILITIES.md
+++ b/.agent/CAPABILITIES.md
@@ -52,6 +52,14 @@ AgentOS now treats reusable work as a capability, not a project-specific side ef
 | **Video Indexing Hub** | `video-indexing` | 🧠 Proposed | Central visual indexing, transcript grounding, and scene-map artifact producer for all video-aware projects. |
 
 ### Governance Capability
+
+ONE active continuation read candidate (#179): existing provider
+`agent_core.active_continuation` via the authenticated Realm controller API.
+`agentos.continuation.inspect` is an optional identity-only Control Inbox read,
+not a hydration or execution capability. Source tests do not establish live
+availability; acceptance and private/public boundaries are documented in
+`docs/CHATGPT_ONE_TRANSPORT.md`.
+
 | Capability | Provider | Status | Notes |
 | :--- | :--- | :--- | :--- |
 | **Spec Stewardship** | `scripts/spec_steward.py` | ✅ 現行 | Scans specs, project declarations, and STATUS files to surface drift, stale specs, and missing ownership. |

--- a/.github/workflows/control-inbox-bridge-guard.yml
+++ b/.github/workflows/control-inbox-bridge-guard.yml
@@ -6,6 +6,10 @@ on:
       - core/integration
     paths:
       - 'agent_core/control_inbox_bridge.py'
+      - 'agent_core/active_continuation.py'
+      - 'agent_core/realm_server.py'
+      - 'tests/test_active_continuation.py'
+      - 'tests/test_realm_resolve_endpoint.py'
       - 'tests/test_control_inbox_bridge.py'
       - '.agent/scripts/agentos-control-inbox-bridge.service'
       - 'config/control-inbox.env.example'
@@ -17,6 +21,10 @@ on:
       - core/integration
     paths:
       - 'agent_core/control_inbox_bridge.py'
+      - 'agent_core/active_continuation.py'
+      - 'agent_core/realm_server.py'
+      - 'tests/test_active_continuation.py'
+      - 'tests/test_realm_resolve_endpoint.py'
       - 'tests/test_control_inbox_bridge.py'
       - '.agent/scripts/agentos-control-inbox-bridge.service'
       - 'config/control-inbox.env.example'
@@ -40,7 +48,7 @@ jobs:
       - name: Install test dependency
         run: python -m pip install --disable-pip-version-check pytest
       - name: Run Control Inbox bridge regressions
-        run: python -m pytest tests/test_control_inbox_bridge.py -q
+        run: python -m pytest tests/test_control_inbox_bridge.py tests/test_active_continuation.py tests/test_realm_resolve_endpoint.py -q
       - name: Verify service is secret-free and bounded
         shell: bash
         run: |

--- a/agent_core/active_continuation.py
+++ b/agent_core/active_continuation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -83,7 +84,30 @@ def resolve_active_continuation(
             f"selector={selector['index_id']}/{selector['ir_id']} "
             f"canonical={index_id}/{ir_id}"
         )
+    latest = read_active_continuation(data_root)
+    if any(latest[key] != selector[key] for key in ("project_id", "index_id", "ir_id")):
+        raise ValueError("active continuation selector changed during resolution")
     return {"selector": selector, "resolution": resolved}
+
+
+def active_continuation_identity(active: dict[str, Any]) -> dict[str, Any]:
+    """Public-safe identity proof, never a working-state or hydration payload."""
+    selector = active["selector"]
+    identity = {}
+    for key in ("project_id", "index_id", "ir_id"):
+        value = selector.get(key)
+        if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", value):
+            raise ValueError("continuation identity is not exportable")
+        identity[key] = value
+    return {
+        "schema": "agentos.continuation-identity/v1",
+        "source": "ONE_ACTIVE_CONTINUATION",
+        **identity,
+        "observed_at": _now(),
+        "canonical_ir_included": False,
+        "hydration_complete": False,
+        "credential_exposed": False,
+    }
 
 
 def activate_continuation(

--- a/agent_core/control_inbox_bridge.py
+++ b/agent_core/control_inbox_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -21,6 +22,7 @@ DEFAULT_ISSUE_NUMBER = 50
 DEFAULT_ALLOWED_LOGIN = 'alstonhuang'
 DEFAULT_ONE_URL = 'http://127.0.0.1:8780'
 MAX_COMMAND_LIFETIME_SECONDS = 600
+CONTINUATION_INSPECT_ACTION = 'agentos.continuation.inspect'
 FORBIDDEN_ACTION_PREFIXES = (
     'shell.', 'filesystem.', 'fs.', 'keyboard.', 'mouse.',
     'gui.input', 'desktop.input',
@@ -120,6 +122,8 @@ def _project_receipt(receipt: Any, action: str) -> dict[str, Any] | None:
     """Return bounded evidence; drop paths, usernames, titles and raw payloads."""
     if not isinstance(receipt, dict):
         return None
+    if action == CONTINUATION_INSPECT_ACTION:
+        return _continuation_identity(receipt)
     projected: dict[str, Any] = {}
     for key in COMMON_RECEIPT_FIELDS:
         if key in receipt:
@@ -161,6 +165,35 @@ def _project_receipt(receipt: Any, action: str) -> dict[str, Any] | None:
             if safe is not None or receipt.get(key) is None:
                 projected[key] = safe
     return projected
+
+
+def _continuation_identity(value: Any) -> dict[str, Any]:
+    """Independent public-mailbox fence; reject malformed proof, drop all extras."""
+    if not isinstance(value, dict) or value.get('schema') != 'agentos.continuation-identity/v1':
+        raise OneControllerError('one_continuation_protocol_error')
+    if (value.get('source') != 'ONE_ACTIVE_CONTINUATION'
+            or any(value.get(key) is not False for key in ('canonical_ir_included', 'hydration_complete', 'credential_exposed'))):
+        raise OneControllerError('one_continuation_protocol_error')
+    result = {}
+    for key in ('project_id', 'index_id', 'ir_id'):
+        item = value.get(key)
+        if not isinstance(item, str) or not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9_.-]{0,127}', item):
+            raise OneControllerError('one_continuation_protocol_error')
+        result[key] = item
+    observed = value.get('observed_at')
+    if not isinstance(observed, str) or not re.fullmatch(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z', observed):
+        raise OneControllerError('one_continuation_protocol_error')
+    try:
+        age = (_utc_now() - _parse_utc(observed)).total_seconds()
+    except ValueError as exc:
+        raise OneControllerError('one_continuation_protocol_error') from exc
+    if not -60 <= age <= 60:
+        raise OneControllerError('one_continuation_stale')
+    return {
+        'schema': 'agentos.continuation-identity/v1', 'source': 'ONE_ACTIVE_CONTINUATION',
+        **result, 'observed_at': observed, 'canonical_ir_included': False,
+        'hydration_complete': False, 'credential_exposed': False,
+    }
 
 
 @dataclass(frozen=True)
@@ -311,6 +344,15 @@ class OneControllerClient:
             raise OneControllerError('one_dispatch_protocol_error')
         return payload
 
+    def inspect_continuation(self) -> dict[str, Any]:
+        # Fixed authenticated read; never request the private full-IR endpoint.
+        status, payload = self._request('GET', '/v1/controller/continuation/active/identity')
+        if status != 200:
+            raise OneControllerError(f'one_continuation_http_{status}')
+        if not isinstance(payload, dict) or payload.get('ok') is not True:
+            raise OneControllerError('one_continuation_protocol_error')
+        return _continuation_identity(payload.get('identity'))
+
     def receipt(self, task_id: str) -> dict[str, Any] | None:
         status, payload = self._request('GET', f'/v1/controller/receipts/{task_id}')
         if status == 404:
@@ -363,6 +405,13 @@ class ControlInboxBridge:
             raise ValueError('missing_command_identity')
         if action not in self.config.allowed_actions or _is_forbidden_action(action):
             raise ValueError('unauthorized_action')
+        if action == CONTINUATION_INSPECT_ACTION:
+            if node_id != 'oracle-core-node':
+                raise ValueError('unsupported_continuation_node')
+            if not isinstance(payload.get('args', {}), dict) or payload.get('args', {}) != {}:
+                raise ValueError('unsupported_continuation_args')
+            if set(payload) - {'schema', 'command_id', 'node_id', 'action', 'args', 'issued_at', 'expires_at'}:
+                raise ValueError('unsupported_continuation_fields')
         if issued_at > now + timedelta(seconds=60):
             raise ValueError('issued_at_in_future')
         if expires_at <= now:
@@ -480,17 +529,21 @@ class ControlInboxBridge:
             self._save_state(state)
 
             try:
-                dispatch = self.one.dispatch(command['node_id'], command)
-                task_id = str(dispatch.get('task_id') or _task_id(command_id))
-                deadline = time.monotonic() + self.config.receipt_wait_seconds
-                receipt = None
-                while time.monotonic() < deadline:
-                    receipt = self.one.receipt(task_id)
-                    if receipt is not None:
-                        break
-                    time.sleep(1)
-                status = 'completed' if receipt is not None else 'queued'
-                result = self._result(command, status=status, task_id=task_id, receipt=receipt)
+                if command['action'] == CONTINUATION_INSPECT_ACTION:
+                    receipt = self.one.inspect_continuation()
+                    result = self._result(command, status='completed', receipt=receipt)
+                else:
+                    dispatch = self.one.dispatch(command['node_id'], command)
+                    task_id = str(dispatch.get('task_id') or _task_id(command_id))
+                    deadline = time.monotonic() + self.config.receipt_wait_seconds
+                    receipt = None
+                    while time.monotonic() < deadline:
+                        receipt = self.one.receipt(task_id)
+                        if receipt is not None:
+                            break
+                        time.sleep(1)
+                    status = 'completed' if receipt is not None else 'queued'
+                    result = self._result(command, status=status, task_id=task_id, receipt=receipt)
             except OneControllerError as exc:
                 result = self._result(command, status='error', error=str(exc))
             except Exception:

--- a/agent_core/realm_server.py
+++ b/agent_core/realm_server.py
@@ -19,6 +19,7 @@ from agent_core.node_bootstrap import bootstrap_snapshot, record_join_regression
 from agent_core.node_registry import NodeRegistry
 from agent_core.realm_fabric import RealmFabricStore
 from agent_core.resolve_facade import resolve_continuation
+from agent_core.active_continuation import resolve_active_continuation, active_continuation_identity
 from agent_core.runtime_converge_capability import installed_core_capabilities
 
 
@@ -155,6 +156,35 @@ class RealmRequestHandler(BaseHTTPRequestHandler):
             if parsed.path == '/v1/controller/realm':
                 self._authorize_controller()
                 self._send(200, {'ok': True, 'realm': self.controller.realm()})
+                return
+            if parsed.path in ('/v1/controller/continuation/active', '/v1/controller/continuation/active/identity'):
+                self._authorize_controller()
+                # The caller cannot choose a workspace, path or another selector.
+                if parsed.query:
+                    self._send(400, {'ok': False, 'error': 'unsupported_continuation_query'})
+                    return
+                try:
+                    active = resolve_active_continuation()
+                    identity = active_continuation_identity(active)
+                    if parsed.path.endswith('/identity'):
+                        self._send(200, {'ok': True, 'identity': identity})
+                    else:
+                        # Reuse the existing credential-isolated executor projection.
+                        from agentos_node.one_mcp import _project_resolve
+                        resolution = _project_resolve(active['resolution'])
+                        original_ir = active['resolution'].get('continuation', {}).get('canonical_ir')
+                        if not isinstance(original_ir, dict) or resolution['continuation']['canonical_ir'] != original_ir:
+                            raise ValueError('canonical IR cannot be projected losslessly')
+                        self._send(200, {
+                            'ok': True, 'schema': 'agentos.one-active-resolve/v1',
+                            'source': 'ONE_ACTIVE_CONTINUATION',
+                            'selector': {key: identity[key] for key in ('project_id', 'index_id', 'ir_id')},
+                            'resolution': resolution,
+                            'credential_exposed': False,
+                        })
+                except Exception:
+                    # No paths, private IR or resolver exception text on failure.
+                    self._send(409, {'ok': False, 'error': 'ONE_IR_HEAD_UNRESOLVED'})
                 return
             if parsed.path == '/v1/controller/nodes':
                 self._authorize_controller()

--- a/config/control-inbox.env.example
+++ b/config/control-inbox.env.example
@@ -14,6 +14,9 @@ AGENTOS_CONTROL_ALLOWED_LOGIN=alstonhuang
 # Generic shell/filesystem/keyboard/mouse/input actions are rejected even if
 # accidentally listed here.
 AGENTOS_CONTROL_ALLOWED_ACTIONS=agent.surface.inspect,desktop.session.inspect,desktop.windows.inspect
+# Optional after governed rollout: agentos.continuation.inspect
+# Fixed Oracle identity-only read, empty args; never exports Canonical IR.
+# Deliberately not enabled by this source example.
 
 AGENTOS_ONE_URL=http://127.0.0.1:8780
 AGENT_DATA_ROOT=/home/ubuntu/agent-data

--- a/docs/CHATGPT_ONE_TRANSPORT.md
+++ b/docs/CHATGPT_ONE_TRANSPORT.md
@@ -62,6 +62,50 @@ The policy requires deterministic routing for the same typed intent and availabi
 
 ## Acceptance boundary
 
+### Active continuation read candidate (#179)
+
+Owner: AgentOS Core / ONE continuation and transport boundaries. This candidate
+closes the missing read route; it is not a live ChatGPT hydration acceptance.
+
+- `GET /v1/controller/continuation/active`: controller-authenticated private
+  executor projection of the existing ONE active selector and resolved Canonical
+  IR. It reuses the existing executor-safe projection and refuses a response if
+  that projection would truncate or redact the Canonical IR. It never selects
+  work from a workspace or caller-supplied project/path.
+- `GET /v1/controller/continuation/active/identity`: same authentication and
+  generation validation, returning only bounded project/index/IR identifiers,
+  observation time, and explicit `canonical_ir_included=false`,
+  `hydration_complete=false`, `credential_exposed=false` flags.
+- Both reject query overrides. Missing, stale, malformed or changing active
+  state fails closed with `ONE_IR_HEAD_UNRESOLVED`; no raw error detail is returned.
+- The public bootstrap command `agentos.continuation.inspect` uses only the
+  identity endpoint. Its envelope retains `agentos.control-command/v0.1`, short
+  expiry, trusted author and command deduplication. The current Oracle bootstrap
+  scope requires `node_id=oracle-core-node` and empty `args`. No URL, path,
+  project override or arbitrary action is accepted. The bridge independently
+  validates the identity response, including observation freshness, and drops
+  all extra response fields before storing or posting it.
+
+The command remains disabled unless explicitly added to the host-local
+`AGENTOS_CONTROL_ALLOWED_ACTIONS` during governed installation. Code presence
+does not change the live allowlist. No Node task, shell or Actions job is used.
+
+The private endpoint must be consumed by a trusted private adapter that retains
+the controller credential outside model context. Never publish its response in
+Issue #50, an artifact, a repository or client configuration. The identity-only
+receipt is an observation, not Canonical IR and not execution authority. Old
+receipts cannot establish the current active generation. Full continuation still
+requires a fresh private read; no working state may be reconstructed from the
+identity receipt or chat history.
+
+Closure: accept the source through `core/integration`, deploy the exact accepted
+generation through governed runtime authority, enable only the bounded inspect
+action, and prove a fresh public identity read plus a private adapter read bind
+the same generation. Exercise stale/changed-head refusal on a disposable
+acceptance fixture. Until the private adapter is available in ChatGPT, report
+hydration as unresolved even if the public inspect command succeeds. Neither
+deployment nor capability availability grants protected-main publication.
+
 The static resolver/tests prove the no-fallback authority rule, but they do not alone prove ChatGPT Web transport transparency.
 
 Core #179 remains incomplete until a fresh ChatGPT conversation demonstrates a Realm/Node control-plane request resolving through Control Inbox/ONE with no Actions workflow invocation. A later AgentOS MCP/App may replace Control Inbox after equivalent acceptance evidence exists.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,6 +6,9 @@
 
 This document is intentionally evidence-bound. A source merge proves implementation, not live operation. A live receipt proves only the exact generation, route, capability, executor, and effect that the receipt attests.
 
+Status terms: **Implemented** requires source; **Verified** requires the stated
+acceptance evidence; **Research** remains an unproven broader claim.
+
 ## Product goal
 
 AgentOS should let a user change conversation, model, executor, extension, Node, or machine without reconstructing the project from conversation history. Durable project state, accepted experience, authority, execution state, and evidence live outside model-local context. Models and IDE extensions are replaceable execution surfaces.
@@ -37,6 +40,7 @@ Lower layers may inform higher layers but may not silently overwrite them.
 | Bounded executor jobs through ONE | Implemented slices | declarative fixed job types route through ONE → bounded Action Relay → sanitized durable receipt; no generic remote shell |
 | Canonical continuation IR | Implemented + verified concrete cross-extension slices | `agentos.ir/v1`, parent-fenced publication, active continuation selector; Gemini/Codex continuity has concrete accepted evidence, but arbitrary portability remains unproven |
 | Active continuation selector | Implemented | pointer stores project/index/IR identity only; it is not another state store and must fail closed on stale references |
+| ChatGPT active continuation read (#179) | Source candidate; live acceptance pending | Private controller-authenticated active resolve plus identity-only Control Inbox inspection; selector changes fail closed. Public identity receipts explicitly do not hydrate IR. Governed deployment, host allowlist and private ChatGPT adapter acceptance remain required. See `docs/CHATGPT_ONE_TRANSPORT.md`. |
 | Experience subsystem v0 prose design | Deprecated | PR #119 direction is superseded; do not merge wholesale |
 | Semantic Experience IR v1 | Active candidate under #117 | current focused design is `agentos.experience/v1` carrying `agentos.experience-ir/v1`, typed semantic nodes, stable digests, extraction validation, ONE-owned Experience Set, semantic hydration receipts; PR #229 remains unmerged as of this snapshot |
 | Master Experience Floor | Strong live evidence, issue still open | observed governed A/B reached baseline 6/7 → prehydrated 7/7; ceiling-aware criterion is the current candidate logic, but #117 remains open and canonical Experience IR integration/ablation evidence is not yet fully accepted |

--- a/tests/test_active_continuation.py
+++ b/tests/test_active_continuation.py
@@ -117,6 +117,15 @@ class ActiveContinuationTests(unittest.TestCase):
             self.assertEqual(result["selector"]["project_id"], "agentos-core")
             self.assertIs(result["resolution"], resolved)
 
+    def test_selector_change_during_resolution_fails_closed(self):
+        first = {"project_id": "agentos-core", "index_id": "idx-1", "ir_id": "ir-1"}
+        second = {**first, "ir_id": "ir-2"}
+        with mock.patch.object(active_continuation, "read_active_continuation", side_effect=[first, second]), mock.patch.object(
+            active_continuation, "resolve_continuation", return_value=self._resolved()
+        ):
+            with self.assertRaisesRegex(ValueError, "changed during resolution"):
+                active_continuation.resolve_active_continuation()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_control_inbox_bridge.py
+++ b/tests/test_control_inbox_bridge.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from agent_core.control_inbox_bridge import (
+    CONTINUATION_INSPECT_ACTION,
     BridgeConfig,
     ControlInboxBridge,
     OneControllerClient,
@@ -340,3 +341,82 @@ def test_action_not_in_local_allowlist_is_rejected(tmp_path: Path):
     assert one.dispatched == []
     assert github.results[0]['status'] == 'rejected'
     assert github.results[0]['error'] == 'unauthorized_action'
+
+
+def _identity():
+    return {
+        'schema': 'agentos.continuation-identity/v1', 'source': 'ONE_ACTIVE_CONTINUATION',
+        'project_id': 'agentos-core', 'index_id': 'idx-1', 'ir_id': 'ir-1',
+        'observed_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'canonical_ir_included': False, 'hydration_complete': False, 'credential_exposed': False,
+    }
+
+
+class IdentityOne(FakeOne):
+    def __init__(self):
+        super().__init__()
+        self.reads = 0
+
+    def inspect_continuation(self):
+        self.reads += 1
+        return {**_identity(), 'canonical_ir': {'goal': 'PRIVATE'}, 'token': 'PRIVATE'}
+
+
+def test_identity_read_never_dispatches_and_deduplicates_across_restart(tmp_path):
+    command = _command(action=CONTINUATION_INSPECT_ACTION)
+    command['node_id'] = 'oracle-core-node'
+    github = FakeGitHub([_comment(201, command)])
+    one = IdentityOne()
+    config = _config(tmp_path, actions={CONTINUATION_INSPECT_ACTION})
+    assert ControlInboxBridge(config, github=github, one=one).process_once() == 1
+    assert ControlInboxBridge(config, github=github, one=one).process_once() == 0
+    assert one.reads == 1
+    assert one.dispatched == []
+    assert github.results[0]['receipt']['hydration_complete'] is False
+    assert 'PRIVATE' not in json.dumps(github.results)
+    assert 'PRIVATE' not in config.state_path.read_text()
+
+
+@pytest.mark.parametrize('change', [
+    {'args': {'url': 'https://other.invalid'}}, {'args': {'project': 'other'}},
+    {'args': []}, {'args': None}, {'node_id': 'node-a'}, {'path': '/private'},
+    {'args': {'action': 'shell.exec'}},
+])
+def test_identity_read_rejects_caller_routing_and_payload(tmp_path, change):
+    command = {**_command(action=CONTINUATION_INSPECT_ACTION), 'node_id': 'oracle-core-node', **change}
+    github = FakeGitHub([_comment(202, command)])
+    one = IdentityOne()
+    ControlInboxBridge(_config(tmp_path, actions={CONTINUATION_INSPECT_ACTION}), github=github, one=one).process_once()
+    assert github.results[0]['status'] == 'rejected'
+    assert one.reads == 0 and one.dispatched == []
+
+
+@pytest.mark.parametrize('change', [
+    {'schema': 'wrong'}, {'source': 'LOCAL_HISTORY'}, {'credential_exposed': True},
+    {'canonical_ir_included': True}, {'hydration_complete': True},
+    {'ir_id': '/home/private'}, {'index_id': 'x' * 129}, {'project_id': None},
+    {'observed_at': '2020-01-01T00:00:00Z'}, {'observed_at': '2026-99-99T00:00:00Z'},
+])
+def test_identity_client_rejects_malformed_or_stale_evidence(change):
+    client = StubOneControllerClient(200, {'ok': True, 'identity': {**_identity(), **change}})
+    with pytest.raises(OneControllerError):
+        client.inspect_continuation()
+
+
+def test_identity_client_uses_only_fixed_metadata_endpoint():
+    client = StubOneControllerClient(200, {'ok': True, 'identity': _identity(), 'resolution': 'PRIVATE'})
+    calls = []
+    def request(method, path, payload=None):
+        calls.append((method, path, payload))
+        return client.status, client.payload
+    client._request = request
+    result = client.inspect_continuation()
+    assert calls == [('GET', '/v1/controller/continuation/active/identity', None)]
+    assert 'PRIVATE' not in json.dumps(result)
+
+
+@pytest.mark.parametrize('status', [401, 404, 409, 500])
+def test_identity_read_errors_do_not_leak_or_fall_back(status):
+    client = StubOneControllerClient(status, {'debug': 'PRIVATE'})
+    with pytest.raises(OneControllerError, match=f'^one_continuation_http_{status}$'):
+        client.inspect_continuation()

--- a/tests/test_realm_resolve_endpoint.py
+++ b/tests/test_realm_resolve_endpoint.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import threading
 import unittest
@@ -9,6 +10,7 @@ from urllib import error, request
 from agent_core.node_registry import NodeRegistry
 from agent_core.realm_fabric import RealmFabricStore
 from agent_core.realm_server import RealmHTTPServer
+from agent_core.control_inbox_bridge import OneControllerClient, OneControllerError
 
 
 class TestRealmResolveEndpoint(unittest.TestCase):
@@ -86,6 +88,97 @@ class TestRealmResolveEndpoint(unittest.TestCase):
         self.assertEqual(status, 401)
         self.assertFalse(payload["ok"])
         resolver.assert_not_called()
+
+    def _get_active(self, suffix='', token='controller-test'):
+        headers = {} if token is None else {'Authorization': f'Bearer {token}'}
+        req = request.Request(self.base_url + '/v1/controller/continuation/active' + suffix, headers=headers)
+        try:
+            with request.urlopen(req, timeout=3) as response:
+                self.assertEqual(response.headers['Cache-Control'], 'no-store')
+                return response.status, json.loads(response.read())
+        except error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+    def _active(self):
+        return {
+            'selector': {'project_id': 'agentos-core', 'index_id': 'idx-1', 'ir_id': 'ir-1', 'reason': 'PRIVATE_REASON'},
+            'resolution': {
+                'schema': 'agentos.resolve/v1', 'project': {'id': 'agentos-core'},
+                'execution_head': {'index_id': 'idx-1'},
+                'continuation': {'canonical_ir': {
+                    'schema_version': 'agentos.ir/v1', 'index_id': 'idx-1', 'ir_id': 'ir-1', 'goal': 'PRIVATE_GOAL'
+                }},
+                'private_path': '/private/path', 'token': 'PRIVATE_TOKEN',
+            },
+        }
+
+    def test_private_and_identity_endpoints_require_auth_before_resolution(self):
+        self.server.controller_token = 'controller-test'
+        with patch('agent_core.realm_server.resolve_active_continuation') as resolver:
+            for suffix in ('', '/identity'):
+                for token in (None, 'wrong'):
+                    self.assertEqual(self._get_active(suffix, token)[0], 401)
+            resolver.assert_not_called()
+
+    def test_active_identity_drops_private_state_and_private_read_preserves_ir(self):
+        self.server.controller_token = 'controller-test'
+        active = self._active()
+        with patch('agent_core.realm_server.resolve_active_continuation', return_value=active):
+            status, public = self._get_active('/identity')
+            self.assertEqual(status, 200)
+            self.assertNotIn('PRIVATE', json.dumps(public))
+            self.assertFalse(public['identity']['hydration_complete'])
+            status, private = self._get_active()
+            self.assertEqual(status, 200)
+            self.assertEqual(private['resolution']['continuation']['canonical_ir'], active['resolution']['continuation']['canonical_ir'])
+            self.assertNotIn('PRIVATE_TOKEN', json.dumps(private))
+            self.assertNotIn('/private/path', json.dumps(private))
+
+    def test_unresolved_active_is_sanitized_and_query_override_is_rejected(self):
+        self.server.controller_token = 'controller-test'
+        with patch('agent_core.realm_server.resolve_active_continuation', side_effect=ValueError('/private/state PRIVATE_TOKEN')) as resolver:
+            for suffix in ('', '/identity'):
+                status, body = self._get_active(suffix)
+                self.assertEqual(status, 409)
+                self.assertEqual(body, {'ok': False, 'error': 'ONE_IR_HEAD_UNRESOLVED'})
+            resolver.reset_mock()
+            self.assertEqual(self._get_active('?project=other')[0], 400)
+            resolver.assert_not_called()
+
+    def test_private_read_refuses_truncated_or_redacted_canonical_ir(self):
+        self.server.controller_token = 'controller-test'
+        for change in ({'goal': 'x' * 513}, {'token': 'PRIVATE_TOKEN'}):
+            active = self._active()
+            active['resolution']['continuation']['canonical_ir'].update(change)
+            with patch('agent_core.realm_server.resolve_active_continuation', return_value=active):
+                self.assertEqual(self._get_active()[0], 409)
+
+    def test_real_file_generation_through_http_client_then_stale_refusal(self):
+        self.server.controller_token = 'controller-test'
+        root = Path(self.tmp.name) / 'data'
+        project_dir = root / 'projects' / 'agentos-core'
+        (project_dir / 'continuity').mkdir(parents=True)
+        (root / 'runtime').mkdir()
+        active = self._active()
+        pointer = {'schema': 'agentos.active-continuation/v1', **active['selector']}
+        selector_file = root / 'runtime' / 'active-continuation.json'
+        selector_file.write_text(json.dumps(pointer))
+        head_file = project_dir / 'execution-head.json'
+        head_file.write_text(json.dumps({'schema': 'agentos.execution-head/v1', 'index_id': 'idx-1'}))
+        ir_file = project_dir / 'continuity' / 'latest.json'
+        ir_file.write_text(json.dumps(active['resolution']['continuation']))
+        files = (selector_file, head_file, ir_file)
+        before = [path.read_bytes() for path in files]
+        project = {'id': 'agentos-core', 'identity_source': 'test', 'integrity': {'complete': True}}
+        client = OneControllerClient(self.base_url, 'controller-test')
+        with patch.dict(os.environ, {'AGENT_DATA_ROOT': str(root)}), patch('agent_core.resolve_facade.resolve_project_identity', return_value=project):
+            identity = client.inspect_continuation()
+            self.assertEqual(identity['index_id'], 'idx-1')
+            self.assertEqual(self._get_active()[0], 200)
+            self.assertEqual(before, [path.read_bytes() for path in files])
+            head_file.write_text(json.dumps({'schema': 'agentos.execution-head/v1', 'index_id': 'idx-2'}))
+            with self.assertRaisesRegex(OneControllerError, '^one_continuation_http_409$'):
+                client.inspect_continuation()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A fresh ChatGPT Core handoff can reach ONE through Control Inbox #50, but that mailbox only dispatches actions and reads receipts. Oracle's local active-continuation MCP is not exposed in ChatGPT. The observed discovery request was rejected because oracle-core-node does not advertise agent.surface.inspect; it did not hydrate Canonical IR.

This is a focused #179 transport/continuation repair, based on core/integration ec69245aba97335b8d4e6c27a6abf78edebe0fc3, not a reconstruction of the unresolved live working state.

## Changes

- Reuse ONE active selector and existing execution-head/IR generation validation; reject selector changes during resolution.
- Add controller-authenticated private active resolve and a separate identity-only endpoint. Reject query overrides and return sanitized ONE_IR_HEAD_UNRESOLVED on resolution failure.
- Reuse the existing executor-safe projection; reject private responses if the canonical IR would be truncated or redacted rather than silently altering its semantics.
- Add opt-in agentos.continuation.inspect to the existing Control Inbox: fixed Oracle scope, empty arguments, fixed authenticated identity GET, no Node task/dispatch or receipt polling.
- Independently validate schema, identifiers, freshness and non-hydration flags before public persistence. Drop all private state and extra response fields.
- Preserve author/action allowlists, short expiry, durable deduplication and crash semantics. No changes to live configuration.
- Update canonical docs, capability documentation and the existing hosted CI guard.

## Validation

60 focused tests passed locally: active continuation, Control Inbox, Realm resolve HTTP, Codex MCP and generation fences.
Integration coverage uses disposable state files and a real local HTTP server/client, then changes the execution head and proves stale reads fail. Read checks preserve source state files.
Documentation Reality Guard passed, including change-set coupling against the pinned base. git diff --check passed.

## Acceptance still required

Source candidate only; no live VERIFIED marker or hydration completion claimed.
After source acceptance, deploy the exact accepted generation through governed authority, explicitly enable only the new bounded inspect action, and prove a fresh identity read.
A trusted private ChatGPT adapter must consume the authenticated private endpoint and retain credentials outside model context. Public identity receipts deliberately cannot supply working state or complete hydration.
Current projection limits may cause a private read to fail closed for large Canonical IR; no truncation is silently accepted.
No protected-main merge, live rollout, arbitrary shell/argv, credential export, or Actions control-plane fallback.

Related #179, #152. Live diagnostic: https://github.com/alston-personal/agentmanager/issues/50#issuecomment-5564393812


## Integration and live attempt — 2026-09-08

All 9 head checks succeeded. Squash-merged to core/integration at c31b48b4a2fd986925f811c6a735a44bc4a5a1f1.

A single governed node.runtime.converge request for that exact SHA was sent through Control Inbox #50. ONE returned a terminal failure: classification=tracked_checkout_dirty, ok=false, status=failed, health=failed, rollback=not_attempted, credential_exposed=false. The outer mailbox status=completed means receipt delivery completed; it does not mean deployment succeeded. No retry, cleanup/reset/stash, force deployment or Actions fallback was performed.

Receipt: https://github.com/alston-personal/agentmanager/issues/50#issuecomment-5577244517

Next required evidence is a read-only tracked-status inventory from the live /home/ubuntu/agentmanager checkout, followed by ownership/provenance review before any reconciliation. This ChatGPT tool surface currently exposes neither Oracle shell access nor the local runtime inspection MCP. The fixed runtime-converge installer also does not itself enable the optional continuation inspect action in the live Control Inbox configuration. Live continuation/hydration acceptance remains open.
