### PR TITLE
Model2IR v0.9.2: correct semantic scores and canonical integrity

### DIFF
--- a/.github/workflows/model2ir-library-v08.yml
+++ b/.github/workflows/model2ir-library-v08.yml
@@ -10,6 +10,7 @@ on:
       - 'tests/test_model2ir_geometry_profile.py'
       - 'tests/fixtures/model2ir/**'
       - 'tests/test_model2ir_glb_reversible_v09.py'
+      - 'tests/test_model2ir_semantic_integrity.py'
       - '.github/workflows/model2ir-library-v08.yml'
   push:
     branches: [main]
@@ -21,6 +22,7 @@ on:
       - 'tests/test_model2ir_geometry_profile.py'
       - 'tests/fixtures/model2ir/**'
       - 'tests/test_model2ir_glb_reversible_v09.py'
+      - 'tests/test_model2ir_semantic_integrity.py'
       - '.github/workflows/model2ir-library-v08.yml'
 
 permissions:
@@ -44,13 +46,14 @@ jobs:
           python -m unittest discover -s tests -p 'test_model2ir_cli.py' -q
           python -m unittest discover -s tests -p 'test_model2ir_geometry_profile.py' -q
           python -m unittest discover -s tests -p 'test_model2ir_glb_reversible_v09.py' -q
+          python -m unittest discover -s tests -p 'test_model2ir_semantic_integrity.py' -q
       - name: Verify public API and console entrypoint
         shell: bash
         run: |
           set -euo pipefail
           python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.9.1'
+          assert model2ir.__version__ == '0.9.2'
           assert callable(model2ir.extract_ir)
           assert callable(model2ir.profile_asset_structure)
           assert callable(model2ir.build_teacher_dataset)
@@ -78,7 +81,7 @@ jobs:
           cd /tmp
           /tmp/model2ir-wheel-venv/bin/python - <<'PY'
           import model2ir
-          assert model2ir.__version__ == '0.9.1'
+          assert model2ir.__version__ == '0.9.2'
           assert callable(model2ir.profile_asset_structure)
           assert callable(model2ir.compile_reversible_glb)
           assert callable(model2ir.build_teacher_dataset)

--- a/.github/workflows/model2ir-real-family-stability-v05.yml
+++ b/.github/workflows/model2ir-real-family-stability-v05.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
       - 'scripts/model2ir_real_family_stability.py'
       - '.github/workflows/model2ir-real-family-stability-v05.yml'
   push:
     branches: [main]
     paths:
       - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
       - 'scripts/model2ir_real_family_stability.py'
       - '.github/workflows/model2ir-real-family-stability-v05.yml'
   workflow_dispatch:
@@ -41,7 +43,8 @@ jobs:
           assert p['gate']['status']=='PASS'
           assert p['gate']['two_independent_humanoids_consistent'] is True
           assert p['gate']['candidate_repeatability']==1.0
-          assert p['gate']['post_stabilization_reversibility']==1.0
+          assert p['gate']['candidate_json_roundtrip']==1.0
+          assert p['gate']['canonical_embedding_rejected'] is True
           assert p['gate']['unknown_when_evidence_removed'] is True
           print('model2ir_real_family_stability=PASS')
           PY
@@ -51,3 +54,4 @@ jobs:
           path: /tmp/model2ir-v05/
           if-no-files-found: error
           retention-days: 30
+

--- a/.github/workflows/model2ir-stabilized-import-v04.yml
+++ b/.github/workflows/model2ir-stabilized-import-v04.yml
@@ -28,7 +28,7 @@ jobs:
       - run: python -m pip install -e libs/model2ir
       - name: Fetch external humanoid asset
         run: curl -fL --retry 3 https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CesiumMan/glTF/CesiumMan.gltf -o /tmp/CesiumMan.gltf
-      - name: Stabilize import and prove future reversibility
+      - name: Stabilize import without promoting candidate truth
         run: |
           rm -rf /tmp/model2ir-v04
           python scripts/model2ir_stabilized_import_regression.py --input /tmp/CesiumMan.gltf --out /tmp/model2ir-v04
@@ -36,8 +36,9 @@ jobs:
           import json
           p=json.load(open('/tmp/model2ir-v04/report.json'))
           assert p['gate']['candidate_repeatability']==1.0
-          assert p['gate']['post_stabilization_reversibility']==1.0
-          assert p['roundtrip']['canonical_difference_count']==0
+          assert p['gate']['candidate_json_roundtrip']==1.0
+          assert p['gate']['canonical_embedding_rejected'] is True
+          assert p['candidate_storage']['candidate_json_exact'] is True
           print('model2ir_stabilized_import_gate=PASS')
           PY
       - uses: actions/upload-artifact@v4
