### PR TITLE
Core #290: add ONE Discussion Index provenance substrate

### DIFF
--- a/agent_core/discussion_index.py
+++ b/agent_core/discussion_index.py
@@ -1,0 +1,374 @@
+"""ONE-owned cross-Node discussion provenance index.
+
+Discussion records answer "where did we discuss this?" without promoting
+vendor chat history into Canonical IR or Experience authority.
+"""
+from __future__ import annotations
+
+import fcntl
+from contextlib import contextmanager
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Iterable, Iterator
+
+RECORD_SCHEMA = "agentos.discussion-record/v1"
+SEARCH_RESULT_SCHEMA = "agentos.discussion-search-result/v1"
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$")
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+TOKEN_RE = re.compile(r"[\w\u3400-\u9fff]+", re.UNICODE)
+SECRET_PATTERNS = (
+    re.compile(r"(?i)\b(?:authorization\s*:\s*)?bearer\s+[A-Za-z0-9._~+/=-]{12,}"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"(?i)\b(?:api[_-]?key|access[_-]?token|password|secret)\s*[:=]\s*\S+"),
+)
+REF_KEYS = ("canonical_ir", "experience", "issues", "receipts", "assignments")
+STORAGE_CLASSES = {"indexed_projection", "private_projection", "vault_linked"}
+
+
+def _data_root() -> Path:
+    return Path(
+        os.environ.get("AGENT_DATA_ROOT")
+        or os.environ.get("AGENTOS_DATA_ROOT")
+        or "/home/ubuntu/agent-data"
+    ).expanduser()
+
+
+def discussion_path(project_id: str, *, data_root: Path | None = None) -> Path:
+    project = _safe_id(project_id, "project_id", required=True)
+    root = data_root or _data_root()
+    return root / "discussion-index" / project / "records.jsonl"
+
+
+def _bounded_string(value: Any, field: str, *, required: bool = False, max_len: int = 4096) -> str:
+    text = str(value or "").strip()
+    if required and not text:
+        raise ValueError(f"{field} is required")
+    if len(text) > max_len:
+        raise ValueError(f"{field} is too long")
+    return text
+
+
+def _safe_id(value: Any, field: str, *, required: bool = False) -> str:
+    text = _bounded_string(value, field, required=required, max_len=192)
+    if text and not ID_RE.fullmatch(text):
+        raise ValueError(f"invalid {field}")
+    return text
+
+
+def _string_list(value: Any, field: str, *, limit: int = 64, item_max: int = 512) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or len(value) > limit:
+        raise ValueError(f"{field} must be a bounded list")
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = _bounded_string(item, field, max_len=item_max)
+        if text and text not in seen:
+            seen.add(text)
+            out.append(text)
+    return out
+
+
+def contains_secret_like(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_PATTERNS)
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
+def semantic_digest(record: dict[str, Any]) -> str:
+    identity = {
+        "project_id": record["project_id"],
+        "provenance": record["provenance"],
+        "semantic": record["semantic"],
+        "source_digest": record.get("source_digest"),
+    }
+    return "sha256:" + sha256(_canonical_bytes(identity)).hexdigest()
+
+
+def validate_record(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("schema") != RECORD_SCHEMA:
+        raise ValueError("unsupported discussion record schema")
+
+    discussion_id = _safe_id(value.get("discussion_id"), "discussion_id", required=True)
+    project_id = _safe_id(value.get("project_id"), "project_id", required=True)
+    realm_id = _safe_id(value.get("realm_id"), "realm_id")
+    observed_start = _bounded_string(
+        value.get("observed_start"), "observed_start", required=True, max_len=64
+    )
+    observed_end = _bounded_string(value.get("observed_end"), "observed_end", max_len=64)
+
+    provenance = value.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError("provenance must be an object")
+    canonical_provenance = {
+        "node_id": _safe_id(provenance.get("node_id"), "node_id"),
+        "surface": _safe_id(provenance.get("surface"), "surface"),
+        "executor_adapter": _safe_id(
+            provenance.get("executor_adapter"), "executor_adapter"
+        ),
+        "backend_model": _bounded_string(
+            provenance.get("backend_model") or "unknown", "backend_model", max_len=192
+        ),
+        "session_ref": _bounded_string(
+            provenance.get("session_ref"), "session_ref", max_len=512
+        ),
+        "source_ref": _bounded_string(
+            provenance.get("source_ref"), "source_ref", required=True, max_len=1024
+        ),
+    }
+
+    semantic = value.get("semantic")
+    if not isinstance(semantic, dict):
+        raise ValueError("semantic must be an object")
+    canonical_semantic = {
+        "summary": _bounded_string(
+            semantic.get("summary"), "summary", required=True, max_len=8192
+        ),
+        "topics": _string_list(semantic.get("topics"), "topics", limit=32),
+        "entities": _string_list(semantic.get("entities"), "entities", limit=64),
+        "keywords": _string_list(semantic.get("keywords"), "keywords", limit=64),
+    }
+    searchable = "\n".join(
+        [
+            canonical_semantic["summary"],
+            *canonical_semantic["topics"],
+            *canonical_semantic["entities"],
+            *canonical_semantic["keywords"],
+        ]
+    )
+    if contains_secret_like(searchable):
+        raise ValueError("secret-like content is not allowed in discussion projection")
+
+    refs = value.get("refs") or {}
+    if not isinstance(refs, dict):
+        raise ValueError("refs must be an object")
+    canonical_refs = {
+        key: _string_list(refs.get(key), f"refs.{key}", limit=64, item_max=512)
+        for key in REF_KEYS
+    }
+
+    promoted_to = _string_list(
+        value.get("promoted_to"), "promoted_to", limit=64, item_max=512
+    )
+    privacy = value.get("privacy") or {}
+    if not isinstance(privacy, dict):
+        raise ValueError("privacy must be an object")
+    storage_class = _bounded_string(
+        privacy.get("storage_class") or "indexed_projection",
+        "storage_class",
+        max_len=64,
+    )
+    if storage_class not in STORAGE_CLASSES:
+        raise ValueError("unsupported storage_class")
+
+    source_digest = _bounded_string(value.get("source_digest"), "source_digest", max_len=80)
+    if source_digest and not SHA256_RE.fullmatch(source_digest):
+        raise ValueError("invalid source_digest")
+
+    canonical = {
+        "schema": RECORD_SCHEMA,
+        "discussion_id": discussion_id,
+        "project_id": project_id,
+        "realm_id": realm_id or None,
+        "observed_start": observed_start,
+        "observed_end": observed_end or observed_start,
+        "provenance": canonical_provenance,
+        "semantic": canonical_semantic,
+        "refs": canonical_refs,
+        "promoted_to": promoted_to,
+        "privacy": {"storage_class": storage_class},
+        "source_digest": source_digest or None,
+    }
+    canonical["semantic_digest"] = semantic_digest(canonical)
+    supplied = _bounded_string(value.get("semantic_digest"), "semantic_digest", max_len=80)
+    if supplied and supplied != canonical["semantic_digest"]:
+        raise ValueError("discussion semantic_digest mismatch")
+    return canonical
+
+
+@contextmanager
+def _lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if lock_path.is_symlink():
+        raise ValueError("discussion lock path must not be a symlink")
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def read_records(project_id: str, *, data_root: Path | None = None) -> list[dict[str, Any]]:
+    path = discussion_path(project_id, data_root=data_root)
+    if path.is_symlink():
+        raise ValueError("discussion store path must not be a symlink")
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw_line.strip():
+            continue
+        try:
+            raw = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid discussion record JSON at line {number}") from exc
+        records.append(validate_record(raw))
+    return records
+
+
+def append_record(
+    record: dict[str, Any], *, data_root: Path | None = None
+) -> dict[str, Any]:
+    canonical = validate_record(record)
+    path = discussion_path(canonical["project_id"], data_root=data_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _lock(path):
+        current = read_records(canonical["project_id"], data_root=data_root)
+        for existing in current:
+            if existing["discussion_id"] != canonical["discussion_id"]:
+                continue
+            if existing["semantic_digest"] != canonical["semantic_digest"]:
+                raise ValueError("discussion_id already exists with a different semantic digest")
+            return {
+                "schema": "agentos.discussion-append-receipt/v1",
+                "ok": True,
+                "persisted": False,
+                "discussion_id": canonical["discussion_id"],
+                "project_id": canonical["project_id"],
+                "semantic_digest": canonical["semantic_digest"],
+                "credential_exposed": False,
+            }
+
+        if path.is_symlink():
+            raise ValueError("discussion store path must not be a symlink")
+        with path.open("ab") as handle:
+            handle.write(_canonical_bytes(canonical))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(path, 0o640)
+
+    return {
+        "schema": "agentos.discussion-append-receipt/v1",
+        "ok": True,
+        "persisted": True,
+        "discussion_id": canonical["discussion_id"],
+        "project_id": canonical["project_id"],
+        "semantic_digest": canonical["semantic_digest"],
+        "credential_exposed": False,
+    }
+
+
+def _tokens(text: str) -> set[str]:
+    return {match.group(0).casefold() for match in TOKEN_RE.finditer(text)}
+
+
+def score_record(record: dict[str, Any], query: str) -> float:
+    query_tokens = _tokens(query)
+    if not query_tokens:
+        return 0.0
+    semantic = record["semantic"]
+    haystack = " ".join(
+        [semantic["summary"], *semantic["topics"], *semantic["entities"], *semantic["keywords"]]
+    )
+    overlap = len(query_tokens & _tokens(haystack)) / len(query_tokens)
+    phrase_boost = 0.35 if query.casefold() in haystack.casefold() else 0.0
+    exact_tag_boost = (
+        0.15
+        if any(
+            query.casefold() == item.casefold()
+            for item in semantic["topics"] + semantic["entities"] + semantic["keywords"]
+        )
+        else 0.0
+    )
+    return min(1.0, overlap + phrase_boost + exact_tag_boost)
+
+
+def search_records(
+    records: Iterable[dict[str, Any]],
+    *,
+    text: str,
+    project_id: str | None = None,
+    node_id: str | None = None,
+    surface: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    query = _bounded_string(text, "text", required=True, max_len=2048)
+    safe_limit = max(1, min(int(limit), 50))
+    hits: list[tuple[float, dict[str, Any]]] = []
+
+    for raw in records:
+        record = validate_record(raw)
+        if project_id and record["project_id"] != project_id:
+            continue
+        if node_id and record["provenance"]["node_id"] != node_id:
+            continue
+        if surface and record["provenance"]["surface"] != surface:
+            continue
+        score = score_record(record, query)
+        if score <= 0:
+            continue
+        hits.append((score, record))
+
+    hits.sort(
+        key=lambda item: (
+            -item[0],
+            item[1]["observed_start"],
+            item[1]["discussion_id"],
+        )
+    )
+    results = []
+    for score, record in hits[:safe_limit]:
+        results.append(
+            {
+                "score": round(score, 6),
+                "discussion_id": record["discussion_id"],
+                "project_id": record["project_id"],
+                "observed_start": record["observed_start"],
+                "observed_end": record["observed_end"],
+                "provenance": record["provenance"],
+                "summary": record["semantic"]["summary"],
+                "topics": record["semantic"]["topics"],
+                "refs": record["refs"],
+                "promoted_to": record["promoted_to"],
+                "semantic_digest": record["semantic_digest"],
+            }
+        )
+    return {
+        "schema": SEARCH_RESULT_SCHEMA,
+        "query": query,
+        "count": len(results),
+        "results": results,
+        "read_only": True,
+        "canonical_authority": False,
+    }
+
+
+def search_from_one(
+    *,
+    project_id: str,
+    text: str,
+    node_id: str | None = None,
+    surface: str | None = None,
+    limit: int = 10,
+    data_root: Path | None = None,
+) -> dict[str, Any]:
+    return search_records(
+        read_records(project_id, data_root=data_root),
+        text=text,
+        project_id=project_id,
+        node_id=node_id,
+        surface=surface,
+        limit=limit,
+    )

--- a/docs/DISCUSSION_INDEX.md
+++ b/docs/DISCUSSION_INDEX.md
@@ -1,0 +1,101 @@
+# AgentOS Discussion Index
+
+**Status:** Core #290 source candidate.
+
+## Purpose
+
+The Discussion Index answers **where did we discuss this?** across Nodes, executor surfaces and sessions. It is searchable provenance, not a continuation or memory authority.
+
+Canonical hierarchy remains:
+
+1. explicit current user intent and governance;
+2. Canonical Project / ONE state (`agentos.ir/v1` and durable runtime state);
+3. accepted Experience artifacts;
+4. governed receipts/evidence;
+5. Discussion Index provenance;
+6. provider/local chat history.
+
+A search hit may explain where a decision came from, but it cannot overwrite Canonical IR or Experience.
+
+## Identity model
+
+Discussion provenance preserves the full boundary:
+
+```text
+Realm -> Node -> Surface -> Executor adapter -> Backend/model -> Session/thread -> Discussion record
+```
+
+Missing backend identity is recorded as `unknown`. Extension/surface branding is never proof of the backend model.
+
+## Storage model
+
+The ONE-owned indexed projection is stored below Agent Data:
+
+```text
+<agent-data>/discussion-index/<project-id>/records.jsonl
+```
+
+`agentos.discussion-record/v1` contains:
+
+- project / realm identity;
+- Node, surface, executor adapter, backend and session/source provenance;
+- bounded summary/topics/entities/keywords for retrieval;
+- source and semantic digests;
+- links to Canonical IR, Experience, issues, receipts and Employee assignments;
+- `promoted_to` links when later accepted state supersedes/promotes the discussion;
+- privacy storage class.
+
+The indexed projection must not contain credentials or secret-like material.
+
+## Optional Transcript Vault
+
+Raw transcripts are deliberately **not** stored in the Discussion Index. A future separately governed Transcript Vault may preserve encrypted raw history when the provider/surface permits explicit export or capture.
+
+The vault is optional. Canonical continuation must continue to work if raw transcript retention is disabled or the transcript is deleted.
+
+## Ingestion model
+
+Provider-specific adapters produce bounded discussion records. Sources may include:
+
+- session/checkpoint handoff emitted by an executor adapter;
+- permitted Node-local session harvest;
+- ChatGPT/App checkpoint through ONE transport;
+- explicit import from a user-owned transcript archive.
+
+Imported history is evidence only. Promotion into Canonical IR or Experience requires the existing governed publication/acceptance path.
+
+## Query model
+
+The initial Core primitive supports bounded read-only keyword/topic retrieval with project, Node and surface filters and returns provenance + canonical links. A later retrieval adapter may add embeddings/semantic-vector ranking without changing the record authority model.
+
+Example intent:
+
+```text
+找我們之前在哪裡討論過 Master Experience Floor？
+```
+
+Expected result is not merely an LLM-generated recollection. It should return matching discussion records with time, Node/surface/session provenance and references such as #117, accepted IR generations or Experience artifacts.
+
+## Security and authority
+
+- discussion evidence != canonical truth;
+- search is read-only;
+- raw provider transcript != continuation authority;
+- no hidden model state is represented as retrievable memory;
+- current user intent outranks stale indexed history;
+- secrets/credentials are rejected from searchable projections;
+- future raw transcript retention must be a separate private boundary;
+- discussion records cannot self-promote into Canonical IR or Experience.
+
+## Current implementation boundary
+
+`agent_core.discussion_index` implements:
+
+- `agentos.discussion-record/v1` validation;
+- deterministic semantic digest;
+- append-only idempotent JSONL persistence with conflict fencing;
+- secret-like projection rejection;
+- provenance-preserving read-only search;
+- `promoted_to` and canonical reference projection.
+
+This first slice intentionally does not claim provider-wide transcript ingestion or embedding-backed semantic retrieval. Those require real surface adapters and operating acceptance across at least two executor surfaces.

--- a/tests/test_discussion_index.py
+++ b/tests/test_discussion_index.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+import pytest
+
+from agent_core.discussion_index import (
+    append_record,
+    read_records,
+    search_from_one,
+    search_records,
+    validate_record,
+)
+
+
+def record(
+    discussion_id: str = "discussion-1",
+    *,
+    surface: str = "chatgpt-web",
+    node_id: str = "oracle-core-node",
+    summary: str = "Discussed Master Experience Floor and ONE hydration regression.",
+):
+    return {
+        "schema": "agentos.discussion-record/v1",
+        "discussion_id": discussion_id,
+        "project_id": "agentos-core",
+        "realm_id": "default",
+        "observed_start": "2026-09-01T00:00:00Z",
+        "observed_end": "2026-09-01T00:10:00Z",
+        "provenance": {
+            "node_id": node_id,
+            "surface": surface,
+            "executor_adapter": f"{surface}-adapter",
+            "backend_model": "unknown",
+            "session_ref": f"session://{discussion_id}",
+            "source_ref": f"provider://{surface}/{discussion_id}",
+        },
+        "semantic": {
+            "summary": summary,
+            "topics": ["Master Experience Floor", "ONE"],
+            "entities": ["AgentOS"],
+            "keywords": ["hydration", "regression"],
+        },
+        "refs": {
+            "canonical_ir": ["ir://agentos-core/1"],
+            "experience": ["experience://agentos-core/floor"],
+            "issues": ["github://agentmanager/issues/117"],
+            "receipts": [],
+            "assignments": [],
+        },
+        "promoted_to": ["experience://agentos-core/floor"],
+        "privacy": {"storage_class": "indexed_projection"},
+    }
+
+
+def test_record_keeps_node_surface_backend_session_distinct():
+    value = validate_record(record())
+    assert value["provenance"]["node_id"] == "oracle-core-node"
+    assert value["provenance"]["surface"] == "chatgpt-web"
+    assert value["provenance"]["backend_model"] == "unknown"
+    assert value["provenance"]["session_ref"] == "session://discussion-1"
+    assert value["promoted_to"] == ["experience://agentos-core/floor"]
+
+
+def test_search_returns_provenance_and_canonical_links():
+    unrelated = record(
+        "discussion-2",
+        surface="openai-codex",
+        summary="Investigated unrelated runtime packaging details.",
+    )
+    unrelated["semantic"] = {
+        "summary": "Investigated unrelated runtime packaging details.",
+        "topics": ["runtime packaging"],
+        "entities": ["Python"],
+        "keywords": ["wheel"],
+    }
+    unrelated["promoted_to"] = []
+    result = search_records([record(), unrelated], text="Master Experience Floor")
+    assert result["read_only"] is True
+    assert result["canonical_authority"] is False
+    assert result["count"] == 1
+    hit = result["results"][0]
+    assert hit["discussion_id"] == "discussion-1"
+    assert hit["provenance"]["surface"] == "chatgpt-web"
+    assert hit["refs"]["issues"] == ["github://agentmanager/issues/117"]
+    assert hit["promoted_to"] == ["experience://agentos-core/floor"]
+
+
+def test_store_is_idempotent_and_conflicts_fail_closed(tmp_path: Path):
+    first = append_record(record(), data_root=tmp_path)
+    second = append_record(record(), data_root=tmp_path)
+    assert first["persisted"] is True
+    assert second["persisted"] is False
+    assert len(read_records("agentos-core", data_root=tmp_path)) == 1
+
+    changed = record(summary="A different semantic record under the same id.")
+    with pytest.raises(ValueError, match="different semantic digest"):
+        append_record(changed, data_root=tmp_path)
+
+
+def test_secret_like_projection_is_rejected():
+    value = record(summary="Use Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456")
+    with pytest.raises(ValueError, match="secret-like"):
+        validate_record(value)
+
+
+def test_cross_surface_search_and_filter(tmp_path: Path):
+    append_record(record(), data_root=tmp_path)
+    append_record(
+        record(
+            "discussion-2",
+            surface="openai-codex",
+            node_id="vopc5750",
+            summary="Master Experience Floor comparison through Codex.",
+        ),
+        data_root=tmp_path,
+    )
+
+    all_hits = search_from_one(
+        project_id="agentos-core",
+        text="Master Experience Floor",
+        data_root=tmp_path,
+    )
+    assert all_hits["count"] == 2
+
+    codex = search_from_one(
+        project_id="agentos-core",
+        text="Master Experience Floor",
+        surface="openai-codex",
+        data_root=tmp_path,
+    )
+    assert codex["count"] == 1
+    assert codex["results"][0]["provenance"]["node_id"] == "vopc5750"


### PR DESCRIPTION
## Scope

Implements the first bounded Core substrate for cross-Node discussion provenance and search.

### Adds
- `agentos.discussion-record/v1` with explicit Realm/Node/surface/executor/backend/session identity separation;
- ONE-owned append-only store under Agent Data, not repository/chat history authority;
- deterministic semantic digest and idempotent append conflict fence;
- secret-like projection rejection;
- read-only bounded search with project/Node/surface filters;
- provenance results containing source/session identity plus Canonical IR / Experience / issue / receipt / assignment refs;
- `promoted_to` links so a historical discussion can point to the accepted Canonical IR/Experience that superseded it;
- canonical architecture doc defining Discussion Index vs Canonical IR/Experience vs optional Transcript Vault.

## Validation

Focused local unit suite before publication: **5/5 PASS**.

## Important boundary

This slice deliberately provides deterministic keyword/topic retrieval only. It does not claim embedding-backed semantic retrieval, provider-wide transcript harvesting, or raw Transcript Vault support yet. Those require later adapters and live acceptance across at least two executor surfaces.

Discussion evidence is not canonical authority and cannot self-promote into IR/Experience.

Refs #290. Target is `core/integration` only; no protected-main publication authority.