### PR TITLE
Core #117: add fixed B-minus branch-authority Experience ablation

### DIFF
--- a/.github/workflows/bounded-executor-job-guard.yml
+++ b/.github/workflows/bounded-executor-job-guard.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
+      - 'scripts/oracle_codex_experience_ablation.py'
       - 'tests/test_executor_job_contract.py'
       - 'tests/test_executor_job_adapter.py'
       - 'tests/test_executor_job_action_relay.py'
@@ -29,6 +30,7 @@ on:
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_issue117_regression_floor.py'
       - 'tests/test_experience_attribution_contract.py'
+      - 'tests/test_issue117_experience_ablation.py'
       - 'tests/test_control_inbox_bridge.py'
       - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
@@ -52,6 +54,7 @@ on:
       - 'scripts/repair_antigravity_relay_user.sh'
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
+      - 'scripts/oracle_codex_experience_ablation.py'
       - 'tests/test_executor_job_contract.py'
       - 'tests/test_executor_job_adapter.py'
       - 'tests/test_executor_job_action_relay.py'
@@ -61,6 +64,7 @@ on:
       - 'tests/test_issue117_experience_provider.py'
       - 'tests/test_issue117_regression_floor.py'
       - 'tests/test_experience_attribution_contract.py'
+      - 'tests/test_issue117_experience_ablation.py'
       - 'tests/test_control_inbox_bridge.py'
       - 'tests/test_exact_generation_live_rollout_contract.py'
       - '.github/workflows/bounded-executor-job-guard.yml'
@@ -89,6 +93,7 @@ jobs:
             tests/test_issue117_experience_provider.py \
             tests/test_issue117_regression_floor.py \
             tests/test_experience_attribution_contract.py \
+            tests/test_issue117_experience_ablation.py \
             tests/test_control_inbox_bridge.py \
             tests/test_exact_generation_live_rollout_contract.py \
             -q
@@ -147,7 +152,8 @@ jobs:
             agentos_node/issue117_experience_provider.py \
             agentos_node/experience_mcp_stdio.py \
             scripts/oracle_codex_experience_regression.py \
-            scripts/oracle_codex_experience_regression_entry_v2.py
+            scripts/oracle_codex_experience_regression_entry_v2.py \
+            scripts/oracle_codex_experience_ablation.py
       - name: Validate governed runtime installers
         run: |
           bash -n scripts/install_action_relay_user.sh

--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -19,6 +19,7 @@ on:
       - 'scripts/seed_one_experience.py'
       - 'scripts/oracle_codex_experience_regression.py'
       - 'scripts/oracle_codex_experience_regression_entry_v2.py'
+      - 'scripts/oracle_codex_experience_ablation.py'
       - 'agent_core/executor_job_contract.py'
       - 'agent_core/experience_attribution_contract.py'
       - 'agentos_node/executor_job_action_relay.py'
@@ -155,7 +156,10 @@ jobs:
           PYTHONPATH="$RUNTIME" python3 - "$ACTION_ROOT" "$SUBMISSION" "$EVIDENCE" <<'PY'
           import json, sys, time
           from pathlib import Path
-          from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json
+          from agent_core.experience_attribution_contract import (
+              parse_attribution_evidence_json,
+              sanitize_attribution_evidence_json,
+          )
           from agentos_node.executor_job_action_relay import ActionRelayExecutorJobDispatcher
 
           root = Path(sys.argv[1]); submission_path = Path(sys.argv[2]); evidence = Path(sys.argv[3])
@@ -191,12 +195,21 @@ jobs:
           ) if key in receipt}
           attribution_json = receipt.get("attribution_evidence_json")
           assert attribution_json is not None, "live #117 attribution evidence missing from bounded receipt"
-          safe["attribution_evidence_json"] = sanitize_attribution_evidence_json(attribution_json)
+          safe_attr = sanitize_attribution_evidence_json(attribution_json)
+          parsed_attr = parse_attribution_evidence_json(safe_attr)
+          assert parsed_attr.get("schema") == "agentos.experience-attribution-evidence/v2", parsed_attr
+          ablation = parsed_attr.get("ablation")
+          assert isinstance(ablation, dict), parsed_attr
+          assert ablation.get("withheld_experience_id") == "core.branch-authority.v2", ablation
+          assert ablation.get("target_dimension") == "canonical_development_branch", ablation
+          assert ablation.get("repeat_count") == 3, ablation
+          safe["attribution_evidence_json"] = safe_attr
           safe["one_controller_entered"] = True
           evidence.write_text(json.dumps(safe, sort_keys=True, indent=2) + "\n", encoding="utf-8")
           print("one_controller_dispatch=PASS")
           print("executor_job_transport_receipt=PASS")
           print("executor_job_attribution_evidence=PASS")
+          print("executor_job_ablation_evidence=PASS")
           print("executor_job_id=" + job_id)
           print("executor_job_classification=" + str(receipt.get("classification")))
           print("executor_job_successful=" + str(bool(receipt.get("successful"))).lower())

