### PR TITLE
Core #288: governed LeopardCat exact-SHA frontend reconcile

### DIFF
--- a/.github/workflows/core-issue-288-leopardcat-reconcile.yml
+++ b/.github/workflows/core-issue-288-leopardcat-reconcile.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'governance/execution-authority.json'
       - 'scripts/reconcile_leopardcat_frontend.py'
+      - 'scripts/reconcile_leopardcat_frontend_enrolled.py'
       - '.github/workflows/core-issue-288-leopardcat-reconcile.yml'
   pull_request:
     paths:
       - 'governance/execution-authority.json'
       - 'scripts/reconcile_leopardcat_frontend.py'
+      - 'scripts/reconcile_leopardcat_frontend_enrolled.py'
       - '.github/workflows/core-issue-288-leopardcat-reconcile.yml'
 
 permissions:
@@ -28,16 +30,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate bounded reconcile source
         run: |
-          python3 -m py_compile scripts/run_governed_execution_request.py scripts/reconcile_leopardcat_frontend.py
+          python3 -m py_compile scripts/run_governed_execution_request.py scripts/reconcile_leopardcat_frontend.py scripts/reconcile_leopardcat_frontend_enrolled.py
           python3 - <<'PY'
           import json
           from pathlib import Path
           r=json.loads(Path('governance/execution-authority.json').read_text())
+          p=r['projects']['leopardcat-tarot']
           c=r['capabilities']['leopardcat.production.frontend.reconcile']
           assert c['replay_policy']=='convergent-idempotent'
           assert c['parameters']=={'listen_port':8088}
-          assert c['runtime']['execution_user']=='ubuntu'
-          assert r['projects']['leopardcat-tarot']['reconcile_request_path']=='.agentos/execution-requests/production-reconcile.json'
+          assert 'execution_user' not in p['request_source']
+          assert 'execution_user' not in c['runtime']
+          assert p['reconcile_request_path']=='.agentos/execution-requests/production-reconcile.json'
           print('core288_contract=PASS')
           PY
 
@@ -51,7 +55,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          python3 scripts/reconcile_leopardcat_frontend.py \
+          python3 scripts/reconcile_leopardcat_frontend_enrolled.py \
             governance/execution-authority.json \
             /tmp/leopardcat-production-reconcile-receipt.json
           code=$?

