### PR TITLE
Core #238: bound missing Employee wake receipts

### DIFF
--- a/.github/workflows/employee-runtime-guard.yml
+++ b/.github/workflows/employee-runtime-guard.yml
@@ -42,6 +42,7 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_employee_wake_delivery.py'
+      - 'tests/test_employee_wake_receipt_timeout.py'
       - 'tests/test_employee_wake_inbox_security.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
@@ -109,6 +110,7 @@ on:
       - 'tests/test_employee_threads.py'
       - 'tests/test_employee_realm_mailbox.py'
       - 'tests/test_employee_wake_delivery.py'
+      - 'tests/test_employee_wake_receipt_timeout.py'
       - 'tests/test_employee_wake_inbox_security.py'
       - 'tests/test_core_supervisor.py'
       - 'tests/test_core_work_items.py'
@@ -163,6 +165,8 @@ jobs:
         run: python -m unittest tests.test_employee_realm_mailbox -v
       - name: Run governed Employee wake-delivery regressions
         run: python -m unittest tests.test_employee_wake_delivery -v
+      - name: Run bounded Employee wake receipt-timeout regressions
+        run: python -m unittest tests.test_employee_wake_receipt_timeout -v
       - name: Run Employee wake-inbox privacy regressions
         run: python -m unittest tests.test_employee_wake_inbox_security -v
       - name: Run Core Supervisor reconciliation regressions

--- a/agent_core/employee_wake_delivery.py
+++ b/agent_core/employee_wake_delivery.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +15,12 @@ from agent_core.employee_wake import EmployeeWakeIntent
 
 DELIVERY_SCHEMA = "agentos.employee-wake-delivery-state/v1"
 PRESENCE_ROUTE_SCHEMA = "agentos.employee-wake-route/v1"
+# ONE wake clients poll on a short cadence and Employee presence has a 120-second
+# minimum production TTL. A missing receipt must therefore become UNKNOWN before
+# that route can expire, while still allowing ample time for normal Node polling.
+# This is source-owned rather than host-configurable so operators cannot weaken
+# at-most-once semantics by forcing an immediate retry.
+NODE_RECEIPT_WAIT_SECONDS = 60
 
 
 def _utcnow() -> datetime:
@@ -23,6 +29,10 @@ def _utcnow() -> datetime:
 
 def _iso(value: datetime | None = None) -> str:
     return (value or _utcnow()).astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
 def _safe_id(value: str) -> str:
@@ -204,11 +214,32 @@ class EmployeeWakeDelivery:
         state = self.get(wake_id, presence_generation)
         if state is None:
             raise FileNotFoundError(wake_id)
+        current = now or _utcnow()
         receipt = self.controller.fabric.get_receipt(state.task_id)
         if receipt is None:
+            queued_at = state.queued_at or state.updated_at or state.attempted_at
+            try:
+                queued_time = _parse_timestamp(queued_at)
+            except (TypeError, ValueError):
+                state.status = "unknown"
+                state.error_code = "node_receipt_wait_timestamp_invalid"
+                state.completed_at = _iso(current)
+                state.updated_at = _iso(current)
+                _atomic_write(self._path(wake_id, presence_generation), asdict(state))
+                return state
+            if current - queued_time < timedelta(seconds=NODE_RECEIPT_WAIT_SECONDS):
+                return state
+            # The task crossed the durable controller boundary but no trustworthy
+            # receipt arrived inside the bounded wait. Mark UNKNOWN rather than
+            # replaying this exact task/presence. The Supervisor may only deliver
+            # the same wake again after a strictly newer Employee presence exists.
+            state.status = "unknown"
+            state.error_code = "node_receipt_timeout"
+            state.completed_at = _iso(current)
+            state.updated_at = _iso(current)
+            _atomic_write(self._path(wake_id, presence_generation), asdict(state))
             return state
 
