### PR TITLE
Core #117: emit sanitized live Experience digest probe

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -16,6 +16,7 @@ on:
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/install_action_relay_user.sh'
       - 'scripts/publish_action_relay_capability.py'
+      - 'scripts/seed_one_experience.py'
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'agent_core/executor_job_contract.py'

--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -5,14 +5,45 @@ import argparse
 import json
 from pathlib import Path
 
-from agent_core.experience_store import seed_experience_set
+from agent_core.experience_store import (
+    digest_set,
+    experience_path,
+    read_experience_set,
+    seed_experience_set,
+    validate_set,
+)
+
+
+def probe_seed(seed_path: Path) -> dict:
+    incoming = validate_set(json.loads(seed_path.read_text(encoding="utf-8")))
+    project_id = incoming["project_id"]
+    incoming_digest = digest_set(incoming)
+    target = experience_path(project_id)
+    current_digest = None
+    exists = target.is_file()
+    if exists:
+        current_digest = digest_set(read_experience_set(project_id))
+    return {
+        "schema": "agentos.experience-seed-probe/v1",
+        "project_id": project_id,
+        "exists": exists,
+        "current_digest": current_digest,
+        "incoming_digest": incoming_digest,
+        "same_digest": current_digest == incoming_digest if current_digest is not None else False,
+        "credential_exposed": False,
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Seed accepted Experience into the ONE data layer")
     parser.add_argument("--seed", default="experience/agentos-core-oracle.seed.json")
+    parser.add_argument("--probe-only", action="store_true")
     args = parser.parse_args()
-    receipt = seed_experience_set(Path(args.seed).resolve())
+    seed_path = Path(args.seed).resolve()
+    if args.probe_only:
+        print(json.dumps(probe_seed(seed_path), ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    receipt = seed_experience_set(seed_path)
     print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -40,8 +40,9 @@ def main() -> int:
     parser.add_argument("--probe-only", action="store_true")
     args = parser.parse_args()
     seed_path = Path(args.seed).resolve()
+    probe = probe_seed(seed_path)
+    print(json.dumps(probe, ensure_ascii=False, sort_keys=True))
     if args.probe_only:
-        print(json.dumps(probe_seed(seed_path), ensure_ascii=False, indent=2, sort_keys=True))
         return 0
     receipt = seed_experience_set(seed_path)
     print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))


### PR DESCRIPTION
First phase of an explicit digest-bound ONE Experience convergence after exact rollout #26 proved transport repair but the existing accepted Experience set differs from the current repository seed.

This PR does not overwrite Experience. It adds a sanitized probe to `seed_one_experience.py` that reports only project_id, whether accepted state exists, current digest, incoming digest, equality, and `credential_exposed=false` before the existing guarded seed operation. The existing `seed_experience_set` mismatch refusal remains unchanged and will still fail closed.

The exact-generation rollout now watches `scripts/seed_one_experience.py` as a pinned runtime input, so the live Oracle run will capture the predecessor digest. A subsequent generation may perform replacement only if that exact observed digest is explicitly authorized; any changed predecessor must be refused.