### PR TITLE
Core #238: make Realm fabric atomic and add hash-bound tail repair

### DIFF
--- a/.github/workflows/product-employee-contract-guard.yml
+++ b/.github/workflows/product-employee-contract-guard.yml
@@ -15,6 +15,7 @@ on:
       - '.agent/scripts/agentos-employee-wake-node.service'
       - '.agent/scripts/agentos-employee-worker-host.service'
       - 'agent_core/node_registry.py'
+      - 'agent_core/realm_fabric.py'
       - 'agentos_node/employee_wake_node.py'
       - 'agentos_node/employee_worker_host.py'
       - 'agentos_node/employee_worker_host_runtime.py'
@@ -22,11 +23,13 @@ on:
       - 'agentos_node/product_employee_worker_cli.py'
       - 'scripts/bootstrap_product_employees.py'
       - 'scripts/activate_product_employees_oracle.sh'
+      - 'scripts/repair_realm_fabric_truncated_tail.py'
       - 'tests/test_product_employee_contracts.py'
       - 'tests/test_product_employee_worker_plan.py'
       - 'tests/test_product_employee_worker.py'
       - 'tests/test_product_employee_activation.py'
       - 'tests/test_node_registry_recovery.py'
+      - 'tests/test_realm_fabric_atomic_repair.py'
       - 'docs/PRODUCT_EMPLOYEE_ACCEPTANCE.md'
       - '.github/workflows/product-employee-contract-guard.yml'
   workflow_dispatch:
@@ -46,7 +49,7 @@ jobs:
           python-version: '3.12'
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check pytest pyyaml
-      - name: Verify product Employee contracts, bounded runner host, activation boundary, and NodeRegistry recovery
+      - name: Verify product Employee contracts and durable Realm state boundaries
         run: >-
           python -m pytest -q
           tests/test_product_employee_contracts.py
@@ -54,3 +57,4 @@ jobs:
           tests/test_product_employee_worker.py
           tests/test_product_employee_activation.py
           tests/test_node_registry_recovery.py
+          tests/test_realm_fabric_atomic_repair.py

--- a/agent_core/realm_fabric.py
+++ b/agent_core/realm_fabric.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
 import secrets
+import tempfile
+import threading
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Iterator, TypeVar
 
 from agent_core.node_registry import NodeRegistry
+
+
+T = TypeVar('T')
 
 
 def _utc_now() -> str:
@@ -35,11 +42,20 @@ class RealmFabricStore:
     Raw node credentials and device-flow claim secrets are never persisted.
     Only SHA-256 hashes are stored. v0.1 keeps the store JSON-backed while the
     protocol and governance boundaries stabilize.
