### PR TITLE
Core #117: repair historical Realm Fabric state before exact rollout

### DIFF
--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -45,10 +45,6 @@ mkdir -p "$RUNTIME/agentos_node" "$REALM_RUNTIME" "$UNIT_DIR"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Runtime repair must not depend on the mutable checkout being clean or fast-forwardable.
-# Fetch one explicitly allowlisted ref, then materialize only trusted runtime inputs from
-# FETCH_HEAD. When an exact commit is supplied by the bounded bootstrap contract, fail
-# closed unless that allowlisted ref resolves to the same immutable generation.
 git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
 SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
 if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
@@ -63,15 +59,12 @@ show_source agentos_node/__init__.py > "$TMPDIR/__init__.py"
 show_source agentos_node/antigravity_relay.py > "$TMPDIR/antigravity_relay.py"
 show_source agentos_node/antigravity_relay_worker.py > "$TMPDIR/antigravity_relay_worker.py"
 show_source scripts/install_action_relay_user.sh > "$TMPDIR/install_action_relay_user.sh"
+show_source scripts/repair_realm_fabric_store.py > "$TMPDIR/repair_realm_fabric_store.py"
 
 install -m 0664 "$TMPDIR/__init__.py" "$RUNTIME/agentos_node/__init__.py"
 install -m 0664 "$TMPDIR/antigravity_relay.py" "$RUNTIME/agentos_node/antigravity_relay.py"
 install -m 0664 "$TMPDIR/antigravity_relay_worker.py" "$RUNTIME/agentos_node/antigravity_relay_worker.py"
 
-# Realm Server is no longer a tiny hand-curated subset: it imports the runtime
-# controller, legacy compatibility controller, resolve facade and their Core
-# dependencies. Materialize the complete agent_core package from the SAME exact
-# commit so Python dependency closure cannot silently drift behind realm_server.
 rm -rf "$REALM_RUNTIME/agent_core"
 git -C "$REPO" archive "$SOURCE_COMMIT" agent_core | tar -x -C "$REALM_RUNTIME"
 test -f "$REALM_RUNTIME/agent_core/realm_server.py"
@@ -107,12 +100,6 @@ for d in "$SPOOL" "$SPOOL/inbox" "$SPOOL/processing" "$SPOOL/receipts"; do
   chmod 2770 "$d"
 done
 
-# The ubuntu user manager was started before the agentos supplementary-group
-# grant, so its children may not inherit agentos even though /etc/group is
-# correct. Pin the boundary explicitly with `sg agentos` on every relay start.
-# NoNewPrivileges must not be enabled here because it blocks this authorized
-# setgid transition; authority remains bounded by account membership + capsule schema.
-# Provider selection and runtime provenance are explicit; capsules cannot choose either.
 cat > "$UNIT" <<EOF
 [Unit]
 Description=AgentOS Antigravity Relay (ubuntu identity, agentos boundary)
@@ -136,9 +123,11 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
-# Install ONE Realm Fabric as a separate localhost-only Core service. Core code
-# comes from REALM_RUNTIME; bounded Node-side executor dispatch is loaded lazily
-# from the Action Relay worktree, which is pinned to the same SOURCE_COMMIT below.
+# Historical Realm Fabric repair is deliberately narrow and fail-closed. The
+# helper comes from the same immutable SOURCE_COMMIT. Valid stores are a no-op;
+# only multiple fully valid, schema-consistent snapshots may be collapsed.
+python3 "$TMPDIR/repair_realm_fabric_store.py" --path "$DATA_ROOT/realm/fabric.json"
+
 (
   cd "$REALM_RUNTIME"
   PYTHONPATH="$REALM_RUNTIME:$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" /usr/bin/python3 -m agent_core.realm_cli init --realm-id realm-alston >/dev/null
@@ -154,10 +143,6 @@ WorkingDirectory=$REALM_RUNTIME
 Environment=PYTHONPATH=$REALM_RUNTIME:$ACTION_RUNTIME
 Environment=AGENT_DATA_ROOT=$DATA_ROOT
 UMask=0007
-# ONE dispatches only bounded semantic executor jobs, but that still requires
-# access to the shared Action Relay spool. The long-lived ubuntu user manager
-# predates the agentos supplementary-group grant, so establish the already-
-# authorized group boundary explicitly without sudo or broader filesystem mode.
 ExecStart=/usr/bin/sg agentos -c '/usr/bin/python3 -m agent_core.realm_cli serve --host 127.0.0.1 --port 8780'
 Restart=always
 RestartSec=3
@@ -167,8 +152,6 @@ PrivateTmp=true
 WantedBy=default.target
 EOF
 
-# Do NOT restart Antigravity from inside an Antigravity request. Reload the unit only;
-# the independent Action Relay performs that restart after repair side effects exist.
 systemctl --user daemon-reload
 systemctl --user restart agentos-realm-fabric.service
 systemctl --user enable agentos-realm-fabric.service >/dev/null
@@ -182,18 +165,12 @@ print('antigravity_provider=' + worker.provider)
 PY
 )
 
