### PR TITLE
Core #117: align attribution digest with canonical hydration projection

### DIFF
--- a/agent_core/experience_attribution_contract.py
+++ b/agent_core/experience_attribution_contract.py
@@ -27,7 +27,10 @@ DELTAS = {
     "unchanged-wrong",
     "regressed",
 }
-_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+# HydrationProjection.digest is canonically the raw lowercase SHA-256 hex digest
+# of the projection payload. Attribution evidence must preserve that established
+# representation rather than inventing a second prefixed digest syntax.
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _EXPERIENCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 

--- a/tests/test_experience_attribution_contract.py
+++ b/tests/test_experience_attribution_contract.py
@@ -35,7 +35,7 @@ def evidence() -> dict:
         "improved_dimensions": [improved],
         "regressed_dimensions": [],
         "hydration": {
-            "projection_digest": "sha256:" + "a" * 64,
+            "projection_digest": "a" * 64,
             "experience_ids": ["core.branch-authority.v2"],
         },
     }
@@ -45,7 +45,15 @@ def test_round_trip_canonicalizes_fixed_schema():
     encoded = canonicalize_attribution_evidence(evidence())
     decoded = parse_attribution_evidence_json(encoded)
     assert decoded["improved_dimensions"] == [DIMENSIONS[0]]
+    assert decoded["hydration"]["projection_digest"] == "a" * 64
     assert decoded["hydration"]["experience_ids"] == ["core.branch-authority.v2"]
+
+
+def test_prefixed_digest_is_rejected_to_prevent_second_digest_syntax():
+    value = evidence()
+    value["hydration"]["projection_digest"] = "sha256:" + "a" * 64
+    with pytest.raises(ValueError, match="projection digest"):
+        canonicalize_attribution_evidence(value)
 
 
 def test_arbitrary_dimension_is_rejected():

--- a/tests/test_issue117_experience_provider.py
+++ b/tests/test_issue117_experience_provider.py
@@ -105,8 +105,8 @@ def test_provider_builds_fixed_attribution_evidence_from_complete_private_inputs
             "project_id": "agentos-core",
             "executor_class": "openai-codex-local",
             "credential_exposed": False,
-            "projection_digest": "sha256:" + "a" * 64,
-            "experience_ids": ["core.branch-authority.v2", "core.node-executor-separation.v1"],
+            "projection_digest": "a" * 64,
+            "experience_ids": ["core.branch-authority.v2", "core.node-executor-boundary.v1"],
         }),
         encoding="utf-8",
     )
@@ -148,7 +148,7 @@ def test_provider_builds_fixed_attribution_evidence_from_complete_private_inputs
     }
     assert evidence["hydration"]["experience_ids"] == [
         "core.branch-authority.v2",
-        "core.node-executor-separation.v1",
+        "core.node-executor-boundary.v1",
     ]
     rendered = json.dumps(evidence, sort_keys=True)
     for forbidden in ("stdout", "stderr", "/home/", "prompt", "session"):


### PR DESCRIPTION
Exact rollout #31 correctly failed because live attribution evidence was absent from the bounded receipt. Root cause is contract mismatch, not missing hydration: `HydrationProjection.digest` has always been the raw lowercase 64-hex SHA-256 digest, while the new attribution contract incorrectly required a `sha256:` prefix.

This patch:
- aligns `agentos.experience-attribution-evidence/v1` with the established hydration digest representation (`[0-9a-f]{64}`);
- explicitly rejects the prefixed form so a second digest syntax does not emerge;
- updates provider fixtures to use the same canonical hydration receipt shape and an actual accepted Experience ID.

No Experience runtime/storage format changes, no executor authority changes, and no weakening of the exact-rollout attribution requirement.