-        current = now or _utcnow()
         valid_identity = (
             receipt.get("schema") == "agentos.node-receipt/v0.1"
             and receipt.get("task_id") == state.task_id

--- a/tests/test_employee_wake_receipt_timeout.py
+++ b/tests/test_employee_wake_receipt_timeout.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent_core.controller_service import ControllerService
+from agent_core.employee_lifecycle import EmployeeLifecycle
+from agent_core.employee_presence import EmployeePresenceRegistry
+from agent_core.employee_runtime import EmployeeRuntime
+from agent_core.employee_wake import EmployeeWakePlanner
+from agent_core.employee_wake_delivery import NODE_RECEIPT_WAIT_SECONDS, EmployeeWakeDelivery
+from agent_core.node_registry import NodeRegistry
+from agent_core.realm_fabric import RealmFabricStore
+from agentos_node.thin_client import NodeIdentity, ThinClient, ThinClientPolicy
+
+
+class EmployeeWakeReceiptTimeoutTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.now = datetime(2026, 9, 11, 2, 0, 0, tzinfo=timezone.utc)
+        self.runtime = EmployeeRuntime(self.root / "employee-runtime")
+        self.runtime.create_employee(
+            "worker",
+            "Worker",
+            role_ids=["governance.spec_steward"],
+            skill_ids=["spec.audit"],
+        )
+        self.runtime.create_assignment(
+            "assignment-1",
+            "worker",
+            "Run bounded work",
+            thread_head="ir:start",
+            constraints=["read-only-first"],
+        )
+        self.lifecycle = EmployeeLifecycle(self.runtime)
+        self.planner = EmployeeWakePlanner(self.lifecycle)
+        self.registry = NodeRegistry(self.root / "one" / "realm" / "nodes.json")
+        self.fabric = RealmFabricStore(
+            self.root / "one" / "realm" / "fabric.json",
+            node_registry=self.registry,
+        )
+        self.fabric.initialize_realm("realm-test")
+        self.wake_root = self.root / "wakes"
+        self.client = ThinClient(
+            NodeIdentity("realm-test", "node-a"),
+            ThinClientPolicy(employee_wake_root=self.wake_root),
+        )
+        manifest = self.client.capability_manifest()
+        invite = self.fabric.create_invite(expires_minutes=5, label="receipt-timeout-test")
+        enrolled = self.fabric.enroll(
+            invite_id=invite["invite_id"],
+            code=invite["code"],
+            manifest=manifest,
+        )
+        self.node_token = enrolled["node_token"]
+        self.fabric.record_heartbeat(
+            {
+                "schema": "agentos.node-heartbeat/v0.1",
+                "realm_id": "realm-test",
+                "node_id": "node-a",
+                "status": "online",
+                "observed_at": None,
+                "uptime_seconds": 10,
+                "surface_count": 0,
+                "manifest": manifest,
+            },
+            self.node_token,
+        )
+        self.presence = EmployeePresenceRegistry(self.runtime, self.registry)
+        self.presence.bind(
+            "worker",
+            "node-a",
+            "presence-a",
+            ttl_seconds=120,
+            now=self.now,
+        )
+        self.delivery = EmployeeWakeDelivery(self.presence, ControllerService(self.fabric))
+        self.intent = self.planner.plan_next("worker", now=self.now)
+        self.assertIsNotNone(self.intent)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_missing_receipt_wait_is_bounded_then_becomes_unknown(self) -> None:
+        queued = self.delivery.deliver_intent(self.intent, now=self.now)
+        self.assertEqual(queued.status, "queued")
+
+        early = self.delivery.reconcile(
+            self.intent.wake_id,
+            queued.presence_generation,
+            now=self.now + timedelta(seconds=NODE_RECEIPT_WAIT_SECONDS - 1),
+        )
+        self.assertEqual(early.status, "queued")
+        self.assertIsNone(early.error_code)
+
+        timed_out = self.delivery.reconcile(
+            self.intent.wake_id,
+            queued.presence_generation,
+            now=self.now + timedelta(seconds=NODE_RECEIPT_WAIT_SECONDS),
+        )
+        self.assertEqual(timed_out.status, "unknown")
+        self.assertEqual(timed_out.error_code, "node_receipt_timeout")
+        self.assertIsNotNone(timed_out.completed_at)
+
+    def test_receipt_timeout_never_replays_same_presence_generation(self) -> None:
+        queued = self.delivery.deliver_intent(self.intent, now=self.now)
+        task_id = queued.task_id
+        before = list(self.fabric.load()["tasks"]["node-a"])
+        self.assertEqual(len(before), 1)
+
+        timed_out = self.delivery.reconcile(
+            self.intent.wake_id,
+            queued.presence_generation,
+            now=self.now + timedelta(seconds=NODE_RECEIPT_WAIT_SECONDS + 1),
+        )
+        self.assertEqual(timed_out.status, "unknown")
+
+        repeated = self.delivery.deliver_intent(
+            self.intent,
+            now=self.now + timedelta(seconds=NODE_RECEIPT_WAIT_SECONDS + 2),
+        )
+        self.assertEqual(repeated.status, "unknown")
+        self.assertEqual(repeated.task_id, task_id)
+        after = list(self.fabric.load()["tasks"]["node-a"])
+        self.assertEqual(len(after), 1)
+        self.assertEqual(after[0]["task_id"], task_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_employee_wake_receipt_timeout.py
+++ b/tests/test_employee_wake_receipt_timeout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -84,9 +85,18 @@ class EmployeeWakeReceiptTimeoutTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
+    def _pin_queued_clock(self, presence_generation: int) -> None:
+        path = self.delivery._path(self.intent.wake_id, presence_generation)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        stamp = self.now.isoformat().replace("+00:00", "Z")
+        payload["queued_at"] = stamp
+        payload["updated_at"] = stamp
+        path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
     def test_missing_receipt_wait_is_bounded_then_becomes_unknown(self) -> None:
         queued = self.delivery.deliver_intent(self.intent, now=self.now)
         self.assertEqual(queued.status, "queued")
+        self._pin_queued_clock(queued.presence_generation)
 
         early = self.delivery.reconcile(
             self.intent.wake_id,
@@ -107,6 +117,7 @@ class EmployeeWakeReceiptTimeoutTests(unittest.TestCase):
 
     def test_receipt_timeout_never_replays_same_presence_generation(self) -> None:
         queued = self.delivery.deliver_intent(self.intent, now=self.now)
+        self._pin_queued_clock(queued.presence_generation)
         task_id = queued.task_id
         before = list(self.fabric.load()["tasks"]["node-a"])
         self.assertEqual(len(before), 1)


### PR DESCRIPTION
Live #238 acceptance proved both product Employee deliveries had remained `queued` since 2026-09-05 even though Supervisor cycles continued and current Employee presence had advanced to generation 121. The cause is `EmployeeWakeDelivery.reconcile()`: when the ONE task receipt is missing it returned the queued state forever, with no bounded transition.

This PR preserves at-most-once semantics while making the wait finite:
- source-owned 60s receipt wait (not host-configurable);
- before timeout, state remains `queued`;
- after timeout with no receipt, the exact task/presence becomes `unknown` with `node_receipt_timeout`;
- the exact same presence is never redispatched;
- existing Supervisor semantics may only follow the same durable wake to a strictly newer Employee presence generation.

Adds dedicated regression coverage and wires it into Employee Runtime Guard. No live state is changed and no VERIFIED marker is emitted.

Refs #238