@@ -46,3 +47,4 @@ jobs:
           path: /tmp/model2ir-v04/
           if-no-files-found: error
           retention-days: 30
+

--- a/.github/workflows/model2ir-vrm-topology-v06.yml
+++ b/.github/workflows/model2ir-vrm-topology-v06.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
       - 'scripts/model2ir_vrm_topology_regression.py'
       - '.github/workflows/model2ir-vrm-topology-v06.yml'
   push:
     branches: [main]
     paths:
       - 'libs/model2ir/**'
+      - 'scripts/model2ir_stabilized_import_regression.py'
       - 'scripts/model2ir_vrm_topology_regression.py'
       - '.github/workflows/model2ir-vrm-topology-v06.yml'
   workflow_dispatch:
@@ -73,3 +75,4 @@ jobs:
           path: /tmp/model2ir-v06/
           if-no-files-found: error
           retention-days: 30
+

--- a/libs/model2ir/README.md
+++ b/libs/model2ir/README.md
@@ -86,6 +86,56 @@ The original JSON `.gltf` reversible API remains available for compatibility. Mu
 4. Unknown and unresolved fields are retained instead of filled merely to make the IR dense.
 5. Reversibility and semantic certainty are separate dimensions. An embedded Canonical Character IR may round-trip exactly even when the original external asset required inference.
 
+## v0.9.2 correctness and compatibility
+
+- Semantic comparison accepts every retained Model2IR envelope version, direct
+  candidate/Character IR `parts`, and Image→IR `inferred.parts`. Structured v0.3
+  evidence supplies envelope labels; a recovered canonical payload takes
+  precedence over carrier node names. Empty-set Jaccard is still conventionally
+  1.0, so a semantic score alone is never proof of useful evidence or appearance.
+- Both JSON glTF and binary GLB/VRM writers now share the same guard against
+  explicitly candidate/inferred/unknown truth statuses. Stabilization yields a
+  repeatable candidate, not confirmation. Keep it as standalone JSON until an
+  explicit review establishes canonical design intent. No helper promotes it.
+- Recovery requires an existing matching digest and rejects explicitly candidate
+  payloads, including carriers produced by the older permissive glTF writer.
+  These errors leave the source unchanged. Preserve such payloads as candidate
+  JSON for review; do not simply remove `truth_status` to evade the boundary.
+- Valid legacy IR without `truth_status` remains supported. This is a declared
+  status guard for compatibility, not authentication of an author's assertions.
+  Digest verification proves integrity, not semantic correctness.
+- Ribbon/bow tails are accessory candidates; anatomical tails and ponytails
+  retain their separate tail/hair classifications. Naming remains inference.
+
+The v0.4/v0.5/v0.6 regression adapters now explicitly test candidate JSON
+preservation plus rejection of unconfirmed canonical embedding. Their report
+schemas are v0.9.2: `candidate_json_roundtrip` replaces the misleading
+`post_stabilization_reversibility` gate. Canonical carrier round-trips remain
+tested separately by the reversible v0.2 and GLB v0.9 suites. The library CI also
+runs `tests/test_model2ir_semantic_integrity.py`.
+
+### Character generator integration boundary
+
+This repair does not turn Model2IR into a mesh generator. Extraction measures
+structure and recovers embedded data; the reversible compiler requires the
+source model. The current candidate projection does not contain enough geometry,
+texture coordinates, animation curves, or hair construction parameters to
+recreate the source appearance on its own.
+
+For a parameterized Character Blueprint producer, preserve its own versioned
+construction description in the existing Character IR payload, alongside an
+explicit coordinate/unit convention and pinned asset/compiler references.
+Hair curve control points, cross-section width/depth, layers and gradient
+positions must originate from that producer; Model2IR must not guess them from
+mesh names. Preserve the observed/inferred/assumed provenance of each design
+choice. Candidate designs remain standalone JSON until confirmed.
+
+Acceptance for that later integration must include IR-only regeneration by the
+identified producer, fixed-camera rendered comparisons, and an intentional hair
+parameter edit that changes the expected geometry. Exact payload/container
+round-trips alone are insufficient. No new generator or cross-project adapter
+is implemented by v0.9.2.
+
 ## Teacher dataset API
 
 The multi-view teacher contract is library-owned. Rendering is intentionally an injected adapter so `model2ir` itself does not depend on Playwright, Three.js, a browser, or an AgentOS repository layout.

--- a/libs/model2ir/pyproject.toml
+++ b/libs/model2ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model2ir"
-version = "0.9.1"
+version = "0.9.2"
 description = "Standalone evidence-fused reversible Canonical Character IR decompiler for 3D assets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/model2ir/src/model2ir/__init__.py
