### PR TITLE
Core #117: prevent script-directory shadowing in capability publisher

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -15,6 +15,7 @@ on:
       - 'agentos_node/bootstrap_control.py'
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/install_action_relay_user.sh'
+      - 'scripts/publish_action_relay_capability.py'
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'agent_core/executor_job_contract.py'

--- a/scripts/publish_action_relay_capability.py
+++ b/scripts/publish_action_relay_capability.py
@@ -6,7 +6,17 @@ import grp
 import json
 import os
 from pathlib import Path
+import sys
 import tempfile
+
+# This helper is intentionally executable by absolute file path from the governed
+# bootstrap boundary. Anchor imports at the immutable runtime root so
+# `scripts/agentos_node.py` cannot shadow the real `agentos_node` package through
+# Python's script-directory sys.path[0].
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNTIME_ROOT = SCRIPT_DIR.parent
+sys.path = [entry for entry in sys.path if Path(entry or ".").resolve() != SCRIPT_DIR]
+sys.path.insert(0, str(RUNTIME_ROOT))
 
 from agentos_node.runtime_converge_action_relay import capability_marker_payload
 


### PR DESCRIPTION
Fixes the live blocker isolated by exact rollout #25 after the `agentos` group-context handoff itself succeeded.

Observed failure:
`ModuleNotFoundError: No module named 'agentos_node.runtime_converge_action_relay'; 'agentos_node' is not a package`

Cause: the fixed capability publisher is executed by absolute file path under `scripts/`; Python inserts that directory at `sys.path[0]`, where the repository also contains `scripts/agentos_node.py`. That file shadows the actual top-level `agentos_node` package despite `PYTHONPATH` pointing at the exact runtime root.

Fix: before importing the canonical capability payload function, remove the publisher's script directory from the import search path and prepend the immutable runtime root. The existing `sg agentos` boundary, capability schema, atomic publication, authority constraints, and request surface remain unchanged.

Acceptance: existing Readiness/Runtime Converge/Bounded Executor guards must pass, then exact-generation rollout must prove transport repair and proceed to ONE dispatch.