--- a/.github/workflows/core-issue-288-leopardcat-reconcile.yml
+++ b/.github/workflows/core-issue-288-leopardcat-reconcile.yml
@@ -1,0 +1,70 @@
+name: Core 288 LeopardCat Governed Reconcile
+
+on:
+  push:
+    branches:
+      - core/issue-288-leopardcat-reconcile
+    paths:
+      - 'governance/execution-authority.json'
+      - 'scripts/reconcile_leopardcat_frontend.py'
+      - '.github/workflows/core-issue-288-leopardcat-reconcile.yml'
+  pull_request:
+    paths:
+      - 'governance/execution-authority.json'
+      - 'scripts/reconcile_leopardcat_frontend.py'
+      - '.github/workflows/core-issue-288-leopardcat-reconcile.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-288-leopardcat-reconcile
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate bounded reconcile source
+        run: |
+          python3 -m py_compile scripts/run_governed_execution_request.py scripts/reconcile_leopardcat_frontend.py
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          r=json.loads(Path('governance/execution-authority.json').read_text())
+          c=r['capabilities']['leopardcat.production.frontend.reconcile']
+          assert c['replay_policy']=='convergent-idempotent'
+          assert c['parameters']=={'listen_port':8088}
+          assert c['runtime']['execution_user']=='ubuntu'
+          assert r['projects']['leopardcat-tarot']['reconcile_request_path']=='.agentos/execution-requests/production-reconcile.json'
+          print('core288_contract=PASS')
+          PY
+
+  reconcile:
+    runs-on: [self-hosted, Linux, ARM64, oracle]
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - name: Execute governed exact-SHA frontend reconcile
+        id: reconcile
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/reconcile_leopardcat_frontend.py \
+            governance/execution-authority.json \
+            /tmp/leopardcat-production-reconcile-receipt.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Persist sanitized reconcile receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: leopardcat-production-reconcile-receipt
+          path: /tmp/leopardcat-production-reconcile-receipt.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Enforce reconcile result
+        if: always()
+        run: test "${{ steps.reconcile.outputs.exit_code }}" = "0"

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -4,6 +4,7 @@
     "leopardcat-tarot": {
       "repository": "alston-personal/leopardcat-tarot",
       "request_path": ".agentos/execution-requests/production-parity.json",
+      "reconcile_request_path": ".agentos/execution-requests/production-reconcile.json",
       "allowed_source_refs": ["main"],
       "request_source": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
@@ -34,6 +35,32 @@
       "runtime": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
         "public_origin": "https://leopardcat-tarot.milkcat.org"
+      }
+    },
+    "leopardcat.production.frontend.reconcile": {
+      "project_id": "leopardcat-tarot",
+      "environment": "production",
+      "adapter": "leopardcat_frontend_reconcile",
+      "parameters": {
+        "listen_port": 8088
+      },
+      "replay_policy": "convergent-idempotent",
+      "runtime": {
+        "repo_root": "/home/ubuntu/leopardcat-tarot",
+        "public_origin": "https://leopardcat-tarot.milkcat.org",
+        "execution_user": "ubuntu",
+        "build_root": "website",
+        "dist_path": "website/dist",
+        "preserve_paths": ["website/stats.json"],
+        "allowed_dirty_exact": ["website/dist/index.html", "website/stats.json"],
+        "allowed_dirty_prefixes": ["website/node_modules/.vite/", ".claude/"],
+        "allowed_changed_exact": [
+          ".agentos/execution-requests/production-parity.json",
+          ".agentos/execution-requests/production-reconcile.json",
+          "website/share_snapshot.js",
+          "website/vite.config.js"
+        ],
+        "allowed_changed_prefixes": ["docs/", "website/tests/", "tests/"]
       }
     },
     "vendor.production.runtime.inspect": {

--- a/governance/execution-authority.json
+++ b/governance/execution-authority.json
@@ -8,8 +8,7 @@
       "allowed_source_refs": ["main"],
       "request_source": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
-        "source_ref": "main",
-        "execution_user": "ubuntu"
+        "source_ref": "main"
       }
     },
     "vendor-reputation-service": {
@@ -48,7 +47,6 @@
       "runtime": {
         "repo_root": "/home/ubuntu/leopardcat-tarot",
         "public_origin": "https://leopardcat-tarot.milkcat.org",
-        "execution_user": "ubuntu",
         "build_root": "website",
         "dist_path": "website/dist",
         "preserve_paths": ["website/stats.json"],

--- a/scripts/reconcile_leopardcat_frontend.py
+++ b/scripts/reconcile_leopardcat_frontend.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Governed, frontend-only LeopardCat production reconcile for Core #288.
+
+The product owns only the exact source SHA intent. Core owns repository path,
+release lane, runtime user, build/swap procedure, public origin, and rollback policy.
+No request-controlled shell, executable, argv, path, or secret is accepted.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from run_governed_execution_request import (
+    git_state,
+    inspect_leopardcat_parity,
+    load_json,
+    resolve_authority,
+)
+
+PROJECT_ID = "leopardcat-tarot"
+CAPABILITY_ID = "leopardcat.production.frontend.reconcile"
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def run(argv, *, cwd=None):
+    return subprocess.run(argv, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def as_user(user, argv, *, cwd=None):
+    fixed = ["sudo", "-n", "-u", user, "--", *argv]
+    return run(fixed, cwd=cwd)
+
+
+def require(proc, label):
+    if proc.returncode:
+        # Never echo command output from privileged git/build operations: remotes or
+        # package-manager diagnostics may contain environment-specific information.
+        fail(f"{label} failed")
+    return proc
+
+
+def path_allowed(path, exact, prefixes):
+    return path in exact or any(path.startswith(prefix) for prefix in prefixes)
+
+
+def fetch_request(project, registry):
+    source = project["request_source"]
+    repo_root = source["repo_root"]
+    source_ref = source["source_ref"]
+    user = source.get("execution_user") or "ubuntu"
+    request_path = project.get("reconcile_request_path")
+    if not request_path or request_path.startswith("/") or ".." in Path(request_path).parts:
+        fail("invalid registry-owned reconcile request path")
+    require(as_user(user, ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root,
+                           "fetch", "--depth=64", "origin", source_ref]), "product request fetch")
+    shown = require(as_user(user, ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root,
+                                    "show", f"FETCH_HEAD:{request_path}"]), "product request read")
+    try:
+        request = json.loads(shown.stdout)
+    except json.JSONDecodeError:
+        fail("product reconcile request is not valid JSON")
+    _, capability = resolve_authority(request, registry)
+    if request["project_id"] != PROJECT_ID or request["capability"] != CAPABILITY_ID:
+        fail("unexpected reconcile project/capability")
+    return request, capability, user
+
+
+def git_user(user, repo_root, *args):
+    return as_user(user, ["git", "-c", f"safe.directory={repo_root}", "-C", repo_root, *args])
+
+
+def capture_file(user, path, backup):
+    if not path.exists():
+        return False
+    require(as_user(user, ["cp", "--", str(path), str(backup)]), "preserve runtime file")
+    return True
+
+
+def restore_file(user, backup, path, existed):
+    if existed:
+        require(as_user(user, ["cp", "--", str(backup), str(path)]), "restore runtime file")
+
+
+def main():
+    registry_path = sys.argv[1] if len(sys.argv) > 1 else "governance/execution-authority.json"
+    receipt_path = Path(sys.argv[2] if len(sys.argv) > 2 else "/tmp/leopardcat-production-reconcile-receipt.json")
+    receipt = {
+        "schema": "agentos.execution-receipt/v1",
+        "request_id": None,
+        "project_id": PROJECT_ID,
+        "repository": None,
+        "environment": "production",
+        "source_ref": None,
+        "source_sha": None,
+        "capability": CAPABILITY_ID,
+        "result_status": "failed",
+        "evidence_level": None,
+        "artifact_digest": None,
+        "executor_identity": os.environ.get("RUNNER_NAME") or os.uname().nodename,
+        "started_at": now(),
+        "completed_at": None,
+        "evidence": {},
+        "error": None,
+    }
+    old_head = None
+    source_switched = False
+    dist_swapped = False
+    old_dist = None
+    new_dist = None
+    preserve = []
+    try:
+        registry = load_json(registry_path)
+        project = registry["projects"][PROJECT_ID]
+        request, capability, user = fetch_request(project, registry)
+        runtime = capability["runtime"]
+        repo_root = runtime["repo_root"]
+        public_origin = runtime["public_origin"]
+        build_root = Path(repo_root) / runtime["build_root"]
+        dist_path = Path(repo_root) / runtime["dist_path"]
+        receipt.update({
+            "request_id": request["request_id"],
+            "repository": request["repository"],
+            "source_ref": request["source_ref"],
+            "source_sha": request["source_sha"],
+        })
+
+        pre = git_state(repo_root,
+            allowed_dirty_exact=runtime.get("allowed_dirty_exact", ()),
+            allowed_dirty_prefixes=runtime.get("allowed_dirty_prefixes", ()))
+        if pre["unexpected_dirty_paths"]:
+            fail("unexpected production dirty state")
+        old_head = pre["head"]
+
+        # The desired SHA must be contained by the registry-owned release lane fetched above.
+        contain = git_user(user, repo_root, "merge-base", "--is-ancestor", request["source_sha"], "FETCH_HEAD")
+        if contain.returncode:
+            fail("requested source SHA is outside fetched main release lane")
+
+        changed = require(git_user(user, repo_root, "diff", "--name-only", f"{old_head}..{request['source_sha']}"),
+                          "changed-path inspection").stdout.splitlines()
+        exact = runtime.get("allowed_changed_exact", [])
+        prefixes = runtime.get("allowed_changed_prefixes", [])
+        rejected = [p for p in changed if p and not path_allowed(p, exact, prefixes)]
+        if rejected:
+            fail("requested release contains changes outside frontend-only authority")
+
+        tmp = Path(tempfile.mkdtemp(prefix="lc-reconcile-"))
+        new_dist = tmp / "new-dist"
+        old_dist = tmp / "old-dist"
+        for rel in runtime.get("preserve_paths", []):
+            src = Path(repo_root) / rel
+            backup = tmp / (Path(rel).name + ".preserved")
+            preserve.append((src, backup, capture_file(user, src, backup)))
+
+        if old_head != request["source_sha"]:
+            require(git_user(user, repo_root, "reset", "--hard", request["source_sha"]), "source reconcile")
+            source_switched = True
+            for src, backup, existed in preserve:
+                restore_file(user, backup, src, existed)
+
+        # Build to a separate directory first; production dist is untouched until build success.
+        require(as_user(user, ["npm", "ci"], cwd=str(build_root)), "npm ci")
+        require(as_user(user, ["npx", "vite", "build", "--outDir", str(new_dist), "--emptyOutDir"],
+                        cwd=str(build_root)), "frontend build")
+        if not (new_dist / "index.html").is_file():
+            fail("frontend build produced no index.html")
+
+        if dist_path.exists():
+            require(as_user(user, ["mv", "--", str(dist_path), str(old_dist)]), "stage old dist")
+        require(as_user(user, ["mv", "--", str(new_dist), str(dist_path)]), "activate new dist")
+        dist_swapped = True
+
+        evidence, digest, accepted, level = inspect_leopardcat_parity(request, capability)
+        if not accepted:
+            fail("post-reconcile production parity mismatch")
+        receipt["evidence"] = {
+            "mutation": "frontend-only transactional reconcile",
+            "previous_runtime_head": old_head,
+            "changed_paths": changed,
+            "rollback_available_during_execution": True,
+            **evidence,
+        }
+        receipt["artifact_digest"] = digest
+        receipt["evidence_level"] = level + "+governed_mutation"
+        receipt["result_status"] = "success"
+        if old_dist and old_dist.exists():
+            shutil.rmtree(old_dist, ignore_errors=True)
+    except Exception as exc:
+        receipt["error"] = f"{type(exc).__name__}: {exc}"
+        # Best-effort rollback. Do not mask the original failure with rollback output.
+        try:
+            if dist_swapped and old_dist and old_dist.exists():
+                current_dist = Path(registry["capabilities"][CAPABILITY_ID]["runtime"]["repo_root"]) / \
+                    registry["capabilities"][CAPABILITY_ID]["runtime"]["dist_path"]
+                failed_dist = old_dist.parent / "failed-dist"
+                as_user(user, ["mv", "--", str(current_dist), str(failed_dist)])
+                as_user(user, ["mv", "--", str(old_dist), str(current_dist)])
+            if source_switched and old_head:
+                repo_root = registry["capabilities"][CAPABILITY_ID]["runtime"]["repo_root"]
+                git_user(user, repo_root, "reset", "--hard", old_head)
+                for src, backup, existed in preserve:
+                    restore_file(user, backup, src, existed)
+        except Exception:
+            pass
+    finally:
+        receipt["completed_at"] = now()
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0 if receipt["result_status"] == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_leopardcat_frontend_enrolled.py
+++ b/scripts/reconcile_leopardcat_frontend_enrolled.py
@@ -3,9 +3,12 @@
 
 LeopardCat's runtime repository is readable/writable by the enrolled AgentOS runner
 boundary; unlike Vendor, it does not require or authorize a sudo user transition.
-The underlying reconcile code remains identical and request data still cannot choose
-an executable, user, path, or argv.
+The request is fetched from the registry-owned canonical public repository URL rather
+than trusting a mutable local remote configuration.
 """
+import json
+from pathlib import Path
+
 import reconcile_leopardcat_frontend as reconcile
 
 
@@ -13,7 +16,40 @@ def direct_identity(_user, argv, *, cwd=None):
     return reconcile.run(argv, cwd=cwd)
 
 
+def fetch_request_from_canonical_origin(project, registry):
+    source = project["request_source"]
+    repo_root = source["repo_root"]
+    source_ref = source["source_ref"]
+    request_path = project.get("reconcile_request_path")
+    if not request_path or request_path.startswith("/") or ".." in Path(request_path).parts:
+        reconcile.fail("invalid registry-owned reconcile request path")
+    canonical_url = f"https://github.com/{project['repository']}.git"
+    reconcile.require(
+        reconcile.run([
+            "git", "-c", f"safe.directory={repo_root}", "-C", repo_root,
+            "fetch", "--depth=64", canonical_url, source_ref,
+        ]),
+        "product request fetch",
+    )
+    shown = reconcile.require(
+        reconcile.run([
+            "git", "-c", f"safe.directory={repo_root}", "-C", repo_root,
+            "show", f"FETCH_HEAD:{request_path}",
+        ]),
+        "product request read",
+    )
+    try:
+        request = json.loads(shown.stdout)
+    except json.JSONDecodeError:
+        reconcile.fail("product reconcile request is not valid JSON")
+    _, capability = reconcile.resolve_authority(request, registry)
+    if request["project_id"] != reconcile.PROJECT_ID or request["capability"] != reconcile.CAPABILITY_ID:
+        reconcile.fail("unexpected reconcile project/capability")
+    return request, capability, ""
+
+
 reconcile.as_user = direct_identity
+reconcile.fetch_request = fetch_request_from_canonical_origin
 
 if __name__ == "__main__":
     raise SystemExit(reconcile.main())

--- a/scripts/reconcile_leopardcat_frontend_enrolled.py
+++ b/scripts/reconcile_leopardcat_frontend_enrolled.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Run Core #288 reconcile under the already-enrolled Oracle runner identity.
+
+LeopardCat's runtime repository is readable/writable by the enrolled AgentOS runner
+boundary; unlike Vendor, it does not require or authorize a sudo user transition.
+The underlying reconcile code remains identical and request data still cannot choose
+an executable, user, path, or argv.
+"""
+import reconcile_leopardcat_frontend as reconcile
+
+
+def direct_identity(_user, argv, *, cwd=None):
+    return reconcile.run(argv, cwd=cwd)
+
+
+reconcile.as_user = direct_identity
+
+if __name__ == "__main__":
+    raise SystemExit(reconcile.main())


### PR DESCRIPTION
Dependent follow-up to #165 / PR #283.

Adds a narrow mutating capability for LeopardCat frontend-only production reconciliation:
- product-owned exact SHA request;
- Core-owned runtime path/user/origin/build/swap policy;
- release-lane ancestry check;
- changed-path allowlist so backend/runtime authority cannot widen silently;
- build to isolated dist, then atomic activation;
- preserve runtime stats;
- rollback source/dist on failure;
- reuse three-way local/localhost/public parity evidence;
- sanitized receipt artifact;
- convergent-idempotent replay semantics.

This PR targets the clean #165 branch rather than protected main. It does not add backend restart/deploy authority.