### PR TITLE
Core: make exact-generation rollout immune to moving integration ref

### DIFF
--- a/scripts/repair_antigravity_relay_user.sh
+++ b/scripts/repair_antigravity_relay_user.sh
@@ -48,11 +48,26 @@ mkdir -p "$RUNTIME/agentos_node" "$REALM_RUNTIME" "$UNIT_DIR"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
-SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
-if [ -n "$EXPECTED_SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
-  echo "ERROR: runtime source generation mismatch: ref=$SOURCE_REF observed=$SOURCE_COMMIT expected=$EXPECTED_SOURCE_COMMIT" >&2
-  exit 7
+# The governed ref proves lane membership; the exact commit determines bytes.
+# Snapshot the ref first, then fetch the requested generation itself. A parallel
+# merge may advance SOURCE_REF after the rollout starts without invalidating a
+# commit that was already accepted into that lane.
+if [ -n "$EXPECTED_SOURCE_COMMIT" ]; then
+  git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+  SOURCE_REF_HEAD=$(git -C "$REPO" rev-parse FETCH_HEAD)
+  git -C "$REPO" fetch --no-tags origin "$EXPECTED_SOURCE_COMMIT"
+  SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
+  if [ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]; then
+    echo "ERROR: exact runtime source fetch mismatch: observed=$SOURCE_COMMIT expected=$EXPECTED_SOURCE_COMMIT" >&2
+    exit 7
+  fi
+  if ! git -C "$REPO" merge-base --is-ancestor "$SOURCE_COMMIT" "$SOURCE_REF_HEAD"; then
+    echo "ERROR: exact runtime source commit is not in governed ref: ref=$SOURCE_REF ref_head=$SOURCE_REF_HEAD commit=$SOURCE_COMMIT" >&2
+    exit 7
+  fi
+else
+  git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"
+  SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)
 fi
 show_source() {
   git -C "$REPO" show "$SOURCE_COMMIT:$1"

--- a/tests/test_antigravity_repair_contract.py
+++ b/tests/test_antigravity_repair_contract.py
@@ -19,8 +19,13 @@ class AntigravityRepairContractTests(unittest.TestCase):
         self.assertIn('main|core/integration|feature/realm-node-fabric-readiness', text)
         self.assertNotIn('core/issue-194-bounded-executor-jobs)', text)
         self.assertIn('git -C "$REPO" fetch --no-tags origin "$SOURCE_REF"', text)
+        self.assertIn('SOURCE_REF_HEAD=$(git -C "$REPO" rev-parse FETCH_HEAD)', text)
+        self.assertIn('git -C "$REPO" fetch --no-tags origin "$EXPECTED_SOURCE_COMMIT"', text)
         self.assertIn('SOURCE_COMMIT=$(git -C "$REPO" rev-parse FETCH_HEAD)', text)
         self.assertIn('[ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]', text)
+        self.assertIn('git -C "$REPO" merge-base --is-ancestor "$SOURCE_COMMIT" "$SOURCE_REF_HEAD"', text)
+        self.assertIn('exact runtime source commit is not in governed ref', text)
+        self.assertNotIn('runtime source generation mismatch: ref=$SOURCE_REF observed=$SOURCE_COMMIT expected=$EXPECTED_SOURCE_COMMIT', text)
         self.assertNotIn('origin/main:', text)
 
     def test_realm_runtime_materializes_complete_exact_core_package(self):

--- a/tests/test_exact_generation_live_rollout_contract.py
+++ b/tests/test_exact_generation_live_rollout_contract.py
@@ -18,8 +18,12 @@ class ExactGenerationLiveRolloutContractTests(unittest.TestCase):
         text = _text(REPAIR)
         self.assertIn('EXPECTED_SOURCE_COMMIT="${AGENTOS_SOURCE_COMMIT:-}"', text)
         self.assertIn('^[0-9a-f]{40}$', text)
+        self.assertIn('git -C "$REPO" fetch --no-tags origin "$EXPECTED_SOURCE_COMMIT"', text)
         self.assertIn('[ "$SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]', text)
-        self.assertIn('runtime source generation mismatch', text)
+        self.assertIn('exact runtime source fetch mismatch', text)
+        self.assertIn('git -C "$REPO" merge-base --is-ancestor "$SOURCE_COMMIT" "$SOURCE_REF_HEAD"', text)
+        self.assertIn('exact runtime source commit is not in governed ref', text)
+        self.assertNotIn('runtime source generation mismatch: ref=$SOURCE_REF observed=$SOURCE_COMMIT expected=$EXPECTED_SOURCE_COMMIT', text)
         self.assertIn('AGENTOS_ACTION_SOURCE_COMMIT="$SOURCE_COMMIT"', text)
 
     def test_bootstrap_exact_repair_owns_integration_lane_selection(self):


### PR DESCRIPTION
Exact rollout #33 exposed a race: bootstrap correctly pinned `source_commit=bcb5cbc4...`, but the repair script re-resolved moving `core/integration` and rejected the rollout after a parallel Core merge advanced the branch.

This patch keeps the fail-closed governance boundary while making generation selection truly immutable:
- snapshot the allowlisted governed ref only to prove lane membership;
- fetch the exact requested commit separately and require exact SHA equality;
- require the exact commit to be an ancestor of the governed-ref snapshot;
- materialize/install/provenance continue to use only that exact commit;
- later parallel merges may advance `core/integration` without invalidating an already-authorized exact rollout.

No caller-controlled branch/source authority is added, no shell/argv authority is broadened, and protected `main` remains untouched. Static contract coverage explicitly guards the exact-SHA + ancestor-membership semantics and rejects the previous moving-head equality contract.