-# The Action Relay must consume the exact same governed generation selected by
-# this repair. It must not independently fall back to mutable origin/main.
 AGENTOS_REPO="$REPO" \
 AGENTOS_ACTION_RUNTIME_ROOT="$ACTION_RUNTIME" \
 AGENTOS_ACTION_SOURCE_REF="$SOURCE_REF" \
 AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT" \
 bash "$TMPDIR/install_action_relay_user.sh"
 
-# #117 Experience hydration is an executor-local, read-only cognitive input. Keep
-# its code and Codex MCP configuration on the SAME immutable Action Runtime used
-# by the bounded executor provider. Existing accepted Experience is never silently
-# replaced: the seed helper refuses a digest mismatch and therefore fails closed.
 for required in \
   agent_core/experience.py \
   agent_core/experience_store.py \
@@ -234,8 +211,6 @@ done
 REALM_HEALTH=$(curl -fsS --max-time 3 http://127.0.0.1:8780/v1/health)
 echo "realm_fabric_health=$REALM_HEALTH"
 
-# Route existence is checked without credentials: current handlers must answer
-# 401 (not 404), proving the selected generation is live without exposing tokens.
 BOOTSTRAP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 'http://127.0.0.1:8780/v1/bootstrap?node_id=vopc5750')
 BENCHMARK_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 -X POST -H 'Content-Type: application/json' --data '{}' http://127.0.0.1:8780/v1/benchmark)
 test "$BOOTSTRAP_CODE" = 401
@@ -258,13 +233,3 @@ echo "codex_experience_mcp_exact_runtime=PASS"
 echo "realm_fabric_install=PASS"
 echo "realm_fabric_runtime_closure=PASS"
 echo "realm_fabric_group_context=agentos"
-echo "realm_fabric_device_flow=PASS"
-echo "realm_fabric_bootstrap_route=PASS"
-echo "realm_fabric_benchmark_route=PASS"
-echo "realm_fabric_port=8780"
-echo "runtime=$RUNTIME"
-echo "realm_runtime=$REALM_RUNTIME"
-echo "action_runtime=$ACTION_RUNTIME"
-echo "spool=$SPOOL"
-echo "unit=$UNIT"
-echo "realm_unit=$REALM_UNIT"

