### PR TITLE
fix(core): publish Action Relay capability marker in agentos group

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -53,6 +53,19 @@ Lower layers may inform higher layers but may not silently overwrite them.
 | Evidence-first acceptance | Canonical | `.agentos/evidence/`, sanitized receipts, exact source/runtime identity; static CI cannot manufacture live VERIFIED markers |
 | Protected publication authority | Canonical | `core/issue-* -> core/integration`; publication to protected `main` is separate explicit authority and is never implied by `continue`, CI green, mergeability, capability availability, or worker completion |
 
+## Action Relay publication follow-up (2026-09-10)
+
+The #117 rollout at `8705e0ef` reported Realm Fabric valid, but failed creating
+an atomic capability-marker temporary file in the shared Action Relay directory.
+Evidence: https://github.com/alston-personal/agentmanager/actions/runs/34332816868
+
+The service already runs through `sg agentos`; the installer previously published
+its marker under the caller's inherited groups. The candidate fix uses that same
+fixed group boundary for publication, preserving atomic replace and the liveness
+gate. It does not change directory ownership or permissions. This source fix has
+not yet been accepted on Oracle; the inherited-group explanation is an inference
+from the permission error and the differing execution contexts.
+
 ## Current Node Map semantics
 
 The canonical map is generated from ONE-side `NodeRegistry`; it is not a manually maintained list. `agentos.node-map/v0.1` includes:

--- a/scripts/install_action_relay_user.sh
+++ b/scripts/install_action_relay_user.sh
@@ -174,7 +174,13 @@ fi
 # deterministic `capabilities.tmp` files may be foreign-owned; they are ignored
 # rather than chmod/unlinked so this installer never takes ownership of evidence
 # it did not create.
-PYTHONPATH="$RUNTIME_ROOT" python3 - "$CAPABILITY_MARKER" "$SOURCE_REF" "$SOURCE_COMMIT" <<'PY'
+# SSH sessions can retain a group list from before enrollment. Use the same
+# fixed agentos group context as the running service, including for mkstemp.
+# Pass values through the environment, never interpolate them into shell code.
+AGENTOS_MARKER_PATH="$CAPABILITY_MARKER" \
+AGENTOS_MARKER_SOURCE_REF="$SOURCE_REF" \
+AGENTOS_MARKER_SOURCE_COMMIT="$SOURCE_COMMIT" \
+PYTHONPATH="$RUNTIME_ROOT" sg agentos -c 'exec python3 - "$AGENTOS_MARKER_PATH" "$AGENTOS_MARKER_SOURCE_REF" "$AGENTOS_MARKER_SOURCE_COMMIT"' <<'PY'
 import json
 import os
 import sys
@@ -203,7 +209,6 @@ try:
 finally:
     tmp.unlink(missing_ok=True)
 PY
-chgrp agentos "$CAPABILITY_MARKER"
 
 echo "action_relay_install=PASS"
 echo "action_relay_executor_job_extension=PASS"

--- a/tests/test_runtime_converge_capability.py
+++ b/tests/test_runtime_converge_capability.py
@@ -88,3 +88,41 @@ def test_installer_publishes_marker_only_after_stable_liveness():
     assert stable_gate < marker_write
     assert 'rm -f "$CAPABILITY_MARKER"' in text
     assert "runtime_converge_action_loaded=PASS" in text
+
+
+def test_marker_publication_uses_fixed_group_and_preserves_old_temp(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    repo = Path(__file__).resolve().parents[1]
+    source = (repo / 'scripts/install_action_relay_user.sh').read_text()
+    command = source.split('AGENTOS_MARKER_PATH=', 1)[1].split('\necho "action_relay_install=PASS"', 1)[0]
+    command = 'AGENTOS_MARKER_PATH=' + command
+    # Exercise the installer publication block without installing/restarting services.
+    # The shim verifies sg routing and runs its fixed command; OS group enrollment
+    # remains a live acceptance requirement.
+    shim = tmp_path / 'sg'
+    shim.write_text('#!' + sys.executable + '\n'
+                    'import subprocess,sys\n'
+                    'assert sys.argv[1:3] == ["agentos", "-c"]\n'
+                    'assert sys.argv[3].startswith("exec python3 - ")\n'
+                    'raise SystemExit(subprocess.call(["/bin/sh", "-c", sys.argv[3]]))\n')
+    shim.chmod(0o755)
+    shared = tmp_path / "shared ' $(false)"
+    shared.mkdir()
+    old_temp = shared / 'capabilities.tmp'
+    old_temp.write_text('preserve prior evidence')
+    env = dict(os.environ, PATH=str(tmp_path) + ':' + os.environ['PATH'],
+               CAPABILITY_MARKER=str(shared / 'capabilities.json'),
+               RUNTIME_ROOT=str(repo), SOURCE_REF='core/integration', SOURCE_COMMIT='a' * 40)
+    subprocess.run(['bash', '-e', '-c', command], env=env, check=True, capture_output=True)
+    assert validate_installed_marker(__import__('json').loads((shared / 'capabilities.json').read_text())) is not None
+    assert old_temp.read_text() == 'preserve prior evidence'
+    assert not list(shared.glob('.capabilities-*.tmp'))
+    # A group-entry failure must propagate and leave the accepted marker intact.
+    before = (shared / 'capabilities.json').read_bytes()
+    shim.write_text('#!/bin/sh\nexit 17\n')
+    result = subprocess.run(['bash', '-e', '-c', command], env=env, capture_output=True)
+    assert result.returncode == 17
+    assert (shared / 'capabilities.json').read_bytes() == before


### PR DESCRIPTION
The exact-generation rollout for 8705e0ef failed at capability marker mkstemp with PermissionError in the shared Action Relay directory: https://github.com/alston-personal/agentmanager/actions/runs/34332816868. That same receipt reported Realm Fabric VALID and the relay service active. The service uses `sg agentos`, while marker publication previously used the SSH caller's inherited groups.

This change publishes through the same fixed `sg agentos` context. Marker path/ref/SHA are passed through quoted environment values rather than interpolated shell code. The existing stable-liveness gate and unique-temp/fsync/atomic-replace behavior remain. The redundant caller-context chgrp is removed; the created inode has the publishing process's agentos group (or the shared directory's agentos setgid group). No directory ownership/mode changes or new caller execution authority.

Validation: 65 tests passed across the five Runtime Converge Contract Guard suites, plus bash syntax check. New publication-block test verifies fixed group routing, safe paths containing shell metacharacters, valid marker publication, preservation of historical temp evidence, and group-command failure propagation without modifying the accepted marker. The test shim verifies routing, not actual Oracle group enrollment; live acceptance is pending.

Related: #291 / #117, following #298. No new Actions bootstrap run or protected-main publication has been performed. This source fix does not claim runtime health or ChatGPT continuation acceptance.

## Superseded — 2026-09-11

Closed without merging: core/integration already includes #305 (6088bc50) and #307 (9026bf2a), which implement fixed agentos-group publication with explicit effective-GID/parent-GID validation and anchored runtime imports. Those changes supersede this draft. The latest integration also includes #309 Worker Host group-before-NNP changes. Source integration is not live health acceptance; latest generation convergence is being checked separately.