### PR TITLE
Core #117: make Action Relay capability publication collision-safe

### DIFF
--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -169,22 +169,39 @@ fi
 
 # Capability availability is installed-state evidence, not a source-code claim.
 # Publish only after the exact immutable runtime imports both fixed semantic
-# actions and the worker demonstrates stable liveness. The marker contains no
-# credentials, executable path, argv, environment or mutable authority.
+# actions and the worker demonstrates stable liveness. Use a unique inode in the
+# same shared directory, fsync it, then atomically replace the marker. Historical
+# deterministic `capabilities.tmp` files may be foreign-owned; they are ignored
+# rather than chmod/unlinked so this installer never takes ownership of evidence
+# it did not create.
 PYTHONPATH="$RUNTIME_ROOT" python3 - "$CAPABILITY_MARKER" "$SOURCE_REF" "$SOURCE_COMMIT" <<'PY'
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 from agentos_node.runtime_converge_action_relay import capability_marker_payload
 
 path = Path(sys.argv[1])
 payload = capability_marker_payload(source_ref=sys.argv[2], source_commit=sys.argv[3])
-tmp = path.with_suffix('.tmp')
-tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
-os.chmod(tmp, 0o640)
-tmp.replace(path)
+path.parent.mkdir(parents=True, exist_ok=True)
+fd, tmp_name = tempfile.mkstemp(prefix='.capabilities-', suffix='.tmp', dir=str(path.parent), text=True)
+tmp = Path(tmp_name)
+try:
+    with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n')
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(tmp, 0o640)
+    os.replace(tmp, path)
+    dir_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+finally:
+    tmp.unlink(missing_ok=True)
 PY
 chgrp agentos "$CAPABILITY_MARKER"
 
@@ -192,6 +209,7 @@ echo "action_relay_install=PASS"
 echo "action_relay_executor_job_extension=PASS"
 echo "action_relay_runtime_converge_extension=PASS"
 echo "action_relay_capability_marker=PASS"
+echo "action_relay_capability_atomic_publish=PASS"
 echo "action_relay_group_context=agentos"
 echo "action_relay_user_bus=ubuntu:/run/user/1001/bus"
 echo "action_relay_stable_liveness=PASS"


### PR DESCRIPTION
Fixes the next live blocker from exact rollout #23 after the Realm Fabric repair succeeded.

Observed failure:
`PermissionError: /home/ubuntu/agent-data/runtime/action-relay/capabilities.tmp`

Root cause: the installer publishes the capability marker through a deterministic `capabilities.tmp`. Bootstrap deliberately marks the shared Action Relay spool as preprovisioned, so a historical foreign-owned temp inode can survive and permanently block future ubuntu-owned installations.

Fix:
- create a unique temp inode in the same shared spool directory;
- write + fsync;
- chmod only the inode created by this process;
- atomic `os.replace()` onto `capabilities.json`;
- fsync parent directory;
- never chmod/unlink/take ownership of historical deterministic temp evidence;
- preserve `agentos` group on the final marker.

No new authority, executable path, argv, env, or credential surface is introduced. This should allow exact-generation transport repair to finish and continue into ONE -> #117 Experience regression.