### PR TITLE
Core #238: gate product child launch on S4 readiness

### DIFF
--- a/agentos_node/employee_worker_host_runtime.py
+++ b/agentos_node/employee_worker_host_runtime.py
@@ -11,6 +11,7 @@ from agentos_node.employee_worker_host import (
     EmployeeWorkerHost,
     WorkerHostCandidate,
 )
+from agentos_node.product_employee_worker import require_governed_product_delivery
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -21,6 +22,7 @@ V2_RUNNER_KINDS = {
     "zeus_writer_v1",
     "youtube_ai_manager_scan_v1",
 }
+PRODUCT_RUNNER_KINDS = {"zeus_writer_v1", "youtube_ai_manager_scan_v1"}
 V2_RESULT_SCHEMAS = {
     "spec_steward_o3": "agentos.spec-steward-o3-worker-cli-result/v1",
     "zeus_writer_v1": "agentos.zeus-writer-worker-cli-result/v1",
@@ -117,6 +119,12 @@ class ExactEmployeeWorkerHost(EmployeeWorkerHost):
     The underlying EmployeeWorkerHost still owns the durable dispatch ledger,
     crash/UNKNOWN semantics and allowlisted child environment. This wrapper only
     expands source-controlled runner selection and pins one exact wake per launch.
+
+    Product runners have an additional read-only prelaunch fence: the exact
+    Supervisor/S4 delivery must already be `awaiting_claim` before a child process
+    is started. The child repeats the same check immediately before claim, so this
+    avoids the capsule-vs-S4 race without weakening claim authority or TOCTOU
+    protection.
     """
 
     def __init__(self, **kwargs: Any) -> None:
@@ -127,10 +135,28 @@ class ExactEmployeeWorkerHost(EmployeeWorkerHost):
         self.registry = ProductEmployeeWorkerAdapterRegistry()
         self._pinned_candidate: WorkerHostCandidate | None = None
 
+    def _product_preclaim_ready(self, candidate: WorkerHostCandidate) -> bool:
+        if candidate.adapter.runner_kind not in PRODUCT_RUNNER_KINDS:
+            return True
+        try:
+            require_governed_product_delivery(
+                self.runtime_root,
+                candidate.adapter.runner_kind,
+                candidate.capsule,
+            )
+        except PermissionError as exc:
+            # The normal race is a capsule arriving before the Supervisor has
+            # persisted the matching S4 `awaiting_claim` state. Do not create a
+            # dispatch ledger or launch a child yet; the daemon will poll again.
+            if str(exc) == "product_employee_worker_governed_delivery_missing":
+                return False
+            raise
+        return True
+
     def _candidates(self) -> list[WorkerHostCandidate]:
         if self._pinned_candidate is not None:
             return [self._pinned_candidate]
-        candidates = super()._candidates()
+        candidates = [candidate for candidate in super()._candidates() if self._product_preclaim_ready(candidate)]
         if candidates:
             self._pinned_candidate = candidates[0]
         return candidates
@@ -141,7 +167,7 @@ class ExactEmployeeWorkerHost(EmployeeWorkerHost):
             raise RuntimeError("employee_worker_exact_candidate_missing")
         if adapter.runner_kind == "spec_steward_o3":
             command = EmployeeWorkerHost._child_command(self, adapter)
-        elif adapter.runner_kind in {"zeus_writer_v1", "youtube_ai_manager_scan_v1"}:
+        elif adapter.runner_kind in PRODUCT_RUNNER_KINDS:
             command = [
                 sys.executable,
                 "-m",

--- a/tests/test_product_employee_worker.py
+++ b/tests/test_product_employee_worker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import agentos_node.employee_worker_host_runtime as worker_runtime
 from agentos_node.employee_worker_host import WorkerHostCandidate
 from agentos_node.employee_worker_host_runtime import (
     ExactEmployeeWorkerHost,
@@ -99,6 +100,45 @@ def test_exact_shared_host_maps_product_runner_to_fixed_cli(tmp_path: Path) -> N
     assert "--wake-id wake-1" in joined
     assert "--presence-generation 1" in joined
     assert "shell" not in joined
+
+
+def test_product_host_waits_for_s4_awaiting_claim_before_launch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_root = tmp_path / "runtime"
+    wake_root = tmp_path / "wake"
+    host_root = tmp_path / "host"
+    worker_root = tmp_path / "worker"
+    for path in (runtime_root, wake_root, host_root, worker_root):
+        path.mkdir()
+
+    host = ExactEmployeeWorkerHost(
+        runtime_root=runtime_root,
+        wake_root=wake_root,
+        host_state_root=host_root,
+        worker_state_root=worker_root,
+        node_id="oracle-core-node",
+    )
+    capsule = _capsule(
+        "zeus-writer",
+        "zeus-writer-continuation-v1",
+        "product.zeus_writer",
+        "writing.project.continue",
+    )
+    employee_wake_root = wake_root / "zeus-writer"
+    employee_wake_root.mkdir()
+    (employee_wake_root / "wake-1.json").write_text(json.dumps(capsule), encoding="utf-8")
+
+    def not_ready(*args, **kwargs):
+        raise PermissionError("product_employee_worker_governed_delivery_missing")
+
+    monkeypatch.setattr(worker_runtime, "require_governed_product_delivery", not_ready)
+    assert host.process_one() is None
+    assert list((host_root / "dispatches").glob("*/*.json")) == []
+
+    monkeypatch.setattr(worker_runtime, "require_governed_product_delivery", lambda *args, **kwargs: {"status": "awaiting_claim"})
+    candidates = host._candidates()  # noqa: SLF001 - prelaunch race boundary test
+    assert len(candidates) == 1
+    assert candidates[0].capsule["wake_id"] == "wake-1"
+    assert list((host_root / "dispatches").glob("*/*.json")) == []
 
 
 def test_shared_host_accepts_only_runner_specific_result_schema(tmp_path: Path) -> None:


### PR DESCRIPTION
Live #238 acceptance exposed a deterministic preclaim race after Worker Host stabilization and wake-receipt recovery. Fresh generation-123 product wake capsules were consumed by the Worker Host at 02:48:59, while the matching Supervisor delivery did not become `awaiting_claim` until 02:49:02. The product child correctly requires exact governed `awaiting_claim` evidence before claim, so it exited before emitting trusted JSON and the host persisted `employee_worker_child_result_untrusted`.

This PR does not weaken child authority. It adds a read-only prelaunch fence in the shared exact Worker Host for product runners:
- product capsule is launch-eligible only when the exact governed Supervisor/S4 delivery already satisfies the same `require_governed_product_delivery()` contract;
- normal `governed_delivery_missing` means defer without creating a dispatch ledger or launching a child;
- the child repeats the same check immediately before claim, preserving TOCTOU protection;
- Spec Steward behavior and fixed runner mapping are unchanged;
- ambiguous/non-normal authority failures remain fail-closed.

Regression proves no dispatch is created before S4 readiness and the same capsule becomes eligible once `awaiting_claim` evidence is available.

No live state is changed and no VERIFIED marker is emitted.

Refs #238