--- a/agent_core/experience_attribution_contract.py
+++ b/agent_core/experience_attribution_contract.py
@@ -1,16 +1,13 @@
-"""Bounded machine-readable attribution evidence for issue #117.
-
-The executor-job transport deliberately does not allow arbitrary nested provider
-results. This module validates the one structured #117 evidence payload and
-canonicalizes it into a bounded JSON scalar before it may cross Action Relay / ONE.
-"""
+"""Bounded machine-readable attribution evidence for issue #117."""
 from __future__ import annotations
 
 import json
 import re
 from typing import Any, Mapping
 
-SCHEMA = "agentos.experience-attribution-evidence/v1"
+SCHEMA_V1 = "agentos.experience-attribution-evidence/v1"
+SCHEMA_V2 = "agentos.experience-attribution-evidence/v2"
+SCHEMA = SCHEMA_V2
 MAX_ENCODED_BYTES = 16_384
 DIMENSIONS = (
     "canonical_development_branch",
@@ -21,17 +18,11 @@ DIMENSIONS = (
     "node_online_implies_executor_available",
     "executor_owns_realm_credentials",
 )
-DELTAS = {
-    "improved",
-    "unchanged-correct",
-    "unchanged-wrong",
-    "regressed",
-}
-# HydrationProjection.digest is canonically the raw lowercase SHA-256 hex digest
-# of the projection payload. Attribution evidence must preserve that established
-# representation rather than inventing a second prefixed digest syntax.
+DELTAS = {"improved", "unchanged-correct", "unchanged-wrong", "regressed"}
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _EXPERIENCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_FIXED_ABLATION_ID = "core.branch-authority.v2"
+_FIXED_ABLATION_DIMENSION = "canonical_development_branch"
 
 
 def _safe_value(value: Any) -> str | bool | None:
@@ -44,7 +35,7 @@ def _safe_value(value: Any) -> str | bool | None:
 
 def _safe_ids(value: Any) -> list[str]:
     if not isinstance(value, list) or len(value) > 20:
-        raise ValueError("hydration experience_ids must be a bounded list")
+        raise ValueError("Experience IDs must be a bounded list")
     result: list[str] = []
     for raw in value:
         if not isinstance(raw, str) or not _EXPERIENCE_ID_RE.fullmatch(raw):
@@ -55,12 +46,7 @@ def _safe_ids(value: Any) -> list[str]:
     return result
 
 
-def validate_attribution_evidence(value: Mapping[str, Any]) -> dict[str, Any]:
-    if not isinstance(value, Mapping) or value.get("schema") != SCHEMA:
-        raise ValueError("unsupported Experience attribution evidence schema")
-    if set(value) != {"schema", "dimensions", "improved_dimensions", "regressed_dimensions", "hydration"}:
-        raise ValueError("unexpected Experience attribution evidence fields")
-
+def _validate_dimensions(value: Mapping[str, Any]) -> tuple[dict[str, dict[str, Any]], list[str], list[str]]:
     raw_dimensions = value.get("dimensions")
     if not isinstance(raw_dimensions, Mapping) or set(raw_dimensions) != set(DIMENSIONS):
         raise ValueError("attribution evidence must contain exactly the fixed benchmark dimensions")
@@ -100,37 +86,100 @@ def validate_attribution_evidence(value: Mapping[str, Any]) -> dict[str, Any]:
             raise ValueError(f"{field} must be a bounded list")
         result: list[str] = []
         for item in raw:
-            if item not in DIMENSIONS or item in result:
+            if item not in DIMENSIONS or item in result or dimensions[item]["delta"] != expected_delta:
                 raise ValueError(f"invalid {field} entry")
-            if dimensions[item]["delta"] != expected_delta:
-                raise ValueError(f"{field} disagrees with dimension delta")
             result.append(item)
         expected = [key for key in DIMENSIONS if dimensions[key]["delta"] == expected_delta]
         if set(result) != set(expected):
             raise ValueError(f"{field} is incomplete")
         return result
 
-    improved = dimension_list("improved_dimensions", "improved")
-    regressed = dimension_list("regressed_dimensions", "regressed")
+    return dimensions, dimension_list("improved_dimensions", "improved"), dimension_list("regressed_dimensions", "regressed")
 
+
+def _validate_hydration(value: Mapping[str, Any]) -> dict[str, Any]:
     hydration = value.get("hydration")
     if not isinstance(hydration, Mapping) or set(hydration) != {"projection_digest", "experience_ids"}:
         raise ValueError("invalid hydration manifest shape")
     digest = hydration.get("projection_digest")
     if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
         raise ValueError("invalid hydration projection digest")
-    experience_ids = _safe_ids(hydration.get("experience_ids"))
+    return {"projection_digest": digest, "experience_ids": _safe_ids(hydration.get("experience_ids"))}
 
+
+def _validate_ablation(raw: Any, dimensions: Mapping[str, Mapping[str, Any]], hydration: Mapping[str, Any]) -> dict[str, Any]:
+    required = {
+        "withheld_experience_id", "target_dimension", "projection_digest", "remaining_experience_ids",
+        "repeat_count", "target_values", "target_passes", "effect", "confidence",
+    }
+    if not isinstance(raw, Mapping) or set(raw) != required:
+        raise ValueError("invalid attribution ablation shape")
+    if raw.get("withheld_experience_id") != _FIXED_ABLATION_ID:
+        raise ValueError("unsupported attribution ablation Experience ID")
+    if raw.get("target_dimension") != _FIXED_ABLATION_DIMENSION:
+        raise ValueError("unsupported attribution ablation dimension")
+    if dimensions[_FIXED_ABLATION_DIMENSION]["delta"] != "improved":
+        raise ValueError("ablation target must be an improved full-hydration dimension")
+    digest = raw.get("projection_digest")
+    if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+        raise ValueError("invalid ablation projection digest")
+    remaining = _safe_ids(raw.get("remaining_experience_ids"))
+    full_ids = list(hydration.get("experience_ids") or [])
+    if _FIXED_ABLATION_ID not in full_ids or _FIXED_ABLATION_ID in remaining:
+        raise ValueError("ablation Experience membership mismatch")
+    if set(remaining) != set(full_ids) - {_FIXED_ABLATION_ID}:
+        raise ValueError("ablation remaining Experience IDs mismatch")
+    if raw.get("repeat_count") != 3:
+        raise ValueError("branch-authority ablation requires exactly three fresh runs")
+    values = raw.get("target_values")
+    passes = raw.get("target_passes")
+    if not isinstance(values, list) or not isinstance(passes, list) or len(values) != 3 or len(passes) != 3:
+        raise ValueError("ablation observations must contain exactly three runs")
+    safe_values = [_safe_value(item) for item in values]
+    if any(not isinstance(item, bool) for item in passes):
+        raise ValueError("ablation target_passes must be boolean")
+    if all(not item for item in passes):
+        expected_effect, expected_confidence = "lost-improvement", "supported"
+    elif all(passes):
+        expected_effect, expected_confidence = "retained-improvement", "no-observed-effect"
+    else:
+        expected_effect, expected_confidence = "mixed", "ambiguous"
+    if raw.get("effect") != expected_effect or raw.get("confidence") != expected_confidence:
+        raise ValueError("ablation effect/confidence mismatch")
     return {
-        "schema": SCHEMA,
+        "withheld_experience_id": _FIXED_ABLATION_ID,
+        "target_dimension": _FIXED_ABLATION_DIMENSION,
+        "projection_digest": digest,
+        "remaining_experience_ids": remaining,
+        "repeat_count": 3,
+        "target_values": safe_values,
+        "target_passes": list(passes),
+        "effect": expected_effect,
+        "confidence": expected_confidence,
+    }
+
+
+def validate_attribution_evidence(value: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or value.get("schema") not in {SCHEMA_V1, SCHEMA_V2}:
+        raise ValueError("unsupported Experience attribution evidence schema")
+    schema = value["schema"]
+    expected = {"schema", "dimensions", "improved_dimensions", "regressed_dimensions", "hydration"}
+    if schema == SCHEMA_V2:
+        expected.add("ablation")
+    if set(value) != expected:
+        raise ValueError("unexpected Experience attribution evidence fields")
+    dimensions, improved, regressed = _validate_dimensions(value)
+    hydration = _validate_hydration(value)
+    result: dict[str, Any] = {
+        "schema": schema,
         "dimensions": dimensions,
         "improved_dimensions": improved,
         "regressed_dimensions": regressed,
-        "hydration": {
-            "projection_digest": digest,
-            "experience_ids": experience_ids,
-        },
+        "hydration": hydration,
     }
+    if schema == SCHEMA_V2:
+        result["ablation"] = _validate_ablation(value.get("ablation"), dimensions, hydration)
+    return result
 
 
 def canonicalize_attribution_evidence(value: Mapping[str, Any]) -> str:

--- a/agentos_node/issue117_experience_provider.py
+++ b/agentos_node/issue117_experience_provider.py
@@ -1,14 +1,4 @@
-"""Trusted provider bridge from the generic executor-job contract to issue #117.
-
-#117 owns Experience discovery/hydration/regression semantics. This module does
-not copy or reimplement that benchmark. It registers only when the *same
-immutable runtime generation* already contains #117's regression entrypoint.
-
-The provider executes a fixed read-only regression entry with fixed arguments,
-uses a private temporary evidence file, and returns only bounded evidence. No
-caller-controlled command, argv, executable path, output path, environment,
-prompt, stdout/stderr, session state, or Experience body can cross the receipt.
-"""
+"""Trusted provider bridge from the generic executor-job contract to issue #117."""
 from __future__ import annotations
 
 import importlib.util
@@ -20,18 +10,15 @@ import tempfile
 from typing import Any, Mapping
 
 from agent_core.executor_job_contract import validate_executor_job
-from agent_core.experience_attribution_contract import (
-    DIMENSIONS,
-    canonicalize_attribution_evidence,
-)
+from agent_core.experience_attribution_contract import DIMENSIONS, canonicalize_attribution_evidence
 from agentos_node.executor_job_adapter import DEFAULT_PROVIDERS, ExecutorJobProviderRegistry
-
 
 JOB_TYPE = "experience.regression"
 PROVIDER_ID = "issue117-experience-regression-v2"
 EXECUTOR_CLASS = "openai-codex-local"
 _ENTRY_REL = Path("scripts/oracle_codex_experience_regression_entry_v2.py")
 _BASE_REL = Path("scripts/oracle_codex_experience_regression.py")
+_ABLATION_REL = Path("scripts/oracle_codex_experience_ablation.py")
 _PROVIDER_TIMEOUT_SECONDS = 420
 _INNER_TIMEOUT_SECONDS = 180
 
@@ -99,13 +86,32 @@ def _hydration_manifest(regression: Any) -> dict[str, Any]:
         raise ValueError("hydration receipt identity mismatch")
     if payload.get("executor_class") != EXECUTOR_CLASS or payload.get("credential_exposed") is not False:
         raise ValueError("hydration receipt executor/credential boundary mismatch")
+    return {"projection_digest": payload.get("projection_digest"), "experience_ids": payload.get("experience_ids")}
+
+
+def _ablation_projection(raw: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(raw, Mapping):
+        return None
+    if raw.get("schema") != "agentos.experience-ablation/v1":
+        return None
+    if raw.get("project_id") != "agentos-core" or raw.get("executor") != EXECUTOR_CLASS:
+        return None
+    if raw.get("credential_exposed") is not False or raw.get("run_ok") is not True:
+        return None
     return {
-        "projection_digest": payload.get("projection_digest"),
-        "experience_ids": payload.get("experience_ids"),
+        "withheld_experience_id": raw.get("withheld_experience_id"),
+        "target_dimension": raw.get("target_dimension"),
+        "projection_digest": raw.get("projection_digest"),
+        "remaining_experience_ids": raw.get("remaining_experience_ids"),
+        "repeat_count": raw.get("repeat_count"),
+        "target_values": raw.get("target_values"),
+        "target_passes": raw.get("target_passes"),
+        "effect": raw.get("effect"),
+        "confidence": raw.get("confidence"),
     }
 
 
-def _attribution_evidence(payload: Mapping[str, Any], regression: Any) -> str:
+def _attribution_evidence(payload: Mapping[str, Any], regression: Any, *, ablation: Mapping[str, Any] | None = None) -> str:
     baseline_values, baseline_passes = _lane_evidence(payload, "baseline")
     hydrated_values, hydrated_passes = _lane_evidence(payload, "hydrated")
     dimensions: dict[str, dict[str, Any]] = {}
@@ -119,130 +125,89 @@ def _attribution_evidence(payload: Mapping[str, Any], regression: Any) -> str:
         if baseline_pass and hydrated_pass:
             delta = "unchanged-correct"
         elif baseline_pass and not hydrated_pass:
-            delta = "regressed"
-            regressed.append(key)
+            delta = "regressed"; regressed.append(key)
         elif not baseline_pass and hydrated_pass:
-            delta = "improved"
-            improved.append(key)
+            delta = "improved"; improved.append(key)
         else:
             delta = "unchanged-wrong"
         dimensions[key] = {
-            "baseline_value": baseline_values.get(key),
-            "baseline_pass": baseline_pass,
-            "hydrated_value": hydrated_values.get(key),
-            "hydrated_pass": hydrated_pass,
-            "delta": delta,
+            "baseline_value": baseline_values.get(key), "baseline_pass": baseline_pass,
+            "hydrated_value": hydrated_values.get(key), "hydrated_pass": hydrated_pass, "delta": delta,
         }
-    return canonicalize_attribution_evidence({
-        "schema": "agentos.experience-attribution-evidence/v1",
+    result: dict[str, Any] = {
+        "schema": "agentos.experience-attribution-evidence/v2" if ablation is not None else "agentos.experience-attribution-evidence/v1",
         "dimensions": dimensions,
         "improved_dimensions": improved,
         "regressed_dimensions": regressed,
         "hydration": _hydration_manifest(regression),
-    })
+    }
+    if ablation is not None:
+        result["ablation"] = dict(ablation)
+    return canonicalize_attribution_evidence(result)
 
 
-def _bounded_failure(
-    classification: str,
-    *,
-    executor_available: bool,
-    routable: bool = True,
-    authorized: bool = True,
-) -> dict[str, Any]:
+def _bounded_failure(classification: str, *, executor_available: bool, routable: bool = True, authorized: bool = True) -> dict[str, Any]:
     return {
-        "verdict": "FAIL",
-        "classification": classification,
-        "executor_available": executor_available,
-        "routable": routable,
-        "authorized": authorized,
-        "successful": False,
-        "credential_exposed": False,
+        "verdict": "FAIL", "classification": classification,
+        "executor_available": executor_available, "routable": routable,
+        "authorized": authorized, "successful": False, "credential_exposed": False,
     }
 
 
-def run_issue117_experience_regression(
-    request: Mapping[str, Any],
-    *,
-    runtime_root: str | Path | None = None,
-) -> dict[str, Any]:
-    """Execute #117's existing entrypoint with fixed provider-owned authority."""
+def run_issue117_experience_regression(request: Mapping[str, Any], *, runtime_root: str | Path | None = None) -> dict[str, Any]:
     spec = validate_executor_job(request)
     if spec.job_type != JOB_TYPE or spec.executor_class != EXECUTOR_CLASS:
-        return _bounded_failure(
-            "EXPERIENCE_PROVIDER_CONTRACT_MISMATCH",
-            executor_available=False,
-            routable=False,
-            authorized=False,
-        )
+        return _bounded_failure("EXPERIENCE_PROVIDER_CONTRACT_MISMATCH", executor_available=False, routable=False, authorized=False)
 
     root = Path(runtime_root) if runtime_root is not None else _runtime_root()
     entry, base = _provider_files(root)
     if not entry.is_file() or not base.is_file():
-        return _bounded_failure(
-            "EXPERIENCE_PROVIDER_IMPLEMENTATION_UNAVAILABLE",
-            executor_available=False,
-            routable=False,
-            authorized=False,
-        )
+        return _bounded_failure("EXPERIENCE_PROVIDER_IMPLEMENTATION_UNAVAILABLE", executor_available=False, routable=False, authorized=False)
 
     try:
         regression = _load_regression_module(base)
         regression.find_codex()
     except FileNotFoundError:
-        return _bounded_failure(
-            "EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE",
-            executor_available=False,
-        )
+        return _bounded_failure("EXPERIENCE_CODEX_EXECUTOR_UNAVAILABLE", executor_available=False)
     except Exception:
-        return _bounded_failure(
-            "EXPERIENCE_CODEX_DISCOVERY_ERROR",
-            executor_available=False,
-        )
+        return _bounded_failure("EXPERIENCE_CODEX_DISCOVERY_ERROR", executor_available=False)
 
+    payload: Mapping[str, Any] | None = None
+    ablation_payload: Mapping[str, Any] | None = None
     with tempfile.TemporaryDirectory(prefix="agentos-issue117-provider-") as tmp:
         output = Path(tmp) / "regression.json"
-        argv = [
-            sys.executable,
-            str(entry),
-            "--output",
-            str(output),
-            "--timeout",
-            str(_INNER_TIMEOUT_SECONDS),
-        ]
+        argv = [sys.executable, str(entry), "--output", str(output), "--timeout", str(_INNER_TIMEOUT_SECONDS)]
         try:
             proc = subprocess.run(
-                argv,
-                cwd=root,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                timeout=_PROVIDER_TIMEOUT_SECONDS,
-                check=False,
+                argv, cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True, timeout=_PROVIDER_TIMEOUT_SECONDS, check=False,
             )
         except subprocess.TimeoutExpired:
-            return _bounded_failure(
-                "EXPERIENCE_REGRESSION_PROVIDER_TIMEOUT",
-                executor_available=True,
-            )
+            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_TIMEOUT", executor_available=True)
         except Exception:
-            return _bounded_failure(
-                "EXPERIENCE_REGRESSION_PROVIDER_ERROR",
-                executor_available=True,
-            )
-
+            return _bounded_failure("EXPERIENCE_REGRESSION_PROVIDER_ERROR", executor_available=True)
         if not output.is_file():
-            return _bounded_failure(
-                "EXPERIENCE_REGRESSION_EVIDENCE_MISSING",
-                executor_available=True,
-            )
+            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_MISSING", executor_available=True)
         try:
             payload = json.loads(output.read_text(encoding="utf-8"))
         except Exception:
-            return _bounded_failure(
-                "EXPERIENCE_REGRESSION_EVIDENCE_INVALID",
-                executor_available=True,
-            )
+            return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
+
+        ablation_script = root / _ABLATION_REL
+        if ablation_script.is_file() and isinstance(payload, Mapping) and payload.get("verdict") == "PASS":
+            ablation_output = Path(tmp) / "ablation.json"
+            try:
+                ab_proc = subprocess.run(
+                    [sys.executable, str(ablation_script), "--output", str(ablation_output), "--timeout", str(_INNER_TIMEOUT_SECONDS)],
+                    cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    text=True, timeout=_PROVIDER_TIMEOUT_SECONDS, check=False,
+                )
+                if ab_proc.returncode == 0 and ablation_output.is_file():
+                    loaded = json.loads(ablation_output.read_text(encoding="utf-8"))
+                    if isinstance(loaded, Mapping):
+                        ablation_payload = loaded
+            except Exception:
+                ablation_payload = None
 
     if not isinstance(payload, Mapping):
         return _bounded_failure("EXPERIENCE_REGRESSION_EVIDENCE_INVALID", executor_available=True)
@@ -250,7 +215,6 @@ def run_issue117_experience_regression(
         return _bounded_failure("EXPERIENCE_REGRESSION_SCHEMA_INVALID", executor_available=True)
     if payload.get("project_id") != "agentos-core" or payload.get("executor") != EXECUTOR_CLASS:
         return _bounded_failure("EXPERIENCE_REGRESSION_IDENTITY_MISMATCH", executor_available=True)
-
     verdict = payload.get("verdict")
     if verdict not in {"PASS", "FAIL"}:
         return _bounded_failure("EXPERIENCE_REGRESSION_VERDICT_INVALID", executor_available=True)
@@ -260,14 +224,13 @@ def run_issue117_experience_regression(
     if not isinstance(classification, str) or not classification:
         classification = "EXPERIENCE_REGRESSION_PASS" if verdict == "PASS" else "EXPERIENCE_REGRESSION_FAILED"
 
-    # Attribution is additional #117 promotion evidence, not a prerequisite for
-    # the legacy aggregate provider contract. Older fixtures/runtimes may lack
-    # parsed dimensions or an independent hydration receipt; in that case keep
-    # the aggregate receipt intact and simply omit the structured field. Live
-    # promotion acceptance separately requires observing this field.
     attribution_evidence_json: str | None = None
     try:
-        attribution_evidence_json = _attribution_evidence(payload, regression)
+        attribution_evidence_json = _attribution_evidence(
+            payload,
+            regression,
+            ablation=_ablation_projection(ablation_payload),
+        )
     except (AttributeError, FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
         attribution_evidence_json = None
 
@@ -275,32 +238,20 @@ def run_issue117_experience_regression(
         classification = "EXPERIENCE_REGRESSION_EXIT_MISMATCH"
     credential_boundary_ok = payload.get("credential_exposed") is False
     successful = bool(proc.returncode == 0 and verdict == "PASS" and credential_boundary_ok)
-
     result = {
-        "experiment_id": payload.get("experiment_id"),
-        "verdict": verdict,
-        "baseline_score": _score(payload, "baseline"),
-        "hydrated_score": _score(payload, "hydrated"),
+        "experiment_id": payload.get("experiment_id"), "verdict": verdict,
+        "baseline_score": _score(payload, "baseline"), "hydrated_score": _score(payload, "hydrated"),
         "uplift": payload.get("uplift") if isinstance(payload.get("uplift"), (int, float)) else None,
         "hydration_receipt_ok": checks.get("hydration_receipt_ok") is True,
-        "classification": classification,
-        "executor_available": True,
-        "routable": True,
-        "authorized": True,
-        "successful": successful,
-        "credential_exposed": not credential_boundary_ok,
+        "classification": classification, "executor_available": True, "routable": True,
+        "authorized": True, "successful": successful, "credential_exposed": not credential_boundary_ok,
     }
     if attribution_evidence_json is not None:
         result["attribution_evidence_json"] = attribution_evidence_json
     return result
 
 
-def register_issue117_provider_if_available(
-    *,
-    registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS,
-    runtime_root: str | Path | None = None,
-) -> bool:
-    """Register only when #117 exists in this same immutable runtime snapshot."""
+def register_issue117_provider_if_available(*, registry: ExecutorJobProviderRegistry = DEFAULT_PROVIDERS, runtime_root: str | Path | None = None) -> bool:
     root = Path(runtime_root) if runtime_root is not None else _runtime_root()
     if not provider_implementation_available(root):
         return False
@@ -313,10 +264,5 @@ def register_issue117_provider_if_available(
     def handler(request: Mapping[str, Any]) -> Mapping[str, Any]:
         return run_issue117_experience_regression(request, runtime_root=root)
 
-    registry.register(
-        job_type=JOB_TYPE,
-        provider_id=PROVIDER_ID,
-        executor_class=EXECUTOR_CLASS,
-        handler=handler,
-    )
+    registry.register(job_type=JOB_TYPE, provider_id=PROVIDER_ID, executor_class=EXECUTOR_CLASS, handler=handler)
     return True

--- a/scripts/oracle_codex_experience_ablation.py
+++ b/scripts/oracle_codex_experience_ablation.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fixed B-minus-Ei counterfactual for #117 branch-authority attribution.
+
+This is deliberately not a generic Experience filter. The withheld Experience ID,
+target dimension, executor, query, and repeat count are fixed in trusted source.
+The accepted ONE Experience store is read-only; counterfactual projections exist
+only in memory and never replace accepted state or the normal hydration receipt.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any
+
+from agent_core.experience import ExperienceQuery, hydrate_experience
+from agent_core.experience_store import discover_from_one
+from scripts import oracle_codex_experience_regression as regression
+from scripts import oracle_codex_experience_regression_entry_v2 as entry_v2
+
+WITHHELD_EXPERIENCE_ID = "core.branch-authority.v2"
+TARGET_DIMENSION = "canonical_development_branch"
+REPEAT_COUNT = 3
+
+
+def counterfactual_projection() -> dict[str, Any]:
+    query = ExperienceQuery(
+        project_id=regression.PROJECT_ID,
+        realm="oracle",
+        capabilities=tuple(regression.CAPABILITIES),
+        executor="codex",
+        limit=20,
+    )
+    discovered = discover_from_one(query)
+    ids = [str(item.get("experience_id") or "") for item in discovered]
+    if WITHHELD_EXPERIENCE_ID not in ids:
+        raise ValueError("fixed ablation target is not present in discovered ONE Experience")
+    filtered = [item for item in discovered if item.get("experience_id") != WITHHELD_EXPERIENCE_ID]
+    projection = hydrate_experience(
+        project_id=regression.PROJECT_ID,
+        active_goal=regression.GOAL,
+        artifacts=filtered,
+    ).as_dict()
+    projection["source"] = "ONE_EXPERIENCE_ABLATION"
+    projection["ablation"] = {"withheld_experience_id": WITHHELD_EXPERIENCE_ID}
+    projection["credential_exposed"] = False
+    return projection
+
+
+def run_codex_with_projection(exe: Path, projection: dict[str, Any], *, timeout: int) -> dict[str, Any]:
+    argv = [
+        str(exe),
+        "exec",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--color",
+        "never",
+        entry_v2._hydrated_prompt(projection),
+    ]
+    with tempfile.TemporaryDirectory(prefix="agentos-exp117-ablation-") as tmp:
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=tmp,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, "CI": "1"},
+                check=False,
+            )
+            return {
+                "returncode": proc.returncode,
+                "timed_out": False,
+                "stdout": proc.stdout[-12000:],
+            }
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "returncode": None,
+                "timed_out": True,
+                "stdout": (exc.stdout or "")[-12000:] if isinstance(exc.stdout, str) else "",
+            }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+
+    projection = counterfactual_projection()
+    exe = regression.find_codex()
+    target_values: list[Any] = []
+    target_passes: list[bool] = []
+    run_ok = True
+    for _ in range(REPEAT_COUNT):
+        run = run_codex_with_projection(exe, projection, timeout=args.timeout)
+        if run.get("returncode") != 0 or run.get("timed_out") is True:
+            run_ok = False
+            target_values.append(None)
+            target_passes.append(False)
+            continue
+        scored = regression.score(str(run.get("stdout") or ""))
+        parsed = scored.get("parsed") if isinstance(scored.get("parsed"), dict) else {}
+        target_values.append(parsed.get(TARGET_DIMENSION))
+        target_passes.append(bool(scored.get("dimensions", {}).get(TARGET_DIMENSION)))
+
+    if all(not value for value in target_passes):
+        effect = "lost-improvement"
+        confidence = "supported"
+    elif all(target_passes):
+        effect = "retained-improvement"
+        confidence = "no-observed-effect"
+    else:
+        effect = "mixed"
+        confidence = "ambiguous"
+
+    payload = {
+        "schema": "agentos.experience-ablation/v1",
+        "project_id": regression.PROJECT_ID,
+        "executor": "openai-codex-local",
+        "withheld_experience_id": WITHHELD_EXPERIENCE_ID,
+        "target_dimension": TARGET_DIMENSION,
+        "projection_digest": projection.get("digest"),
+        "remaining_experience_ids": list(projection.get("experience_ids") or []),
+        "repeat_count": REPEAT_COUNT,
+        "run_ok": run_ok,
+        "target_values": target_values,
+        "target_passes": target_passes,
+        "effect": effect,
+        "confidence": confidence,
+        "credential_exposed": False,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "schema": payload["schema"],
+        "withheld_experience_id": WITHHELD_EXPERIENCE_ID,
+        "target_dimension": TARGET_DIMENSION,
+        "repeat_count": REPEAT_COUNT,
+        "run_ok": run_ok,
+        "effect": effect,
+        "confidence": confidence,
+        "credential_exposed": False,
+    }, sort_keys=True))
+    return 0 if run_ok else 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -67,11 +67,18 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
     def test_rollout_validates_and_preserves_bounded_attribution_evidence(self):
         text = _text(WORKFLOW)
         self.assertIn("'agent_core/experience_attribution_contract.py'", text)
-        self.assertIn('from agent_core.experience_attribution_contract import sanitize_attribution_evidence_json', text)
+        self.assertIn("'scripts/oracle_codex_experience_ablation.py'", text)
+        self.assertIn('parse_attribution_evidence_json', text)
+        self.assertIn('sanitize_attribution_evidence_json', text)
         self.assertIn('attribution_json = receipt.get("attribution_evidence_json")', text)
         self.assertIn('assert attribution_json is not None', text)
-        self.assertIn('safe["attribution_evidence_json"] = sanitize_attribution_evidence_json(attribution_json)', text)
+        self.assertIn('parsed_attr.get("schema") == "agentos.experience-attribution-evidence/v2"', text)
+        self.assertIn('ablation.get("withheld_experience_id") == "core.branch-authority.v2"', text)
+        self.assertIn('ablation.get("target_dimension") == "canonical_development_branch"', text)
+        self.assertIn('ablation.get("repeat_count") == 3', text)
+        self.assertIn('safe["attribution_evidence_json"] = safe_attr', text)
         self.assertIn('executor_job_attribution_evidence=PASS', text)
+        self.assertIn('executor_job_ablation_evidence=PASS', text)
         self.assertNotIn('safe = dict(receipt)', text)
 
     def test_legacy_bootstrap_is_manual_read_only_and_exact_generation_only(self):

--- a/tests/test_experience_attribution_contract.py
+++ b/tests/test_experience_attribution_contract.py
@@ -41,12 +41,78 @@ def evidence() -> dict:
     }
 
 
+def v2_evidence() -> dict:
+    value = evidence()
+    value["schema"] = "agentos.experience-attribution-evidence/v2"
+    value["hydration"]["experience_ids"] = [
+        "core.branch-authority.v2",
+        "core.evidence-scope-and-capability-semantics.v2",
+    ]
+    value["ablation"] = {
+        "withheld_experience_id": "core.branch-authority.v2",
+        "target_dimension": "canonical_development_branch",
+        "projection_digest": "b" * 64,
+        "remaining_experience_ids": ["core.evidence-scope-and-capability-semantics.v2"],
+        "repeat_count": 3,
+        "target_values": [None, None, None],
+        "target_passes": [False, False, False],
+        "effect": "lost-improvement",
+        "confidence": "supported",
+    }
+    return value
+
+
 def test_round_trip_canonicalizes_fixed_schema():
     encoded = canonicalize_attribution_evidence(evidence())
     decoded = parse_attribution_evidence_json(encoded)
     assert decoded["improved_dimensions"] == [DIMENSIONS[0]]
     assert decoded["hydration"]["projection_digest"] == "a" * 64
     assert decoded["hydration"]["experience_ids"] == ["core.branch-authority.v2"]
+
+
+def test_v2_round_trip_preserves_fixed_ablation():
+    decoded = parse_attribution_evidence_json(canonicalize_attribution_evidence(v2_evidence()))
+    assert decoded["schema"] == "agentos.experience-attribution-evidence/v2"
+    assert decoded["ablation"]["withheld_experience_id"] == "core.branch-authority.v2"
+    assert decoded["ablation"]["target_dimension"] == "canonical_development_branch"
+    assert decoded["ablation"]["effect"] == "lost-improvement"
+    assert decoded["ablation"]["confidence"] == "supported"
+
+
+def test_v2_ablation_target_is_not_caller_selectable():
+    value = v2_evidence()
+    value["ablation"]["withheld_experience_id"] = "core.workspace-not-continuation-authority.v1"
+    with pytest.raises(ValueError, match="unsupported attribution ablation Experience ID"):
+        canonicalize_attribution_evidence(value)
+
+    value = v2_evidence()
+    value["ablation"]["target_dimension"] = "workspace_is_continuation_authority"
+    with pytest.raises(ValueError, match="unsupported attribution ablation dimension"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_v2_ablation_requires_exact_remaining_set_and_three_runs():
+    value = v2_evidence()
+    value["ablation"]["remaining_experience_ids"] = []
+    with pytest.raises(ValueError, match="remaining Experience IDs mismatch"):
+        canonicalize_attribution_evidence(value)
+
+    value = v2_evidence()
+    value["ablation"]["repeat_count"] = 1
+    value["ablation"]["target_values"] = [None]
+    value["ablation"]["target_passes"] = [False]
+    with pytest.raises(ValueError, match="exactly three"):
+        canonicalize_attribution_evidence(value)
+
+
+def test_v2_ablation_effect_and_confidence_follow_observations():
+    value = v2_evidence()
+    value["ablation"]["target_values"] = [None, "core/integration", None]
+    value["ablation"]["target_passes"] = [False, True, False]
+    value["ablation"]["effect"] = "lost-improvement"
+    value["ablation"]["confidence"] = "supported"
+    with pytest.raises(ValueError, match="effect/confidence mismatch"):
+        canonicalize_attribution_evidence(value)
 
 
 def test_prefixed_digest_is_rejected_to_prevent_second_digest_syntax():

--- a/tests/test_issue117_experience_ablation.py
+++ b/tests/test_issue117_experience_ablation.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "oracle_codex_experience_ablation.py"
+
+
+def test_ablation_target_and_repeat_count_are_fixed_in_trusted_source():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert 'WITHHELD_EXPERIENCE_ID = "core.branch-authority.v2"' in text
+    assert 'TARGET_DIMENSION = "canonical_development_branch"' in text
+    assert "REPEAT_COUNT = 3" in text
+    assert 'parser.add_argument("--output", required=True)' in text
+    assert 'parser.add_argument("--timeout", type=int, default=180)' in text
+    assert "--experience-id" not in text
+    assert "--target-dimension" not in text
+    assert "--repeat-count" not in text
+
+
+def test_ablation_is_read_only_counterfactual_not_store_mutation():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "discover_from_one(query)" in text
+    assert "hydrate_experience(" in text
+    assert "filtered = [item for item in discovered" in text
+    assert "seed_experience_set" not in text
+    assert "converge_experience_set" not in text
+    assert "write_text" in text  # evidence file only
+    assert '"credential_exposed": False' in text


### PR DESCRIPTION
Implements the minimal counterfactual required by the revised #117 promotion gate after live rollout #32 showed exactly one material improvement: `canonical_development_branch` changed from baseline `null`/FAIL to hydrated `core/integration`/PASS.

The only directly matching hydrated Experience is `core.branch-authority.v2`, so this does NOT add arbitrary caller-selected ablation.

Fixed trusted-source contract:
- withheld Experience: `core.branch-authority.v2`
- target dimension: `canonical_development_branch`
- repeat count: 3 fresh Codex runs
- read-only ONE accepted store; counterfactual projection exists only in memory
- no accepted Experience mutation and no Canonical IR mutation
- caller cannot choose Experience ID, target dimension, or repeat count

Attribution result is conservative:
- 3/3 loses the improvement => `lost-improvement` / `supported`
- 3/3 retains it => `retained-improvement` / `no-observed-effect`
- mixed => `mixed` / `ambiguous`

`agentos.experience-attribution-evidence/v2` preserves the existing v1 hydration/dimension evidence and adds one strictly validated fixed ablation block. Exact Oracle rollout now requires live v2 evidence before it can pass.

No protected-main authority, generic shell/argv/env authority, or caller-selectable executor/Experience authority is added.