### PR TITLE
Core #117: retrigger exact Oracle attribution acceptance

### DIFF
--- a/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
+++ b/.github/workflows/oracle-exact-generation-executor-job-rollout.yml
@@ -4,6 +4,8 @@ name: Oracle Exact Generation Executor Job Rollout
 # runs only after the rollout contract itself (or one of its pinned runtime
 # inputs) lands on core/integration. It never writes repository state and never
 # grants shell/argv/env authority to the submitted executor job.
+# Touching this contract intentionally re-runs the live Oracle acceptance after
+# the exact-generation moving-ref race fix; runtime semantics are unchanged.
 on:
   push:
     branches:


### PR DESCRIPTION
No runtime semantics change. This PR touches only the canonical exact-generation workflow comment so GitHub creates a fresh live Oracle rollout after the moving-ref race fix in #322. The workflow itself remains read-only with the same fixed ONE bounded-executor request and still requires attribution v2 with the fixed 3-run `core.branch-authority.v2` ablation.