### PR TITLE
Core #117: converge ONE Experience behind live digest fence

### DIFF
--- a/agent_core/experience_store.py
+++ b/agent_core/experience_store.py
@@ -11,6 +11,7 @@ from hashlib import sha256
 import json
 import os
 from pathlib import Path
+import re
 import tempfile
 from typing import Any, Iterator
 from contextlib import contextmanager
@@ -18,6 +19,7 @@ from contextlib import contextmanager
 from agent_core.experience import ExperienceQuery, discover_experience, hydrate_experience, validate_experience
 
 SET_SCHEMA = "agentos.experience-set/v0"
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def _data_root() -> Path:
@@ -79,6 +81,25 @@ def _lock(path: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+def _atomic_write_set(target: Path, value: dict[str, Any]) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(_canonical_bytes(value))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o640)
+        os.replace(tmp, target)
+        dir_fd = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 def read_experience_set(project_id: str, *, data_root: Path | None = None) -> dict[str, Any]:
     path = experience_path(project_id, data_root=data_root)
     if path.is_symlink():
@@ -114,23 +135,7 @@ def seed_experience_set(seed_path: Path, *, data_root: Path | None = None) -> di
                 "path": str(target),
                 "credential_exposed": False,
             }
-        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
-        tmp = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(_canonical_bytes(incoming))
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.chmod(tmp, 0o640)
-            os.replace(tmp, target)
-            dir_fd = os.open(target.parent, os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        finally:
-            if tmp.exists():
-                tmp.unlink()
+        _atomic_write_set(target, incoming)
     return {
         "schema": "agentos.experience-seed-receipt/v1",
         "ok": True,
@@ -138,6 +143,94 @@ def seed_experience_set(seed_path: Path, *, data_root: Path | None = None) -> di
         "project_id": project_id,
         "digest": incoming_digest,
         "path": str(target),
+        "credential_exposed": False,
+    }
+
+
+def converge_experience_set(
+    seed_path: Path,
+    *,
+    expected_current_digest: str,
+    data_root: Path | None = None,
+) -> dict[str, Any]:
+    """Explicitly replace one accepted Experience set behind a digest fence.
+
+    This is intentionally separate from ordinary seeding. A different current
+    set may be replaced only when its validated canonical digest exactly matches
+    the caller-supplied predecessor digest. The previous bytes are backed up
+    before atomic replacement; changed or malformed state fails closed.
+    """
+    expected_current_digest = str(expected_current_digest or "").strip()
+    if not _DIGEST_RE.fullmatch(expected_current_digest):
+        raise ValueError("expected_current_digest must be sha256:<64 lowercase hex>")
+
+    seed_path = Path(seed_path)
+    incoming = validate_set(json.loads(seed_path.read_text(encoding="utf-8")))
+    project_id = incoming["project_id"]
+    incoming_digest = digest_set(incoming)
+    target = experience_path(project_id, data_root=data_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    with _lock(target):
+        if target.is_symlink():
+            raise ValueError("experience store path must not be a symlink")
+        if not target.is_file():
+            raise FileNotFoundError(target)
+
+        original_bytes = target.read_bytes()
+        current = validate_set(json.loads(original_bytes.decode("utf-8")), project_id=project_id)
+        current_digest = digest_set(current)
+
+        if current_digest == incoming_digest:
+            return {
+                "schema": "agentos.experience-converge-receipt/v1",
+                "ok": True,
+                "replaced": False,
+                "project_id": project_id,
+                "previous_digest": current_digest,
+                "digest": incoming_digest,
+                "backup_path": None,
+                "credential_exposed": False,
+            }
+
+        if current_digest != expected_current_digest:
+            raise ValueError(
+                "ONE Experience predecessor digest changed; refusing explicit convergence"
+            )
+
+        backup = target.with_name(
+            f"accepted.pre-converge-{current_digest.removeprefix('sha256:')}.json"
+        )
+        if backup.is_symlink():
+            raise ValueError("experience backup path must not be a symlink")
+        if backup.exists():
+            if not backup.is_file() or backup.read_bytes() != original_bytes:
+                raise ValueError("experience backup collision")
+        else:
+            fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640)
+            try:
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(original_bytes)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            except BaseException:
+                backup.unlink(missing_ok=True)
+                raise
+
+        _atomic_write_set(target, incoming)
+        verified = validate_set(json.loads(target.read_text(encoding="utf-8")), project_id=project_id)
+        verified_digest = digest_set(verified)
+        if verified_digest != incoming_digest:
+            raise RuntimeError("ONE Experience convergence verification failed")
+
+    return {
+        "schema": "agentos.experience-converge-receipt/v1",
+        "ok": True,
+        "replaced": True,
+        "project_id": project_id,
+        "previous_digest": current_digest,
+        "digest": incoming_digest,
+        "backup_path": str(backup),
         "credential_exposed": False,
     }
 

--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -22,6 +22,7 @@ MANIFEST="$RUNTIME/runtime-provenance.json"
 CODEX_CONFIG="/home/ubuntu/.codex/config.toml"
 REALM_FABRIC_EXPECTED_FILE_SHA256="6e328861419b18c4194de44f66e72344f22a32a39bdc204d92410d7c6523e216"
 REALM_FABRIC_EXPECTED_PREFIX_SHA256="16fe1100378068a06264c6d6415560fdcd049595a094e537bef132fe3e45abc2"
+ONE_EXPERIENCE_EXPECTED_PREDECESSOR="sha256:f0fcb879fef89117084b4730aa0e74d0a78c1a61a02b63a47bbe825f5d70a959"
 
 case "$SOURCE_REF" in
   main|core/integration|feature/realm-node-fabric-readiness) ;;
