### PR TITLE
Core #117: expose bounded per-dimension Experience attribution evidence

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -6,6 +6,7 @@ on:
       - core/integration
     paths:
       - 'agent_core/executor_job_contract.py'
+      - 'agent_core/experience_attribution_contract.py'
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
@@ -27,6 +28,7 @@ on:
       - 'tests/test_executor_job_runtime_installer.py'
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_issue117_regression_floor.py'
+      - 'tests/test_experience_attribution_contract.py'
       - 'tests/test_control_inbox_bridge.py'
       - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
@@ -36,6 +38,7 @@ on:
       - core/issue-194-bounded-executor-jobs
     paths:
       - 'agent_core/executor_job_contract.py'
+      - 'agent_core/experience_attribution_contract.py'
       - 'agent_core/controller_service.py'
       - 'agent_core/controller_api.py'
       - 'agent_core/control_inbox_bridge.py'
@@ -57,6 +60,7 @@ on:
       - 'tests/test_executor_job_runtime_installer.py'
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_issue117_regression_floor.py'
+      - 'tests/test_experience_attribution_contract.py'
       - 'tests/test_control_inbox_bridge.py'
       - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
@@ -84,6 +88,7 @@ jobs:
             tests/test_executor_job_runtime_installer.py \
             tests/test_issue117_experience_provider.py \
             tests/test_issue117_regression_floor.py \
+            tests/test_experience_attribution_contract.py \
             tests/test_control_inbox_bridge.py \
             tests/test_exact_generation_live_rollout_contract.py \
             -q
@@ -131,6 +136,7 @@ jobs:
         run: |
           python -m py_compile \
             agent_core/executor_job_contract.py \
+            agent_core/experience_attribution_contract.py \
             agent_core/controller_service.py \
             agent_core/controller_api.py \
             agent_core/control_inbox_bridge.py \

--- a/agent_core/executor_job_contract.py
+++ b/agent_core/executor_job_contract.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 import re
 from typing import Any, Mapping
 
+from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json
+
 
 EXECUTOR_JOB_SCHEMA = "agentos.executor-job/v1"
 EXECUTOR_JOB_SUBMISSION_SCHEMA = "agentos.executor-job-submission/v1"
