### PR TITLE
Core #117: persist validated attribution evidence from exact rollout

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
       - 'agent_core/executor_job_contract.py'
+      - 'agent_core/experience_attribution_contract.py'
       - 'agentos_node/executor_job_action_relay.py'
       - 'agentos_node/executor_job_adapter.py'
       - 'agentos_node/issue117_experience_provider.py'
@@ -154,6 +155,7 @@ jobs:
           PYTHONPATH="$RUNTIME" python3 - "$ACTION_ROOT" "$SUBMISSION" "$EVIDENCE" <<'PY'
           import json, sys, time
           from pathlib import Path
+          from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json
           from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
 
           root = Path(sys.argv[1]); submission_path = Path(sys.argv[2]); evidence = Path(sys.argv[3])
@@ -187,10 +189,14 @@ jobs:
               "experiment_id", "verdict", "baseline_score", "hydrated_score", "uplift",
               "hydration_receipt_ok", "classification",
           ) if key in receipt}
+          attribution_json = receipt.get("attribution_evidence_json")
+          assert attribution_json is not None, "live #117 attribution evidence missing from bounded receipt"
+          safe["attribution_evidence_json"] = sanitize_attribution_evidence_json(attribution_json)
           safe["one_controller_entered"] = True
           evidence.write_text(json.dumps(safe, sort_keys=True, indent=2) + "\n", encoding="utf-8")
           print("one_controller_dispatch=PASS")
           print("executor_job_transport_receipt=PASS")
+          print("executor_job_attribution_evidence=PASS")
           print("executor_job_id=" + job_id)
           print("executor_job_classification=" + str(receipt.get("classification")))
           print("executor_job_successful=" + str(bool(receipt.get("successful"))).lower())

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -64,6 +64,16 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
         self.assertIn('actions/upload-artifact@v4', text)
         self.assertNotIn("assert receipt['successful'] is True", text)
 
+    def test_rollout_validates_and_preserves_bounded_attribution_evidence(self):
+        text = _text(WORKFLOW)
+        self.assertIn("'agent_core/experience_attribution_contract.py'", text)
+        self.assertIn('from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json', text)
+        self.assertIn('attribution_json = receipt.get("attribution_evidence_json")', text)
+        self.assertIn('assert attribution_json is not None', text)
+        self.assertIn('safe["attribution_evidence_json"] = sanitize_attribution_evidence_json(attribution_json)', text)
+        self.assertIn('executor_job_attribution_evidence=PASS', text)
+        self.assertNotIn('safe = dict(receipt)', text)
+
     def test_legacy_bootstrap_is_manual_read_only_and_exact_generation_only(self):
         text = _text(LEGACY_BOOTSTRAP_WORKFLOW)
         compact = text.replace(' ', '')


### PR DESCRIPTION
The #30 live rollout proved the new attribution evidence crosses ONE/Action Relay successfully, but the exact-rollout artifact projection still used the previous scalar-only whitelist and discarded `attribution_evidence_json`.

This patch changes only the evidence plumbing:
- adds `agent_core/experience_attribution_contract.py` to exact-rollout watched inputs;
- requires the live bounded receipt to contain `attribution_evidence_json`;
- validates/canonicalizes it again with the same fixed #117 attribution contract before artifact persistence;
- keeps the existing scalar whitelist and does not dump the raw receipt;
- adds a rollout contract test that forbids replacing this with unrestricted `dict(receipt)` passthrough.

No regression semantics, executor authority, command/argv/env authority, or protected-main authority are broadened. A missing or invalid live attribution field now fails the exact rollout rather than producing incomplete promotion evidence.