+
+    All state-changing operations are serialized across threads and processes.
+    One exclusive transaction owns load -> mutate -> fsync -> atomic replace, so
+    concurrent heartbeat/task/receipt requests cannot lose each other's updates
+    or share one temporary pathname. Arbitrary malformed JSON remains fail-closed;
+    repair of a historical truncated store is an explicit, hash-bound operation.
     """
+
+    _process_lock = threading.RLock()
 
     def __init__(self, path: str | Path | None = None, *, node_registry: NodeRegistry | None = None):
         data_root = Path(os.environ.get('AGENT_DATA_ROOT', '/home/ubuntu/agent-data'))
         self.path = Path(path) if path else data_root / 'realm' / 'fabric.json'
+        self.lock_path = self.path.with_suffix(self.path.suffix + '.lock')
         self.node_registry = node_registry or NodeRegistry()
 
     def _empty(self) -> dict[str, Any]:
@@ -53,35 +69,96 @@ class RealmFabricStore:
             'receipts': {},
         }
 
-    def load(self) -> dict[str, Any]:
-        if not self.path.exists():
-            return self._empty()
-        data = json.loads(self.path.read_text(encoding='utf-8'))
-        if data.get('schema') != 'agentos.realm-fabric/v0.1':
+    def _validate(self, data: Any) -> dict[str, Any]:
+        if not isinstance(data, dict) or data.get('schema') != 'agentos.realm-fabric/v0.1':
             raise ValueError(f'invalid Realm fabric store: {self.path}')
-        # Backward-compatible promotion of stores created before device flow.
-        data.setdefault('invites', {})
-        data.setdefault('join_requests', {})
-        data.setdefault('nodes', {})
-        data.setdefault('tasks', {})
-        data.setdefault('receipts', {})
+        for field in ('invites', 'join_requests', 'nodes', 'tasks', 'receipts'):
+            value = data.setdefault(field, {})
+            if not isinstance(value, dict):
+                raise ValueError(f'invalid Realm fabric field {field}: {self.path}')
         return data
 
-    def save(self, data: dict[str, Any]) -> None:
+    def _load_unlocked(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return self._empty()
+        # Deliberately strict. Historical corruption must be repaired through the
+        # explicit hash-bound repair tool, never silently guessed in normal reads.
+        return self._validate(json.loads(self.path.read_text(encoding='utf-8')))
+
+    def load(self) -> dict[str, Any]:
+        # Published files are replaced atomically, so readers never need to hold
+        # the writer lock after the historical store has been repaired.
+        return self._load_unlocked()
+
+    @contextmanager
+    def _exclusive_lock(self) -> Iterator[None]:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(self.path.suffix + '.tmp')
-        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
-        tmp.replace(self.path)
+        with self._process_lock:
+            with self.lock_path.open('a+', encoding='utf-8') as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def _save_unlocked(self, data: dict[str, Any]) -> None:
+        self._validate(data)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=self.path.name + '.',
+            suffix='.tmp',
+            dir=str(self.path.parent),
+            text=True,
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp, 0o640)
+            os.replace(tmp, self.path)
+            dir_fd = os.open(self.path.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+
+    def save(self, data: dict[str, Any]) -> None:
+        with self._exclusive_lock():
+            self._save_unlocked(data)
+
+    def _mutate(self, mutator: Callable[[dict[str, Any]], T]) -> T:
+        with self._exclusive_lock():
+            data = self._load_unlocked()
+            result = mutator(data)
+            self._save_unlocked(data)
+            return result
+
+    @staticmethod
+    def _authenticate_data(data: dict[str, Any], node_id: str, token: str) -> dict[str, Any]:
+        node = data['nodes'].get(node_id)
+        if not node or node.get('revoked_at'):
+            raise PermissionError('unknown or revoked node')
+        if not secrets.compare_digest(str(node.get('token_hash') or ''), _hash_secret(token)):
+            raise PermissionError('invalid node credential')
+        return node
 
     def initialize_realm(self, realm_id: str) -> dict[str, Any]:
         if not realm_id:
             raise ValueError('realm_id is required')
-        data = self.load()
-        if data['realm_id'] not in (None, realm_id):
-            raise ValueError('Realm fabric already belongs to another Realm')
-        data['realm_id'] = realm_id
-        self.save(data)
-        return {'realm_id': realm_id}
+
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            if data['realm_id'] not in (None, realm_id):
+                raise ValueError('Realm fabric already belongs to another Realm')
+            data['realm_id'] = realm_id
+            return {'realm_id': realm_id}
+
+        return self._mutate(mutate)
 
     def _normalize_manifest(self, manifest: dict[str, Any], realm_id: str) -> dict[str, Any]:
         if manifest.get('schema') != 'agentos.node-manifest/v0.1':
@@ -119,92 +196,95 @@ class RealmFabricStore:
             'node': node_entry,
         }
 
-    # Legacy invitation flow retained for v0.1 compatibility. New clients should
-    # prefer request_join -> approve_join -> claim_join so humans never shuttle a
-    # secret out of the Core control plane.
     def create_invite(self, *, expires_minutes: int = 10, label: str | None = None) -> dict[str, Any]:
-        data = self.load()
-        if not data.get('realm_id'):
-            raise ValueError('initialize Realm before creating invites')
-        invite_id = 'enr_' + secrets.token_hex(8)
-        code = secrets.token_urlsafe(24)
-        now = datetime.now(timezone.utc)
-        data['invites'][invite_id] = {
-            'invite_id': invite_id,
-            'code_hash': _hash_secret(code),
-            'label': label,
-            'created_at': _utc_now(),
-            'expires_at': (now + timedelta(minutes=max(1, expires_minutes))).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
-            'used_at': None,
-        }
-        self.save(data)
-        return {
-            'schema': 'agentos.enrollment-invite/v0.1',
-            'realm_id': data['realm_id'],
-            'invite_id': invite_id,
-            'code': code,
-            'expires_at': data['invites'][invite_id]['expires_at'],
-            'label': label,
-        }
+        holder: dict[str, Any] = {}
+
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            if not data.get('realm_id'):
+                raise ValueError('initialize Realm before creating invites')
+            invite_id = 'enr_' + secrets.token_hex(8)
+            code = secrets.token_urlsafe(24)
+            now = datetime.now(timezone.utc)
+            data['invites'][invite_id] = {
+                'invite_id': invite_id,
+                'code_hash': _hash_secret(code),
+                'label': label,
+                'created_at': _utc_now(),
+                'expires_at': (now + timedelta(minutes=max(1, expires_minutes))).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+                'used_at': None,
+            }
+            holder['code'] = code
+            return {
+                'schema': 'agentos.enrollment-invite/v0.1',
+                'realm_id': data['realm_id'],
+                'invite_id': invite_id,
+                'code': code,
+                'expires_at': data['invites'][invite_id]['expires_at'],
+                'label': label,
+            }
+
+        return self._mutate(mutate)
 
     def enroll(self, *, invite_id: str, code: str, manifest: dict[str, Any]) -> dict[str, Any]:
-        data = self.load()
-        invite = data['invites'].get(invite_id)
-        if not invite:
-            raise PermissionError('unknown enrollment invite')
-        if invite.get('used_at'):
-            raise PermissionError('enrollment invite already used')
-        if _parse_utc(invite['expires_at']) < datetime.now(timezone.utc):
-            raise PermissionError('enrollment invite expired')
-        if not secrets.compare_digest(invite['code_hash'], _hash_secret(code)):
-            raise PermissionError('invalid enrollment code')
-        normalized = self._normalize_manifest(manifest, data['realm_id'])
-        result = self._register_node(data, normalized)
-        invite['used_at'] = _utc_now()
-        data['invites'][invite_id] = invite
-        self.save(data)
-        return result
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            invite = data['invites'].get(invite_id)
+            if not invite:
+                raise PermissionError('unknown enrollment invite')
+            if invite.get('used_at'):
+                raise PermissionError('enrollment invite already used')
+            if _parse_utc(invite['expires_at']) < datetime.now(timezone.utc):
+                raise PermissionError('enrollment invite expired')
+            if not secrets.compare_digest(invite['code_hash'], _hash_secret(code)):
+                raise PermissionError('invalid enrollment code')
+            normalized = self._normalize_manifest(manifest, data['realm_id'])
+            result = self._register_node(data, normalized)
+            invite['used_at'] = _utc_now()
+            data['invites'][invite_id] = invite
+            return result
+
+        return self._mutate(mutate)
 
     def request_join(self, *, manifest: dict[str, Any], expires_minutes: int = 10) -> dict[str, Any]:
-        data = self.load()
-        realm_id = str(data.get('realm_id') or '')
-        if not realm_id:
-            raise ValueError('initialize Realm before requesting enrollment')
-        normalized = self._normalize_manifest(manifest, realm_id)
-        node_id = normalized['node_id']
-        if node_id in data['nodes'] and not data['nodes'][node_id].get('revoked_at'):
-            raise ValueError('node_id already enrolled')
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            realm_id = str(data.get('realm_id') or '')
+            if not realm_id:
+                raise ValueError('initialize Realm before requesting enrollment')
+            normalized = self._normalize_manifest(manifest, realm_id)
+            node_id = normalized['node_id']
+            if node_id in data['nodes'] and not data['nodes'][node_id].get('revoked_at'):
+                raise ValueError('node_id already enrolled')
 
-        request_id = 'join_' + secrets.token_hex(10)
-        claim_secret = secrets.token_urlsafe(32)
-        user_code = _user_code()
-        existing_codes = {str(v.get('user_code') or '') for v in data['join_requests'].values()}
-        while user_code in existing_codes:
+            request_id = 'join_' + secrets.token_hex(10)
+            claim_secret = secrets.token_urlsafe(32)
             user_code = _user_code()
-        now = datetime.now(timezone.utc)
-        expires_at = (now + timedelta(minutes=max(1, min(int(expires_minutes), 30)))).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
-        data['join_requests'][request_id] = {
-            'request_id': request_id,
-            'user_code': user_code,
-            'claim_secret_hash': _hash_secret(claim_secret),
-            'manifest': normalized,
-            'created_at': _utc_now(),
-            'expires_at': expires_at,
-            'approved_at': None,
-            'denied_at': None,
-            'claimed_at': None,
-        }
-        self.save(data)
-        return {
-            'schema': 'agentos.join-request/v0.1',
-            'realm_id': realm_id,
-            'request_id': request_id,
-            'user_code': user_code,
-            'claim_secret': claim_secret,
-            'expires_at': expires_at,
-            'node_id': node_id,
-            'status': 'pending',
-        }
+            existing_codes = {str(v.get('user_code') or '') for v in data['join_requests'].values()}
+            while user_code in existing_codes:
+                user_code = _user_code()
+            now = datetime.now(timezone.utc)
+            expires_at = (now + timedelta(minutes=max(1, min(int(expires_minutes), 30)))).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+            data['join_requests'][request_id] = {
+                'request_id': request_id,
+                'user_code': user_code,
+                'claim_secret_hash': _hash_secret(claim_secret),
+                'manifest': normalized,
+                'created_at': _utc_now(),
+                'expires_at': expires_at,
+                'approved_at': None,
+                'denied_at': None,
+                'claimed_at': None,
+            }
+            return {
+                'schema': 'agentos.join-request/v0.1',
+                'realm_id': realm_id,
+                'request_id': request_id,
+                'user_code': user_code,
+                'claim_secret': claim_secret,
+                'expires_at': expires_at,
+                'node_id': node_id,
+                'status': 'pending',
+            }
+
+        return self._mutate(mutate)
 
     def _find_join(self, data: dict[str, Any], selector: str) -> tuple[str, dict[str, Any]]:
         selector = str(selector or '').strip().upper()
@@ -216,25 +296,26 @@ class RealmFabricStore:
         raise KeyError(selector)
 
     def approve_join(self, selector: str) -> dict[str, Any]:
-        data = self.load()
-        request_id, entry = self._find_join(data, selector)
-        if entry.get('claimed_at'):
-            raise ValueError('join request already claimed')
-        if entry.get('denied_at'):
-            raise ValueError('join request was denied')
-        if _parse_utc(entry['expires_at']) < datetime.now(timezone.utc):
-            raise PermissionError('join request expired')
-        entry['approved_at'] = entry.get('approved_at') or _utc_now()
-        data['join_requests'][request_id] = entry
-        self.save(data)
-        return {
-            'schema': 'agentos.join-approval/v0.1',
-            'ok': True,
-            'request_id': request_id,
-            'user_code': entry['user_code'],
-            'node_id': entry['manifest']['node_id'],
-            'approved_at': entry['approved_at'],
-        }
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            request_id, entry = self._find_join(data, selector)
+            if entry.get('claimed_at'):
+                raise ValueError('join request already claimed')
+            if entry.get('denied_at'):
+                raise ValueError('join request was denied')
+            if _parse_utc(entry['expires_at']) < datetime.now(timezone.utc):
+                raise PermissionError('join request expired')
+            entry['approved_at'] = entry.get('approved_at') or _utc_now()
+            data['join_requests'][request_id] = entry
+            return {
+                'schema': 'agentos.join-approval/v0.1',
+                'ok': True,
+                'request_id': request_id,
+                'user_code': entry['user_code'],
+                'node_id': entry['manifest']['node_id'],
+                'approved_at': entry['approved_at'],
+            }
+
+        return self._mutate(mutate)
 
     def join_status(self, *, request_id: str, claim_secret: str) -> dict[str, Any]:
         data = self.load()
@@ -256,82 +337,86 @@ class RealmFabricStore:
         }
 
     def claim_join(self, *, request_id: str, claim_secret: str) -> dict[str, Any]:
-        data = self.load()
-        entry = data['join_requests'].get(request_id)
-        if not entry or not secrets.compare_digest(str(entry.get('claim_secret_hash') or ''), _hash_secret(claim_secret)):
-            raise PermissionError('invalid join request credential')
-        if entry.get('claimed_at'):
-            raise PermissionError('join request already claimed')
-        if entry.get('denied_at'):
-            raise PermissionError('join request denied')
-        if _parse_utc(entry['expires_at']) < datetime.now(timezone.utc):
-            raise PermissionError('join request expired')
-        if not entry.get('approved_at'):
-            return {'schema': 'agentos.join-status/v0.1', 'status': 'pending', 'request_id': request_id}
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            entry = data['join_requests'].get(request_id)
+            if not entry or not secrets.compare_digest(str(entry.get('claim_secret_hash') or ''), _hash_secret(claim_secret)):
+                raise PermissionError('invalid join request credential')
+            if entry.get('claimed_at'):
+                raise PermissionError('join request already claimed')
+            if entry.get('denied_at'):
+                raise PermissionError('join request denied')
+            if _parse_utc(entry['expires_at']) < datetime.now(timezone.utc):
+                raise PermissionError('join request expired')
+            if not entry.get('approved_at'):
+                return {'schema': 'agentos.join-status/v0.1', 'status': 'pending', 'request_id': request_id}
 
-        result = self._register_node(data, dict(entry['manifest']))
-        entry['claimed_at'] = _utc_now()
-        data['join_requests'][request_id] = entry
-        self.save(data)
-        return {'status': 'enrolled', **result}
+            result = self._register_node(data, dict(entry['manifest']))
+            entry['claimed_at'] = _utc_now()
+            data['join_requests'][request_id] = entry
+            return {'status': 'enrolled', **result}
+
+        return self._mutate(mutate)
 
     def authenticate(self, node_id: str, token: str) -> dict[str, Any]:
-        data = self.load()
-        node = data['nodes'].get(node_id)
-        if not node or node.get('revoked_at'):
-            raise PermissionError('unknown or revoked node')
-        if not secrets.compare_digest(node['token_hash'], _hash_secret(token)):
-            raise PermissionError('invalid node credential')
-        return node
+        return self._authenticate_data(self.load(), node_id, token)
 
     def record_heartbeat(self, heartbeat: dict[str, Any], token: str) -> dict[str, Any]:
         node_id = str(heartbeat.get('node_id') or '')
-        self.authenticate(node_id, token)
-        entry = self.node_registry.record_heartbeat(heartbeat)
-        data = self.load()
-        data['nodes'][node_id]['last_seen_at'] = heartbeat.get('observed_at') or _utc_now()
-        self.save(data)
-        return entry
+        observed_at = heartbeat.get('observed_at') or _utc_now()
+        # NodeRegistry has its own independent lock. Authenticate the Fabric and
+        # reserve this Fabric mutation first, then update the NodeRegistry while
+        # this transaction remains serialized. A failed registry update prevents
+        # publication of a new Fabric last_seen_at.
+        with self._exclusive_lock():
+            data = self._load_unlocked()
+            self._authenticate_data(data, node_id, token)
+            entry = self.node_registry.record_heartbeat(heartbeat)
+            data['nodes'][node_id]['last_seen_at'] = observed_at
+            self._save_unlocked(data)
+            return entry
 
     def queue_task(self, node_id: str, task: dict[str, Any]) -> dict[str, Any]:
         if task.get('schema') != 'agentos.node-task/v0.1':
             raise ValueError('invalid task schema')
         if not task.get('task_id'):
             raise ValueError('task_id is required')
-        data = self.load()
-        if node_id not in data['nodes']:
-            raise KeyError(node_id)
-        queued = dict(task)
-        queued['queued_at'] = _utc_now()
-        data['tasks'].setdefault(node_id, []).append(queued)
-        self.save(data)
-        return queued
+
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            if node_id not in data['nodes']:
+                raise KeyError(node_id)
+            queued = dict(task)
+            queued['queued_at'] = _utc_now()
+            data['tasks'].setdefault(node_id, []).append(queued)
+            return queued
+
+        return self._mutate(mutate)
 
     def pull_tasks(self, node_id: str, token: str, *, limit: int = 10) -> list[dict[str, Any]]:
-        self.authenticate(node_id, token)
-        data = self.load()
-        queue = list(data['tasks'].get(node_id, []))
-        take = queue[:max(1, min(limit, 50))]
-        data['tasks'][node_id] = queue[len(take):]
-        self.save(data)
-        return take
+        def mutate(data: dict[str, Any]) -> list[dict[str, Any]]:
+            self._authenticate_data(data, node_id, token)
+            queue = list(data['tasks'].get(node_id, []))
+            take = queue[:max(1, min(limit, 50))]
+            data['tasks'][node_id] = queue[len(take):]
+            return take
+
+        return self._mutate(mutate)
 
     def record_receipt(self, receipt: dict[str, Any], token: str) -> dict[str, Any]:
         if receipt.get('schema') != 'agentos.node-receipt/v0.1':
             raise ValueError('invalid receipt schema')
         node_id = str(receipt.get('node_id') or '')
-        self.authenticate(node_id, token)
         task_id = str(receipt.get('task_id') or '')
         if not task_id:
             raise ValueError('receipt task_id is required')
-        data = self.load()
-        data['receipts'][task_id] = {
-            **receipt,
-            'received_at': _utc_now(),
-        }
-        data['nodes'][node_id]['last_seen_at'] = _utc_now()
-        self.save(data)
-        return data['receipts'][task_id]
+
+        def mutate(data: dict[str, Any]) -> dict[str, Any]:
+            self._authenticate_data(data, node_id, token)
+            stored = {**receipt, 'received_at': _utc_now()}
+            data['receipts'][task_id] = stored
+            data['nodes'][node_id]['last_seen_at'] = _utc_now()
+            return stored
+
+        return self._mutate(mutate)
 
     def get_receipt(self, task_id: str) -> dict[str, Any] | None:
         return self.load()['receipts'].get(task_id)

--- a/scripts/repair_realm_fabric_truncated_tail.py
+++ b/scripts/repair_realm_fabric_truncated_tail.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+
+
+def _validate_snapshot(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get('schema') != 'agentos.realm-fabric/v0.1':
+        raise RuntimeError('realm_fabric_repair_first_snapshot_invalid')
+    realm_id = str(value.get('realm_id') or '').strip()
+    if not realm_id:
+        raise RuntimeError('realm_fabric_repair_realm_missing')
+    for field in ('invites', 'join_requests', 'nodes', 'tasks', 'receipts'):
+        if not isinstance(value.get(field), dict):
+            raise RuntimeError(f'realm_fabric_repair_field_invalid:{field}')
+    return value
+
+
+def repair_truncated_tail(
+    fabric_path: Path,
+    *,
+    expected_file_sha256: str,
+    expected_prefix_sha256: str,
+    backup_dir: Path,
+) -> dict[str, Any]:
+    fabric_path = Path(fabric_path).expanduser().resolve()
+    backup_dir = Path(backup_dir).expanduser().resolve()
+    lock_path = fabric_path.with_suffix(fabric_path.suffix + '.lock')
+    fabric_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open('a+', encoding='utf-8') as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            original = fabric_path.read_bytes()
+            observed_file_sha = _sha256_bytes(original)
+            if observed_file_sha != expected_file_sha256:
+                raise RuntimeError('realm_fabric_repair_file_sha_mismatch')
+
+            try:
+                text = original.decode('utf-8')
+            except UnicodeDecodeError as exc:
+                raise RuntimeError('realm_fabric_repair_not_utf8') from exc
+
+            try:
+                json.loads(text)
+            except json.JSONDecodeError:
+                pass
+            else:
+                raise RuntimeError('realm_fabric_repair_store_already_valid')
+
+            decoder = json.JSONDecoder()
+            try:
+                first, end = decoder.raw_decode(text, 0)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError('realm_fabric_repair_no_complete_prefix') from exc
+            first = _validate_snapshot(first)
+            prefix_text = text[:end]
+            prefix_bytes = prefix_text.encode('utf-8')
+            observed_prefix_sha = _sha256_bytes(prefix_bytes)
+            if observed_prefix_sha != expected_prefix_sha256:
+                raise RuntimeError('realm_fabric_repair_prefix_sha_mismatch')
+
+            tail = text[end:]
+            stripped = tail.lstrip()
+            if not stripped:
+                raise RuntimeError('realm_fabric_repair_no_truncated_tail')
+
+            # If the remainder itself contains one complete JSON value, this is
+            # not the narrowly approved truncated-tail case. Refuse rather than
+            # choosing between multiple valid snapshots here.
+            try:
+                second, second_end = decoder.raw_decode(stripped, 0)
+            except json.JSONDecodeError:
+                second = None
+                second_end = 0
+            if second is not None and not stripped[second_end:].strip():
+                raise RuntimeError('realm_fabric_repair_complete_second_snapshot_refused')
+
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_path = backup_dir / f'fabric.json.corrupt-{_utc_stamp()}-{observed_file_sha[:12]}'
+            if backup_path.exists():
+                raise RuntimeError('realm_fabric_repair_backup_collision')
+            with backup_path.open('xb') as handle:
+                handle.write(original)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(backup_path, 0o600)
+
+            canonical = prefix_bytes + b'\n'
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=fabric_path.name + '.repair.',
+                suffix='.tmp',
+                dir=str(fabric_path.parent),
+            )
+            tmp = Path(tmp_name)
+            try:
+                with os.fdopen(fd, 'wb') as handle:
+                    handle.write(canonical)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.chmod(tmp, 0o640)
+                os.replace(tmp, fabric_path)
+                dir_fd = os.open(fabric_path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            finally:
+                if tmp.exists():
+                    tmp.unlink()
+
+            repaired = json.loads(fabric_path.read_text(encoding='utf-8'))
+            _validate_snapshot(repaired)
+            return {
+                'schema': 'agentos.realm-fabric-repair/v1',
+                'ok': True,
+                'realm_id': first['realm_id'],
+                'original_sha256': observed_file_sha,
+                'restored_snapshot_sha256': observed_prefix_sha,
+                'tail_bytes_quarantined': len(original) - len(prefix_bytes),
+                'backup_path': str(backup_path),
+                'credential_exposed': False,
+            }
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog='repair-realm-fabric-truncated-tail')
+    parser.add_argument('--fabric', type=Path, required=True)
+    parser.add_argument('--expected-file-sha256', required=True)
+    parser.add_argument('--expected-prefix-sha256', required=True)
+    parser.add_argument('--backup-dir', type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = repair_truncated_tail(
+        args.fabric,
+        expected_file_sha256=args.expected_file_sha256,
+        expected_prefix_sha256=args.expected_prefix_sha256,
+        backup_dir=args.backup_dir,
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_realm_fabric_atomic_repair.py
+++ b/tests/test_realm_fabric_atomic_repair.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from agent_core.realm_fabric import RealmFabricStore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPAIR_PATH = ROOT / 'scripts' / 'repair_realm_fabric_truncated_tail.py'
+spec = importlib.util.spec_from_file_location('repair_realm_fabric_truncated_tail', REPAIR_PATH)
+assert spec and spec.loader
+repair_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(repair_mod)
+
+
+def sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def fabric_snapshot() -> dict:
+    return {
+        'schema': 'agentos.realm-fabric/v0.1',
+        'realm_id': 'realm-alston',
+        'invites': {},
+        'join_requests': {},
+        'nodes': {
+            'node-a': {
+                'node_id': 'node-a',
+                'token_hash': 'x' * 64,
+                'enrolled_at': '2026-09-09T00:00:00Z',
+                'last_seen_at': None,
+                'revoked_at': None,
+            }
+        },
+        'tasks': {'node-a': []},
+        'receipts': {},
+    }
+
+
+def test_concurrent_queue_mutations_do_not_lose_updates(tmp_path: Path):
+    path = tmp_path / 'realm' / 'fabric.json'
+    store = RealmFabricStore(path)
+    store.save(fabric_snapshot())
+
+    def enqueue(i: int) -> None:
+        store.queue_task('node-a', {
+            'schema': 'agentos.node-task/v0.1',
+            'task_id': f'task-{i}',
+            'action': 'bounded.test',
+        })
+
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        list(pool.map(enqueue, range(60)))
+
+    data = store.load()
+    tasks = data['tasks']['node-a']
+    assert len(tasks) == 60
+    assert {task['task_id'] for task in tasks} == {f'task-{i}' for i in range(60)}
+    assert not list(path.parent.glob('fabric.json.*.tmp'))
+
+
+def test_malformed_store_remains_fail_closed_in_normal_load(tmp_path: Path):
+    path = tmp_path / 'fabric.json'
+    prefix = json.dumps(fabric_snapshot(), sort_keys=True)
+    path.write_text(prefix + '\npartial-tail', encoding='utf-8')
+    with pytest.raises(json.JSONDecodeError):
+        RealmFabricStore(path).load()
+
+
+def test_hash_bound_repair_backs_up_original_and_restores_complete_prefix(tmp_path: Path):
+    path = tmp_path / 'realm' / 'fabric.json'
+    path.parent.mkdir(parents=True)
+    prefix = json.dumps(fabric_snapshot(), sort_keys=True)
+    tail = '\n  partial-tail-without-object-start'
+    original = (prefix + tail).encode('utf-8')
+    path.write_bytes(original)
+    backup_dir = tmp_path / 'backups'
+
+    result = repair_mod.repair_truncated_tail(
+        path,
+        expected_file_sha256=sha(original),
+        expected_prefix_sha256=sha(prefix.encode('utf-8')),
+        backup_dir=backup_dir,
+    )
+
+    assert result['ok'] is True
+    assert result['realm_id'] == 'realm-alston'
+    assert result['credential_exposed'] is False
+    backup = Path(result['backup_path'])
+    assert backup.read_bytes() == original
+    assert (backup.stat().st_mode & 0o777) == 0o600
+    assert json.loads(path.read_text(encoding='utf-8')) == fabric_snapshot()
+
+
+def test_repair_refuses_if_full_file_hash_changed(tmp_path: Path):
+    path = tmp_path / 'fabric.json'
+    prefix = json.dumps(fabric_snapshot(), sort_keys=True)
+    original = (prefix + '\npartial').encode('utf-8')
+    path.write_bytes(original)
+    before = path.read_bytes()
+    with pytest.raises(RuntimeError, match='file_sha_mismatch'):
+        repair_mod.repair_truncated_tail(
+            path,
+            expected_file_sha256='0' * 64,
+            expected_prefix_sha256=sha(prefix.encode('utf-8')),
+            backup_dir=tmp_path / 'backups',
+        )
+    assert path.read_bytes() == before
+
+
+def test_repair_refuses_complete_second_snapshot(tmp_path: Path):
+    path = tmp_path / 'fabric.json'
+    first = json.dumps(fabric_snapshot(), sort_keys=True)
+    second_data = fabric_snapshot()
+    second_data['receipts'] = {'task-x': {'status': 'completed'}}
+    second = json.dumps(second_data, sort_keys=True)
+    original = (first + '\n' + second).encode('utf-8')
+    path.write_bytes(original)
+    with pytest.raises(RuntimeError, match='complete_second_snapshot_refused'):
+        repair_mod.repair_truncated_tail(
+            path,
+            expected_file_sha256=sha(original),
+            expected_prefix_sha256=sha(first.encode('utf-8')),
+            backup_dir=tmp_path / 'backups',
+        )
+
+
+def test_repair_refuses_prefix_hash_mismatch_without_backup(tmp_path: Path):
+    path = tmp_path / 'fabric.json'
+    prefix = json.dumps(fabric_snapshot(), sort_keys=True)
+    original = (prefix + '\npartial').encode('utf-8')
+    path.write_bytes(original)
+    backup_dir = tmp_path / 'backups'
+    with pytest.raises(RuntimeError, match='prefix_sha_mismatch'):
+        repair_mod.repair_truncated_tail(
+            path,
+            expected_file_sha256=sha(original),
+            expected_prefix_sha256='f' * 64,
+            backup_dir=backup_dir,
+        )
+    assert not backup_dir.exists()


### PR DESCRIPTION
Live #238 acceptance found the remaining upstream failure: Realm Fabric durable state is malformed. `/v1/health` and every wake-node heartbeat fail with `JSONDecodeError: Extra data`. A bounded structural probe shows one complete valid `agentos.realm-fabric/v0.1` snapshot for `realm-alston` followed by a 1909-character invalid/truncated tail, with no complete recovery candidate.

The current `RealmFabricStore` uses a fixed `.tmp` path and many independent `load -> modify -> save` sequences under a ThreadingHTTPServer, with no transaction lock. This can corrupt shared state and lose concurrent heartbeat/task/receipt updates.

This PR:
- keeps ordinary RealmFabric reads strict/fail-closed for malformed JSON;
- serializes every state-changing operation with a process/thread boundary plus `flock`;
- makes load→mutate→fsync→atomic replace one transaction;
- uses unique temp files, fsync, atomic replace and directory fsync;
- keeps NodeRegistry updates on its separate governed lock boundary;
- adds a separate explicit repair tool for the historical truncated-tail case;
- repair requires exact full-file SHA256 and exact complete-prefix SHA256, refuses a changed file or a complete second snapshot, backs up the complete original bytes before publishing the verified complete prefix, and emits only a sanitized repair receipt;
- tests concurrent queue mutations for lost updates, strict malformed-load behavior, backup/restore, hash mismatch refusal, and complete-second-snapshot refusal.

This source change does not repair the live file by itself and emits no product Employee VERIFIED marker.

Refs #238