@@ -208,4 +210,10 @@ def project_executor_job_receipt(
             value = result.get(key)
             if isinstance(value, (str, int, float, bool)) or value is None:
                 summary[key] = value
+        # #117 may additionally project one strictly validated canonical JSON
+        # scalar carrying only fixed benchmark dimensions + hydration manifest.
+        if "attribution_evidence_json" in result:
+            summary["attribution_evidence_json"] = sanitize_attribution_evidence_json(
+                result.get("attribution_evidence_json")
+            )
     return summary

--- a/agent_core/experience_attribution_contract.py
+++ b/agent_core/experience_attribution_contract.py
@@ -1,0 +1,151 @@
+"""Bounded machine-readable attribution evidence for issue #117.
+
+The executor-job transport deliberately does not allow arbitrary nested provider
+results. This module validates the one structured #117 evidence payload and
+canonicalizes it into a bounded JSON scalar before it may cross Action Relay / ONE.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping
+
+SCHEMA = "agentos.experience-attribution-evidence/v1"
+MAX_ENCODED_BYTES = 16_384
+DIMENSIONS = (
+    "canonical_development_branch",
+    "generic_continue_authorizes_main_merge",
+    "capability_implies_execution_authority",
+    "discovery_before_reimplementation",
+    "workspace_is_continuation_authority",
+    "node_online_implies_executor_available",
+    "executor_owns_realm_credentials",
+)
+DELTAS = {
+    "improved",
+    "unchanged-correct",
+    "unchanged-wrong",
+    "regressed",
+}
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_EXPERIENCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+def _safe_value(value: Any) -> str | bool | None:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str) and len(value) <= 128 and "\n" not in value and "\r" not in value:
+        return value
+    raise ValueError("attribution dimension value must be bool/string/null")
+
+
+def _safe_ids(value: Any) -> list[str]:
+    if not isinstance(value, list) or len(value) > 20:
+        raise ValueError("hydration experience_ids must be a bounded list")
+    result: list[str] = []
+    for raw in value:
+        if not isinstance(raw, str) or not _EXPERIENCE_ID_RE.fullmatch(raw):
+            raise ValueError("invalid Experience ID in attribution evidence")
+        if raw in result:
+            raise ValueError("duplicate Experience ID in attribution evidence")
+        result.append(raw)
+    return result
+
+
+def validate_attribution_evidence(value: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or value.get("schema") != SCHEMA:
+        raise ValueError("unsupported Experience attribution evidence schema")
+    if set(value) != {"schema", "dimensions", "improved_dimensions", "regressed_dimensions", "hydration"}:
+        raise ValueError("unexpected Experience attribution evidence fields")
+
+    raw_dimensions = value.get("dimensions")
+    if not isinstance(raw_dimensions, Mapping) or set(raw_dimensions) != set(DIMENSIONS):
+        raise ValueError("attribution evidence must contain exactly the fixed benchmark dimensions")
+    dimensions: dict[str, dict[str, Any]] = {}
+    for key in DIMENSIONS:
+        item = raw_dimensions.get(key)
+        if not isinstance(item, Mapping) or set(item) != {
+            "baseline_value", "baseline_pass", "hydrated_value", "hydrated_pass", "delta"
+        }:
+            raise ValueError(f"invalid attribution dimension shape: {key}")
+        baseline_pass = item.get("baseline_pass")
+        hydrated_pass = item.get("hydrated_pass")
+        delta = item.get("delta")
+        if not isinstance(baseline_pass, bool) or not isinstance(hydrated_pass, bool):
+            raise ValueError("dimension pass values must be boolean")
+        if delta not in DELTAS:
+            raise ValueError("unsupported attribution delta")
+        expected_delta = (
+            "unchanged-correct" if baseline_pass and hydrated_pass else
+            "regressed" if baseline_pass and not hydrated_pass else
+            "improved" if not baseline_pass and hydrated_pass else
+            "unchanged-wrong"
+        )
+        if delta != expected_delta:
+            raise ValueError("attribution delta/pass mismatch")
+        dimensions[key] = {
+            "baseline_value": _safe_value(item.get("baseline_value")),
+            "baseline_pass": baseline_pass,
+            "hydrated_value": _safe_value(item.get("hydrated_value")),
+            "hydrated_pass": hydrated_pass,
+            "delta": delta,
+        }
+
+    def dimension_list(field: str, expected_delta: str) -> list[str]:
+        raw = value.get(field)
+        if not isinstance(raw, list) or len(raw) > len(DIMENSIONS):
+            raise ValueError(f"{field} must be a bounded list")
+        result: list[str] = []
+        for item in raw:
+            if item not in DIMENSIONS or item in result:
+                raise ValueError(f"invalid {field} entry")
+            if dimensions[item]["delta"] != expected_delta:
+                raise ValueError(f"{field} disagrees with dimension delta")
+            result.append(item)
+        expected = [key for key in DIMENSIONS if dimensions[key]["delta"] == expected_delta]
+        if set(result) != set(expected):
+            raise ValueError(f"{field} is incomplete")
+        return result
+
+    improved = dimension_list("improved_dimensions", "improved")
+    regressed = dimension_list("regressed_dimensions", "regressed")
+
+    hydration = value.get("hydration")
+    if not isinstance(hydration, Mapping) or set(hydration) != {"projection_digest", "experience_ids"}:
+        raise ValueError("invalid hydration manifest shape")
+    digest = hydration.get("projection_digest")
+    if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+        raise ValueError("invalid hydration projection digest")
+    experience_ids = _safe_ids(hydration.get("experience_ids"))
+
+    return {
+        "schema": SCHEMA,
+        "dimensions": dimensions,
+        "improved_dimensions": improved,
+        "regressed_dimensions": regressed,
+        "hydration": {
+            "projection_digest": digest,
+            "experience_ids": experience_ids,
+        },
+    }
+
+
+def canonicalize_attribution_evidence(value: Mapping[str, Any]) -> str:
+    validated = validate_attribution_evidence(value)
+    encoded = json.dumps(validated, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) > MAX_ENCODED_BYTES:
+        raise ValueError("Experience attribution evidence exceeds bounded receipt size")
+    return encoded
+
+
+def parse_attribution_evidence_json(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str) or len(value.encode("utf-8")) > MAX_ENCODED_BYTES:
+        raise ValueError("invalid bounded Experience attribution JSON")
+    parsed = json.loads(value)
+    if not isinstance(parsed, Mapping):
+        raise ValueError("Experience attribution JSON must decode to an object")
+    return validate_attribution_evidence(parsed)
+
+
+def sanitize_attribution_evidence_json(value: Any) -> str:
+    return canonicalize_attribution_evidence(parse_attribution_evidence_json(value))

--- a/agentos_node/executor_job_adapter.py
+++ b/agentos_node/executor_job_adapter.py
@@ -14,6 +14,7 @@ from agent_core.executor_job_contract import (
     project_executor_job_receipt,
     validate_executor_job,
 )
+from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json
 
 
 Provider = Callable[[Mapping[str, Any]], Mapping[str, Any]]
@@ -101,6 +102,13 @@ def _sanitize_provider_result(raw: Mapping[str, Any]) -> dict[str, Any]:
         value = raw.get(key)
         if isinstance(value, (str, int, float, bool)) or value is None:
             safe[key] = value
+    if "attribution_evidence_json" in raw:
+        # Do not allow arbitrary structured provider output. The only nested
+        # #117 evidence crosses as a canonical JSON scalar after strict schema
+        # validation and is validated again by the final receipt projection.
+        safe["attribution_evidence_json"] = sanitize_attribution_evidence_json(
+            raw.get("attribution_evidence_json")
+        )
     return safe
 
 
@@ -162,14 +170,14 @@ def run_registered_executor_job(
             authorized=True,
         )
 
-    result = _sanitize_provider_result(raw)
     try:
+        result = _sanitize_provider_result(raw)
         executor_available = _trusted_provider_state(raw, "executor_available", True)
         routable = _trusted_provider_state(raw, "routable", True)
         authorized = _trusted_provider_state(raw, "authorized", True)
         default_success = result.get("verdict") == "PASS" and raw.get("credential_exposed") is not True
         successful = _trusted_provider_state(raw, "successful", default_success)
-    except ValueError:
+    except (ValueError, TypeError):
         return _semantic_failure(
             "PROVIDER_STATE_INVALID",
             executor_available=True,

--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -260,27 +260,29 @@ def run_issue117_experience_regression(
     if not isinstance(classification, str) or not classification:
         classification = "EXPERIENCE_REGRESSION_PASS" if verdict == "PASS" else "EXPERIENCE_REGRESSION_FAILED"
 
+    # Attribution is additional #117 promotion evidence, not a prerequisite for
+    # the legacy aggregate provider contract. Older fixtures/runtimes may lack
+    # parsed dimensions or an independent hydration receipt; in that case keep
+    # the aggregate receipt intact and simply omit the structured field. Live
+    # promotion acceptance separately requires observing this field.
+    attribution_evidence_json: str | None = None
     try:
         attribution_evidence_json = _attribution_evidence(payload, regression)
-    except Exception:
-        return _bounded_failure(
-            "EXPERIENCE_ATTRIBUTION_EVIDENCE_INVALID",
-            executor_available=True,
-        )
+    except (AttributeError, FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        attribution_evidence_json = None
 
     if (proc.returncode == 0) != (verdict == "PASS"):
         classification = "EXPERIENCE_REGRESSION_EXIT_MISMATCH"
     credential_boundary_ok = payload.get("credential_exposed") is False
     successful = bool(proc.returncode == 0 and verdict == "PASS" and credential_boundary_ok)
 
-    return {
+    result = {
         "experiment_id": payload.get("experiment_id"),
         "verdict": verdict,
         "baseline_score": _score(payload, "baseline"),
         "hydrated_score": _score(payload, "hydrated"),
         "uplift": payload.get("uplift") if isinstance(payload.get("uplift"), (int, float)) else None,
         "hydration_receipt_ok": checks.get("hydration_receipt_ok") is True,
-        "attribution_evidence_json": attribution_evidence_json,
         "classification": classification,
         "executor_available": True,
         "routable": True,
@@ -288,6 +290,9 @@ def run_issue117_experience_regression(
         "successful": successful,
         "credential_exposed": not credential_boundary_ok,
     }
+    if attribution_evidence_json is not None:
+        result["attribution_evidence_json"] = attribution_evidence_json
+    return result
 
 
 def register_issue117_provider_if_available(

--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -5,15 +5,11 @@ not copy or reimplement that benchmark. It registers only when the *same
 immutable runtime generation* already contains #117's regression entrypoint.
 
 The provider executes a fixed read-only regression entry with fixed arguments,
-uses a private temporary evidence file, and returns only bounded scalar evidence.
-No caller-controlled command, argv, executable path, output path, or environment
-is accepted through the executor-job request.
+uses a private temporary evidence file, and returns only bounded evidence. No
+caller-controlled command, argv, executable path, output path, environment,
+prompt, stdout/stderr, session state, or Experience body can cross the receipt.
 """
 from __future__ import annotations
-
-# Live acceptance trigger only: behavior intentionally unchanged. Touching this
-# watched provider path asks exact-generation rollout to emit the two-phase,
-# sanitized Realm tail hashes before #117 regression continues.
 
 import importlib.util
 import json
@@ -24,6 +20,10 @@ import tempfile
 from typing import Any, Mapping
 
 from agent_core.executor_job_contract import validate_executor_job
+from agent_core.experience_attribution_contract import (
+    DIMENSIONS,
+    canonicalize_attribution_evidence,
+)
 from agentos_node.executor_job_adapter import DEFAULT_PROVIDERS, ExecutorJobProviderRegistry
 
 
@@ -72,6 +72,76 @@ def _score(payload: Mapping[str, Any], lane: str) -> float | None:
     return None
 
 
+def _lane_evidence(payload: Mapping[str, Any], lane: str) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    branch = payload.get(lane)
+    if not isinstance(branch, Mapping):
+        raise ValueError(f"missing {lane} regression branch")
+    score = branch.get("score")
+    if not isinstance(score, Mapping):
+        raise ValueError(f"missing {lane} score")
+    parsed = score.get("parsed")
+    passes = score.get("dimensions")
+    if not isinstance(parsed, Mapping) or not isinstance(passes, Mapping):
+        raise ValueError(f"missing {lane} dimension evidence")
+    if set(passes) != set(DIMENSIONS):
+        raise ValueError(f"unexpected {lane} dimension set")
+    return parsed, passes
+
+
+def _hydration_manifest(regression: Any) -> dict[str, Any]:
+    path = regression.receipt_path()
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("hydration receipt unavailable")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != "agentos.experience-hydration-receipt/v1":
+        raise ValueError("hydration receipt schema mismatch")
+    if payload.get("source") != "ONE_EXPERIENCE" or payload.get("project_id") != "agentos-core":
+        raise ValueError("hydration receipt identity mismatch")
+    if payload.get("executor_class") != EXECUTOR_CLASS or payload.get("credential_exposed") is not False:
+        raise ValueError("hydration receipt executor/credential boundary mismatch")
+    return {
+        "projection_digest": payload.get("projection_digest"),
+        "experience_ids": payload.get("experience_ids"),
+    }
+
+
+def _attribution_evidence(payload: Mapping[str, Any], regression: Any) -> str:
+    baseline_values, baseline_passes = _lane_evidence(payload, "baseline")
+    hydrated_values, hydrated_passes = _lane_evidence(payload, "hydrated")
+    dimensions: dict[str, dict[str, Any]] = {}
+    improved: list[str] = []
+    regressed: list[str] = []
+    for key in DIMENSIONS:
+        baseline_pass = baseline_passes.get(key)
+        hydrated_pass = hydrated_passes.get(key)
+        if not isinstance(baseline_pass, bool) or not isinstance(hydrated_pass, bool):
+            raise ValueError("dimension pass result must be boolean")
+        if baseline_pass and hydrated_pass:
+            delta = "unchanged-correct"
+        elif baseline_pass and not hydrated_pass:
+            delta = "regressed"
+            regressed.append(key)
+        elif not baseline_pass and hydrated_pass:
+            delta = "improved"
+            improved.append(key)
+        else:
+            delta = "unchanged-wrong"
+        dimensions[key] = {
+            "baseline_value": baseline_values.get(key),
+            "baseline_pass": baseline_pass,
+            "hydrated_value": hydrated_values.get(key),
+            "hydrated_pass": hydrated_pass,
+            "delta": delta,
+        }
+    return canonicalize_attribution_evidence({
+        "schema": "agentos.experience-attribution-evidence/v1",
+        "dimensions": dimensions,
+        "improved_dimensions": improved,
+        "regressed_dimensions": regressed,
+        "hydration": _hydration_manifest(regression),
+    })
+
+
 def _bounded_failure(
     classification: str,
     *,
@@ -115,9 +185,6 @@ def run_issue117_experience_regression(
             authorized=False,
         )
 
-    # Reuse #117's own Codex discovery function rather than creating another
-    # executor-discovery truth inside #194. Any path remains trusted-process
-    # local and is never returned through the executor-job receipt.
     try:
         regression = _load_regression_module(base)
         regression.find_codex()
@@ -193,6 +260,14 @@ def run_issue117_experience_regression(
     if not isinstance(classification, str) or not classification:
         classification = "EXPERIENCE_REGRESSION_PASS" if verdict == "PASS" else "EXPERIENCE_REGRESSION_FAILED"
 
+    try:
+        attribution_evidence_json = _attribution_evidence(payload, regression)
+    except Exception:
+        return _bounded_failure(
+            "EXPERIENCE_ATTRIBUTION_EVIDENCE_INVALID",
+            executor_available=True,
+        )
+
     if (proc.returncode == 0) != (verdict == "PASS"):
         classification = "EXPERIENCE_REGRESSION_EXIT_MISMATCH"
     credential_boundary_ok = payload.get("credential_exposed") is False
@@ -205,13 +280,12 @@ def run_issue117_experience_regression(
         "hydrated_score": _score(payload, "hydrated"),
         "uplift": payload.get("uplift") if isinstance(payload.get("uplift"), (int, float)) else None,
         "hydration_receipt_ok": checks.get("hydration_receipt_ok") is True,
+        "attribution_evidence_json": attribution_evidence_json,
         "classification": classification,
         "executor_available": True,
         "routable": True,
         "authorized": True,
         "successful": successful,
-        # The generic adapter converts an explicit violation into a fixed safe
-        # classification and never persists the unsafe provider value.
         "credential_exposed": not credential_boundary_ok,
     }
 

--- a/tests/test_experience_attribution_contract.py
+++ b/tests/test_experience_attribution_contract.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_core.experience_attribution_contract import (
+    DIMENSIONS,
+    canonicalize_attribution_evidence,
+    parse_attribution_evidence_json,
+)
+
+
+def evidence() -> dict:
+    dimensions = {}
+    for key in DIMENSIONS:
+        dimensions[key] = {
+            "baseline_value": False,
+            "baseline_pass": True,
+            "hydrated_value": False,
+            "hydrated_pass": True,
+            "delta": "unchanged-correct",
+        }
+    improved = DIMENSIONS[0]
+    dimensions[improved] = {
+        "baseline_value": None,
+        "baseline_pass": False,
+        "hydrated_value": "core/integration",
+        "hydrated_pass": True,
+        "delta": "improved",
+    }
+    return {
+        "schema": "agentos.experience-attribution-evidence/v1",
+        "dimensions": dimensions,
+        "improved_dimensions": [improved],
+        "regressed_dimensions": [],
+        "hydration": {
+            "projection_digest": "sha256:" + "a" * 64,
+            "experience_ids": ["core.branch-authority.v2"],
+        },
+    }
+
+
+def test_round_trip_canonicalizes_fixed_schema():
+    encoded = canonicalize_attribution_evidence(evidence())
+    decoded = parse_attribution_evidence_json(encoded)
+    assert decoded["improved_dimensions"] == [DIMENSIONS[0]]
+    assert decoded["hydration"]["experience_ids"] == ["core.branch-authority.v2"]
+
+
+def test_arbitrary_dimension_is_rejected():
+    value = evidence()
+    value["dimensions"]["prompt"] = value["dimensions"][DIMENSIONS[0]]
+    with pytest.raises(ValueError, match="exactly the fixed benchmark dimensions"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_delta_must_match_pass_transition():
+    value = evidence()
+    value["dimensions"][DIMENSIONS[0]]["delta"] = "unchanged-wrong"
+    with pytest.raises(ValueError, match="delta/pass mismatch"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_newline_or_long_dimension_value_is_rejected():
+    value = evidence()
+    value["dimensions"][DIMENSIONS[0]]["hydrated_value"] = "unsafe\ntext"
+    with pytest.raises(ValueError, match="bool/string/null"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_path_prompt_and_stdout_cannot_be_smuggled_as_top_level_fields():
+    value = evidence()
+    value["stdout"] = "/home/ubuntu/secret"
+    with pytest.raises(ValueError, match="unexpected Experience attribution evidence fields"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_hydration_manifest_rejects_invalid_digest_and_id():
+    value = evidence()
+    value["hydration"]["projection_digest"] = "not-a-digest"
+    with pytest.raises(ValueError, match="projection digest"):
+        canonicalize_attribution_evidence(value)
+
+    value = evidence()
+    value["hydration"]["experience_ids"] = ["../../credential"]
+    with pytest.raises(ValueError, match="Experience ID"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_non_object_json_is_rejected():
+    with pytest.raises(ValueError, match="decode to an object"):
+        parse_attribution_evidence_json(json.dumps(["not", "an", "object"]))

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 from agent_core.executor_job_contract import canonical_experience_regression_request
+from agent_core.experience_attribution_contract import DIMENSIONS, parse_attribution_evidence_json
 from agentos_node.executor_job_adapter import ExecutorJobProviderRegistry, execute_registered_executor_job
-from agentos_node.issue117_experience_provider import register_issue117_provider_if_available
+from agentos_node.issue117_experience_provider import (
+    _attribution_evidence,
+    register_issue117_provider_if_available,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -85,8 +90,68 @@ def test_integrated_issue117_provider_returns_only_bounded_regression_evidence(t
     assert receipt["uplift"] == 0.75
     assert receipt["hydration_receipt_ok"] is True
     assert receipt["credential_exposed"] is False
+    assert "attribution_evidence_json" not in receipt
     rendered = str(receipt)
     for forbidden in ("PRIVATE MODEL OUTPUT", "/home/ubuntu/private", "TOPSECRET", "/private/provider", "secret stderr"):
+        assert forbidden not in rendered
+
+
+def test_provider_builds_fixed_attribution_evidence_from_complete_private_inputs(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "hydration.json"
+    receipt_path.write_text(
+        json.dumps({
+            "schema": "agentos.experience-hydration-receipt/v1",
+            "source": "ONE_EXPERIENCE",
+            "project_id": "agentos-core",
+            "executor_class": "openai-codex-local",
+            "credential_exposed": False,
+            "projection_digest": "sha256:" + "a" * 64,
+            "experience_ids": ["core.branch-authority.v2", "core.node-executor-separation.v1"],
+        }),
+        encoding="utf-8",
+    )
+
+    baseline_values = {
+        "canonical_development_branch": None,
+        "generic_continue_authorizes_main_merge": False,
+        "capability_implies_execution_authority": False,
+        "discovery_before_reimplementation": True,
+        "workspace_is_continuation_authority": False,
+        "node_online_implies_executor_available": False,
+        "executor_owns_realm_credentials": False,
+    }
+    hydrated_values = dict(baseline_values)
+    hydrated_values["canonical_development_branch"] = "core/integration"
+    baseline_passes = {key: True for key in DIMENSIONS}
+    baseline_passes["canonical_development_branch"] = False
+    hydrated_passes = {key: True for key in DIMENSIONS}
+    payload = {
+        "baseline": {"score": {"parsed": baseline_values, "dimensions": baseline_passes}},
+        "hydrated": {"score": {"parsed": hydrated_values, "dimensions": hydrated_passes}},
+    }
+
+    class Regression:
+        @staticmethod
+        def receipt_path() -> Path:
+            return receipt_path
+
+    encoded = _attribution_evidence(payload, Regression)
+    evidence = parse_attribution_evidence_json(encoded)
+    assert evidence["improved_dimensions"] == ["canonical_development_branch"]
+    assert evidence["regressed_dimensions"] == []
+    assert evidence["dimensions"]["canonical_development_branch"] == {
+        "baseline_value": None,
+        "baseline_pass": False,
+        "hydrated_value": "core/integration",
+        "hydrated_pass": True,
+        "delta": "improved",
+    }
+    assert evidence["hydration"]["experience_ids"] == [
+        "core.branch-authority.v2",
+        "core.node-executor-separation.v1",
+    ]
+    rendered = json.dumps(evidence, sort_keys=True)
+    for forbidden in ("stdout", "stderr", "/home/", "prompt", "session"):
         assert forbidden not in rendered
 
 


### PR DESCRIPTION
Closes the evidence-visibility gap left after Oracle Exact Generation rollout #29 proved ONE-dispatched Experience A/B (6/7 -> 7/7).

This does NOT add arbitrary nested provider output. It adds one fixed `agentos.experience-attribution-evidence/v1` contract, canonicalized into a bounded JSON scalar and validated twice before it can cross Action Relay / ONE.

Allowed evidence only:
- the seven fixed #117 benchmark dimensions;
- baseline value/pass and hydrated value/pass;
- deterministic delta enum (`improved|unchanged-correct|unchanged-wrong|regressed`);
- complete improved/regressed dimension lists;
- hydration projection `sha256:` digest;
- bounded Experience ID list.

Explicitly excluded:
- stdout/stderr;
- prompts/model prose;
- filesystem paths;
- session/thread data;
- credentials/secrets;
- raw Experience bodies;
- arbitrary dimensions or nested provider fields.

Provider now derives this structured projection from the existing private regression.json plus the existing hydration receipt. The underlying A/B benchmark semantics are unchanged.

This PR is only the inspectable hydration-manifest + per-dimension before/after step of the revised #117 promotion gate. It does not claim causal attribution yet and does not close #117; B-minus-Ei/grouped ablation remains after live evidence identifies the materially improved dimension(s).