### PR TITLE
Core #238: repair Worker Host group boundary and NodeRegistry recovery

### DIFF
--- a/.agent/scripts/agentos-employee-worker-host.service
+++ b/.agent/scripts/agentos-employee-worker-host.service
@@ -6,7 +6,12 @@ After=network.target
 Type=simple
 WorkingDirectory=/home/ubuntu/agentmanager
 EnvironmentFile=/home/ubuntu/.config/agentos/employee-worker-host.env
-ExecStart=/usr/bin/python3 -m agentos_node.employee_worker_host_daemon
+# The long-lived systemd --user manager may predate membership in the shared
+# agentos group. Enter the fixed group boundary explicitly so the host and every
+# fixed child inherit read/write access to governed Employee runtime surfaces.
+# No caller-controlled shell/argv is accepted here; this is one source-owned
+# command with a fixed module.
+ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'
 Restart=always
 RestartSec=5
 NoNewPrivileges=true

--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -13,6 +13,8 @@ on:
       - 'governance/employee-worker-adapters.json'
       - 'governance/employee-worker-adapters-v2.json'
       - '.agent/scripts/agentos-employee-wake-node.service'
+      - '.agent/scripts/agentos-employee-worker-host.service'
+      - 'agent_core/node_registry.py'
       - 'agentos_node/employee_wake_node.py'
       - 'agentos_node/employee_worker_host.py'
       - 'agentos_node/employee_worker_host_runtime.py'
@@ -24,6 +26,7 @@ on:
       - 'tests/test_product_employee_worker_plan.py'
       - 'tests/test_product_employee_worker.py'
       - 'tests/test_product_employee_activation.py'
+      - 'tests/test_node_registry_recovery.py'
       - 'docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md'
       - '.github/workflows/product-employee-contract-guard.yml'
   workflow_dispatch:
@@ -43,10 +46,11 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest pyyaml
-      - name: Verify product Employee contracts, bounded runner host, and activation boundary
+      - name: Verify product Employee contracts, bounded runner host, activation boundary, and NodeRegistry recovery
         run: >-
           python -m pytest -q
           tests/test_product_employee_contracts.py
           tests/test_product_employee_worker_plan.py
           tests/test_product_employee_worker.py
           tests/test_product_employee_activation.py
+          tests/test_node_registry_recovery.py

--- a/agent_core/node_registry.py
+++ b/agent_core/node_registry.py
@@ -42,10 +42,55 @@ class NodeRegistry:
             raise ValueError(f'invalid node registry: {self.path}')
         return data
 
+    def _recover_concatenated_snapshots(self, text: str) -> dict[str, Any]:
+        """Recover only a sequence of complete canonical registry snapshots.
+
+        Older runtime generations could leave multiple complete JSON snapshots
+        concatenated in the registry file.  That state is mechanically
+        recoverable, unlike arbitrary/truncated JSON.  Every segment must decode
+        fully as a valid NodeRegistry snapshot, all snapshots must belong to the
+        same Realm, and there must be at least two snapshots.  Text order is the
+        publication order, so the final complete snapshot is the current view.
+
+        The next mutating operation runs under the existing flock and publishes
+        the recovered state through the normal temp-file + os.replace path,
+        thereby canonicalising the file back to one JSON document.
+        """
+        decoder = json.JSONDecoder()
+        snapshots: list[dict[str, Any]] = []
+        index = 0
+        length = len(text)
+        while True:
+            while index < length and text[index].isspace():
+                index += 1
+            if index >= length:
+                break
+            value, end = decoder.raw_decode(text, index)
+            if not isinstance(value, dict):
+                raise ValueError('node_registry_recovery_segment_not_object')
+            snapshots.append(self._validate(value))
+            index = end
+
+        if len(snapshots) < 2:
+            raise ValueError('node_registry_recovery_not_concatenated')
+        realm_ids = {snapshot.get('realm_id') for snapshot in snapshots}
+        if len(realm_ids) != 1:
+            raise ValueError('node_registry_recovery_realm_mismatch')
+        return snapshots[-1]
+
     def _load_unlocked(self) -> dict[str, Any]:
         if not self.path.exists():
             return self._empty()
-        return self._validate(json.loads(self.path.read_text(encoding='utf-8')))
+        text = self.path.read_text(encoding='utf-8')
+        try:
+            return self._validate(json.loads(text))
+        except json.JSONDecodeError as original:
+            try:
+                return self._recover_concatenated_snapshots(text)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                # Arbitrary corruption remains fail-closed.  Never guess through
+                # truncated data, garbage, or snapshots from different Realms.
+                raise original
 
     def load(self) -> dict[str, Any]:
         # Readers need no lock because writers publish only through os.replace().

