### PR TITLE
Core #117: preserve sanitized Experience probe in bootstrap receipt

### DIFF
--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 
 from agent_core.experience_store import (
     digest_set,
@@ -41,9 +42,14 @@ def main() -> int:
     args = parser.parse_args()
     seed_path = Path(args.seed).resolve()
     probe = probe_seed(seed_path)
-    print(json.dumps(probe, ensure_ascii=False, sort_keys=True))
+    encoded_probe = json.dumps(probe, ensure_ascii=False, sort_keys=True)
     if args.probe_only:
+        print(encoded_probe)
         return 0
+    # The governed installer suppresses normal seed stdout. Emit only this
+    # bounded digest/identity probe on stderr so a mismatch receipt preserves
+    # predecessor evidence without exposing Experience contents.
+    print(encoded_probe, file=sys.stderr, flush=True)
     receipt = seed_experience_set(seed_path)
     print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
     return 0


### PR DESCRIPTION
Follow-up to #308 after exact rollout #27 proved the digest probe executed under a seed command whose stdout is intentionally redirected to `/dev/null` by the governed installer.

This change does not mutate or weaken Experience persistence. For normal guarded seed mode only, the bounded probe (project_id, current/incoming digest, equality, existence, credential_exposed=false) is emitted to stderr before `seed_experience_set`; `--probe-only` remains stdout. Thus a digest mismatch remains fail-closed while the bootstrap receipt can retain the exact predecessor digest needed for a later explicit digest-bound convergence.

`seed_one_experience.py` is now a pinned exact-rollout input, so merge acceptance will automatically run on Oracle.