### PR TITLE
Core #291: safely converge target-equivalent dirty Oracle checkouts

### DIFF
--- a/agentos_node/runtime_converge_action_relay.py
+++ b/agentos_node/runtime_converge_action_relay.py
@@ -1,7 +1,7 @@
 """Bounded Oracle Core runtime convergence through the existing Action Relay.
 
-The external capability is ``node.runtime.converge``.  The relay action below is
-an implementation detail owned by the trusted ubuntu worker.  Callers provide
+The external capability is ``node.runtime.converge``. The relay action below is
+an implementation detail owned by the trusted ubuntu worker. Callers provide
 only the canonical typed request; executable names, argv, paths, environment,
 service names and installer sequence are fixed here.
 """
@@ -15,7 +15,7 @@ import subprocess
 import urllib.request
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterator, Mapping
 
 from agent_core.runtime_converge_contract import validate_runtime_converge_request
@@ -85,7 +85,11 @@ def _git_value(repo: Path, *args: str) -> str:
 
 def _health() -> bool:
     for unit in ("agentos-realm-fabric.service", "agentos-core-supervisor.service"):
-        result = _run(["systemctl", "--user", "is-active", "--quiet", unit], cwd=DEFAULT_REPO, timeout=20)
+        result = _run(
+            ["systemctl", "--user", "is-active", "--quiet", unit],
+            cwd=DEFAULT_REPO,
+            timeout=20,
+        )
         if result.returncode != 0:
             return False
     try:
@@ -117,15 +121,61 @@ def _checkout_exact(repo: Path, commit: str) -> bool:
     return result.returncode == 0 and _git_value(repo, "rev-parse", "HEAD") == commit
 
 
-def _preflight(repo: Path, request: Mapping[str, Any]) -> tuple[str, bool]:
+def _tracked_status(repo: Path) -> str:
+    result = _git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=no")
+    if result.returncode != 0:
+        raise RuntimeError("git_preflight_failed")
+    return result.stdout
+
+
+def _safe_repo_relative_path(raw: str) -> str | None:
+    path = PurePosixPath(raw)
+    if not raw or path.is_absolute() or ".." in path.parts:
+        return None
+    return path.as_posix()
+
+
+def _target_equivalent_dirty(repo: Path, source_commit: str, status: str) -> bool:
+    """Prove a narrow partial rollout is already byte-identical to target.
+
+    Only ordinary *unstaged content modifications* are eligible. Staged changes,
+    deletes, renames, conflicts, type/mode changes and any path whose worktree
+    blob differs from the exact fetched target fail closed.
+    """
+    entries = [entry for entry in status.split("\0") if entry]
+    if not entries:
+        return False
+
+    for entry in entries:
+        if len(entry) < 4 or entry[:2] != " M" or entry[2] != " ":
+            return False
+        rel = _safe_repo_relative_path(entry[3:])
+        if rel is None:
+            return False
+        path = repo / rel
+        if path.is_symlink() or not path.is_file():
+            return False
+
+        summary = _git(repo, "diff", "--summary", "--", rel)
+        if summary.returncode != 0 or summary.stdout.strip():
+            return False
+
+        worktree_blob = _git(repo, "hash-object", "--", rel)
+        target_blob = _git(repo, "rev-parse", f"{source_commit}:{rel}")
+        if worktree_blob.returncode != 0 or target_blob.returncode != 0:
+            return False
+        if worktree_blob.stdout.strip() != target_blob.stdout.strip():
+            return False
+
+    return True
+
+
+def _preflight(repo: Path, request: Mapping[str, Any]) -> tuple[str, bool, bool]:
     if not repo.is_dir() or not (repo / ".git").exists():
         raise RuntimeError("repo_unavailable")
     origin = _git_value(repo, "remote", "get-url", "origin")
     if not ALLOWED_ORIGIN_RE.fullmatch(origin):
         raise RuntimeError("repository_origin_not_allowed")
-    dirty = _git_value(repo, "status", "--porcelain", "--untracked-files=no")
-    if dirty:
-        raise RuntimeError("tracked_checkout_dirty")
 
     previous = _git_value(repo, "rev-parse", "HEAD")
     source_ref = str(request["source_ref"])
@@ -136,11 +186,28 @@ def _preflight(repo: Path, request: Mapping[str, Any]) -> tuple[str, bool]:
     observed_head = _git_value(repo, "rev-parse", "FETCH_HEAD")
     if observed_head != source_commit:
         raise RuntimeError("exact_source_head_mismatch")