+++ b/libs/model2ir/src/model2ir/__init__.py
@@ -52,4 +52,4 @@ __all__ = [
     "validate_teacher_dataset_manifest",
 ]
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/libs/model2ir/src/model2ir/audit.py
+++ b/libs/model2ir/src/model2ir/audit.py
@@ -60,7 +60,10 @@ def audit_asset(path: str | Path, extract_fn: Callable[[Any], dict[str, Any]], s
         'status':status,
         'reversible_now':bool(first.get('reversibility',{}).get('lossless')),
         'stabilizable':stabilizable,
-        'after_stabilization_contract':'lossless-canonical-roundtrip' if stabilizable else None,
+        'after_stabilization_contract':(
+            'lossless-canonical-roundtrip' if authority == 'embedded-canonical'
+            else 'candidate-json; canonical-embedding-requires-confirmation' if stabilizable else None
+        ),
         'coverage':{
             'humanoid_core_semantic_coverage':round(core_coverage,4),
             'candidate_part_count':part_count,

--- a/libs/model2ir/src/model2ir/core.py
+++ b/libs/model2ir/src/model2ir/core.py
@@ -213,18 +213,33 @@ def extract_ir(asset_or_path: Asset | str | Path) -> dict[str, Any]:
 
 
 def _semantic_labels(ir: dict[str, Any]) -> set[str]:
-    if ir.get("schema") == "model2ir-character-ir/v0.1":
-        comps = ir.get("semantic_ir", {}).get("candidates", []) or []
-        return {c.get("semantic_candidate", {}).get("label") for c in comps if c.get("semantic_candidate", {}).get("label") not in (None, "unknown")}
-    parts = ir.get("inferred", {}).get("parts", []) or []
+    # Compare the payload when a carrier contains IR; carrier node names describe
+    # the asset, not necessarily the embedded design intent.
+    canonical = ir.get("canonical_ir")
+    if isinstance(canonical, dict):
+        return _semantic_labels(canonical)
+    if str(ir.get("schema", "")).startswith("model2ir-character-ir/"):
+        semantic = ir.get("semantic_evidence_v03") or {}
+        if isinstance(semantic.get("parts"), dict):
+            parts = list(semantic["parts"])
+        else:
+            comps = (ir.get("semantic_ir") or {}).get("candidates", []) or []
+            parts = [(c.get("semantic_candidate") or {}).get("label")
+                     for c in comps if isinstance(c, dict)]
+    elif isinstance(ir.get("parts"), list):
+        parts = ir["parts"]
+    else:
+        parts = (ir.get("inferred") or {}).get("parts", []) or []
     out: set[str] = set()
     for p in parts:
         if isinstance(p, str):
-            out.add(p)
+            x = p
         elif isinstance(p, dict):
             x = p.get("id") or p.get("part") or p.get("name")
-            if x:
-                out.add(x)
+        else:
+            continue
+        if isinstance(x, str) and x and x != "unknown":
+            out.add(x)
     return out
 
 
@@ -251,7 +266,7 @@ def diff_ir(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
 def reconcile_ir(image_ir: dict[str, Any], model_ir: dict[str, Any]) -> dict[str, Any]:
     img = _semantic_labels(image_ir)
     mdl = _semantic_labels(model_ir)
-    unresolved = model_ir.get("semantic_ir", {}).get("unresolved", []) or []
+    unresolved = (model_ir.get("semantic_ir") or {}).get("unresolved", model_ir.get("unresolved", [])) or []
     return {
         "schema": "model2ir-reconciliation/v0.1",
         "matched": sorted(img & mdl),

--- a/libs/model2ir/src/model2ir/glb_container.py
+++ b/libs/model2ir/src/model2ir/glb_container.py
@@ -8,21 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .reversible import embed_ir_in_gltf, ir_digest, recover_embedded_ir
+from .reversible import assert_canonical_input, embed_ir_in_gltf, ir_digest, recover_embedded_ir
 
 GLB_MAGIC = b"glTF"
 GLB_VERSION = 2
 JSON_CHUNK = 0x4E4F534A
 BIN_CHUNK = 0x004E4942
 SUPPORTED_CONTAINER_SUFFIXES = {".glb", ".vrm"}
-NON_CANONICAL_TRUTH_STATUSES = {
-    "candidate",
-    "inferred",
-    "unknown",
-    "stable-candidate",
-    "stable-unknown",
-    "stable-but-ambiguous",
-}
 
 
 @dataclass(frozen=True)
@@ -108,16 +100,6 @@ def external_resource_uris(gltf: dict[str, Any]) -> list[str]:
     return [uri for uri in _resource_uris(gltf) if not uri.startswith("data:")]
 
 
-def _assert_canonical_input(canonical_ir: dict[str, Any]) -> None:
-    if not isinstance(canonical_ir, dict):
-        raise ValueError("canonical IR must be a JSON object")
-    status = canonical_ir.get("truth_status")
-    if isinstance(status, str) and status.lower().replace("_", "-") in NON_CANONICAL_TRUTH_STATUSES:
-        raise ValueError(
-            f"refusing to embed truth_status={status!r} as canonical IR; confirm/promote it explicitly first"
-        )
-
-
 def _encode_json_chunk(gltf: dict[str, Any]) -> bytes:
     payload = json.dumps(
         gltf,
@@ -160,7 +142,7 @@ def compile_reversible_glb(
     moving the output could otherwise silently break them.
     """
 
-    _assert_canonical_input(canonical_ir)
+    assert_canonical_input(canonical_ir)
     container = parse_glb_container(source)
     external = external_resource_uris(container.gltf)
     if require_relocatable and external:

--- a/libs/model2ir/src/model2ir/normalize.py
+++ b/libs/model2ir/src/model2ir/normalize.py
@@ -8,8 +8,8 @@ def project_candidate_ir(model_ir: dict[str, Any]) -> dict[str, Any]:
     """Project extracted 3D evidence into a stable, explicit candidate Character IR.
 
     This is not canonical truth. It is the deterministic import boundary: once
-    created, this candidate IR can be embedded in a carrier and round-tripped
-    losslessly even if the original external asset had no model2ir metadata.
+    created, this candidate can be saved as JSON. Canonical embedding requires
+    explicit confirmation first; deterministic import does not confer authority.
     """
     sem = model_ir.get('semantic_evidence_v03') or {}
     body = sem.get('body_plan') or {}

--- a/libs/model2ir/src/model2ir/reversible.py
+++ b/libs/model2ir/src/model2ir/reversible.py
@@ -7,6 +7,25 @@ from typing import Any
 
 EXTENSION_KEY = "OPENAI_model2ir_character_ir"
 EXTENSION_VERSION = "0.2.0"
+NON_CANONICAL_TRUTH_STATUSES = {
+    "candidate", "inferred", "unknown", "stable-candidate",
+    "stable-unknown", "stable-but-ambiguous",
+}
+
+
+def assert_canonical_input(ir: dict[str, Any]) -> None:
+    """Apply the same canonical boundary to JSON and binary carriers.
+
+    Legacy IR without truth_status remains supported. This checks the declared
+    status; neither a digest nor this guard can establish semantic correctness.
+    """
+    if not isinstance(ir, dict):
+        raise ValueError("canonical IR must be a JSON object")
+    status = ir.get("truth_status")
+    if isinstance(status, str) and status.strip().lower().replace("_", "-") in NON_CANONICAL_TRUTH_STATUSES:
+        raise ValueError(
+            f"refusing to embed truth_status={status!r} as canonical IR; confirm/promote it explicitly first"
+        )
 
 
 def canonical_json(value: Any) -> str:
@@ -24,6 +43,7 @@ def embed_ir_in_gltf(gltf: dict[str, Any], ir: dict[str, Any]) -> dict[str, Any]
     resulting asset remains standards-compatible without claiming Khronos registry
     status. Geometry is untouched.
     """
+    assert_canonical_input(ir)
     out = copy.deepcopy(gltf)
     extras = out.setdefault("extras", {})
     extras[EXTENSION_KEY] = {
@@ -42,10 +62,13 @@ def recover_embedded_ir(gltf: dict[str, Any]) -> dict[str, Any] | None:
         return None
     ir = payload.get("character_ir")
     if not isinstance(ir, dict):
-        return None
+        raise ValueError("embedded Character IR must be a JSON object")
+    assert_canonical_input(ir)
     expected = payload.get("digest")
+    if not isinstance(expected, str) or not expected:
+        raise ValueError("embedded Character IR digest is required for verified recovery")
     actual = ir_digest(ir)
-    if expected and expected != actual:
+    if expected != actual:
         raise ValueError("embedded Character IR digest mismatch")
     return copy.deepcopy(ir)
 

--- a/libs/model2ir/src/model2ir/semantic3d.py
+++ b/libs/model2ir/src/model2ir/semantic3d.py
@@ -29,6 +29,10 @@ def _part(name: str | None) -> tuple[str | None, float]:
     if any(k in n for k in ['foot','ankle']): return f'{side}_foot' if side else 'foot', 0.86
     if any(k in n for k in ['hair','bang','pony','braid']): return 'hair', 0.82
     if any(k in n for k in ['dress','shirt','coat','robe','jacket','skirt','cloth','garment']): return 'garment', 0.8
+    # A ribbon/bow tail is a decorative strip, not an anatomical appendage.
+    # Ponytails were already classified as hair above; animal tails still follow.
+    words = set(_norm(re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', name or '')).split('_'))
+    if 'tail' in words and words & {'ribbon', 'bow'}: return 'accessory', 0.78
     if any(k in n for k in ['tail']): return 'tail', 0.82
     if any(k in n for k in ['wing']): return 'wing', 0.82
     if any(k in n for k in ['book','weapon','sword','staff','crown','hat','bag']): return 'accessory', 0.78

--- a/libs/model2ir/src/model2ir/v04.py
+++ b/libs/model2ir/src/model2ir/v04.py
@@ -20,6 +20,7 @@ def extract_ir(asset_or_path) -> dict[str, Any]:
             'mode': 'external-import-candidate',
             'candidate_created': True,
             'future_roundtrip_can_be_lossless_if_embedded': True,
+            'canonical_embedding_requires_confirmation': True,
         }
     else:
         out['candidate_ir'] = None

--- a/scripts/model2ir_real_family_stability.py
+++ b/scripts/model2ir_real_family_stability.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import argparse, copy, json
 from pathlib import Path
-from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip, ir_digest
+from model2ir import extract_ir, stabilize_external_ir, ir_digest
+from model2ir_stabilized_import_regression import verify_candidate_storage
 
 CORE={'torso','left_arm','right_arm','left_leg','right_leg','neck'}
 
@@ -14,12 +15,7 @@ def stabilize(path: Path, out: Path):
     m=extract_ir(path)
     c=stabilize_external_ir(m)
     raw=json.loads(path.read_text())
-    carrier=compile_reversible_gltf(raw,c)
-    p=out/f'{path.stem}-stable.gltf'
-    p.write_text(json.dumps(carrier,ensure_ascii=False,indent=2)+'\n')
-    back=extract_ir(p)
-    s=score_roundtrip(c,back)
-    assert s['lossless_reversible'] is True
+    s=verify_candidate_storage(raw,c,out/f'{path.stem}-candidate.json')
     return m,c,s
 
 def main():
@@ -45,7 +41,7 @@ def main():
           'labels':sorted(labs),
           'candidate_digest':ir_digest(c),
           'joint_count':c['skeleton'].get('joint_count',0),
-          'roundtrip_exact':s['lossless_reversible'],
+          'candidate_storage':s,
         }
 
     shared=set.intersection(*human_labels)
@@ -62,26 +58,23 @@ def main():
     sani=extract_ir(sanp)
     assert (sani.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind')!='humanoid'
     sc=stabilize_external_ir(sani)
-    carrier=compile_reversible_gltf(sanitized,sc)
-    stable=out/'rigged-no-names-stable.gltf'; stable.write_text(json.dumps(carrier,indent=2)+'\n')
-    back=extract_ir(stable)
-    score=score_roundtrip(sc,back)
-    assert score['lossless_reversible'] is True
+    storage=verify_candidate_storage(sanitized,sc,out/'rigged-no-names-candidate.json')
 
     report={
-      'schema':'model2ir-real-family-stability/v0.5',
+      'schema':'model2ir-real-family-stability/v0.9.2',
       'humanoid_models':results,
       'shared_core_labels':sorted(shared),
       'negative_control_kind':(neg.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind'),
       'name_erasure':{
         'body_plan_after_erasure':(sani.get('semantic_evidence_v03') or {}).get('body_plan',{}).get('kind'),
         'hallucination_avoided':True,
-        'stabilized_roundtrip_exact':score['lossless_reversible'],
+        'candidate_storage':storage,
       },
       'gate':{
         'two_independent_humanoids_consistent':True,
         'candidate_repeatability':1.0,
-        'post_stabilization_reversibility':1.0,
+        'candidate_json_roundtrip':1.0,
+        'canonical_embedding_rejected':True,
         'negative_control_correct':True,
         'unknown_when_evidence_removed':True,
         'status':'PASS'

--- a/scripts/model2ir_stabilized_import_regression.py
+++ b/scripts/model2ir_stabilized_import_regression.py
@@ -3,7 +3,24 @@ from __future__ import annotations
 
 import argparse, json
 from pathlib import Path
-from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip, ir_digest
+from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, ir_digest
+
+
+def verify_candidate_storage(raw, candidate, output):
+    """Regression-only check: preserve candidates without asserting truth."""
+    assert candidate['truth_status'] == 'candidate'
+    try:
+        compile_reversible_gltf(raw, candidate)
+    except ValueError as exc:
+        assert 'refusing to embed truth_status' in str(exc), str(exc)
+    else:
+        raise AssertionError('candidate silently promoted to canonical')
+    output.write_text(json.dumps(candidate, ensure_ascii=False, indent=2) + '\n')
+    recovered = json.loads(output.read_text())
+    assert recovered == candidate
+    assert ir_digest(recovered) == ir_digest(candidate)
+    return {'candidate_json_exact': True, 'candidate_digest': ir_digest(candidate),
+            'canonical_embedding_rejected': True, 'canonical_promotion': False}
 
 
 def main():
@@ -23,30 +40,21 @@ def main():
     assert a['reversibility']['lossless'] is False
     assert ca['truth_status']=='candidate'
 
-    # Stabilize the external model by embedding the candidate IR into its glTF carrier.
+    # Deterministic projection is not semantic confirmation. Preserve it as JSON;
+    # canonical carrier reversibility is tested separately with declared fixtures.
     raw=json.loads(Path(args.input).read_text())
-    carrier=compile_reversible_gltf(raw, ca)
-    stable_path=out/'stabilized.gltf'
-    stable_path.write_text(json.dumps(carrier,ensure_ascii=False,indent=2)+'\n')
-    recovered=extract_ir(stable_path)
-    assert recovered['reversibility']['lossless'] is True
-    assert recovered['canonical_ir'] == ca
-    assert recovered['canonical_ir_digest'] == ir_digest(ca)
-    score=score_roundtrip(ca,recovered)
-    assert score['lossless_reversible'] is True
-    assert score['canonical_difference_count']==0
+    storage=verify_candidate_storage(raw, ca, out/'candidate-ir.json')
 
     report={
-      'schema':'model2ir-stabilized-import-regression/v0.4',
+      'schema':'model2ir-stabilized-import-regression/v0.9.2',
       'source_lossless':False,
       'candidate_digest':ir_digest(ca),
       'deterministic_initial_projection':True,
-      'stabilized_lossless':True,
-      'roundtrip':score,
+      'candidate_storage':storage,
       'candidate_body_plan':ca['body_plan'],
       'candidate_parts':[p['id'] for p in ca['parts']],
       'unresolved_count':len(ca['unresolved']),
-      'gate':{'status':'PASS','candidate_repeatability':1.0,'post_stabilization_reversibility':1.0},
+      'gate':{'status':'PASS','candidate_repeatability':1.0,'candidate_json_roundtrip':1.0,'canonical_embedding_rejected':True},
     }
     (out/'report.json').write_text(json.dumps(report,indent=2)+'\n')
     print(json.dumps(report['gate']))

--- a/scripts/model2ir_vrm_topology_regression.py
+++ b/scripts/model2ir_vrm_topology_regression.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import argparse, json
 from pathlib import Path
-from model2ir import extract_ir, stabilize_external_ir, compile_reversible_gltf, score_roundtrip
+from model2ir import extract_ir, stabilize_external_ir
+from model2ir_stabilized_import_regression import verify_candidate_storage
 
 CORE={'pelvis','torso','head','left_arm','right_arm','left_leg','right_leg'}
 
@@ -50,11 +51,8 @@ def main():
         assert CORE <= ids, (label, sorted(CORE-ids))
         assert cand['body_plan']['source'].startswith('VRM-')
         assert cand['body_plan']['confidence'] >= .99
-        carrier=compile_reversible_gltf(obj,cand)
-        sp=out/f'{label}-stable.gltf'; write(sp,carrier)
-        back=extract_ir(sp); score=score_roundtrip(cand,back)
-        assert score['lossless_reversible']
-        vrm_results[label]={'coverage':ev['core_coverage'],'confidence':cand['body_plan']['confidence'],'roundtrip':True}
+        storage=verify_candidate_storage(obj,cand,out/f'{label}-candidate.json')
+        vrm_results[label]={'coverage':ev['core_coverage'],'confidence':cand['body_plan']['confidence'],'candidate_storage':storage}
 
     rig=json.loads(Path(args.rigged).read_text())
     for n in rig.get('nodes',[]): n.pop('name',None)
@@ -68,21 +66,18 @@ def main():
     # topology may infer body-plan class, but must not invent left/right semantic parts
     ids={x['id'] for x in rc.get('parts',[])}
     assert not ({'left_arm','right_arm','left_leg','right_leg'} & ids), sorted(ids)
-    carrier=compile_reversible_gltf(rig,rc)
-    stable=out/'rigged-no-names-stable.gltf'; write(stable,carrier)
-    rback=extract_ir(stable); rscore=score_roundtrip(rc,rback)
-    assert rscore['lossless_reversible']
+    storage=verify_candidate_storage(rig,rc,out/'rigged-no-names-candidate.json')
 
     simple=extract_ir(args.simpleskin)
     st= simple['topology_evidence']
     assert st['kind']=='unknown', st
 
     report={
-      'schema':'model2ir-vrm-topology-regression/v0.6',
+      'schema':'model2ir-vrm-topology-regression/v0.9.2',
       'vrm':vrm_results,
       'unnamed_full_rig':{
         'topology_kind':topo['kind'], 'confidence':topo['confidence'],
-        'side_assignments':topo['side_assignments'], 'roundtrip_exact':rscore['lossless_reversible']
+        'side_assignments':topo['side_assignments'], 'candidate_storage':storage
       },
       'insufficient_simple_skin':{'topology_kind':st['kind'],'reason':st['reason'],'joint_count':st['joint_count']},
       'gate':{
@@ -91,7 +86,8 @@ def main():
         'unnamed_full_rig_body_plan':True,
         'unnamed_side_hallucination_avoided':True,
         'insufficient_rig_unknown':True,
-        'post_stabilization_reversibility':1.0,
+        'candidate_json_roundtrip':1.0,
+        'canonical_embedding_rejected':True,
         'status':'PASS'
       }
     }

--- a/tests/test_model2ir_semantic_integrity.py
+++ b/tests/test_model2ir_semantic_integrity.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from model2ir import (
+    audit_asset, compile_reversible_glb, compile_reversible_gltf, diff_ir,
+    extract_ir, reconcile_ir, score_roundtrip, stabilize_external_ir,
+)
+from model2ir.core import Asset
+from model2ir.reversible import EXTENSION_KEY, ir_digest, recover_embedded_ir
+from test_model2ir_glb_reversible_v09 import make_glb
+
+
+def evidence(name):
+    gltf = {"asset": {"version": "2.0"}, "nodes": [{"name": name, "mesh": 0}],
+            "meshes": [{"name": name, "primitives": []}]}
+    return extract_ir(Asset(Path(name + ".gltf"), "gltf", gltf, 0, []))
+
+
+class SemanticIntegrityTest(unittest.TestCase):
+    def test_new_envelopes_do_not_report_disjoint_parts_as_equal(self):
+        a, b = evidence("head"), evidence("hair")
+        result = diff_ir(a, b)["semantic"]
+        self.assertEqual(result["jaccard"], 0.0)
+        self.assertEqual(result["only_a"], ["head"])
+        self.assertEqual(result["only_b"], ["hair"])
+        self.assertEqual(score_roundtrip(a, b)["semantic_preservation"], 0.0)
+
+    def test_all_envelope_versions_and_direct_candidates_keep_labels(self):
+        image = {"inferred": {"parts": ["head"]}}
+        for version in ("0.1", "0.2", "0.4", "0.6"):
+            model = evidence("head")
+            model["schema"] = "model2ir-character-ir/v" + version
+            with self.subTest(version=version):
+                self.assertEqual(reconcile_ir(image, model)["semantic_recovery_ratio"], 1.0)
+        candidate = stabilize_external_ir(evidence("head"))
+        self.assertEqual(diff_ir(image, candidate)["semantic"]["jaccard"], 1.0)
+        self.assertEqual(reconcile_ir(image, candidate)["matched"], ["head"])
+
+    def test_embedded_payload_is_compared_instead_of_carrier_names(self):
+        model = evidence("hair")
+        model["canonical_ir"] = {"schema": "character-ir/v0.6", "parts": [{"id": "head"}]}
+        self.assertEqual(diff_ir({"inferred": {"parts": ["head"]}}, model)["semantic"]["jaccard"], 1.0)
+
+    def test_legacy_v01_candidates_without_v03_evidence(self):
+        model = {"schema": "model2ir-character-ir/v0.1", "semantic_ir": {
+            "candidates": [{"semantic_candidate": {"label": "head"}}]}}
+        self.assertEqual(reconcile_ir({"inferred": {"parts": ["head"]}}, model)["matched"], ["head"])
+
+    def test_empty_and_unknown_labels_do_not_become_parts(self):
+        self.assertEqual(diff_ir({"parts": ["unknown", None, {}]}, {"parts": []})["semantic"]["shared"], [])
+
+    def test_ribbon_tail_is_accessory_but_animal_tail_remains_tail(self):
+        for name in ("RibbonTail", "ribbon_tail", "BowTail"):
+            with self.subTest(name=name):
+                self.assertNotIn("tail", evidence(name)["semantic_evidence_v03"]["parts"])
+                self.assertIn("accessory", evidence(name)["semantic_evidence_v03"]["parts"])
+        for name in ("Tail", "FoxTail", "tail_01", "RainbowTail"):
+            self.assertIn("tail", evidence(name)["semantic_evidence_v03"]["parts"])
+        self.assertIn("hair", evidence("PonyTail")["semantic_evidence_v03"]["parts"])
+
+
+class CanonicalBoundaryTest(unittest.TestCase):
+    def setUp(self):
+        self.gltf = {"asset": {"version": "2.0"}}
+        self.source = make_glb(self.gltf, b"original-geometry")
+
+    def test_both_writers_reject_explicit_candidate_statuses(self):
+        for status in ("candidate", "inferred", "unknown", "stable-candidate",
+                       "stable-unknown", "stable-but-ambiguous", "STABLE_CANDIDATE"):
+            ir = {"schema": "character-ir-candidate/v0.6", "truth_status": status}
+            for writer, source in ((compile_reversible_gltf, self.gltf), (compile_reversible_glb, self.source)):
+                with self.subTest(status=status, writer=writer.__name__):
+                    with self.assertRaisesRegex(ValueError, "refusing to embed truth_status"):
+                        writer(source, ir)
+
+    def test_existing_candidate_carrier_cannot_claim_canonical_authority(self):
+        ir = {"schema": "character-ir-candidate/v0.6", "truth_status": "candidate"}
+        carrier = {**self.gltf, "extras": {EXTENSION_KEY: {
+            "version": "0.2.0", "encoding": "json", "digest": ir_digest(ir),
+            "character_ir": ir, "truth_class": "embedded_canonical_ir"}}}
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "legacy-candidate.gltf"
+            path.write_text(json.dumps(carrier))
+            with self.assertRaisesRegex(ValueError, "candidate"):
+                audit_asset(path)
+
+    def test_missing_digest_cannot_be_reported_as_verified(self):
+        carrier = compile_reversible_gltf(self.gltf, {"schema": "character-ir/v0.6", "parts": []})
+        for value in (None, "", False):
+            invalid = copy.deepcopy(carrier)
+            invalid["extras"][EXTENSION_KEY]["digest"] = value
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "digest"):
+                    recover_embedded_ir(invalid)
+
+    def test_valid_legacy_ir_remains_reversible_without_mutating_input(self):
+        ir = {"schema": "character-ir/v0.6", "parts": [{"id": "head"}], "unresolved": ["back"]}
+        before = copy.deepcopy(self.gltf)
+        carrier = compile_reversible_gltf(self.gltf, ir)
+        self.assertEqual(recover_embedded_ir(carrier), ir)
+        self.assertEqual(self.gltf, before)
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "valid.gltf"
+            path.write_text(json.dumps(carrier))
+            self.assertTrue(score_roundtrip(ir, extract_ir(path))["canonical_exact"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Current v0.6 evidence envelopes fall through the v0.1-only semantic label reader: a head-only asset and a hair-only asset score Jaccard 1.0, while matching image/model head labels reconcile to zero. The legacy glTF writer also accepts explicit candidate IR as canonical, and recovery can claim verification without a digest. RibbonTail is misidentified as an anatomical tail.

## Changes
- Read semantic labels from retained envelope versions, direct candidate/Character IR parts, and Image→IR parts; compare embedded payloads rather than carrier names when present.
- Share the existing canonical-status guard between glTF and GLB/VRM. Require matching recovery digests and reject explicit candidate carriers. Preserve valid legacy IR without truth_status for compatibility; a digest still does not establish semantic truth.
- Classify ribbon/bow tails as accessory candidates while retaining animal-tail and ponytail behavior.
- Update legacy regression adapters to preserve candidate JSON and explicitly reject unconfirmed canonical embedding. Canonical carrier tests remain separate.
- Add regression tests and CI coverage, bump the package to 0.9.2, and document migration plus the existing Character Blueprint producer integration boundary.

## Validation
- 31 local Model2IR unit tests pass, including new cases reproduced as failures before the fix.
- Stabilized import, two-real-humanoid family with negative control, and VRM 0/1 plus unnamed-topology regressions pass using Khronos sample metadata.
- Five canonical fixture round-trips and tamper detection pass.
- Binary preservation passes on the 6.3 MB character GLB from the current experiment; its source is unchanged and is not committed.
- Character extraction now labels RibbonTail as accessory, with no inferred extra tail.

## Compatibility and scope
Explicit candidate carriers created by the old glTF writer now raise instead of claiming canonical authority. Preserve their payload as candidate JSON pending explicit review; do not delete status to evade validation. The three migrated adapter report schemas are v0.9.2 and use candidate_json_roundtrip instead of post_stabilization_reversibility.

This repairs the existing library. It does not add an IR-only mesh generator or modify AgentOS Core governance/runtime. Producer parameter capture and rendered regeneration validation remain a follow-up described in the package README.

Protected main is unchanged. Merge requires the separate human authorization required by AGENTS.md.