@@ -211,9 +212,15 @@ PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" python3 -m py_compile 
   "$ACTION_RUNTIME/scripts/install_codex_experience_mcp_oracle.py"
 (
   cd "$ACTION_RUNTIME"
+  # One-time #117 Experience convergence is fenced by the exact live predecessor
+  # digest emitted by exact-generation rollout #28. If the accepted Experience
+  # changed after that probe, converge_experience_set refuses the replacement.
   PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" \
-    python3 scripts/seed_one_experience.py --seed experience/agentos-core-oracle.seed.json >/dev/null
+    python3 scripts/seed_one_experience.py \
+      --seed experience/agentos-core-oracle.seed.json \
+      --expected-current-digest "$ONE_EXPERIENCE_EXPECTED_PREDECESSOR" >/dev/null
   echo "one_experience_seed=PASS"
+  echo "one_experience_digest_convergence=PASS"
   PYTHONPATH="$ACTION_RUNTIME" AGENT_DATA_ROOT="$DATA_ROOT" \
     python3 scripts/install_codex_experience_mcp_oracle.py >/dev/null
   echo "codex_experience_mcp_install=PASS"
@@ -251,6 +258,7 @@ echo "antigravity_restart_pending=YES"
 echo "action_relay_install=PASS"
 echo "action_relay_source_generation_pinned=PASS"
 echo "one_experience_seed=PASS"
+echo "one_experience_digest_convergence=PASS"
 echo "codex_experience_mcp_install=PASS"
 echo "codex_experience_mcp_exact_runtime=PASS"
 echo "realm_fabric_install=PASS"

--- a/scripts/seed_one_experience.py
+++ b/scripts/seed_one_experience.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 
 from agent_core.experience_store import (
+    converge_experience_set,
     digest_set,
     experience_path,
     read_experience_set,
@@ -39,6 +40,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Seed accepted Experience into the ONE data layer")
     parser.add_argument("--seed", default="experience/agentos-core-oracle.seed.json")
     parser.add_argument("--probe-only", action="store_true")
+    parser.add_argument(
+        "--expected-current-digest",
+        help="Explicit predecessor fence for one digest-bound Experience convergence",
+    )
     args = parser.parse_args()
     seed_path = Path(args.seed).resolve()
     probe = probe_seed(seed_path)
@@ -46,11 +51,18 @@ def main() -> int:
     if args.probe_only:
         print(encoded_probe)
         return 0
+
     # The governed installer suppresses normal seed stdout. Emit only this
     # bounded digest/identity probe on stderr so a mismatch receipt preserves
     # predecessor evidence without exposing Experience contents.
     print(encoded_probe, file=sys.stderr, flush=True)
-    receipt = seed_experience_set(seed_path)
+    if args.expected_current_digest:
+        receipt = converge_experience_set(
+            seed_path,
+            expected_current_digest=args.expected_current_digest,
+        )
+    else:
+        receipt = seed_experience_set(seed_path)
     print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -16,8 +16,6 @@ class AntigravityRepairContractTests(unittest.TestCase):
         text = _text(SCRIPT)
         self.assertIn('SOURCE_REF="${AGENTOS_REF:-main}"', text)
         self.assertIn('EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"', text)
-        # core/integration is the governed integration generation. Development
-        # worker branches remain excluded from the runtime repair allowlist.
         self.assertIn('main|core/integration|feature/realm-node-fabric-readiness', text)
         self.assertNotIn('core/issue-194-bounded-executor-jobs)', text)
         self.assertIn('git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"', text)
@@ -98,14 +96,19 @@ class AntigravityRepairContractTests(unittest.TestCase):
         ):
             self.assertIn(path, text)
         self.assertIn('cd "$ACTION_RUNTIME"', text)
-        self.assertIn('python3 scripts/seed_one_experience.py --seed experience/agentos-core-oracle.seed.json', text)
+        self.assertIn('python3 scripts/seed_one_experience.py', text)
+        self.assertIn('--seed experience/agentos-core-oracle.seed.json', text)
+        self.assertIn('--expected-current-digest "$ONE_EXPERIENCE_EXPECTED_PREDECESSOR"', text)
+        self.assertIn('ONE_EXPERIENCE_EXPECTED_PREDECESSOR="sha256:', text)
         self.assertIn('python3 scripts/install_codex_experience_mcp_oracle.py', text)
         self.assertIn('grep -Fq "cwd = \\"$ACTION_RUNTIME\\"" "$CODEX_CONFIG"', text)
         self.assertIn('grep -Fq "PYTHONPATH = \\"$ACTION_RUNTIME\\"" "$CODEX_CONFIG"', text)
         self.assertIn('one_experience_seed=PASS', text)
+        self.assertIn('one_experience_digest_convergence=PASS', text)
         self.assertIn('codex_experience_mcp_install=PASS', text)
         self.assertIn('codex_experience_mcp_exact_runtime=PASS', text)
         self.assertNotIn('AGENTOS_EXPERIENCE_MCP_ALLOW_OVERWRITE', text)
+        self.assertNotIn('--force', text)
 
     def test_action_relay_installer_preserves_correct_foreign_owned_shared_boundary(self):
         text = _text(ACTION_INSTALLER)

--- a/tests/test_experience_digest_converge.py
+++ b/tests/test_experience_digest_converge.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_core.experience_store import (
+    converge_experience_set,
+    digest_set,
+    experience_path,
+    read_experience_set,
+)
+
+
+def artifact(experience_id: str, summary: str) -> dict:
+    return {
+        "schema": "agentos.experience/v0",
+        "experience_id": experience_id,
+        "project_id": "agentos-core",
+        "realm_scope": ["*"],
+        "capability_scope": ["agentos.core.develop"],
+        "executor_scope": ["*"],
+        "kind": "decision",
+        "summary": summary,
+        "payload": {},
+        "provenance": {"sources": [], "accepted_evidence": []},
+        "authority": {"status": "accepted", "supersedes": [], "superseded_by": []},
+        "validity": {"conditions": [], "invalidated_by": []},
+    }
+
+
+def experience(summary: str) -> dict:
+    return {
+        "schema": "agentos.experience-set/v0",
+        "project_id": "agentos-core",
+        "artifacts": [artifact("core.test.v1", summary)],
+    }
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def test_exact_predecessor_replaces_with_backup(tmp_path: Path):
+    current = experience("before")
+    incoming = experience("after")
+    target = experience_path("agentos-core", data_root=tmp_path)
+    seed = tmp_path / "seed.json"
+    write_json(target, current)
+    original = target.read_bytes()
+    write_json(seed, incoming)
+
+    receipt = converge_experience_set(
+        seed,
+        expected_current_digest=digest_set(current),
+        data_root=tmp_path,
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["replaced"] is True
+    assert receipt["previous_digest"] == digest_set(current)
+    assert receipt["digest"] == digest_set(incoming)
+    assert receipt["credential_exposed"] is False
+    backup = Path(receipt["backup_path"])
+    assert backup.read_bytes() == original
+    assert read_experience_set("agentos-core", data_root=tmp_path) == incoming
+
+
+def test_wrong_predecessor_refuses_without_mutation(tmp_path: Path):
+    current = experience("before")
+    incoming = experience("after")
+    target = experience_path("agentos-core", data_root=tmp_path)
+    seed = tmp_path / "seed.json"
+    write_json(target, current)
+    before = target.read_bytes()
+    write_json(seed, incoming)
+
+    with pytest.raises(ValueError, match="predecessor digest changed"):
+        converge_experience_set(seed, expected_current_digest="sha256:" + "0" * 64, data_root=tmp_path)
+    assert target.read_bytes() == before
+    assert not list(target.parent.glob("accepted.pre-converge-*.json"))
+
+
+def test_same_digest_is_idempotent_without_backup(tmp_path: Path):
+    current = experience("same")
+    target = experience_path("agentos-core", data_root=tmp_path)
+    seed = tmp_path / "seed.json"
+    write_json(target, current)
+    write_json(seed, current)
+
+    receipt = converge_experience_set(
+        seed,
+        expected_current_digest="sha256:" + "0" * 64,
+        data_root=tmp_path,
+    )
+    assert receipt["replaced"] is False
+    assert receipt["digest"] == digest_set(current)
+    assert receipt["backup_path"] is None
+
+
+def test_malformed_current_refuses(tmp_path: Path):
+    target = experience_path("agentos-core", data_root=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("{broken", encoding="utf-8")
+    seed = tmp_path / "seed.json"
+    write_json(seed, experience("after"))
+    with pytest.raises(json.JSONDecodeError):
+        converge_experience_set(seed, expected_current_digest="sha256:" + "0" * 64, data_root=tmp_path)
+
+
+def test_symlink_target_refuses(tmp_path: Path):
+    real = tmp_path / "real.json"
+    write_json(real, experience("before"))
+    target = experience_path("agentos-core", data_root=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.symlink_to(real)
+    seed = tmp_path / "seed.json"
+    write_json(seed, experience("after"))
+    with pytest.raises(ValueError, match="symlink"):
+        converge_experience_set(seed, expected_current_digest=digest_set(experience("before")), data_root=tmp_path)


### PR DESCRIPTION
Second phase of the #117 Experience mismatch repair, using exact predecessor evidence from Oracle exact rollout #28.

Live fence from #28:
- current accepted digest: `sha256:f0fcb879fef89117084b4730aa0e74d0a78c1a61a02b63a47bbe825f5d70a959`
- canonical incoming seed digest: `sha256:fe544820f3913cb3fb83bee8627e745bf573394dd48da2bc6d860f0d5a1f6dc6`
- project: `agentos-core`

Changes:
- preserve ordinary `seed_experience_set()` mismatch refusal unchanged;
- add separate `converge_experience_set()` requiring an exact `sha256:<64hex>` predecessor fence;
- validate current/incoming Experience sets under the existing file lock;
- same digest is idempotent/no-op;
- different digest is replaceable only when current == exact expected predecessor;
- back up the exact prior accepted bytes before mutation;
- use fsync + atomic replace + post-write digest verification;
- expose convergence only through explicit `--expected-current-digest`, never `--force`;
- bind the governed Oracle repair entry to the exact #28 predecessor digest;
- add tests for exact replacement/backup, wrong predecessor no-mutation, idempotence, malformed current refusal, and symlink refusal.

No Experience contents or credentials are added to receipts. If the live predecessor has changed since #28, rollout must fail closed rather than overwrite it.