### PR TITLE
Core #117: publish Action Relay capability in agentos group context

### DIFF
--- a/docs/notes/issue-117-action-capability-group-context.md
+++ b/docs/notes/issue-117-action-capability-group-context.md
@@ -1,0 +1,7 @@
+# Issue #117 Action Relay capability group-context gate
+
+Live exact rollout #24 proved Realm Fabric is valid and the Action Relay service starts, but the bootstrap process cannot create a capability marker temp inode in the shared spool because its effective supplementary group state does not include the already-configured `agentos` boundary.
+
+This change does not repair or take ownership of foreign-owned spool inodes. Capability publication is delegated to a fixed publisher invoked under `/usr/bin/sg agentos -c`, matching the governed Action Relay worker boundary. The publisher verifies effective GID and parent spool GID, creates a unique same-directory temp inode, fsyncs, atomically replaces `capabilities.json`, and fsyncs the directory.
+
+Acceptance remains fail-closed: no generic shell/argv/path authority is added to the ONE executor-job request surface, and no Experience regression PASS is claimed until a fresh exact-generation rollout reaches ONE dispatch and returns a sanitized terminal receipt.

--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -174,6 +174,7 @@ fi
 # caller-controlled shell, argv, path, or credential surface is introduced.
 PUBLISHER="$RUNTIME_ROOT/scripts/publish_action_relay_capability.py"
 test -f "$PUBLISHER" || { echo "ERROR: capability publisher missing from exact runtime" >&2; exit 4; }
+grep -Fq 'capability_marker_payload' "$PUBLISHER" || { echo "ERROR: capability publisher is not bound to canonical capability_marker_payload" >&2; exit 4; }
 /usr/bin/sg agentos -c "PYTHONPATH='$RUNTIME_ROOT' /usr/bin/python3 '$PUBLISHER' --marker '$CAPABILITY_MARKER' --source-ref '$SOURCE_REF' --source-commit '$SOURCE_COMMIT'"
 
 echo "action_relay_install=PASS"

--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -169,47 +169,19 @@ fi
 
 # Capability availability is installed-state evidence, not a source-code claim.
 # Publish only after the exact immutable runtime imports both fixed semantic
-# actions and the worker demonstrates stable liveness. Use a unique inode in the
-# same shared directory, fsync it, then atomically replace the marker. Historical
-# deterministic `capabilities.tmp` files may be foreign-owned; they are ignored
-# rather than chmod/unlinked so this installer never takes ownership of evidence
-# it did not create.
-PYTHONPATH="$RUNTIME_ROOT" python3 - "$CAPABILITY_MARKER" "$SOURCE_REF" "$SOURCE_COMMIT" <<'PY'
-import json
-import os
-import sys
-import tempfile
-from pathlib import Path
-
-from agentos_node.runtime_converge_action_relay import capability_marker_payload
-
-path = Path(sys.argv[1])
-payload = capability_marker_payload(source_ref=sys.argv[2], source_commit=sys.argv[3])
-path.parent.mkdir(parents=True, exist_ok=True)
-fd, tmp_name = tempfile.mkstemp(prefix='.capabilities-', suffix='.tmp', dir=str(path.parent), text=True)
-tmp = Path(tmp_name)
-try:
-    with os.fdopen(fd, 'w', encoding='utf-8') as handle:
-        handle.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n')
-        handle.flush()
-        os.fsync(handle.fileno())
-    os.chmod(tmp, 0o640)
-    os.replace(tmp, path)
-    dir_fd = os.open(path.parent, os.O_RDONLY)
-    try:
-        os.fsync(dir_fd)
-    finally:
-        os.close(dir_fd)
-finally:
-    tmp.unlink(missing_ok=True)
-PY
-chgrp agentos "$CAPABILITY_MARKER"
+# actions and the worker demonstrates stable liveness. Publication runs in the
+# same fixed `agentos` effective-group boundary as the Action Relay worker; no
+# caller-controlled shell, argv, path, or credential surface is introduced.
+PUBLISHER="$RUNTIME_ROOT/scripts/publish_action_relay_capability.py"
+test -f "$PUBLISHER" || { echo "ERROR: capability publisher missing from exact runtime" >&2; exit 4; }
+/usr/bin/sg agentos -c "PYTHONPATH='$RUNTIME_ROOT' /usr/bin/python3 '$PUBLISHER' --marker '$CAPABILITY_MARKER' --source-ref '$SOURCE_REF' --source-commit '$SOURCE_COMMIT'"
 
 echo "action_relay_install=PASS"
 echo "action_relay_executor_job_extension=PASS"
 echo "action_relay_runtime_converge_extension=PASS"
 echo "action_relay_capability_marker=PASS"
 echo "action_relay_capability_atomic_publish=PASS"
+echo "action_relay_capability_group_context=PASS"
 echo "action_relay_group_context=agentos"
 echo "action_relay_user_bus=ubuntu:/run/user/1001/bus"
 echo "action_relay_stable_liveness=PASS"