-    return previous, previous == source_commit
+
+    dirty = _tracked_status(repo)
+    target_equivalent_dirty = False
+    if dirty:
+        target_equivalent_dirty = _target_equivalent_dirty(repo, source_commit, dirty)
+        if not target_equivalent_dirty:
+            raise RuntimeError("tracked_checkout_dirty")
+
+    # A target-equivalent dirty checkout still needs the exact checkout step so
+    # the index/HEAD/worktree become a clean, attestable generation.
+    idempotent = previous == source_commit and not target_equivalent_dirty
+    return previous, idempotent, target_equivalent_dirty
 
 
-def _safe_failure(request: Mapping[str, Any], classification: str, *, previous: str | None = None,
-                  rollback: str = "not_attempted", resulting: str | None = None) -> dict[str, Any]:
+def _safe_failure(
+    request: Mapping[str, Any],
+    classification: str,
+    *,
+    previous: str | None = None,
+    rollback: str = "not_attempted",
+    resulting: str | None = None,
+) -> dict[str, Any]:
     return {
         "request_id": request["request_id"],
         "node_id": request["node_id"],
@@ -162,7 +229,7 @@ def _safe_failure(request: Mapping[str, Any], classification: str, *, previous: 
 def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -> dict[str, Any]:
     """Converge exact source and reconcile its fixed operating profile.
 
-    Source equality is not operating-profile equality.  Even when HEAD already
+    Source equality is not operating-profile equality. Even when HEAD already
     equals the requested generation, the source-owned installer sequence is
     replayed idempotently so stopped services or missing host-local profile state
     cannot survive a successful convergence receipt.
@@ -170,7 +237,7 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
     canonical = validate_runtime_converge_request(request).as_payload()
     previous: str | None = None
     try:
-        previous, idempotent = _preflight(repo, canonical)
+        previous, idempotent, target_equivalent_dirty = _preflight(repo, canonical)
     except RuntimeError as exc:
         return _safe_failure(canonical, str(exc))
 
@@ -187,7 +254,11 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
             "health": "passed" if reconciled else "failed",
             "rollback": "not_needed",
             "status": "completed" if reconciled else "failed",
-            "classification": "CURRENT_GENERATION_RECONCILED" if reconciled else "CURRENT_GENERATION_RECONCILE_FAILED",
+            "classification": (
+                "CURRENT_GENERATION_RECONCILED"
+                if reconciled
+                else "CURRENT_GENERATION_RECONCILE_FAILED"
+            ),
             "idempotent": True,
             "credential_exposed": False,
             "observed_at": _utc_now(),
@@ -208,7 +279,11 @@ def converge_runtime(request: Mapping[str, Any], *, repo: Path = DEFAULT_REPO) -
             "health": "passed",
             "rollback": "not_needed",
             "status": "completed",
-            "classification": "CONVERGED",
+            "classification": (
+                "CONVERGED_FROM_TARGET_EQUIVALENT_DIRTY"
+                if target_equivalent_dirty
+                else "CONVERGED"
+            ),
             "idempotent": False,
             "credential_exposed": False,
             "observed_at": _utc_now(),
@@ -305,18 +380,18 @@ def _request_submit_lock(root: Path) -> Iterator[None]:
         os.close(fd)
 
 
-def _existing_runtime_converge(root: Path, canonical: Mapping[str, Any]) -> tuple[str, str] | None:
-    """Resolve one durable request-id execution without replaying ambiguity.
+def _existing_runtime_converge(
+    root: Path, canonical: Mapping[str, Any]
+) -> tuple[str, str] | None:
+    """Resolve one durable request-id execution without replaying ambiguity."""
+    buckets = {
+        name: root / name
+        for name in ("inbox", "processing", "receipts", "quarantine")
+    }
 
-    Priority is intentionally conservative: a quarantined capsule with an
-    ``outcome=unknown`` receipt wins over any duplicate success left by older
-    buggy submitters.  A request whose execution outcome became unknown may not
-    be replayed merely because another duplicate happened to finish later.
-    """
-    buckets = {name: root / name for name in ("inbox", "processing", "receipts", "quarantine")}
-
-    # First bind quarantined raw capsules to their terminal unknown receipts.
-    for capsule_path in sorted(buckets["quarantine"].glob("action-*.json")) if buckets["quarantine"].exists() else []:
+    # A quarantined unknown always wins. Never replay ambiguous side effects.
+    quarantine = buckets["quarantine"]
+    for capsule_path in sorted(quarantine.glob("action-*.json")) if quarantine.exists() else []:
         capsule = _read_object(capsule_path)
         if not capsule:
             continue
@@ -329,8 +404,8 @@ def _existing_runtime_converge(root: Path, canonical: Mapping[str, Any]) -> tupl
         if receipt and receipt.get("outcome") == "unknown":
             return capsule_id, "unknown"
 
-    # A terminal receipt is authoritative for a clean request-id history.
-    for receipt_path in sorted(buckets["receipts"].glob("action-*.json")) if buckets["receipts"].exists() else []:
+    receipts = buckets["receipts"]
+    for receipt_path in sorted(receipts.glob("action-*.json")) if receipts.exists() else []:
         receipt = _read_object(receipt_path)
         if not receipt:
             continue
@@ -389,15 +464,25 @@ class ActionRelayRuntimeConvergeDispatcher:
             return None
         if receipt.get("action") != ACTION:
             raise RuntimeError("runtime_converge_receipt_action_mismatch")
-        projected = {key: receipt.get(key) for key in SAFE_RESULT_FIELDS if key in receipt}
-        projected.update({
-            "schema": "agentos.runtime-converge-receipt/v1",
-            "ok": projected.get("status") == "completed",
-            "action": "node.runtime.converge",
-            "task_id": str(task_id),
-        })
+        projected = {
+            key: receipt.get(key) for key in SAFE_RESULT_FIELDS if key in receipt
+        }
+        projected.update(
+            {
+                "schema": "agentos.runtime-converge-receipt/v1",
+                "ok": projected.get("status") == "completed",
+                "action": "node.runtime.converge",
+                "task_id": str(task_id),
+            }
+        )
         if receipt.get("outcome") == "unknown":
-            projected.update({"ok": False, "status": "unknown", "classification": "EXECUTION_OUTCOME_UNKNOWN"})
+            projected.update(
+                {
+                    "ok": False,
+                    "status": "unknown",
+                    "classification": "EXECUTION_OUTCOME_UNKNOWN",
+                }
+            )
         return projected
 
 

--- a/tests/test_runtime_converge_action_relay.py
+++ b/tests/test_runtime_converge_action_relay.py
@@ -13,6 +13,8 @@ from agentos_node import runtime_converge_action_relay as relay
 
 SHA = "a" * 40
 PREVIOUS = "b" * 40
+TARGET_BLOB = "1" * 40
+HEAD_BLOB = "2" * 40
 
 
 def request(**overrides):
@@ -61,7 +63,7 @@ def test_fixed_runtime_install_converges_product_employee_profile_after_realm(mo
 
 
 def test_current_generation_still_reconciles_fixed_runtime(monkeypatch, tmp_path):
-    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True))
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True, False))
     installs = []
     monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: installs.append(repo) or True)
     result = relay.converge_runtime(request(), repo=tmp_path)
@@ -74,7 +76,7 @@ def test_current_generation_still_reconciles_fixed_runtime(monkeypatch, tmp_path
 
 
 def test_current_generation_reconcile_failure_is_not_reported_healthy(monkeypatch, tmp_path):
-    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True))
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (SHA, True, False))
     monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: False)
     result = relay.converge_runtime(request(), repo=tmp_path)
     assert result["classification"] == "CURRENT_GENERATION_RECONCILE_FAILED"
@@ -84,20 +86,139 @@ def test_current_generation_reconcile_failure_is_not_reported_healthy(monkeypatc
     assert result["rollback"] == "not_needed"
 
 
-def test_preflight_refuses_dirty_checkout(monkeypatch, tmp_path):
+def test_preflight_refuses_unknown_dirty_checkout_after_exact_target_is_resolved(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+    calls = []
+
+    def fake_git_value(repo, *args):
+        calls.append(("value", args))
+        if args[:3] == ("remote", "get-url", "origin"):
+            return "https://github.com/alston-personal/agentmanager.git"
+        if args == ("rev-parse", "HEAD"):
+            return PREVIOUS
+        if args == ("rev-parse", "FETCH_HEAD"):
+            return SHA
+        raise AssertionError(args)
+
+    def fake_git(repo, *args, timeout=120):
+        calls.append(("git", args))
+        assert args == ("fetch", "--no-tags", "origin", "core/integration")
+        return Proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(relay, "_git_value", fake_git_value)
+    monkeypatch.setattr(relay, "_git", fake_git)
+    monkeypatch.setattr(relay, "_tracked_status", lambda repo: " M agent_core/realm_server.py\0")
+    monkeypatch.setattr(relay, "_target_equivalent_dirty", lambda repo, target, status: False)
+    result = relay.converge_runtime(request(), repo=tmp_path)
+    assert result["status"] == "failed"
+    assert result["classification"] == "tracked_checkout_dirty"
+    assert result["credential_exposed"] is False
+    assert ("value", ("rev-parse", "FETCH_HEAD")) in calls
+
+
+def test_preflight_accepts_only_proven_target_equivalent_dirty(monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
 
     def fake_git_value(repo, *args):
         if args[:3] == ("remote", "get-url", "origin"):
-            return "https://github.com/alston-personal/agentmanager.git"
-        if args[:2] == ("status", "--porcelain"):
-            return " M agent_core/realm_server.py"
+            return "git@github.com:alston-personal/agentmanager.git"
+        if args == ("rev-parse", "HEAD"):
+            return PREVIOUS
+        if args == ("rev-parse", "FETCH_HEAD"):
+            return SHA
         raise AssertionError(args)
 
     monkeypatch.setattr(relay, "_git_value", fake_git_value)
+    monkeypatch.setattr(relay, "_git", lambda *a, **k: Proc(returncode=0, stdout=""))
+    status = " M agentos_node/bootstrap_control.py\0"
+    monkeypatch.setattr(relay, "_tracked_status", lambda repo: status)
+    seen = []
+    monkeypatch.setattr(
+        relay,
+        "_target_equivalent_dirty",
+        lambda repo, target, observed: seen.append((target, observed)) or True,
+    )
+    assert relay._preflight(tmp_path, request()) == (PREVIOUS, False, True)
+    assert seen == [(SHA, status)]
+
+
+def test_target_equivalent_dirty_requires_plain_unstaged_content_and_equal_target_blob(monkeypatch, tmp_path):
+    rel = "agentos_node/bootstrap_control.py"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    path.write_text("target content\n", encoding="utf-8")
+
+    def fake_git(repo, *args, timeout=120):
+        if args == ("diff", "--summary", "--", rel):
+            return Proc(returncode=0, stdout="")
+        if args == ("hash-object", "--", rel):
+            return Proc(returncode=0, stdout=TARGET_BLOB + "\n")
+        if args == ("rev-parse", f"{SHA}:{rel}"):
+            return Proc(returncode=0, stdout=TARGET_BLOB + "\n")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(relay, "_git", fake_git)
+    assert relay._target_equivalent_dirty(tmp_path, SHA, f" M {rel}\0") is True
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "M  agentos_node/bootstrap_control.py\0",
+        " D agentos_node/bootstrap_control.py\0",
+        "D  agentos_node/bootstrap_control.py\0",
+        "R  agentos_node/bootstrap_control.py\0",
+        "UU agentos_node/bootstrap_control.py\0",
+    ],
+)
+def test_target_equivalent_dirty_rejects_staged_delete_rename_and_conflict(monkeypatch, tmp_path, status):
+    monkeypatch.setattr(relay, "_git", lambda *a, **k: (_ for _ in ()).throw(AssertionError("git must not run")))
+    assert relay._target_equivalent_dirty(tmp_path, SHA, status) is False
+
+
+def test_target_equivalent_dirty_rejects_mode_change(monkeypatch, tmp_path):
+    rel = "agentos_node/bootstrap_control.py"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    path.write_text("target content\n", encoding="utf-8")
+    monkeypatch.setattr(
+        relay,
+        "_git",
+        lambda repo, *args, timeout=120: Proc(returncode=0, stdout=" mode change 100644 => 100755 x\n"),
+    )
+    assert relay._target_equivalent_dirty(tmp_path, SHA, f" M {rel}\0") is False
+
+
+def test_target_equivalent_dirty_rejects_different_blob(monkeypatch, tmp_path):
+    rel = "agentos_node/bootstrap_control.py"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    path.write_text("different content\n", encoding="utf-8")
+
+    def fake_git(repo, *args, timeout=120):
+        if args == ("diff", "--summary", "--", rel):
+            return Proc(returncode=0, stdout="")
+        if args == ("hash-object", "--", rel):
+            return Proc(returncode=0, stdout=HEAD_BLOB + "\n")
+        if args == ("rev-parse", f"{SHA}:{rel}"):
+            return Proc(returncode=0, stdout=TARGET_BLOB + "\n")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(relay, "_git", fake_git)
+    assert relay._target_equivalent_dirty(tmp_path, SHA, f" M {rel}\0") is False
+
+
+def test_target_equivalent_dirty_converges_with_explicit_classification(monkeypatch, tmp_path):
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False, True))
+    checkouts = []
+    monkeypatch.setattr(relay, "_checkout_exact", lambda repo, sha: checkouts.append(sha) or True)
+    monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: True)
     result = relay.converge_runtime(request(), repo=tmp_path)
-    assert result["status"] == "failed"
-    assert result["classification"] == "tracked_checkout_dirty"
+    assert checkouts == [SHA]
+    assert result["classification"] == "CONVERGED_FROM_TARGET_EQUIVALENT_DIRTY"
+    assert result["status"] == "completed"
+    assert result["health"] == "passed"
+    assert result["resulting_commit"] == SHA
     assert result["credential_exposed"] is False
 
 
@@ -107,8 +228,6 @@ def test_preflight_refuses_requested_sha_that_is_not_exact_ref_head(monkeypatch,
     def fake_git_value(repo, *args):
         if args[:3] == ("remote", "get-url", "origin"):
             return "git@github.com:alston-personal/agentmanager.git"
-        if args[:2] == ("status", "--porcelain"):
-            return ""
         if args == ("rev-parse", "HEAD"):
             return PREVIOUS
         if args == ("rev-parse", "FETCH_HEAD"):
@@ -123,7 +242,7 @@ def test_preflight_refuses_requested_sha_that_is_not_exact_ref_head(monkeypatch,
 
 def test_health_failure_rolls_back_exact_previous_generation(monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
-    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False))
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False, False))
     checkouts = []
     monkeypatch.setattr(relay, "_checkout_exact", lambda repo, sha: checkouts.append(sha) or True)
     outcomes = iter([False, True])
@@ -137,7 +256,7 @@ def test_health_failure_rolls_back_exact_previous_generation(monkeypatch, tmp_pa
 
 def test_rollback_ambiguity_is_unknown_and_not_success(monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
-    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False))
+    monkeypatch.setattr(relay, "_preflight", lambda repo, req: (PREVIOUS, False, False))
     monkeypatch.setattr(relay, "_checkout_exact", lambda repo, sha: True)
     monkeypatch.setattr(relay, "_install_fixed_runtime", lambda repo: False)
     result = relay.converge_runtime(request(), repo=tmp_path)
@@ -155,10 +274,20 @@ class _FileOnlyRelayClient:
             (root / name).mkdir(parents=True, exist_ok=True)
 
     def submit(self, action, params):
-        existing = sum(len(list((self.root / name).glob("action-test-*.json"))) for name in ("inbox", "processing", "receipts", "quarantine"))
+        existing = sum(
+            len(list((self.root / name).glob("action-test-*.json")))
+            for name in ("inbox", "processing", "receipts", "quarantine")
+        )
         capsule_id = f"action-test-{existing + 1}"
-        payload = {"schema": "agentos.action-relay/v1", "capsule_id": capsule_id, "action": action, "params": params}
-        (self.root / "inbox" / f"{capsule_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+        payload = {
+            "schema": "agentos.action-relay/v1",
+            "capsule_id": capsule_id,
+            "action": action,
+            "params": params,
+        }
+        (self.root / "inbox" / f"{capsule_id}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
         return payload
 
     def receipt(self, capsule_id):
@@ -210,7 +339,9 @@ def test_runtime_converge_terminal_receipt_is_reused_not_resubmitted(tmp_path):
         "classification": "CURRENT_GENERATION_RECONCILED",
         "credential_exposed": False,
     }
-    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(json.dumps(receipt), encoding="utf-8")
+    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(
+        json.dumps(receipt), encoding="utf-8"
+    )
     second = dispatcher.submit(request=request())
     assert second["task_id"] == first["task_id"]
     assert second["state"] == "completed"
@@ -232,7 +363,9 @@ def test_runtime_converge_quarantined_unknown_wins_and_is_never_replayed(tmp_pat
         "replayed": False,
         "ok": False,
     }
-    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(json.dumps(unknown_receipt), encoding="utf-8")
+    (dispatcher.root / "receipts" / f'{first["task_id"]}.json').write_text(
+        json.dumps(unknown_receipt), encoding="utf-8"
+    )
     second = dispatcher.submit(request=request())
     assert second["task_id"] == first["task_id"]
     assert second["state"] == "unknown"
@@ -251,7 +384,15 @@ def test_runtime_converge_request_id_collision_fails_closed(tmp_path):
 
 class NodeRegistry:
     def node_map(self):
-        return {"nodes": [{"node_id": "oracle-core-node", "status": "online", "capabilities": ["node.runtime.converge"]}]}
+        return {
+            "nodes": [
+                {
+                    "node_id": "oracle-core-node",
+                    "status": "online",
+                    "capabilities": ["node.runtime.converge"],
+                }
+            ]
+        }
 
 
 class Fabric:
@@ -267,23 +408,37 @@ class RuntimeDispatcher:
 
     def submit(self, *, request):
         self.seen = request
-        return {"ok": True, "action": "node.runtime.converge", "task_id": "action-123", "state": "queued"}
+        return {
+            "ok": True,
+            "action": "node.runtime.converge",
+            "task_id": "action-123",
+            "state": "queued",
+        }
 
 
 def test_controller_routes_typed_converge_to_fixed_relay_not_node_queue():
     dispatcher = RuntimeDispatcher()
     controller = ControllerService(Fabric(), runtime_converge_dispatcher=dispatcher)
-    result = controller.dispatch({
-        "node_id": "oracle-core-node",
-        "task_id": "ctl_runtime_1",
-        "action": "node.runtime.converge",
-        "repository": ALLOWED_REPOSITORY,
-        "source_ref": "core/integration",
-        "source_commit": SHA,
-    })
+    result = controller.dispatch(
+        {
+            "node_id": "oracle-core-node",
+            "task_id": "ctl_runtime_1",
+            "action": "node.runtime.converge",
+            "repository": ALLOWED_REPOSITORY,
+            "source_ref": "core/integration",
+            "source_commit": SHA,
+        }
+    )
     assert result["task_id"] == "action-123"
     assert dispatcher.seen["request_id"] == "ctl_runtime_1"
-    assert set(dispatcher.seen) == {"schema", "request_id", "node_id", "repository", "source_ref", "source_commit"}
+    assert set(dispatcher.seen) == {
+        "schema",
+        "request_id",
+        "node_id",
+        "repository",
+        "source_ref",
+        "source_commit",
+    }
 
 
 @pytest.mark.parametrize("field", ["shell", "argv", "command", "module", "token", "environment"])


### PR DESCRIPTION
## Trigger

Live ChatGPT/#50 convergence to `core/integration@c31b48b4a2fd986925f811c6a735a44bc4a5a1f1` failed `tracked_checkout_dirty`.

Read-only Oracle diagnostics proved the only tracked dirty path is `agentos_node/bootstrap_control.py`, and its worktree blob is byte-identical to that exact target commit. Oracle HEAD is still an older generation, so this is a partial target rollout rather than unknown operator data.

## Fix

Keep dirty-checkout refusal fail-closed, with one narrowly proven recovery class:

1. validate repository origin;
2. fetch the allowlisted `core/integration` ref;
3. prove `FETCH_HEAD == requested exact SHA`;
4. inspect tracked porcelain status only;
5. accept recovery only when every dirty entry is an ordinary **unstaged content modification** (` M`);
6. reject staged/delete/rename/conflict/type/mode changes;
7. reject symlink/non-file/path anomalies;
8. compare each worktree blob to the exact requested commit blob;
9. only if every blob is identical, perform the existing fixed exact checkout + source-owned installer sequence.

Successful recovery is explicitly classified `CONVERGED_FROM_TARGET_EQUIVALENT_DIRTY`.

All other dirty states remain `tracked_checkout_dirty`. No generic clean/reset/stash/delete capability is introduced and callers gain no path/argv/shell authority.

## Regression

Focused tests cover:
- exact target must be resolved before dirty equivalence can be trusted;
- unknown dirty content fails closed;
- target-equivalent unstaged content is eligible;
- staged/delete/rename/conflict are rejected;
- mode change is rejected;
- differing blob is rejected;
- success has explicit recovery classification;
- existing idempotence/rollback/request-dedup/unknown semantics remain covered.

## Live acceptance still required

After source CI and integration, install this exact accepted Action Relay generation through the existing governed bootstrap boundary, then:
1. rerun `node.runtime.converge`;
2. require `health=passed` and exact resulting SHA;
3. repeat same SHA and require idempotent reconciliation;
4. proceed to #287/#179 fresh ChatGPT active-continuation acceptance.

Target: `core/integration` only. No protected-main publication authority.

Refs #291 #242 #179