### PR TITLE
Core #117: recover safe NUL-padded Realm Fabric state

### DIFF
--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -125,7 +125,7 @@ EOF
 
 # Historical Realm Fabric repair is deliberately narrow and fail-closed. The
 # helper comes from the same immutable SOURCE_COMMIT. Valid stores are a no-op;
-# only multiple fully valid, schema-consistent snapshots may be collapsed.
+# only fully valid schema-consistent snapshots with bounded NUL/whitespace padding may be collapsed.
 python3 "$TMPDIR/repair_realm_fabric_store.py" --path "$DATA_ROOT/realm/fabric.json"
 
 (

--- a/scripts/repair_realm_fabric_store.py
+++ b/scripts/repair_realm_fabric_store.py
@@ -21,20 +21,22 @@ def _validate_snapshot(value: Any) -> dict[str, Any]:
     return value
 
 
-def _decode_all(text: str) -> list[dict[str, Any]]:
+def _decode_all(text: str) -> tuple[list[dict[str, Any]], bool]:
     decoder = json.JSONDecoder()
     idx = 0
     values: list[dict[str, Any]] = []
+    used_nul_padding = False
     length = len(text)
     while idx < length:
-        while idx < length and text[idx].isspace():
+        while idx < length and (text[idx].isspace() or text[idx] == "\x00"):
+            used_nul_padding = used_nul_padding or text[idx] == "\x00"
             idx += 1
         if idx >= length:
             break
         value, end = decoder.raw_decode(text, idx)
         values.append(_validate_snapshot(value))
         idx = end
-    return values
+    return values, used_nul_padding
 
 
 def repair(path: Path) -> str:
@@ -46,9 +48,11 @@ def repair(path: Path) -> str:
     try:
         single = json.loads(text)
     except json.JSONDecodeError:
-        snapshots = _decode_all(text)
-        if len(snapshots) < 2:
-            raise ValueError("Realm fabric corruption is not a safe concatenated-snapshot case")
+        snapshots, used_nul_padding = _decode_all(text)
+        if not snapshots:
+            raise ValueError("Realm fabric corruption contains no valid snapshot")
+        if len(snapshots) < 2 and not used_nul_padding:
+            raise ValueError("Realm fabric corruption is not a safe concatenated/padded snapshot case")
         realm_ids = {snapshot.get("realm_id") for snapshot in snapshots}
         if len(realm_ids) != 1:
             raise ValueError("concatenated Realm snapshots disagree on realm_id")
@@ -88,7 +92,7 @@ def repair(path: Path) -> str:
     _validate_snapshot(repaired)
     if repaired.get("realm_id") not in realm_ids:
         raise ValueError("Realm fabric repair verification failed")
-    return f"realm_fabric_store=REPAIRED source_sha256={digest} snapshots={len(snapshots)} backup={backup}"
+    return f"realm_fabric_store=REPAIRED source_sha256={digest} snapshots={len(snapshots)} nul_padding={str(used_nul_padding).lower()} backup={backup}"
 
 
 def main() -> int:

--- a/tests/test_repair_realm_fabric_store.py
+++ b/tests/test_repair_realm_fabric_store.py
@@ -54,6 +54,31 @@ def test_concatenated_valid_snapshots_keep_last_and_backup_original(tmp_path: Pa
     assert backup.read_bytes() == original
 
 
+def test_nul_padded_single_snapshot_is_safe_to_trim(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    snapshot = _snapshot("realm-alston", "one")
+    original = (json.dumps(snapshot) + "\n\x00\x00\x00\n").encode()
+    path.write_bytes(original)
+    digest = hashlib.sha256(original).hexdigest()
+    result = module.repair(path)
+    assert "realm_fabric_store=REPAIRED" in result
+    assert "nul_padding=true" in result
+    assert json.loads(path.read_text(encoding="utf-8")) == snapshot
+    assert (tmp_path / f"fabric.json.corrupt-{digest}.bak").read_bytes() == original
+
+
+def test_nul_separator_between_valid_snapshots_keeps_last(tmp_path: Path) -> None:
+    module = _load_module()
+    path = tmp_path / "fabric.json"
+    first = _snapshot("realm-alston", "old")
+    last = _snapshot("realm-alston", "new")
+    path.write_bytes((json.dumps(first) + "\x00\n" + json.dumps(last)).encode())
+    result = module.repair(path)
+    assert "nul_padding=true" in result
+    assert json.loads(path.read_text(encoding="utf-8")) == last
+
+
 def test_partial_or_garbage_corruption_is_rejected(tmp_path: Path) -> None:
     module = _load_module()
     path = tmp_path / "fabric.json"


### PR DESCRIPTION
Follow-up to PR #300 based on fresh live rollout evidence. The store is not two valid JSON documents; the first valid Realm snapshot is followed by non-JSON trailing bytes. This change expands the historical repair policy by exactly one safe case: NUL/whitespace padding between or after otherwise fully valid `agentos.realm-fabric/v0.1` snapshots.

Safety remains fail-closed:
- arbitrary garbage/truncated JSON still rejects;
- schema mismatch still rejects;
- cross-Realm snapshots still reject;
- original bytes are SHA-bound and backed up before atomic replacement.

Tests add single-snapshot NUL tail and NUL-separated multi-snapshot cases while preserving garbage/cross-Realm rejection.