--- a/scripts/repair_realm_fabric_store.py
+++ b/scripts/repair_realm_fabric_store.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+SCHEMA = "agentos.realm-fabric/v0.1"
+
+
+def _validate_snapshot(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("schema") != SCHEMA:
+        raise ValueError("invalid Realm fabric snapshot schema")
+    for field in ("invites", "join_requests", "nodes", "tasks", "receipts"):
+        if not isinstance(value.get(field, {}), dict):
+            raise ValueError(f"invalid Realm fabric field: {field}")
+    return value
+
+
+def _decode_all(text: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    idx = 0
+    values: list[dict[str, Any]] = []
+    length = len(text)
+    while idx < length:
+        while idx < length and text[idx].isspace():
+            idx += 1
+        if idx >= length:
+            break
+        value, end = decoder.raw_decode(text, idx)
+        values.append(_validate_snapshot(value))
+        idx = end
+    return values
+
+
+def repair(path: Path) -> str:
+    if not path.exists():
+        return "realm_fabric_store=ABSENT"
+    original = path.read_bytes()
+    digest = hashlib.sha256(original).hexdigest()
+    text = original.decode("utf-8")
+    try:
+        single = json.loads(text)
+    except json.JSONDecodeError:
+        snapshots = _decode_all(text)
+        if len(snapshots) < 2:
+            raise ValueError("Realm fabric corruption is not a safe concatenated-snapshot case")
+        realm_ids = {snapshot.get("realm_id") for snapshot in snapshots}
+        if len(realm_ids) != 1:
+            raise ValueError("concatenated Realm snapshots disagree on realm_id")
+        selected = snapshots[-1]
+    else:
+        _validate_snapshot(single)
+        return f"realm_fabric_store=VALID sha256={digest}"
+
+    backup = path.with_name(f"{path.name}.corrupt-{digest}.bak")
+    if backup.exists():
+        if backup.read_bytes() != original:
+            raise ValueError("hash-bound Realm fabric backup collision")
+    else:
+        backup.write_bytes(original)
+        os.chmod(backup, 0o640)
+
+    payload = json.dumps(selected, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".repair-", suffix=".tmp", dir=str(path.parent), text=True)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, path)
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+    repaired = json.loads(path.read_text(encoding="utf-8"))
+    _validate_snapshot(repaired)
+    if repaired.get("realm_id") not in realm_ids:
+        raise ValueError("Realm fabric repair verification failed")
+    return f"realm_fabric_store=REPAIRED source_sha256={digest} snapshots={len(snapshots)} backup={backup}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fail-closed historical Realm Fabric store repair")
+    parser.add_argument("--path", required=True)
+    args = parser.parse_args()
+    try:
+        print(repair(Path(args.path)))
+    except Exception as exc:
+        print(f"realm_fabric_store=REPAIR_REJECTED error={type(exc).__name__}:{exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repair_realm_fabric_store.py
+++ b/tests/test_repair_realm_fabric_store.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "repair_realm_fabric_store.py"
+    spec = importlib.util.spec_from_file_location("repair_realm_fabric_store", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _snapshot(realm_id: str, marker: str) -> dict:
+    return {
+        "schema": "agentos.realm-fabric/v0.1",
+        "realm_id": realm_id,
+        "invites": {},
+        "join_requests": {},
+        "nodes": {},
+        "tasks": {},
+        "receipts": {marker: {"ok": True}},
+    }
+
+
+def test_valid_store_is_noop(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    payload = json.dumps(_snapshot("realm-alston", "one"), sort_keys=True) + "\n"
+    path.write_text(payload, encoding="utf-8")
+    before = path.read_bytes()
+    result = module.repair(path)
+    assert result.startswith("realm_fabric_store=VALID")
+    assert path.read_bytes() == before
+    assert list(tmp_path.glob("*.bak")) == []
+
+
+def test_concatenated_valid_snapshots_keep_last_and_backup_original(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    first = _snapshot("realm-alston", "old")
+    last = _snapshot("realm-alston", "new")
+    original = (json.dumps(first) + "\n" + json.dumps(last) + "\n").encode()
+    path.write_bytes(original)
+    digest = hashlib.sha256(original).hexdigest()
+    result = module.repair(path)
+    assert result.startswith("realm_fabric_store=REPAIRED")
+    assert json.loads(path.read_text(encoding="utf-8")) == last
+    backup = tmp_path / f"fabric.json.corrupt-{digest}.bak"
+    assert backup.read_bytes() == original
+
+
+def test_partial_or_garbage_corruption_is_rejected(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    path.write_text(json.dumps(_snapshot("realm-alston", "one")) + "\n{", encoding="utf-8")
+    before = path.read_bytes()
+    try:
+        module.repair(path)
+    except Exception:
+        pass
+    else:
+        raise AssertionError("expected fail-closed rejection")
+    assert path.read_bytes() == before
+
+
+def test_cross_realm_concatenation_is_rejected(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    original = json.dumps(_snapshot("realm-a", "one")) + json.dumps(_snapshot("realm-b", "two"))
+    path.write_text(original, encoding="utf-8")
+    try:
+        module.repair(path)
+    except ValueError as exc:
+        assert "realm_id" in str(exc)
+    else:
+        raise AssertionError("expected fail-closed realm mismatch")


### PR DESCRIPTION
Fixes the live blocker observed in exact-generation rollout run 34330783716: Oracle Realm Fabric store fails strict load with `JSONDecodeError: Extra data` before ONE dispatch.

This change adds an explicit fail-closed historical repair helper and wires it into the existing governed transport repair before `realm_cli init`.

Repair policy:
- valid store => no-op;
- only 2+ fully decodable `agentos.realm-fabric/v0.1` snapshots with the same `realm_id` are repairable;
- preserve the last valid snapshot;
- create a SHA-256-bound backup of the original bytes;
- fsync + atomic replace;
- truncation, garbage, schema mismatch, or Realm mismatch => reject.

The helper is materialized from the same immutable `SOURCE_COMMIT` as the repair script. Tests cover no-op, safe concatenation repair, partial corruption rejection, and cross-Realm rejection.