--- a/tests/test_node_registry_recovery.py
+++ b/tests/test_node_registry_recovery.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_core.node_registry import NodeRegistry
+
+
+def snapshot(*, realm_id: str = "realm-alston", heartbeat: str = "2026-09-09T00:00:00Z") -> dict:
+    return {
+        "schema": "agentos.node-registry/v0.1",
+        "realm_id": realm_id,
+        "nodes": {
+            "oracle-employee-wake-node": {
+                "node_id": "oracle-employee-wake-node",
+                "role": "client",
+                "hostname": "oracle",
+                "platform": "linux",
+                "platform_release": "test",
+                "capabilities": ["agent.employee.wake.deliver"],
+                "tool_presence": {},
+                "surface_inventory": {},
+                "runtime": {},
+                "workspace_roots": {},
+                "status": "online",
+                "first_seen_at": "2026-09-09T00:00:00Z",
+                "last_manifest_at": "2026-09-09T00:00:00Z",
+                "last_heartbeat_at": heartbeat,
+                "benchmark": None,
+            }
+        },
+    }
+
+
+def heartbeat(*, observed_at: str = "2026-09-09T00:02:00Z") -> dict:
+    return {
+        "schema": "agentos.node-heartbeat/v0.1",
+        "realm_id": "realm-alston",
+        "node_id": "oracle-employee-wake-node",
+        "status": "online",
+        "observed_at": observed_at,
+        "uptime_seconds": 10,
+        "surface_count": 0,
+    }
+
+
+def test_normal_single_registry_json_loads_unchanged(tmp_path: Path):
+    path = tmp_path / "nodes.json"
+    expected = snapshot()
+    path.write_text(json.dumps(expected), encoding="utf-8")
+    assert NodeRegistry(path).load() == expected
+
+
+def test_complete_same_realm_concatenated_snapshots_recover_latest(tmp_path: Path):
+    path = tmp_path / "nodes.json"
+    first = snapshot(heartbeat="2026-09-09T00:00:00Z")
+    second = snapshot(heartbeat="2026-09-09T00:01:00Z")
+    path.write_text(json.dumps(first) + "\n" + json.dumps(second) + "\n", encoding="utf-8")
+    loaded = NodeRegistry(path).load()
+    assert loaded == second
+
+
+def test_mutation_after_recovery_canonicalizes_to_one_json_document(tmp_path: Path):
+    path = tmp_path / "nodes.json"
+    first = snapshot(heartbeat="2026-09-09T00:00:00Z")
+    second = snapshot(heartbeat="2026-09-09T00:01:00Z")
+    path.write_text(json.dumps(first) + "\n" + json.dumps(second) + "\n", encoding="utf-8")
+    registry = NodeRegistry(path)
+    registry.record_heartbeat(heartbeat())
+
+    text = path.read_text(encoding="utf-8")
+    decoded = json.loads(text)
+    assert decoded["nodes"]["oracle-employee-wake-node"]["last_heartbeat_at"] == "2026-09-09T00:02:00Z"
+    decoder = json.JSONDecoder()
+    _, end = decoder.raw_decode(text)
+    assert text[end:].strip() == ""
+
+
+def test_concatenated_snapshots_from_different_realms_fail_closed(tmp_path: Path):
+    path = tmp_path / "nodes.json"
+    path.write_text(
+        json.dumps(snapshot(realm_id="realm-alston")) + "\n" + json.dumps(snapshot(realm_id="realm-other")),
+        encoding="utf-8",
+    )
+    with pytest.raises(json.JSONDecodeError):
+        NodeRegistry(path).load()
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        '{"schema":',
+        "garbage",
+        "[]",
+    ],
+)
+def test_truncated_garbage_or_non_object_tail_fails_closed(tmp_path: Path, suffix: str):
+    path = tmp_path / "nodes.json"
+    path.write_text(json.dumps(snapshot()) + "\n" + suffix, encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        NodeRegistry(path).load()

--- a/tests/test_product_employee_activation.py
+++ b/tests/test_product_employee_activation.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 BOOTSTRAP_PATH = ROOT / "scripts" / "bootstrap_product_employees.py"
 ACTIVATE = ROOT / "scripts" / "activate_product_employees_oracle.sh"
 WAKE_UNIT = ROOT / ".agent" / "scripts" / "agentos-employee-wake-node.service"
+WORKER_UNIT = ROOT / ".agent" / "scripts" / "agentos-employee-worker-host.service"
 
 spec = importlib.util.spec_from_file_location("bootstrap_product_employees", BOOTSTRAP_PATH)
 assert spec and spec.loader
@@ -106,3 +107,14 @@ def test_activation_assets_are_fixed_and_do_not_emit_verified_markers():
     assert "youtube" not in unit.casefold()
     assert "zeus" not in unit.casefold()
     assert "employee_wake_node" in unit
+
+
+def test_worker_host_enters_fixed_shared_agentos_group_without_generic_authority():
+    unit = WORKER_UNIT.read_text(encoding="utf-8")
+    assert "ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'" in unit
+    assert "PrivateNetwork=true" in unit
+    assert "NoNewPrivileges=true" in unit
+    assert "shell.exec" not in unit
+    assert "${" not in unit
+    assert "youtube" not in unit.casefold()
+    assert "zeus" not in unit.casefold()


### PR DESCRIPTION
Live #238 acceptance on Oracle exposed two independent production blockers after the runtime-converge restart storm was fixed:

1. Product Worker Host dispatches consistently terminate as `employee_worker_child_result_untrusted` before any Employee lease is claimed. The long-lived Worker Host unit did not explicitly enter the shared `agentos` group execution boundary, even though the shared Employee runtime/wake surfaces require that boundary and the systemd user manager may retain stale supplementary groups.
2. The wake-only Node is crash-looping on ONE heartbeat because the durable NodeRegistry file contains multiple complete JSON snapshots concatenated together. Current NodeRegistry writers already use flock + temp-file + `os.replace`, but current readers have no narrow recovery path for this mechanically recoverable historical corruption.

This PR:
- runs the fixed Worker Host daemon under a source-owned `sg agentos` boundary; no caller-controlled argv/shell/product authority is introduced;
- adds fail-closed NodeRegistry recovery only when the entire file is exactly 2+ complete valid registry snapshots from the same Realm, selecting the final complete snapshot;
- leaves truncated JSON, garbage, non-object tails, and cross-Realm concatenation rejected;
- lets the next normal heartbeat mutation canonicalize recovered state via the existing flock/temp/replace writer;
- adds regression tests and wires them into Product Employee Contract Guard.

No live VERIFIED marker is emitted by this source change.

Refs #238