### PR TITLE
Core #117: emit sanitized Realm tail hashes for #298 repair

### DIFF
--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -12,8 +12,8 @@ is accepted through the executor-job request.
 from __future__ import annotations
 
 # Live acceptance trigger only: behavior intentionally unchanged. Touching this
-# watched provider path asks the canonical exact-generation rollout to certify
-# the new core/integration generation through ONE and #117 regression.
+# watched provider path asks exact-generation rollout to emit the two-phase,
+# sanitized Realm tail hashes before #117 regression continues.
 
 import importlib.util
 import json

--- a/scripts/repair_realm_fabric_store.py
+++ b/scripts/repair_realm_fabric_store.py
@@ -15,6 +15,9 @@ SCHEMA = "agentos.realm-fabric/v0.1"
 def _validate_snapshot(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict) or value.get("schema") != SCHEMA:
         raise ValueError("invalid Realm fabric snapshot schema")
+    realm_id = str(value.get("realm_id") or "").strip()
+    if not realm_id:
+        raise ValueError("Realm fabric realm_id missing")
     for field in ("invites", "join_requests", "nodes", "tasks", "receipts"):
         if not isinstance(value.get(field, {}), dict):
             raise ValueError(f"invalid Realm fabric field: {field}")
@@ -37,6 +40,46 @@ def _decode_all(text: str) -> tuple[list[dict[str, Any]], bool]:
         values.append(_validate_snapshot(value))
         idx = end
     return values, used_nul_padding
+
+
+def probe_truncated_tail(path: Path) -> dict[str, Any]:
+    """Return sanitized structural evidence only; never return tail contents."""
+    original = path.read_bytes()
+    file_sha = hashlib.sha256(original).hexdigest()
+    try:
+        text = original.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Realm fabric store is not UTF-8") from exc
+
+    decoder = json.JSONDecoder()
+    try:
+        first, end = decoder.raw_decode(text, 0)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Realm fabric has no complete prefix snapshot") from exc
+    first = _validate_snapshot(first)
+    prefix_bytes = text[:end].encode("utf-8")
+    prefix_sha = hashlib.sha256(prefix_bytes).hexdigest()
+    tail = text[end:]
+    stripped = tail.lstrip()
+    second_complete = False
+    if stripped:
+        try:
+            _second, second_end = decoder.raw_decode(stripped, 0)
+        except json.JSONDecodeError:
+            pass
+        else:
+            second_complete = not stripped[second_end:].strip()
+
+    return {
+        "schema": "agentos.realm-fabric-tail-probe/v1",
+        "realm_id": first["realm_id"],
+        "file_sha256": file_sha,
+        "complete_prefix_sha256": prefix_sha,
+        "prefix_bytes": len(prefix_bytes),
+        "tail_bytes": len(original) - len(prefix_bytes),
+        "second_complete": second_complete,
+        "credential_exposed": False,
+    }
 
 
 def repair(path: Path) -> str:
@@ -98,11 +141,16 @@ def repair(path: Path) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fail-closed historical Realm Fabric store repair")
     parser.add_argument("--path", required=True)
+    parser.add_argument("--probe-truncated-tail", action="store_true")
     args = parser.parse_args()
     try:
-        print(repair(Path(args.path)))
+        if args.probe_truncated_tail:
+            print(json.dumps(probe_truncated_tail(Path(args.path)), sort_keys=True))
+        else:
+            print(repair(Path(args.path)))
     except Exception as exc:
-        print(f"realm_fabric_store=REPAIR_REJECTED error={type(exc).__name__}:{exc}")
+        kind = "PROBE_REJECTED" if args.probe_truncated_tail else "REPAIR_REJECTED"
+        print(f"realm_fabric_store={kind} error={type(exc).__name__}:{exc}")
         return 2
     return 0
 

--- a/scripts/repair_realm_fabric_store.py
+++ b/scripts/repair_realm_fabric_store.py
@@ -91,6 +91,10 @@ def repair(path: Path) -> str:
     try:
         single = json.loads(text)
     except json.JSONDecodeError:
+        # Two-phase hash-bound recovery: emit only structural hashes/evidence in
+        # the failing generation. A later generation may explicitly authorize
+        # the canonical #298 repair against those exact observed hashes.
+        print(json.dumps(probe_truncated_tail(path), sort_keys=True))
         snapshots, used_nul_padding = _decode_all(text)
         if not snapshots:
             raise ValueError("Realm fabric corruption contains no valid snapshot")


### PR DESCRIPTION
Implements the required first phase of the existing #298 hash-bound Realm Fabric truncated-tail repair.

On malformed Realm state, the historical helper now emits only sanitized structural evidence before remaining fail-closed: realm_id, full-file SHA256, complete-prefix SHA256, prefix/tail byte counts, and whether a complete second snapshot exists. It never emits tail contents or credentials and does not change the live file.

The watched #117 provider is comment-touched only so exact-generation rollout runs this probe on `core/integration`. The next generation will pin the observed hashes into the existing `repair_realm_fabric_truncated_tail.py` authority boundary.