### PR TITLE
Core #238: stage Worker Host group transition before NNP

### DIFF
--- a/.agent/scripts/agentos-employee-worker-host.service
+++ b/.agent/scripts/agentos-employee-worker-host.service
@@ -7,14 +7,16 @@ Type=simple
 WorkingDirectory=/home/ubuntu/agentmanager
 EnvironmentFile=/home/ubuntu/.config/agentos/employee-worker-host.env
 # The long-lived systemd --user manager may predate membership in the shared
-# agentos group. Enter the fixed group boundary explicitly so the host and every
-# fixed child inherit read/write access to governed Employee runtime surfaces.
-# No caller-controlled shell/argv is accepted here; this is one source-owned
-# command with a fixed module.
-ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'
+# agentos group. The fixed source-owned launcher must therefore enter that group
+# before no-new-privileges is locked. Applying NoNewPrivileges at the systemd
+# boundary prevents sg/newgrp from completing the credential transition and was
+# proven live to fail with setgroups/setgid EPERM. After sg succeeds, setpriv
+# immediately restores the no-new-privileges invariant before Python starts.
+# No caller-controlled shell/argv is accepted here.
+ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/setpriv --no-new-privs /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'
 Restart=always
 RestartSec=5
-NoNewPrivileges=true
+NoNewPrivileges=false
 PrivateTmp=true
 PrivateNetwork=true
 ProtectSystem=strict

--- a/tests/test_employee_worker_host_assets.py
+++ b/tests/test_employee_worker_host_assets.py
@@ -18,7 +18,15 @@ class EmployeeWorkerHostAssetTests(unittest.TestCase):
         self.assertNotRegex(text, re.compile(r"^User=", re.MULTILINE))
         self.assertIn("WantedBy=default.target", text)
         self.assertIn("PrivateNetwork=true", text)
-        self.assertIn("NoNewPrivileges=true", text)
+        # The live Oracle user manager predates agentos supplementary membership.
+        # sg must establish the fixed group before NNP is locked; setpriv then
+        # restores NNP before the Python daemon starts.
+        exec_line = next(line for line in text.splitlines() if line.startswith("ExecStart="))
+        self.assertIn("ExecStart=/usr/bin/sg agentos -c '", exec_line)
+        self.assertIn("/usr/bin/setpriv --no-new-privs", exec_line)
+        self.assertLess(exec_line.index("/usr/bin/sg agentos"), exec_line.index("/usr/bin/setpriv --no-new-privs"))
+        self.assertLess(exec_line.index("/usr/bin/setpriv --no-new-privs"), exec_line.index("employee_worker_host_daemon"))
+        self.assertIn("NoNewPrivileges=false", text)
         self.assertIn("ProtectSystem=strict", text)
         self.assertIn("employee_worker_host_daemon", text)
         self.assertNotIn("spec_steward_worker_cli", text)

--- a/tests/test_product_employee_activation.py
+++ b/tests/test_product_employee_activation.py
@@ -111,9 +111,11 @@ def test_activation_assets_are_fixed_and_do_not_emit_verified_markers():
 
 def test_worker_host_enters_fixed_shared_agentos_group_without_generic_authority():
     unit = WORKER_UNIT.read_text(encoding="utf-8")
-    assert "ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'" in unit
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+    assert exec_line == "ExecStart=/usr/bin/sg agentos -c 'exec /usr/bin/setpriv --no-new-privs /usr/bin/python3 -m agentos_node.employee_worker_host_daemon'"
     assert "PrivateNetwork=true" in unit
-    assert "NoNewPrivileges=true" in unit
+    assert "NoNewPrivileges=false" in unit
+    assert "/usr/bin/setpriv --no-new-privs" in exec_line
     assert "shell.exec" not in unit
     assert "${" not in unit
     assert "youtube" not in unit.casefold()

--- a/tests/test_product_employee_contracts.py
+++ b/tests/test_product_employee_contracts.py
@@ -72,3 +72,18 @@ def test_youtube_ai_manager_product_employee_contract_is_read_only_first() -> No
     assert "read-only-first" in constraints
     assert "no-external-youtube-api-mutation-authority" in constraints
     assert "status-or-memory-symlinks-are-not-liveness-proof" in constraints
+
+
+def test_worker_host_enters_group_before_locking_no_new_privileges() -> None:
+    unit = (ROOT / ".agent/scripts/agentos-employee-worker-host.service").read_text(encoding="utf-8")
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+    assert exec_line.startswith("ExecStart=/usr/bin/sg agentos -c ")
+    assert "/usr/bin/setpriv --no-new-privs" in exec_line
+    assert exec_line.index("/usr/bin/sg agentos") < exec_line.index("/usr/bin/setpriv --no-new-privs")
+    assert exec_line.index("/usr/bin/setpriv --no-new-privs") < exec_line.index("python3 -m agentos_node.employee_worker_host_daemon")
+    # systemd-level NNP would disable sg's setgid helper before it can establish
+    # the fixed group. The daemon itself re-enters NNP through setpriv above.
+    assert "NoNewPrivileges=false" in unit
+    assert "PrivateNetwork=true" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "ProtectHome=read-only" in unit


### PR DESCRIPTION
Live #238 acceptance isolated the remaining Worker Host failure after #297: the installed unit correctly used the fixed `sg agentos` boundary, but systemd applied `NoNewPrivileges=true` before `sg` ran. On Oracle this causes `setgroups: Operation not permitted` / `setgid: Operation not permitted` and a five-second Worker Host crash loop, while Realm, Action Relay, Supervisor and Wake Node remain healthy.

This PR keeps the fixed bounded launcher and hardening profile, but stages the credential transition correctly:
- `sg agentos` runs first as the only source-owned group transition;
- immediately after the group transition, `setpriv --no-new-privs` locks NNP before Python starts;
- the daemon still receives no caller-selected executable/argv authority;
- `PrivateTmp`, `PrivateNetwork`, `ProtectSystem=strict`, `ProtectHome=read-only`, and existing path allowlists remain;
- regression asserts exact ordering and retained hardening.

This is source-only. It does not claim live product Employee acceptance and emits no VERIFIED marker.

Refs #238