--- a/scripts/publish_action_relay_capability.py
+++ b/scripts/publish_action_relay_capability.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import grp
+import json
+import os
+from pathlib import Path
+import tempfile
+
+from agentos_node.runtime_converge_action_relay import capability_marker_payload
+
+SHARED_GROUP = "agentos"
+
+
+def publish(marker: Path, *, source_ref: str, source_commit: str) -> dict:
+    expected_gid = grp.getgrnam(SHARED_GROUP).gr_gid
+    if os.getegid() != expected_gid:
+        raise PermissionError(
+            f"capability publisher must run with effective group {SHARED_GROUP}: "
+            f"egid={os.getegid()} expected={expected_gid}"
+        )
+    if not marker.parent.is_dir():
+        raise FileNotFoundError(f"Action Relay spool missing: {marker.parent}")
+    parent = marker.parent.stat()
+    if parent.st_gid != expected_gid:
+        raise PermissionError("Action Relay spool is not owned by the agentos group boundary")
+
+    payload = capability_marker_payload(source_ref=source_ref, source_commit=source_commit)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".capabilities-",
+        suffix=".tmp",
+        dir=str(marker.parent),
+        text=True,
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, marker)
+        os.chown(marker, -1, expected_gid)
+        dir_fd = os.open(marker.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+    observed = json.loads(marker.read_text(encoding="utf-8"))
+    if observed != payload:
+        raise RuntimeError("Action Relay capability marker verification failed")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish the fixed Action Relay capability marker")
+    parser.add_argument("--marker", required=True)
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--source-commit", required=True)
+    args = parser.parse_args()
+    publish(Path(args.marker), source_ref=args.source_ref, source_commit=args.source_commit)
+    print("action_relay_capability_atomic_publish=PASS")
+    print("action_relay_capability_group_context=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install_action_relay_group_context_contract.py
+++ b/tests/test_install_action_relay_group_context_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install_action_relay_user.sh"
+PUBLISHER = ROOT / "scripts" / "publish_action_relay_capability.py"
+
+
+def test_installer_uses_fixed_agentos_group_context_for_capability_publish():
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "/usr/bin/sg agentos -c" in text
+    assert "publish_action_relay_capability.py" in text
+    assert "--marker '$CAPABILITY_MARKER'" in text
+    assert "--source-ref '$SOURCE_REF'" in text
+    assert "--source-commit '$SOURCE_COMMIT'" in text
+    assert "action_relay_capability_group_context=PASS" in text
+
+
+def test_publisher_has_no_generic_execution_surface():
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "subprocess" not in text
+    assert "os.system" not in text
+    assert "shell=True" not in text
+    assert "capability_marker_payload" in text

--- a/tests/test_publish_action_relay_capability.py
+++ b/tests/test_publish_action_relay_capability.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import grp
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "publish_action_relay_capability.py"
+spec = importlib.util.spec_from_file_location("publish_action_relay_capability", SCRIPT)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def test_publisher_refuses_wrong_effective_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    marker = tmp_path / "capabilities.json"
+    expected_gid = grp.getgrnam("agentos").gr_gid
+    monkeypatch.setattr(os, "getegid", lambda: expected_gid + 1)
+    with pytest.raises(PermissionError, match="effective group agentos"):
+        mod.publish(marker, source_ref="core/integration", source_commit="a" * 40)
+
+
+def test_publisher_refuses_non_agentos_spool_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    marker = tmp_path / "capabilities.json"
+    expected_gid = grp.getgrnam("agentos").gr_gid
+    monkeypatch.setattr(os, "getegid", lambda: expected_gid)
+    real_stat = marker.parent.stat
+
+    class FakeStat:
+        st_gid = expected_gid + 1
+
+    monkeypatch.setattr(Path, "stat", lambda self: FakeStat() if self == marker.parent else real_stat())
+    with pytest.raises(PermissionError, match="agentos group boundary"):
+        mod.publish(marker, source_ref="core/integration", source_commit="a" * 40)
+
+
+def test_script_is_fixed_capability_publication_surface():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "shell" not in text.lower()
+    assert "subprocess" not in text
+    assert "capability_marker_payload" in text
+    assert "os.getegid()" in text
+    assert "tempfile.mkstemp" in text


### PR DESCRIPTION
Fixes the live blocker from exact rollout #24 after Realm Fabric repair and collision-safe temp publication were both proven insufficient by themselves.

Observed evidence:
- Realm Fabric strict load remains VALID.
- Action Relay service starts successfully.
- even a fresh unique temp inode cannot be created under `/home/ubuntu/agent-data/runtime/action-relay` from the long-lived bootstrap process.
- the Action Relay worker itself runs under `sg agentos` and the shared spool is governed by the `agentos` group boundary.

Root cause: account membership and current-process supplementary group state diverged. `ubuntu` is configured in the `agentos` group, but the long-lived bootstrap process does not carry that effective shared-group boundary.

Fix:
- add a fixed `publish_action_relay_capability.py` helper;
- require effective GID == `agentos` and parent spool GID == `agentos`;
- create a unique same-directory temp inode, fsync, atomic replace, fsync directory;
- invoke only this fixed publisher through `/usr/bin/sg agentos -c`, matching the existing Action Relay worker boundary;
- do not chmod/chown/remove foreign-owned historical spool files;
- add contract tests for wrong effective GID, wrong spool GID, absence of generic execution surface, and installer wiring.

No caller-controlled shell/argv/path/env/credential surface is added to ONE. The installer path itself triggers the existing exact-generation rollout. Acceptance remains pending until that rollout reaches ONE dispatch and returns the #117 Experience regression receipt.